### PR TITLE
feat: policy hot-reload via PolicySource — platform If-None-Match + local yaml/bundle-dir refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,15 +636,27 @@ The manifest's hashes authenticate the files; the signature authenticates the ma
 
 ### Local enforcement — `FORTIFY_LOCAL_POLICY`
 
-Point an agent at a local bundle and every tool call routes through the WASM engine instead of pydantic — no platform needed. This is the dev-iteration path: edit `policy.yaml`, rebuild, restart, see the change.
+Point an agent at a local source and every tool call routes through the WASM engine instead of pydantic — no platform needed. Two shapes are accepted, and both **hot-reload on save** (no restart, no manual rebuild between turns):
+
+| `FORTIFY_LOCAL_POLICY=…` | What happens | When to use |
+|---|---|---|
+| **`./bundle/`** (output of `fortify policy build`) | Stat the bundle manifest each turn; reload if its mtime changed. | Production-shaped local testing — exercises the exact signed-bundle path. |
+| **`./policy.yaml`** | Stat the yaml each turn; recompile via `opa` when its mtime changed. | The tight dev loop — edit yaml, save, ask again. No build step. |
 
 ```bash
+# Pre-built bundle dir — rebuild it mid-session, next chat picks it up
 fortify policy build policy.yaml --out ./bundle
 FORTIFY_LOCAL_POLICY=./bundle fortify chat --agent researcher
-# [fortify] FORTIFY_LOCAL_POLICY active: ./bundle (wasm_hash=7e6d1f8b..., unsigned)
+# [fortify] FORTIFY_LOCAL_POLICY active (bundle-dir): ./bundle (wasm_hash=7e6d1f8b..., unsigned)
+
+# Raw yaml — edit policy.yaml in your editor, save, next chat sees the new policy
+FORTIFY_LOCAL_POLICY=./policy.yaml fortify chat --agent researcher
+# [fortify] FORTIFY_LOCAL_POLICY active (yaml): ./policy.yaml (wasm_hash=ab12..., unsigned)
 ```
 
-The bundle's integrity (files match the manifest) is verified eagerly at startup — a stale or corrupt bundle fails immediately, not at the first tool call.
+The bundle's integrity (files match the manifest) is verified on every reload — a stale or corrupt bundle fails immediately, not at the first tool call. Yaml sources default to **unsigned**: set `FORTIFY_BUNDLE_SIGN_KEY_PATH=./keys/dev.private` to sign each recompile with your `fortify policy keygen` key, so downstream gates that check `bundle.is_signed` see what they expect.
+
+> **Same refresh seam as the platform.** Under the hood both sources implement `PolicySource.fetch()`; the agent runtime calls it at the top of every turn and only swaps the active policy when the returned bundle is a new instance. Unchanged → identity match → no work. That's the same hot-reload path `fortify serve` uses for platform-edited YAML.
 
 ### Signing & verification
 
@@ -665,7 +677,7 @@ FORTIFY_LOCAL_POLICY=./bundle \
 FORTIFY_BUNDLE_PUBKEY_PATH=./keys/dev.public \
 FORTIFY_BUNDLE_REQUIRE_SIGNATURE=true \
 fortify chat --agent researcher
-# [fortify] FORTIFY_LOCAL_POLICY active: ./bundle (wasm_hash=..., signed)
+# [fortify] FORTIFY_LOCAL_POLICY active (bundle-dir): ./bundle (wasm_hash=..., signed)
 ```
 
 `FORTIFY_BUNDLE_REQUIRE_SIGNATURE` controls strictness — warn-by-default keeps local dev frictionless; opt into refusal for CI/prod:
@@ -900,8 +912,9 @@ Policy-bundle enforcement (see [Policy Bundles](#-policy-bundles--compile-sign-e
 
 | Env var | Purpose |
 |---|---|
-| `FORTIFY_LOCAL_POLICY` | Path to a bundle directory; overrides the agent's policy with the WASM engine |
+| `FORTIFY_LOCAL_POLICY` | Path to a bundle directory **or** a `policy.yaml`; routes enforcement through the WASM engine and hot-reloads on save |
 | `FORTIFY_BUNDLE_PUBKEY_PATH` | base64url Ed25519 public key used to verify a bundle's signature |
+| `FORTIFY_BUNDLE_SIGN_KEY_PATH` | base64url Ed25519 private key used to sign locally-compiled yaml sources (so `bundle.is_signed` is True) |
 | `FORTIFY_BUNDLE_REQUIRE_SIGNATURE` | `true` to refuse unsigned or unverifiable bundles (default: warn only) |
 | `FORTIFY_OPA_BIN` | Override the `opa` binary location (default: search `PATH`) |
 
@@ -1116,7 +1129,7 @@ Behaviour:
 
 - Connects `ws://${FORTIFY_API_URL}/v1/projects/${pid}/serve` with `Authorization: Bearer ${FORTIFY_KEY}`
 - Sends a `hello` frame announcing the agent name (so the dashboard's "Serving" indicator can show it)
-- On each inbound `chat` message, **rebuilds the runtime** (re-fetches agent + policy YAML from the platform) before running, so dashboard edits take effect at turn boundaries without a restart
+- On each inbound `chat` message, **refreshes the active policy** before running. Refresh is an `If-None-Match` round-trip to the platform: a 304 reuses the cached WASM module, a 200 swaps in the new bundle. Dashboard edits take effect at turn boundaries without restarting the process or re-wrapping the tools.
 - Streams every `StreamEvent` (text deltas, tool start/end, run end) back as JSON
 - Auto-approves any `approval_required` tools — there's no TTY in serve mode for prompts (planned: dashboard-side approval UI)
 - Reconnects with exponential backoff on socket drop

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ Walk through one tool call:
 - `FORTIFY_KEY` set, no local override → `PlatformPolicySource` (ETag / `304 Not Modified` refresh)
 - Neither → no source attached; enforcement uses whatever was loaded once
 
+**Scope of the per-turn refresh:** only the policy bundle. `system_prompt`, the manifest's tool list, and the model id are read once at agent construction and stay fixed for the lifetime of the process. Edit those on the dashboard and the change lands at the next `fortify serve` restart — not at the next turn. The split is deliberate: policy is the operator's primary lever (and the one that needs to be auditable per-decision), while the manifest is an author-time concept.
+
 ### Two carve-outs worth knowing
 
 1. **Per-call identity stays explicit.** `User` is the one piece the adapter can't infer from env, because it's per-request, not per-process. One line wrapping each call (`user=User(...)` kwarg on adapters, `async with User(...)` for native).

--- a/README.md
+++ b/README.md
@@ -123,6 +123,86 @@ agent, handler = create_agent(
 )
 ```
 
+## 🚀 Build an Agent — End to End
+
+Devs pick one of two shapes. Both end up at the same enforcement seam — they differ only in **where the policy comes from**.
+
+### Shape A — "I have an existing framework agent"
+
+Dev wrote an OpenAI Agents / LangChain / Google ADK / Pydantic AI agent. They wrap it once and they're done:
+
+```python
+from fortify.adapters.openai import FortifyRunner   # or .langchain.wrap_langchain_agent, .google.FortifyRunner, .pydantic_ai.wrap_pydantic_agent
+from fortify.runtime import User
+
+runner = FortifyRunner()                            # picks up FORTIFY_KEY from env
+await runner.run(
+    my_agent,
+    "refund 30",
+    user=User(user_id="alice", role="billing"),     # per-call scope
+)
+```
+
+That's it. They get:
+
+- Tool-call enforcement at every tool boundary (`PolicyEnforcer.decide()`)
+- Role resolution from the active `User.role` at call time
+- Per-request biscuit attenuation
+- Langfuse traces tagged with the caller's identity
+
+### Shape B — "I want the platform to own the agent's YAML"
+
+Dev authored the agent's `agent.yaml` / `policy.yaml` / `system.md` in the dashboard. SDK fetches them:
+
+```python
+from fortify import load_fortify_agent, stream_agent, User
+
+agent, handler = load_fortify_agent("default")      # name optional, falls back to FORTIFY_AGENT_NAME → "default"
+
+async with User(user_id="alice", role="billing"):
+    async for ev in stream_agent(agent, handler, "refund 30"):
+        ...
+```
+
+Same enforcement seam, same `User` scope. The difference is whose system of record holds the YAML — the dev's code vs the dashboard.
+
+### Env vars: that *is* the whole config surface
+
+| What dev sets | What changes |
+|---|---|
+| `FORTIFY_KEY=fty_test_<project>_…` | Wakes up the platform path. Without it, adapters / `load_agent` fall back to local / builtin. |
+| `FORTIFY_AGENT_NAME=default` *(optional)* | Which agent to fetch. Falls back to `"default"`. |
+| `FORTIFY_API_URL=http://localhost:8000` *(optional)* | Platform endpoint. Defaults to localhost. |
+| `FORTIFY_LOCAL_POLICY=./policy.yaml` *or* `./bundle/` | Dev escape hatch: enforce a policy from disk, hot-reload on save. Wins over the platform's bundle. |
+| `FORTIFY_BUNDLE_SIGN_KEY_PATH=./keys/dev.private` *(optional)* | Sign locally-recompiled yaml so `bundle.is_signed` reads True. |
+| `FORTIFY_BUNDLE_PUBKEY_PATH=./keys/prod.public` *(optional)* | Verify a pre-built bundle dir against this pubkey on every reload. |
+| `FORTIFY_BUNDLE_REQUIRE_SIGNATURE=true` *(optional)* | Strict mode — refuse any unsigned or unverifiable bundle at startup. |
+
+No config object to instantiate, no `enforce_policy(...)` call to remember on the platform path. The adapter / loader threads it all through.
+
+### Where enforcement actually happens
+
+Walk through one tool call:
+
+1. The model emits a tool call. The framework's tool dispatcher invokes the tool.
+2. The tool is *not the dev's original* — it's a copy our adapter made, whose body starts with `enforcer.decide(role, tool_name, args)`.
+3. `PolicyEnforcer.decide` reads `self.policy` — that's either a `PolicySet` (pydantic engine, default fallback) or a `PolicyBundle` (WASM engine, what production runs).
+4. Decision is `allow` → the original tool runs. `deny` → returns a `[policy_denied]` marker the model sees as the tool result. `approval_required` → either calls the dev-supplied approval handler or returns an `[approval_required]` marker.
+5. **Before step 2, every turn:** `refresh_policy()` calls `self._policy_source.fetch()`. If the source returns a new bundle instance, `enforcer.policy` is swapped in place. Tools don't get re-wrapped — they hold a reference to the enforcer, not the bundle.
+
+`_policy_source` is set automatically by the loader based on env:
+
+- `FORTIFY_LOCAL_POLICY` set → `YamlPolicySource` or `BundleDirPolicySource` (mtime-driven refresh)
+- `FORTIFY_KEY` set, no local override → `PlatformPolicySource` (ETag / `304 Not Modified` refresh)
+- Neither → no source attached; enforcement uses whatever was loaded once
+
+### Two carve-outs worth knowing
+
+1. **Per-call identity stays explicit.** `User` is the one piece the adapter can't infer from env, because it's per-request, not per-process. One line wrapping each call (`user=User(...)` kwarg on adapters, `async with User(...)` for native).
+2. **`approval_required` tools.** If the policy uses that mode, dev decides what happens — pass `approval_handler=` (True / False / callable) when wrapping. Default for `fortify serve` is auto-approve; for `fortify chat` it prompts the TTY. Native code gets whatever the dev wires.
+
+Everything else — fetch, verify, hot-reload, role selection, signature check, decision rendering, tracing — the runtime handles. Set `FORTIFY_KEY` and wrap, or set `FORTIFY_LOCAL_POLICY` and wrap. That's the surface.
+
 ## 📦 What You Can Import
 
 The current curated surface includes:
@@ -130,10 +210,7 @@ The current curated surface includes:
 - `create_agent`
 - `create_manifest`
 - `AgentManifest`
-- `enforce_policy`
-- `with_approval_handler`
 - `enforce_policy` — accepts an optional `approval_handler=` for `NEEDS_APPROVAL` outcomes
-- `with_before_action`
 - `invoke_agent`
 - `stream_agent`
 - `stream_agent_raw`
@@ -156,7 +233,6 @@ from fortify import (
     grep,
     read_file,
     write_file,
-    with_before_action,
     agent_tool,
     load_agent,
     load_builtin_agent,
@@ -526,15 +602,9 @@ Supported modes:
 
 Constraint operators: `==`, `!=`, `<`, `<=`, `>`, `>=`, `in`, `not in`. Strings on the right use JSON double quotes. Every constraint must pass for the call to authorize (implicit AND). See [User Scope + Roles](#-user-scope--roles) for the role-aware policy bundle shape that picks a per-role policy at call time.
 
-## 🛡️ Gate 1: Local Policy Enforcement
+## 🛡️ Tool-Call Policy Enforcement
 
-Gate 1 is the current built-in security layer.
-
-Use it when:
-
-- developers should be able to build and test agents freely
-- a host platform or admin layer wants to constrain tool access later
-- you want deny-by-default behavior before a tool actually runs
+Every tool call routes through a `PolicyEnforcer` that returns `allow` / `deny` / `approval_required`. Deny-by-default; the policy file lists what's allowed.
 
 `create_agent(...)` stays close to LangChain. Policy enforcement is applied after agent creation:
 
@@ -696,7 +766,7 @@ Keys are raw Ed25519, base64url-encoded — the same format the platform's JWKS 
 
 ## ✅ Approval-Required Tool Calls
 
-Approval handlers are the bridge between static Gate 1 policy and real product interaction. Use them when a tool should be **generally allowed in principle** but only after a user, CLI host, or UI host explicitly approves the specific call.
+Approval handlers are the bridge between static policy and real product interaction. Use them when a tool should be **generally allowed in principle** but only after a user, CLI host, or UI host explicitly approves the specific call.
 
 The handler is threaded through `enforce_policy(...)` at wrap time:
 
@@ -707,7 +777,7 @@ The handler is threaded through `enforce_policy(...)` at wrap time:
   - sync function `(action: dict, context: dict | None) -> bool`
   - async function `(action: dict, context: dict | None) -> bool | Awaitable[bool]`
 
-The `action` dict carries `{"tool_name", "arguments", "agent_name"}`; `context` comes from an optional `context_provider` (only used when chained with `with_before_action`).
+The `action` dict carries `{"tool_name", "arguments", "agent_name"}`; `context` is reserved for future host-supplied runtime metadata and is `None` today.
 
 Example:
 
@@ -746,78 +816,9 @@ agent = enforce_policy(agent, policy, approval_handler=approval_handler)
 
 The handler returns a boolean today. Future evolution (richer approval decisions, interrupt/resume flows, UI approval cards, audit metadata) is intentionally left open — the current `(action, context) -> bool` API is enough for CLI and simple hosted apps.
 
-## 🚪 Gate 2: Hosted `before_action` Hooks
-
-Gate 2 is the next layer for platform-level enforcement.
-
-Why call this a Gate 2 primitive:
-
-- Gate 1 answers: "is this tool allowed at all for this agent?"
-- Gate 2 answers: "given who is calling, where they are deployed, and the current runtime context, should this specific action be allowed right now?"
-
-So the design intent is:
-
-- agent authors define tools, prompts, and behavior
-- platform or admin layers inject hosted enforcement later
-- runtime context flows down from the host platform, not from the tool author
-
-The primitive is intentionally small:
-
-- `before_action(action, context)`
-- optional `context_provider()`
-
-It runs after Gate 1 and before the real tool executes.
-
-Example:
-
-```python
-from fortify import (
-    create_agent,
-    enforce_policy,
-    fetch,
-    web_search,
-    with_before_action,
-)
-
-def before_action(action: dict, context: dict | None) -> None:
-    if context is None:
-        raise RuntimeError("missing runtime context")
-    if context.get("tenant_id") != "acme":
-        raise RuntimeError("tenant is not allowed to run this action")
-
-def context_provider() -> dict:
-    return {"tenant_id": "acme", "request_id": "req-123"}
-
-agent, handler = create_agent(
-    model="openai:gpt-5.4",
-    tools=[web_search, fetch],
-    system_prompt="You are a careful research assistant.",
-)
-
-agent = enforce_policy(agent, "policy.yaml")  # Gate 1
-agent = with_before_action(
-    agent,
-    before_action=before_action,
-    context_provider=context_provider,
-)  # Gate 2
-```
-
-So the design split is:
-
-- `create_agent(...)`: build the base agent
-- `enforce_policy(..., approval_handler=...)`: local Gate 1 tool authorization, optionally with inline approval resolution for `approval_required` tools
-- `with_before_action(...)`: Gate 2 platform / IAM / approval integration
-
-This is intentionally an open chantier:
-
-- Gate 1 is already concrete and useful
-- approval handlers are the first real host interaction layer
-- Gate 2 starts as a tiny hook, not a full enterprise framework
-- later evolution can add richer approval semantics, external policy engines, or audit sinks without bloating `create_agent(...)`
-
 ## 🧱 Workspace Sandbox
 
-When the `bash` tool executes a command it runs inside an OS-level sandbox configured from the agent's workspace. This is filesystem + network enforcement at the kernel level — a separate concern from Gates 1/2, which decide *whether* a tool may be invoked at all.
+When the `bash` tool executes a command it runs inside an OS-level sandbox configured from the agent's workspace. This is filesystem + network enforcement at the kernel level — a separate concern from policy enforcement, which decides *whether* a tool may be invoked at all.
 
 ### Runtime requirement
 
@@ -878,16 +879,15 @@ The sandboxed child does **not** inherit the parent process's environment. Only 
 
 This means parent-process secrets — `AWS_SECRET_ACCESS_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GH_TOKEN`, `SSH_AUTH_SOCK`, etc. — **don't leak** into the agent. Tools that legitimately need credentials should receive them through `extra_env`, where you control exactly what's passed.
 
-### Layering with Gates 1/2
+### Layering with policy + approval
 
 | Layer | Question | Mechanism |
 |---|---|---|
-| **Gate 1** | Is this tool allowed at all? | `enforce_policy(...)` |
+| **Policy** | Is this tool allowed at all for this caller's role? | adapter / `enforce_policy(...)` |
 | **Approval** | Should this specific call go ahead? | `enforce_policy(..., approval_handler=...)` |
-| **Gate 2** | Should this call run *given runtime context*? | `with_before_action(...)` |
 | **Sandbox** | What can the spawned shell actually do? | OS-level via `srt` |
 
-Gate 1 decides whether the `bash` tool is callable for an agent. Approval and Gate 2 inspect each invocation. The sandbox bounds reach *if a call does run*. They're complementary — deploy whichever combination matches your threat model.
+Policy decides whether the `bash` tool is callable. The approval handler inspects each call gated by `approval_required`. The sandbox bounds reach *if a call does run*. They're complementary — deploy whichever combination matches your threat model.
 
 ### What the sandbox does NOT do
 

--- a/examples/fortify_agent_demo.py
+++ b/examples/fortify_agent_demo.py
@@ -67,14 +67,19 @@ def main() -> int:
     try:
         config = FortifyConfig.from_env()
         client = FortifyClient(config)
-        payload = client.get_agent(agent_name)
+        # get_agent returns (payload, etag) — the etag is for the SDK's
+        # conditional-GET hot-reload path, which this demo doesn't need.
+        payload, _etag = client.get_agent(agent_name)
     except FortifyError as exc:
         print(f"fortify error: {exc}", file=sys.stderr)
         return 1
 
+    assert payload is not None, "first get_agent has no If-None-Match — 304 impossible"
     policy = AgentPolicy.model_validate(yaml.safe_load(payload["policy_yaml"]) or {})
 
-    print(f"fetched '{agent_name}' from {config.base_url}/v1/projects/{config.project_id}")
+    print(
+        f"fetched '{agent_name}' from {config.base_url}/v1/projects/{config.project_id}"
+    )
     print(f"updated_at: {payload['updated_at']}")
     print()
     print("policy:")

--- a/fortify/agents/factory.py
+++ b/fortify/agents/factory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, Self, TypeAlias
@@ -367,6 +369,14 @@ class FortifyAgent:
         client = getattr(self, "fortify_client", None)
         if client is not None:
             rebuilt.fortify_client = client
+        # Phase 8: keep the enforcement seam alive across with_tools rebuilds
+        # so refresh_policy() can still swap engines after the rebuild.
+        enforcer = getattr(self, "_enforcer", None)
+        if enforcer is not None:
+            rebuilt._enforcer = enforcer
+        source = getattr(self, "_policy_source", None)
+        if source is not None:
+            rebuilt._policy_source = source
         return rebuilt
 
     def enforce_policy(
@@ -414,7 +424,40 @@ class FortifyAgent:
                 )
             else:
                 wrapped.append(tool_spec)
-        return self.with_tools(wrapped)
+        rebuilt = self.with_tools(wrapped)
+        # Stash the enforcer so refresh_policy() can swap its policy in
+        # place when the platform serves a new bundle, without rebuilding
+        # the tool wrappers.
+        rebuilt._enforcer = enforcer
+        return rebuilt
+
+    def refresh_policy(self) -> None:
+        """Pull the current policy from the attached source and swap it in.
+
+        Called at the top of every agent run (see :func:`stream_agent` /
+        :func:`invoke_agent` / serve mode) so policy edits land at the
+        next run no matter how the user invokes the agent. The
+        :class:`~fortify.security.source.PlatformPolicySource` does the
+        ETag/304 dance, and the content-addressed
+        :class:`~fortify.security.wasm_engine._WasmPolicyCache` makes the
+        unchanged case a single small HTTP round-trip — no wasmtime
+        re-instantiation, no signature re-verify.
+
+        No-op when no source is attached (programmatic callers that
+        constructed the agent without one) or no enforcer exists (no
+        policy was applied). Failures from the source propagate so
+        callers see them at run boundary, not as silent staleness.
+        """
+        source = getattr(self, "_policy_source", None)
+        enforcer = getattr(self, "_enforcer", None)
+        if source is None or enforcer is None:
+            return
+        new_policy = source.fetch()
+        if new_policy is None or new_policy is enforcer.policy:
+            # Source has nothing to offer, or the same object came back
+            # (e.g. PlatformPolicySource returns the cached bundle on 304).
+            return
+        enforcer.policy = new_policy
 
 
 AgentGraph: TypeAlias = FortifyAgent
@@ -501,6 +544,29 @@ def create_agent(
     return agent, handler
 
 
+_logger = logging.getLogger("fortify.agents.factory")
+
+
+async def _refresh_policy_safely(agent: "AgentGraph") -> None:
+    """Pull the latest policy from the agent's attached source, off the loop.
+
+    Called at the top of every async invocation so policy changes land at
+    the next run without anyone having to know which entry point they're
+    going through. No-op when no source is attached (programmatic
+    construction). Failures log a warning and keep the previous policy —
+    a transient network blip should never crash a chat turn.
+    """
+    refresh = getattr(agent, "refresh_policy", None)
+    if refresh is None:
+        return
+    try:
+        await asyncio.to_thread(refresh)
+    except Exception as exc:  # noqa: BLE001 — refresh failures must not crash the run
+        _logger.warning(
+            "policy refresh failed: %s — keeping previously loaded policy", exc
+        )
+
+
 @observe(name="invoke_fortify_agent")
 async def invoke_agent(
     agent: AgentGraph,
@@ -510,6 +576,7 @@ async def invoke_agent(
     tool_use_context: ToolUseContext | None = None,
 ) -> dict[str, Any]:
     """Invoke the agent for one normalized input payload."""
+    await _refresh_policy_safely(agent)
     token = set_current_tool_use_context(
         _resolve_tool_use_context(agent, tool_use_context)
     )
@@ -530,6 +597,7 @@ async def stream_agent_raw(
     tool_use_context: ToolUseContext | None = None,
 ) -> AsyncIterator[LangChainStreamEvent]:
     """Stream raw LangChain events from the agent runtime."""
+    await _refresh_policy_safely(agent)
     config = get_langfuse_runnable_config(handler)
     config["run_id"] = new_root_run_id()
     token = set_current_tool_use_context(

--- a/fortify/agents/factory.py
+++ b/fortify/agents/factory.py
@@ -6,7 +6,15 @@ import asyncio
 import logging
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from pathlib import Path
-from typing import Any, Self, TypeAlias
+from typing import TYPE_CHECKING, Any, Self, TypeAlias
+
+if TYPE_CHECKING:
+    # Optional seam-attribute types — referenced only in __init__ signatures
+    # / annotations. Imported under TYPE_CHECKING to avoid the runtime cycle
+    # (security.* and cloud.* both eventually import from this module).
+    from fortify.cloud.client import FortifyClient
+    from fortify.security.enforcer import PolicyEnforcer
+    from fortify.security.source import PolicySource
 
 from langchain.agents import create_agent as create_langchain_agent
 from langchain.agents.middleware.types import AgentMiddleware
@@ -193,7 +201,7 @@ def _resolve_user_facts(agent: "FortifyAgent") -> dict[str, list[str | int]] | N
     user = get_current_user()
     if user is None:
         return None
-    client = getattr(agent, "fortify_client", None)
+    client = agent.fortify_client
     if client is None:
         # Local agent or test stub — User scope is set but there's nothing to
         # attenuate against. Surface a single warning so devs see why their
@@ -289,6 +297,9 @@ class FortifyAgent:
         name: str | None = None,
         cache: BaseCache[Any] | None = None,
         workspace: Workspace | None = None,
+        enforcer: "PolicyEnforcer | None" = None,
+        policy_source: "PolicySource | None" = None,
+        fortify_client: "FortifyClient | None" = None,
     ) -> None:
         self.graph = graph
         self.model = model
@@ -306,11 +317,28 @@ class FortifyAgent:
         self.name = name
         self.cache = cache
         self.workspace = workspace
+        # Enforcement seam. Three optional fields populated by the loaders
+        # (load_fortify_agent, _local_policy_override) and the
+        # ``enforce_policy`` builder. Promoted from setattr/getattr-with-
+        # default to first-class fields so the type checker covers the
+        # refresh path and ``with_tools`` rebuilds can't silently drop them
+        # via a misspelled attribute name.
+        self._enforcer: "PolicyEnforcer | None" = enforcer
+        self._policy_source: "PolicySource | None" = policy_source
+        self.fortify_client: "FortifyClient | None" = fortify_client
 
     async def ainvoke(
         self, payload: dict[str, Any], config: dict[str, Any]
     ) -> dict[str, Any]:
-        """Delegate invocation to the underlying graph."""
+        """Delegate invocation to the underlying graph.
+
+        Refreshes the attached policy source before delegating — see
+        :func:`_refresh_policy_safely`. The refresh seam lives here (not
+        only in :func:`invoke_agent`) so a direct caller of
+        ``agent.ainvoke(...)`` gets hot-reload too, instead of silently
+        running with stale policy.
+        """
+        await _refresh_policy_safely(self)
         return await self.graph.ainvoke(payload, config=config)
 
     async def astream_events(
@@ -320,7 +348,13 @@ class FortifyAgent:
         *,
         version: str,
     ) -> AsyncIterator[LangChainStreamEvent]:
-        """Delegate event streaming to the underlying graph."""
+        """Delegate event streaming to the underlying graph.
+
+        Refreshes the attached policy source before delegating, same as
+        :meth:`ainvoke`. Wrapping both methods means hot-reload fires
+        regardless of which entry point a caller picks.
+        """
+        await _refresh_policy_safely(self)
         async for event in self.graph.astream_events(
             payload, config=config, version=version
         ):
@@ -344,7 +378,12 @@ class FortifyAgent:
             name=self.name,
             cache=self.cache,
         )
-        rebuilt = type(self)(
+        # Thread the enforcement seam through the rebuild so policy
+        # refresh + lazy user attenuation keep working after with_tools.
+        # The enforcer / policy_source pair is what makes refresh_policy()
+        # able to swap engines without re-wrapping every tool; the client
+        # is what load_fortify_agent attached for cloud-side attenuation.
+        return type(self)(
             graph=graph,
             model=self.model,
             tools=tools,
@@ -361,23 +400,10 @@ class FortifyAgent:
             name=self.name,
             cache=self.cache,
             workspace=self.workspace,
+            enforcer=self._enforcer,
+            policy_source=self._policy_source,
+            fortify_client=self.fortify_client,
         )
-        # Propagate the optional fortify_client attribute that load_fortify_agent
-        # attaches to the cloud-loaded runtime — enforce_policy funnels through
-        # here, so this keeps the client reachable for lazy user-scope
-        # attenuation after the rebuild.
-        client = getattr(self, "fortify_client", None)
-        if client is not None:
-            rebuilt.fortify_client = client
-        # Phase 8: keep the enforcement seam alive across with_tools rebuilds
-        # so refresh_policy() can still swap engines after the rebuild.
-        enforcer = getattr(self, "_enforcer", None)
-        if enforcer is not None:
-            rebuilt._enforcer = enforcer
-        source = getattr(self, "_policy_source", None)
-        if source is not None:
-            rebuilt._policy_source = source
-        return rebuilt
 
     def enforce_policy(
         self,
@@ -425,18 +451,20 @@ class FortifyAgent:
             else:
                 wrapped.append(tool_spec)
         rebuilt = self.with_tools(wrapped)
-        # Stash the enforcer so refresh_policy() can swap its policy in
-        # place when the platform serves a new bundle, without rebuilding
-        # the tool wrappers.
+        # Stash the enforcer on the rebuilt agent so refresh_policy() can
+        # swap its policy in place when the source serves a new bundle,
+        # without rebuilding the tool wrappers. ``self`` stays untouched.
         rebuilt._enforcer = enforcer
         return rebuilt
 
     def refresh_policy(self) -> None:
         """Pull the current policy from the attached source and swap it in.
 
-        Called at the top of every agent run (see :func:`stream_agent` /
-        :func:`invoke_agent` / serve mode) so policy edits land at the
-        next run no matter how the user invokes the agent. The
+        Called at the top of every agent run — see
+        :meth:`ainvoke` / :meth:`astream_events` (and their tracing
+        wrappers :func:`invoke_agent` / :func:`stream_agent_raw`) — so
+        policy edits land at the next run no matter how the user
+        invokes the agent. The
         :class:`~fortify.security.source.PlatformPolicySource` does the
         ETag/304 dance, and the content-addressed
         :class:`~fortify.security.wasm_engine._WasmPolicyCache` makes the
@@ -445,19 +473,25 @@ class FortifyAgent:
 
         No-op when no source is attached (programmatic callers that
         constructed the agent without one) or no enforcer exists (no
-        policy was applied). Failures from the source propagate so
-        callers see them at run boundary, not as silent staleness.
+        policy was applied).
+
+        Source-side failures are caught by the calling helper
+        (:func:`_refresh_policy_safely`) and logged at WARNING; the
+        previous policy stays active. This method itself doesn't swallow
+        — it raises so the safe-wrapper can log a single line of
+        useful context. The warning is the only refresh-failure signal
+        today (no counter / hook / last_refreshed_at field); if a
+        consumer needs programmatic visibility, open an issue with the
+        use case.
         """
-        source = getattr(self, "_policy_source", None)
-        enforcer = getattr(self, "_enforcer", None)
-        if source is None or enforcer is None:
+        if self._policy_source is None or self._enforcer is None:
             return
-        new_policy = source.fetch()
-        if new_policy is None or new_policy is enforcer.policy:
+        new_policy = self._policy_source.fetch()
+        if new_policy is None or new_policy is self._enforcer.policy:
             # Source has nothing to offer, or the same object came back
             # (e.g. PlatformPolicySource returns the cached bundle on 304).
             return
-        enforcer.policy = new_policy
+        self._enforcer.policy = new_policy
 
 
 AgentGraph: TypeAlias = FortifyAgent
@@ -547,20 +581,23 @@ def create_agent(
 _logger = logging.getLogger("fortify.agents.factory")
 
 
-async def _refresh_policy_safely(agent: "AgentGraph") -> None:
+async def _refresh_policy_safely(agent: "FortifyAgent") -> None:
     """Pull the latest policy from the agent's attached source, off the loop.
 
-    Called at the top of every async invocation so policy changes land at
-    the next run without anyone having to know which entry point they're
-    going through. No-op when no source is attached (programmatic
-    construction). Failures log a warning and keep the previous policy —
-    a transient network blip should never crash a chat turn.
+    Called by :meth:`FortifyAgent.ainvoke` / :meth:`astream_events` at the
+    top of every async invocation, so policy changes land at the next run
+    regardless of which entry point a caller picks (the high-level
+    :func:`invoke_agent` / :func:`stream_agent_raw` wrappers go through
+    those methods too, so they get refresh for free).
+
+    No-op when no source is attached (programmatic construction).
+    Failures log a warning at WARNING level and keep the previous policy
+    — a transient network blip never crashes a chat turn. The log line
+    is the only signal today; programmatic observability (counter /
+    hook / last_refreshed_at) isn't exposed.
     """
-    refresh = getattr(agent, "refresh_policy", None)
-    if refresh is None:
-        return
     try:
-        await asyncio.to_thread(refresh)
+        await asyncio.to_thread(agent.refresh_policy)
     except Exception as exc:  # noqa: BLE001 — refresh failures must not crash the run
         _logger.warning(
             "policy refresh failed: %s — keeping previously loaded policy", exc
@@ -575,8 +612,12 @@ async def invoke_agent(
     *,
     tool_use_context: ToolUseContext | None = None,
 ) -> dict[str, Any]:
-    """Invoke the agent for one normalized input payload."""
-    await _refresh_policy_safely(agent)
+    """Invoke the agent for one normalized input payload.
+
+    Policy refresh is handled by :meth:`FortifyAgent.ainvoke` itself,
+    so direct callers of that method see the same hot-reload behaviour
+    as callers of this wrapper. No double-refresh.
+    """
     token = set_current_tool_use_context(
         _resolve_tool_use_context(agent, tool_use_context)
     )
@@ -596,8 +637,11 @@ async def stream_agent_raw(
     *,
     tool_use_context: ToolUseContext | None = None,
 ) -> AsyncIterator[LangChainStreamEvent]:
-    """Stream raw LangChain events from the agent runtime."""
-    await _refresh_policy_safely(agent)
+    """Stream raw LangChain events from the agent runtime.
+
+    Policy refresh is handled by :meth:`FortifyAgent.astream_events`
+    itself — see :func:`invoke_agent` for the matching rationale.
+    """
     config = get_langfuse_runnable_config(handler)
     config["run_id"] = new_root_run_id()
     token = set_current_tool_use_context(

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -19,12 +19,12 @@ from fortify.agents.factory import (
 from fortify.agents.models import AgentSpec
 from fortify.cloud.client import FortifyClient, FortifyConfig, resolve_agent_name
 from fortify.security import AgentPolicy, PolicyBundle, load_policy
-from fortify.security.bundle import (
-    BundleIntegrityError,
-    BundleLoadError,
-    BundleSignatureError,
-)
 from fortify.security.signing import SignatureError, decode_key
+from fortify.security.source import (
+    BundleDirPolicySource,
+    PolicySource,
+    YamlPolicySource,
+)
 from fortify.tools import (
     bash,
     edit_file,
@@ -57,6 +57,7 @@ REGISTERED_AGENTS: dict[str, AgentFactory] = {}
 _LOCAL_POLICY_ENV_VAR = "FORTIFY_LOCAL_POLICY"
 _BUNDLE_PUBKEY_ENV_VAR = "FORTIFY_BUNDLE_PUBKEY_PATH"
 _REQUIRE_SIGNATURE_ENV_VAR = "FORTIFY_BUNDLE_REQUIRE_SIGNATURE"
+_BUNDLE_SIGN_KEY_ENV_VAR = "FORTIFY_BUNDLE_SIGN_KEY_PATH"
 
 
 def _truthy(value: str | None) -> bool:
@@ -64,116 +65,162 @@ def _truthy(value: str | None) -> bool:
     return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _verify_bundle_signature(bundle: PolicyBundle, override_path: str) -> None:
-    """Apply the signature policy to a locally-loaded override bundle.
+def _resolve_pubkey_for_verification(override_path: str) -> bytes | None:
+    """Resolve ``FORTIFY_BUNDLE_PUBKEY_PATH`` into raw bytes for a local source.
 
-    The matrix, controlled by two env vars:
-
-      * ``FORTIFY_BUNDLE_PUBKEY_PATH`` — path to a base64url public key.
-      * ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE`` — when truthy, refuse
-        anything that isn't signed-and-verified.
-
-    | signature | pubkey set | require | outcome              |
-    |-----------|-----------|---------|----------------------|
-    | present   | yes       | either  | verify; raise if bad |
-    | present   | no        | false   | warn (can't verify)  |
-    | present   | no        | true    | refuse (no key)      |
-    | absent    | —         | false   | warn + proceed       |
-    | absent    | —         | true    | refuse               |
-
-    Local dev (unsigned bundles via `fortify policy build`) stays
-    frictionless by default; CI/prod opt into strictness with
-    REQUIRE_SIGNATURE=true.
+    Returns ``None`` when no pubkey is configured AND the env doesn't
+    require signatures. Raises when ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE``
+    is set but no key is provided (we'd have nothing to verify against).
     """
-    import sys
-
     require = _truthy(os.environ.get(_REQUIRE_SIGNATURE_ENV_VAR))
     pubkey_path = os.environ.get(_BUNDLE_PUBKEY_ENV_VAR)
 
-    if not bundle.is_signed:
-        if require:
-            raise RuntimeError(
-                f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but the bundle at "
-                f"{override_path!r} has no signature (no *.bundle.json.sig). "
-                "Build it with `fortify policy build --sign-key ...`."
-            )
-        print(
-            f"[fortify] warning: override bundle at {override_path} is "
-            "unsigned — authenticity not verified. Set "
-            f"{_REQUIRE_SIGNATURE_ENV_VAR}=true to refuse unsigned bundles.",
-            file=sys.stderr,
-        )
-        return
-
-    # Bundle is signed. We need a public key to check it against.
     if not pubkey_path:
         if require:
             raise RuntimeError(
-                f"{_REQUIRE_SIGNATURE_ENV_VAR} is set and the bundle is signed, "
-                f"but {_BUNDLE_PUBKEY_ENV_VAR} is unset — no key to verify "
-                "against."
+                f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but "
+                f"{_BUNDLE_PUBKEY_ENV_VAR} is unset — no key to verify the "
+                f"bundle at {override_path!r} against."
             )
-        print(
-            f"[fortify] warning: override bundle is signed but "
-            f"{_BUNDLE_PUBKEY_ENV_VAR} is unset — signature NOT verified.",
-            file=sys.stderr,
-        )
-        return
+        return None
 
     try:
-        public_key_raw = decode_key(Path(pubkey_path).read_text(encoding="utf-8").strip())
+        return decode_key(Path(pubkey_path).read_text(encoding="utf-8").strip())
     except (OSError, SignatureError) as exc:
         raise RuntimeError(
             f"{_BUNDLE_PUBKEY_ENV_VAR}={pubkey_path!r} could not be read as a "
             f"base64url public key: {exc}"
         ) from exc
 
+
+def _local_sign_callable() -> "Callable[[bytes], bytes] | None":
+    """Build a sign callback from ``FORTIFY_BUNDLE_SIGN_KEY_PATH`` if set.
+
+    Opt-in: the default :class:`YamlPolicySource` builds unsigned bundles
+    (dev-loop default — signing locally with a key on the dev box adds
+    no real authenticity). When set, the file is read as a base64url raw
+    Ed25519 private key and used to sign every recompile, so the
+    resulting bundle's ``is_signed`` flag matches what the platform
+    would have produced. Useful when a downstream check requires
+    ``is_signed`` to be true.
+    """
+    key_path = os.environ.get(_BUNDLE_SIGN_KEY_ENV_VAR)
+    if not key_path:
+        return None
     try:
-        bundle.verify_signature(public_key_raw)
-    except BundleSignatureError as exc:
+        private_raw = decode_key(Path(key_path).read_text(encoding="utf-8").strip())
+    except (OSError, SignatureError) as exc:
         raise RuntimeError(
-            f"override bundle at {override_path!r} failed signature "
-            f"verification: {exc}"
+            f"{_BUNDLE_SIGN_KEY_ENV_VAR}={key_path!r} could not be read as a "
+            f"base64url private key: {exc}"
         ) from exc
 
+    from fortify.security.signing import sign_bytes
 
-def _local_policy_override() -> PolicyBundle | None:
-    """Load a :class:`PolicyBundle` from ``$FORTIFY_LOCAL_POLICY`` if set.
+    return lambda data: sign_bytes(data, private_raw)
 
-    The env var points at a directory containing a ``*.bundle.json`` +
-    matching ``.yaml`` / ``.rego`` / ``.wasm``. Hash-integrity is checked
-    eagerly so a stale or corrupt bundle fails loudly at startup rather
-    than at the first denied tool call. Signature (authenticity) is then
-    checked per :func:`_verify_bundle_signature`.
 
-    A loud stderr line announces the override — silent overrides of
-    security-relevant config would be a footgun, especially when the dev
-    forgets they have the env var set.
+def _local_policy_source() -> PolicySource | None:
+    """Resolve ``$FORTIFY_LOCAL_POLICY`` into a :class:`PolicySource`, if set.
+
+    Dispatch by path shape:
+
+      * ``<dir>`` → :class:`BundleDirPolicySource` (pre-built bundle from
+        ``fortify policy build``; mtime-refreshed).
+      * ``*.yaml`` / ``*.yml`` → :class:`YamlPolicySource` (auto-compile
+        on save).
+
+    Signature handling preserves today's matrix via
+    :func:`_resolve_pubkey_for_verification` + the
+    ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE`` knob — devs stay frictionless
+    on unsigned bundles, CI opts into strictness.
     """
     override_path = os.environ.get(_LOCAL_POLICY_ENV_VAR)
     if not override_path:
         return None
-    try:
-        bundle = PolicyBundle.from_disk(Path(override_path))
-        bundle.verify_integrity()
-    except (BundleLoadError, BundleIntegrityError) as exc:
+    target = Path(override_path)
+
+    if target.is_dir():
+        verify_with = _resolve_pubkey_for_verification(override_path)
+        return BundleDirPolicySource(target, verify_with=verify_with)
+    if target.suffix in {".yaml", ".yml"} and target.is_file():
+        # REQUIRE_SIGNATURE blocks the unsigned-yaml path unless the user
+        # also configures a sign key. The check fires at fetch time via
+        # _verify_local_source_signature_policy — keeps the surface uniform
+        # with the dir path.
+        return YamlPolicySource(target, sign=_local_sign_callable())
+    raise RuntimeError(
+        f"{_LOCAL_POLICY_ENV_VAR}={override_path!r}: expected a bundle "
+        "directory (output of `fortify policy build`) or a .yaml file."
+    )
+
+
+def _verify_local_source_signature_policy(
+    bundle: PolicyBundle, source: PolicySource
+) -> None:
+    """Apply ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE`` to a freshly-fetched bundle.
+
+    BundleDirPolicySource already verifies the signature against the
+    configured pubkey when it loads, so the only thing left for that
+    branch is the ``require=true & no signature & no key`` case (handled
+    by _resolve_pubkey_for_verification at construction). For
+    YamlPolicySource the rule is: REQUIRE_SIGNATURE=true & sign-key
+    unset → refuse, because we know the bundle is unsigned and there's
+    nothing to verify.
+    """
+    if not _truthy(os.environ.get(_REQUIRE_SIGNATURE_ENV_VAR)):
+        return
+    if isinstance(source, YamlPolicySource) and not bundle.is_signed:
         raise RuntimeError(
-            f"{_LOCAL_POLICY_ENV_VAR} is set to {override_path!r} but the "
-            f"bundle could not be loaded: {exc}"
-        ) from exc
+            f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but {_LOCAL_POLICY_ENV_VAR} "
+            "points at an unsigned yaml source. Set "
+            f"{_BUNDLE_SIGN_KEY_ENV_VAR} to a base64url private key, or use a "
+            "pre-built signed bundle directory instead."
+        )
 
-    _verify_bundle_signature(bundle, override_path)
 
+def _announce_local_override(
+    bundle: PolicyBundle, source: PolicySource, override_path: str
+) -> None:
+    """Loud stderr line so devs notice when the local override is active."""
     import sys
 
     short = bundle.wasm_hash[:12] if bundle.wasm_hash else "?"
     signed = "signed" if bundle.is_signed else "unsigned"
+    kind = "yaml" if isinstance(source, YamlPolicySource) else "bundle-dir"
     print(
-        f"[fortify] {_LOCAL_POLICY_ENV_VAR} active: "
+        f"[fortify] {_LOCAL_POLICY_ENV_VAR} active ({kind}): "
         f"{override_path} (wasm_hash={short}, {signed})",
         file=sys.stderr,
     )
-    return bundle
+
+
+def _local_policy_override() -> tuple[PolicyBundle, PolicySource] | None:
+    """Resolve ``$FORTIFY_LOCAL_POLICY`` into a (bundle, source) pair.
+
+    Returns ``None`` when the env var is unset. The bundle is the
+    initial enforcement policy (ready to hand off to ``enforce_policy``);
+    the source is attached to the agent so per-run refresh picks up
+    yaml edits / bundle rebuilds without a restart.
+
+    Failures (missing file, bad signature, opa not on PATH for a yaml
+    source) raise loudly — silently degrading a security override
+    would defeat the point.
+    """
+    source = _local_policy_source()
+    if source is None:
+        return None
+    bundle = source.fetch()
+    if bundle is None:
+        # Local sources only return None for "no bundle configured" — an
+        # impossible state here since we'd have returned None above.
+        raise RuntimeError(
+            f"{_LOCAL_POLICY_ENV_VAR}: source produced no bundle (internal "
+            "invariant violated)."
+        )
+    _verify_local_source_signature_policy(bundle, source)
+    _announce_local_override(bundle, source, os.environ[_LOCAL_POLICY_ENV_VAR])
+    return bundle, source
 
 
 def _platform_bundle(payload: dict, client: FortifyClient) -> PolicyBundle | None:
@@ -352,7 +399,11 @@ def load_builtin_agent(
     )
     override = _local_policy_override()
     if override is not None:
-        policy = override
+        bundle, source = override
+        policy = bundle
+        enforced = enforce_policy(agent, policy, approval_handler=approval_handler)
+        enforced._policy_source = source
+        return enforced, handler
     return enforce_policy(agent, policy, approval_handler=approval_handler), handler
 
 
@@ -384,7 +435,11 @@ def load_local_agent(
     )
     override = _local_policy_override()
     if override is not None:
-        policy = override
+        bundle, source = override
+        policy = bundle
+        enforced = enforce_policy(agent, policy, approval_handler=approval_handler)
+        enforced._policy_source = source
+        return enforced, handler
     return enforce_policy(agent, policy, approval_handler=approval_handler), handler
 
 
@@ -528,17 +583,19 @@ def load_fortify_agent(
         name=spec.name,
     )
     # Policy precedence:
-    #   1. FORTIFY_LOCAL_POLICY override (dev iteration) — wins outright.
-    #   2. Platform-served signed bundle — verified, WASM-enforced.
+    #   1. FORTIFY_LOCAL_POLICY override (dev iteration) — wins outright,
+    #      with its own mtime-driven refresh source.
+    #   2. Platform-served signed bundle — verified, WASM-enforced, with
+    #      an ETag-driven PlatformPolicySource for per-run refresh.
     #   3. policy_yaml + pydantic — fallback when no bundle was served.
     from fortify.security.source import PlatformPolicySource
 
     override = _local_policy_override()
-    platform_source: PlatformPolicySource | None = None
+    refresh_source: PolicySource | None = None
     if override is not None:
-        policy = override
-        # Local override has its own (8b) refresh mechanism — no platform
-        # source attached.
+        bundle, refresh_source = override
+        policy = bundle
+        # Local override wins; the platform's bundle (if any) is ignored.
     else:
         platform_bundle = _platform_bundle(payload, client)
         if platform_bundle is not None:
@@ -550,11 +607,9 @@ def load_fortify_agent(
                 "not have compiled (is opa available on the control plane?). "
                 "Refusing to fall back to the pydantic engine."
             )
-        # Phase 8a: attach a PolicySource so refresh_policy() can pull
-        # updates at every agent run via If-None-Match. Pre-seed with the
-        # bundle + etag we just fetched so the first refresh is a 304
-        # unless the policy actually changed.
-        platform_source = PlatformPolicySource(
+        # Pre-seed PlatformPolicySource with the bundle + etag we just
+        # fetched so the next refresh is a 304 unless the policy changed.
+        refresh_source = PlatformPolicySource(
             client,
             resolved_name,
             initial_bundle=platform_bundle,
@@ -565,8 +620,8 @@ def load_fortify_agent(
     # Attach the client so the runtime can do lazy attenuation inside an
     # active User scope without the caller having to thread it through.
     enforced.fortify_client = client
-    if platform_source is not None:
-        enforced._policy_source = platform_source
+    if refresh_source is not None:
+        enforced._policy_source = refresh_source
     return enforced, handler
 
 

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -182,7 +182,16 @@ def _verify_local_source_signature_policy(
 def _announce_local_override(
     bundle: PolicyBundle, source: PolicySource, override_path: str
 ) -> None:
-    """Loud stderr line so devs notice when the local override is active."""
+    """Loud stderr line so devs notice when the local override is active.
+
+    Also surfaces an explicit "signature NOT verified" warning when a
+    signed bundle is loaded without a configured pubkey — without the
+    warning the dev sees "signed" in the log and reasonably assumes
+    authenticity was checked. Strict mode
+    (``FORTIFY_BUNDLE_REQUIRE_SIGNATURE=true``) would already have
+    refused the load via :func:`_resolve_pubkey_for_verification`; the
+    permissive default just emits the heads-up here.
+    """
     import sys
 
     short = bundle.wasm_hash[:12] if bundle.wasm_hash else "?"
@@ -193,6 +202,15 @@ def _announce_local_override(
         f"{override_path} (wasm_hash={short}, {signed})",
         file=sys.stderr,
     )
+
+    # Signed-but-unverified is permissive-mode only; strict mode would
+    # have raised in _resolve_pubkey_for_verification before we got here.
+    if bundle.is_signed and not os.environ.get(_BUNDLE_PUBKEY_ENV_VAR):
+        print(
+            f"[fortify] warning: override bundle is signed but "
+            f"{_BUNDLE_PUBKEY_ENV_VAR} is unset — signature NOT verified.",
+            file=sys.stderr,
+        )
 
 
 def _local_policy_override() -> tuple[PolicyBundle, PolicySource] | None:

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -65,32 +65,106 @@ def _truthy(value: str | None) -> bool:
     return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _resolve_pubkey_for_verification(override_path: str) -> bytes | None:
-    """Resolve ``FORTIFY_BUNDLE_PUBKEY_PATH`` into raw bytes for a local source.
+# ---------------------------------------------------------------------------
+# Signature policy — single source of truth for the REQUIRE_SIGNATURE matrix
+# ---------------------------------------------------------------------------
 
-    Returns ``None`` when no pubkey is configured AND the env doesn't
-    require signatures. Raises when ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE``
-    is set but no key is provided (we'd have nothing to verify against).
+
+class SignaturePolicy:
+    """The (pubkey, require_signature) pair resolved once from env.
+
+    Concentrates every cell of the ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE``
+    × ``FORTIFY_BUNDLE_PUBKEY_PATH`` × (yaml | bundle-dir) matrix into
+    one place so the safety story is auditable from a single file.
+
+    Matrix:
+      * require=true  + no pubkey               → :meth:`from_env` raises
+        (no key to verify against — refuse to start).
+      * require=true  + yaml + unsigned bundle  → :meth:`check_yaml_bundle`
+        raises at fetch time (yaml produces unsigned by default; refuse to
+        enforce when strict mode demands authenticity).
+      * require=false + signed bundle + pubkey  → BundleDir verifies via
+        ``verify_with`` on every reload.
+      * require=false + signed bundle + no key  → :meth:`warn_if_unverified`
+        emits a heads-up at announce time. Dev sees "signed" + warning;
+        no enforcement happens.
+      * require=false + unsigned                → silent OK.
+
+    Replaces three scattered helpers (one resolve-at-construction, one
+    verify-at-fetch, one warn-at-announce) that the reviewer flagged as
+    hard to audit cell-by-cell.
     """
-    require = _truthy(os.environ.get(_REQUIRE_SIGNATURE_ENV_VAR))
-    pubkey_path = os.environ.get(_BUNDLE_PUBKEY_ENV_VAR)
 
-    if not pubkey_path:
-        if require:
+    def __init__(self, *, verify_with: bytes | None, require_signature: bool) -> None:
+        self.verify_with = verify_with
+        self.require_signature = require_signature
+
+    @classmethod
+    def from_env(cls, override_path: str) -> "SignaturePolicy":
+        """Build the policy from env vars, raising on require-without-key.
+
+        ``override_path`` is the value of ``FORTIFY_LOCAL_POLICY`` — used
+        only for error messages so the operator sees which load is
+        being refused.
+        """
+        require = _truthy(os.environ.get(_REQUIRE_SIGNATURE_ENV_VAR))
+        pubkey_path = os.environ.get(_BUNDLE_PUBKEY_ENV_VAR)
+
+        if not pubkey_path:
+            if require:
+                raise RuntimeError(
+                    f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but "
+                    f"{_BUNDLE_PUBKEY_ENV_VAR} is unset — no key to verify "
+                    f"the bundle at {override_path!r} against."
+                )
+            return cls(verify_with=None, require_signature=False)
+
+        try:
+            verify_with = decode_key(
+                Path(pubkey_path).read_text(encoding="utf-8").strip()
+            )
+        except (OSError, SignatureError) as exc:
+            raise RuntimeError(
+                f"{_BUNDLE_PUBKEY_ENV_VAR}={pubkey_path!r} could not be read "
+                f"as a base64url public key: {exc}"
+            ) from exc
+        return cls(verify_with=verify_with, require_signature=require)
+
+    def check_yaml_bundle(self, bundle: PolicyBundle, yaml_path: str) -> None:
+        """At fetch time, refuse an unsigned yaml-built bundle under strict mode.
+
+        ``BundleDirPolicySource`` is already covered: its constructor
+        receives :attr:`verify_with` and verifies on every reload. The
+        yaml branch has nothing for BundleDir to verify against (yaml
+        sources build their bundles locally) — so strict mode means
+        either sign locally via ``FORTIFY_BUNDLE_SIGN_KEY_PATH`` or
+        switch to a pre-built signed bundle dir.
+        """
+        if self.require_signature and not bundle.is_signed:
             raise RuntimeError(
                 f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but "
-                f"{_BUNDLE_PUBKEY_ENV_VAR} is unset — no key to verify the "
-                f"bundle at {override_path!r} against."
+                f"{_LOCAL_POLICY_ENV_VAR}={yaml_path!r} points at an "
+                f"unsigned yaml source. Set {_BUNDLE_SIGN_KEY_ENV_VAR} to "
+                "sign locally, or switch to a pre-built signed bundle dir."
             )
-        return None
 
-    try:
-        return decode_key(Path(pubkey_path).read_text(encoding="utf-8").strip())
-    except (OSError, SignatureError) as exc:
-        raise RuntimeError(
-            f"{_BUNDLE_PUBKEY_ENV_VAR}={pubkey_path!r} could not be read as a "
-            f"base64url public key: {exc}"
-        ) from exc
+    def warn_if_unverified(self, bundle: PolicyBundle) -> None:
+        """Emit a heads-up when a signed bundle loads without a pubkey.
+
+        Permissive-mode only — strict mode would already have raised in
+        :meth:`from_env`. Without the warning the dev sees "signed" in
+        the announce line and reasonably assumes authenticity was
+        checked, when it wasn't. Verification behaviour is unchanged
+        (we never verified there); only the heads-up is restored.
+        """
+        if bundle.is_signed and self.verify_with is None:
+            import sys
+
+            print(
+                f"[fortify] warning: override bundle is signed but "
+                f"{_BUNDLE_PUBKEY_ENV_VAR} is unset — signature NOT verified.",
+                file=sys.stderr,
+            )
 
 
 def _local_sign_callable() -> "Callable[[bytes], bytes] | None":
@@ -120,20 +194,22 @@ def _local_sign_callable() -> "Callable[[bytes], bytes] | None":
     return lambda data: sign_bytes(data, private_raw)
 
 
-def _local_policy_source() -> PolicySource | None:
+def _local_policy_source(
+    sig_policy: SignaturePolicy,
+) -> PolicySource | None:
     """Resolve ``$FORTIFY_LOCAL_POLICY`` into a :class:`PolicySource`, if set.
 
     Dispatch by path shape:
 
       * ``<dir>`` → :class:`BundleDirPolicySource` (pre-built bundle from
-        ``fortify policy build``; mtime-refreshed).
+        ``fortify policy build``; mtime-refreshed). Its ``verify_with``
+        comes from ``sig_policy.verify_with``.
       * ``*.yaml`` / ``*.yml`` → :class:`YamlPolicySource` (auto-compile
-        on save).
+        on save). Strict-mode signing is checked at fetch time via
+        ``sig_policy.check_yaml_bundle``.
 
-    Signature handling preserves today's matrix via
-    :func:`_resolve_pubkey_for_verification` + the
-    ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE`` knob — devs stay frictionless
-    on unsigned bundles, CI opts into strictness.
+    The full ``REQUIRE_SIGNATURE`` matrix lives on :class:`SignaturePolicy`
+    — see its docstring for the cell-by-cell table.
     """
     override_path = os.environ.get(_LOCAL_POLICY_ENV_VAR)
     if not override_path:
@@ -141,13 +217,8 @@ def _local_policy_source() -> PolicySource | None:
     target = Path(override_path)
 
     if target.is_dir():
-        verify_with = _resolve_pubkey_for_verification(override_path)
-        return BundleDirPolicySource(target, verify_with=verify_with)
+        return BundleDirPolicySource(target, verify_with=sig_policy.verify_with)
     if target.suffix in {".yaml", ".yml"} and target.is_file():
-        # REQUIRE_SIGNATURE blocks the unsigned-yaml path unless the user
-        # also configures a sign key. The check fires at fetch time via
-        # _verify_local_source_signature_policy — keeps the surface uniform
-        # with the dir path.
         return YamlPolicySource(target, sign=_local_sign_callable())
     raise RuntimeError(
         f"{_LOCAL_POLICY_ENV_VAR}={override_path!r}: expected a bundle "
@@ -155,42 +226,15 @@ def _local_policy_source() -> PolicySource | None:
     )
 
 
-def _verify_local_source_signature_policy(
-    bundle: PolicyBundle, source: PolicySource
-) -> None:
-    """Apply ``FORTIFY_BUNDLE_REQUIRE_SIGNATURE`` to a freshly-fetched bundle.
-
-    BundleDirPolicySource already verifies the signature against the
-    configured pubkey when it loads, so the only thing left for that
-    branch is the ``require=true & no signature & no key`` case (handled
-    by _resolve_pubkey_for_verification at construction). For
-    YamlPolicySource the rule is: REQUIRE_SIGNATURE=true & sign-key
-    unset → refuse, because we know the bundle is unsigned and there's
-    nothing to verify.
-    """
-    if not _truthy(os.environ.get(_REQUIRE_SIGNATURE_ENV_VAR)):
-        return
-    if isinstance(source, YamlPolicySource) and not bundle.is_signed:
-        raise RuntimeError(
-            f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but {_LOCAL_POLICY_ENV_VAR} "
-            "points at an unsigned yaml source. Set "
-            f"{_BUNDLE_SIGN_KEY_ENV_VAR} to a base64url private key, or use a "
-            "pre-built signed bundle directory instead."
-        )
-
-
 def _announce_local_override(
     bundle: PolicyBundle, source: PolicySource, override_path: str
 ) -> None:
     """Loud stderr line so devs notice when the local override is active.
 
-    Also surfaces an explicit "signature NOT verified" warning when a
-    signed bundle is loaded without a configured pubkey — without the
-    warning the dev sees "signed" in the log and reasonably assumes
-    authenticity was checked. Strict mode
-    (``FORTIFY_BUNDLE_REQUIRE_SIGNATURE=true``) would already have
-    refused the load via :func:`_resolve_pubkey_for_verification`; the
-    permissive default just emits the heads-up here.
+    Signed-but-unverified warnings live on
+    :meth:`SignaturePolicy.warn_if_unverified` and fire from
+    :func:`_local_policy_override` — this function is purely the
+    "what got loaded" announce line.
     """
     import sys
 
@@ -203,14 +247,30 @@ def _announce_local_override(
         file=sys.stderr,
     )
 
-    # Signed-but-unverified is permissive-mode only; strict mode would
-    # have raised in _resolve_pubkey_for_verification before we got here.
-    if bundle.is_signed and not os.environ.get(_BUNDLE_PUBKEY_ENV_VAR):
-        print(
-            f"[fortify] warning: override bundle is signed but "
-            f"{_BUNDLE_PUBKEY_ENV_VAR} is unset — signature NOT verified.",
-            file=sys.stderr,
-        )
+
+def _apply_local_override(
+    agent: AgentGraph,
+    approval_handler: ApprovalHandler | None,
+) -> AgentGraph | None:
+    """Apply ``FORTIFY_LOCAL_POLICY`` to a freshly-built agent, if set.
+
+    Returns the policy-wrapped agent with its source attached, or
+    ``None`` when no override is configured — the caller then falls
+    back to the normal :func:`enforce_policy` path with the agent's
+    own packaged policy.
+
+    Extracted from :func:`load_builtin_agent` + :func:`load_local_agent`
+    which shared this exact block verbatim. :func:`load_fortify_agent`
+    deliberately doesn't use this helper — its override interaction is
+    more involved (it layers in alongside the platform-served bundle).
+    """
+    override = _local_policy_override()
+    if override is None:
+        return None
+    bundle, source = override
+    enforced = enforce_policy(agent, bundle, approval_handler=approval_handler)
+    enforced._policy_source = source
+    return enforced
 
 
 def _local_policy_override() -> tuple[PolicyBundle, PolicySource] | None:
@@ -223,21 +283,36 @@ def _local_policy_override() -> tuple[PolicyBundle, PolicySource] | None:
 
     Failures (missing file, bad signature, opa not on PATH for a yaml
     source) raise loudly — silently degrading a security override
-    would defeat the point.
+    would defeat the point. Signature-policy enforcement (the
+    ``REQUIRE_SIGNATURE`` matrix) is centralised on
+    :class:`SignaturePolicy`.
     """
-    source = _local_policy_source()
+    override_path = os.environ.get(_LOCAL_POLICY_ENV_VAR)
+    if not override_path:
+        return None
+    # Build the signature policy once at startup. ``from_env`` raises
+    # immediately if require-signature is set without a pubkey — fail
+    # fast, before any agent code runs.
+    sig_policy = SignaturePolicy.from_env(override_path)
+    source = _local_policy_source(sig_policy)
     if source is None:
+        # Defensive: we already null-checked override_path above; if
+        # _local_policy_source returns None here it'd be an internal
+        # invariant violation.
         return None
     bundle = source.fetch()
     if bundle is None:
-        # Local sources only return None for "no bundle configured" — an
-        # impossible state here since we'd have returned None above.
         raise RuntimeError(
             f"{_LOCAL_POLICY_ENV_VAR}: source produced no bundle (internal "
             "invariant violated)."
         )
-    _verify_local_source_signature_policy(bundle, source)
-    _announce_local_override(bundle, source, os.environ[_LOCAL_POLICY_ENV_VAR])
+    # YamlPolicySource builds unsigned bundles unless FORTIFY_BUNDLE_SIGN_KEY_PATH
+    # is set; strict mode refuses those. BundleDir's own constructor already
+    # gated on verify_with, so this is a no-op for the dir path.
+    if isinstance(source, YamlPolicySource):
+        sig_policy.check_yaml_bundle(bundle, override_path)
+    _announce_local_override(bundle, source, override_path)
+    sig_policy.warn_if_unverified(bundle)
     return bundle, source
 
 
@@ -415,13 +490,9 @@ def load_builtin_agent(
         tags=tags,
         name=spec.name,
     )
-    override = _local_policy_override()
-    if override is not None:
-        bundle, source = override
-        policy = bundle
-        enforced = enforce_policy(agent, policy, approval_handler=approval_handler)
-        enforced._policy_source = source
-        return enforced, handler
+    overridden = _apply_local_override(agent, approval_handler)
+    if overridden is not None:
+        return overridden, handler
     return enforce_policy(agent, policy, approval_handler=approval_handler), handler
 
 
@@ -451,13 +522,9 @@ def load_local_agent(
         tags=tags,
         name=spec.name,
     )
-    override = _local_policy_override()
-    if override is not None:
-        bundle, source = override
-        policy = bundle
-        enforced = enforce_policy(agent, policy, approval_handler=approval_handler)
-        enforced._policy_source = source
-        return enforced, handler
+    overridden = _apply_local_override(agent, approval_handler)
+    if overridden is not None:
+        return overridden, handler
     return enforce_policy(agent, policy, approval_handler=approval_handler), handler
 
 

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import os
 from collections.abc import Callable, Mapping
 from importlib.resources import files
@@ -180,47 +179,15 @@ def _local_policy_override() -> PolicyBundle | None:
 def _platform_bundle(payload: dict, client: FortifyClient) -> PolicyBundle | None:
     """Build + verify the signed bundle the platform served, if any.
 
-    The platform's agent response carries ``bundle_wasm_b64`` /
-    ``bundle_manifest`` / ``bundle_signature_b64`` when it could compile +
-    sign the policy (phase 7a). We rebuild the bundle in memory, verify its
-    signature against the platform's published key — the *same* key the
-    client already trusts for biscuit verification — and check the wasm
-    matches the signed manifest.
-
-    Returns a verified :class:`PolicyBundle`, or ``None`` when the platform
-    served no bundle (older agent, or a control plane without opa). Raises
-    when a bundle *was* served but fails verification — a bad signature is
-    fatal, never a silent downgrade to the pydantic engine.
+    Thin one-shot wrapper around the shared decode-and-verify helper in
+    :mod:`fortify.security.source`. Kept here for back-compat with code
+    that wants a stateless decode of a single response — the stateful
+    refresh path (``If-None-Match``, cache by ``wasm_hash``) lives in
+    :class:`~fortify.security.source.PlatformPolicySource`.
     """
-    wasm_b64 = payload.get("bundle_wasm_b64")
-    manifest_text = payload.get("bundle_manifest")
-    sig_b64 = payload.get("bundle_signature_b64")
-    if not wasm_b64 or not manifest_text or not sig_b64:
-        return None
+    from fortify.security.source import decode_and_verify_platform_bundle
 
-    try:
-        wasm = base64.b64decode(wasm_b64)
-        signature = base64.b64decode(sig_b64)
-    except (ValueError, TypeError) as exc:
-        raise RuntimeError(
-            f"platform served a bundle but its base64 is malformed: {exc}"
-        ) from exc
-
-    bundle = PolicyBundle.from_parts(
-        wasm_bytes=wasm,
-        manifest_bytes=manifest_text.encode("utf-8"),
-        signature=signature,
-    )
-    try:
-        bundle.verify_signature(client.public_key_bytes())
-        bundle.verify_integrity()
-    except (BundleSignatureError, BundleIntegrityError) as exc:
-        raise RuntimeError(
-            f"platform-served policy bundle failed verification: {exc}. "
-            "Refusing to run rather than silently downgrading to the "
-            "pydantic engine."
-        ) from exc
-    return bundle
+    return decode_and_verify_platform_bundle(payload, client.public_key_bytes())
 
 
 def builtin_agents_root() -> Path:
@@ -537,7 +504,8 @@ def load_fortify_agent(
         project_id=project_id, base_url=base_url, api_key=api_key
     )
     client = FortifyClient(config)
-    payload = client.get_agent(resolved_name)
+    payload, initial_etag = client.get_agent(resolved_name)
+    assert payload is not None, "first get_agent has no If-None-Match — 304 impossible"
 
     spec = AgentSpec.model_validate(yaml.safe_load(payload["agent_yaml"]) or {})
     system_prompt = payload.get("system_md") or ""
@@ -563,9 +531,14 @@ def load_fortify_agent(
     #   1. FORTIFY_LOCAL_POLICY override (dev iteration) — wins outright.
     #   2. Platform-served signed bundle — verified, WASM-enforced.
     #   3. policy_yaml + pydantic — fallback when no bundle was served.
+    from fortify.security.source import PlatformPolicySource
+
     override = _local_policy_override()
+    platform_source: PlatformPolicySource | None = None
     if override is not None:
         policy = override
+        # Local override has its own (8b) refresh mechanism — no platform
+        # source attached.
     else:
         platform_bundle = _platform_bundle(payload, client)
         if platform_bundle is not None:
@@ -577,11 +550,23 @@ def load_fortify_agent(
                 "not have compiled (is opa available on the control plane?). "
                 "Refusing to fall back to the pydantic engine."
             )
+        # Phase 8a: attach a PolicySource so refresh_policy() can pull
+        # updates at every agent run via If-None-Match. Pre-seed with the
+        # bundle + etag we just fetched so the first refresh is a 304
+        # unless the policy actually changed.
+        platform_source = PlatformPolicySource(
+            client,
+            resolved_name,
+            initial_bundle=platform_bundle,
+            initial_etag=initial_etag,
+        )
 
     enforced = enforce_policy(agent, policy, approval_handler=approval_handler)
     # Attach the client so the runtime can do lazy attenuation inside an
     # active User scope without the caller having to thread it through.
     enforced.fortify_client = client
+    if platform_source is not None:
+        enforced._policy_source = platform_source
     return enforced, handler
 
 

--- a/fortify/cli/serve.py
+++ b/fortify/cli/serve.py
@@ -21,7 +21,6 @@ import argparse
 import asyncio
 import json
 import logging
-from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
@@ -58,7 +57,6 @@ class ServeContext:
 
     runtime: AgentRuntime
     state: ChatState
-    rebuild: Callable[[], AgentRuntime] | None = None
 
 
 def _user_from_payload(attenuation: Any) -> User | None:
@@ -92,16 +90,6 @@ async def _maybe_user_scope(user: User | None):
             yield
 
 
-async def _refresh_runtime(context: ServeContext) -> None:
-    """Rebuild the agent at turn start so policy edits land without a restart."""
-    if context.rebuild is None:
-        return
-    try:
-        context.runtime = await asyncio.to_thread(context.rebuild)
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("serve: policy refresh failed, using stale runtime: %s", exc)
-
-
 async def _handle_message(
     context: ServeContext,
     ws,
@@ -114,7 +102,9 @@ async def _handle_message(
         text = str(payload.get("message", "")).strip()
         if not text:
             return
-        await _refresh_runtime(context)
+        # Policy refresh is handled inside stream_agent now (Phase 8a) —
+        # the attached PolicySource sends If-None-Match and reuses the
+        # cached bundle on 304. No need for serve to rebuild the runtime.
         context.state.start_turn(text)
         user = _user_from_payload(payload.get("user_attenuation"))
         async with _maybe_user_scope(user):
@@ -168,15 +158,14 @@ async def _serve_loop(context: ServeContext, url: str, console: Console) -> None
             console.print("[yellow]disconnected[/]")
 
 
-async def run_serve(
-    runtime: AgentRuntime,
-    *,
-    rebuild: Callable[[], AgentRuntime] | None = None,
-) -> None:
+async def run_serve(runtime: AgentRuntime) -> None:
     """Top-level serve loop with reconnect + graceful shutdown.
 
-    If ``rebuild`` is provided, it will be invoked at the start of every chat
-    turn to pick up policy edits made in the dashboard without a restart.
+    Policy hot-reload is handled by the agent's attached :class:`~fortify.
+    security.source.PolicySource`: ``stream_agent`` calls
+    ``agent.refresh_policy()`` at the start of every turn, the source
+    sends ``If-None-Match`` to the platform, and a ``304`` short-circuits
+    to the cached bundle. No bespoke runtime rebuild needed here.
     """
     console = Console()
     config = FortifyConfig.from_env()
@@ -189,7 +178,7 @@ async def run_serve(
         ws_base = f"ws://{base}"
     url = f"{ws_base}/v1/projects/{config.project_id}/serve"
 
-    context = ServeContext(runtime=runtime, state=ChatState(), rebuild=rebuild)
+    context = ServeContext(runtime=runtime, state=ChatState())
     backoff = RECONNECT_BASE
 
     console.print(
@@ -260,16 +249,5 @@ def main(args: argparse.Namespace) -> int:
         approval_handler=approval_handler,
     )
 
-    def _rebuild() -> AgentRuntime:
-        """Re-fetch YAMLs and rebuild the agent with the latest policy."""
-        return build_runtime(
-            settings,
-            agent_name=agent_name,
-            base_dir=base_dir,
-            model=args.model,
-            local_only=False,
-            approval_handler=approval_handler,
-        )
-
-    asyncio.run(run_serve(runtime, rebuild=_rebuild))
+    asyncio.run(run_serve(runtime))
     return 0

--- a/fortify/cloud/client.py
+++ b/fortify/cloud/client.py
@@ -32,6 +32,12 @@ from fortify.cloud.biscuit import (
 
 DEFAULT_BASE_URL = "http://localhost:8000"
 DEFAULT_TIMEOUT = 10.0
+# Tight timeout for the conditional-GET hot path (refresh_policy runs at
+# the top of every chat turn). The default 10s would stall every turn up
+# to 10s when the platform is slow, even though policy refresh falls back
+# to the cached bundle on failure anyway — a tight timeout makes the
+# fallback fire fast.
+DEFAULT_REFRESH_TIMEOUT = 2.0
 TOKEN_PREFIX = "fty_"
 DEFAULT_AGENT_NAME = "default"
 
@@ -135,10 +141,20 @@ class FortifyClient:
     """Minimal HTTP client scoped to a single project + key."""
 
     def __init__(
-        self, config: FortifyConfig, *, timeout: float = DEFAULT_TIMEOUT
+        self,
+        config: FortifyConfig,
+        *,
+        timeout: float = DEFAULT_TIMEOUT,
+        refresh_timeout: float = DEFAULT_REFRESH_TIMEOUT,
     ) -> None:
         self.config = config
         self.timeout = timeout
+        # Used only by the conditional-GET path (``if_none_match`` set).
+        # That path runs on every chat turn via ``refresh_policy`` and
+        # tolerates failure (falls back to the cached bundle), so a
+        # slow platform shouldn't tax every turn for up to ``timeout``
+        # seconds.
+        self.refresh_timeout = refresh_timeout
         self._public_key: bytes | None = config.public_key
         self._verified: bool = False
         self._facts: dict[str, list[str | int]] | None = None
@@ -280,9 +296,14 @@ class FortifyClient:
             headers["Authorization"] = f"Bearer {self.config.api_key}"
         if if_none_match is not None:
             headers["If-None-Match"] = if_none_match
+        # Conditional GETs run on the per-turn hot path and fall back to
+        # the cached bundle when they fail — use the tight refresh
+        # timeout so a slow platform doesn't stall every chat turn for
+        # up to ``self.timeout`` seconds.
+        timeout = self.refresh_timeout if if_none_match is not None else self.timeout
         request = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 etag = response.headers.get("ETag")
                 payload = response.read().decode("utf-8")
         except urllib.error.HTTPError as exc:

--- a/fortify/cloud/client.py
+++ b/fortify/cloud/client.py
@@ -147,13 +147,26 @@ class FortifyClient:
     def from_env(cls, **kwargs: Any) -> "FortifyClient":
         return cls(FortifyConfig.from_env(**kwargs))
 
-    def get_agent(self, name: str) -> dict[str, Any]:
-        """Fetch {agent_yaml, policy_yaml, system_md, ...} for a named agent."""
+    def get_agent(
+        self, name: str, *, if_none_match: str | None = None
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        """Fetch ``{agent_yaml, policy_yaml, system_md, ...}`` for a named agent.
+
+        Returns ``(payload, etag)``. When ``if_none_match`` is provided and
+        the platform replies ``304 Not Modified`` (the bundle hasn't changed
+        since the supplied ETag), ``payload`` is ``None`` and the same etag
+        is echoed back — so the caller can keep using its cached
+        :class:`PolicyBundle` without re-decoding or re-verifying anything.
+
+        Without ``if_none_match`` the call always returns ``(payload, etag)``
+        with a fresh body, matching the pre-Phase-8 behavior aside from
+        the now-paired etag.
+        """
         self._ensure_key_verified()
         url = (
             f"{self.config.base_url}/v1/projects/{self.config.project_id}/agents/{name}"
         )
-        return self._get(url)
+        return self._raw_get(url, authorize=True, if_none_match=if_none_match)
 
     # ------------------------------------------------------------------
     # Biscuit verification
@@ -219,7 +232,7 @@ class FortifyClient:
     def _fetch_public_key(self) -> bytes:
         """GET /v1/.well-known/keys and return the first key's raw bytes."""
         url = f"{self.config.base_url}/v1/.well-known/keys"
-        payload = self._raw_get(url, authorize=False)
+        payload, _ = self._raw_get(url, authorize=False)
         try:
             keys = payload["keys"]
             x = keys[0]["x"]
@@ -238,20 +251,45 @@ class FortifyClient:
     # ------------------------------------------------------------------
 
     def _get(self, url: str) -> dict[str, Any]:
-        return self._raw_get(url, authorize=True)
+        """Body-only GET. ``_raw_get`` is the unified HTTP entry point;
+        this drops the ETag tuple for callers that don't care about
+        conditional requests."""
+        payload, _ = self._raw_get(url, authorize=True)
+        assert payload is not None, "_get is never called with If-None-Match"
+        return payload
 
-    def _raw_get(self, url: str, *, authorize: bool) -> dict[str, Any]:
+    def _raw_get(
+        self,
+        url: str,
+        *,
+        authorize: bool,
+        if_none_match: str | None = None,
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        """Single HTTP entry point — returns ``(payload, etag)``.
+
+        ``payload`` is ``None`` when the server replies ``304 Not Modified``
+        (only possible when ``if_none_match`` is set). All callers go
+        through here so tests have one place to mock and the ETag-aware
+        refresh path doesn't duplicate the urllib dance.
+        """
         headers: dict[str, str] = {
             "Accept": "application/json",
             "User-Agent": "fortify-sdk/0.1",
         }
         if authorize:
             headers["Authorization"] = f"Bearer {self.config.api_key}"
+        if if_none_match is not None:
+            headers["If-None-Match"] = if_none_match
         request = urllib.request.Request(url, headers=headers)
         try:
             with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                etag = response.headers.get("ETag")
                 payload = response.read().decode("utf-8")
         except urllib.error.HTTPError as exc:
+            # urllib treats 304 as an HTTPError; it's actually a success
+            # case for conditional GETs.
+            if exc.code == 304:
+                return None, exc.headers.get("ETag") or if_none_match
             detail = exc.read().decode("utf-8", errors="replace")
             raise FortifyError(
                 f"Fortify API error {exc.code} calling {url}: {detail[:200]}"
@@ -261,6 +299,6 @@ class FortifyClient:
                 f"Fortify API unreachable at {url}: {exc.reason}"
             ) from exc
         try:
-            return json.loads(payload)
+            return json.loads(payload), etag
         except json.JSONDecodeError as exc:
             raise FortifyError(f"Fortify API returned non-JSON from {url}") from exc

--- a/fortify/security/__init__.py
+++ b/fortify/security/__init__.py
@@ -65,6 +65,12 @@ from fortify.security.rego_wasm import (
     WasmCompileError,
     compile_to_wasm,
 )
+from fortify.security.source import (
+    BundleDirPolicySource,
+    PlatformPolicySource,
+    PolicySource,
+    YamlPolicySource,
+)
 from fortify.security.wasm_engine import (
     DEFAULT_ENTRYPOINT,
     RegoVerdict,
@@ -84,11 +90,15 @@ __all__ = [
     "FileScope",
     "FileToolPolicy",
     "ApprovalRequiredError",
+    "BundleDirPolicySource",
     "BundleIntegrityError",
     "BundleLoadError",
     "BundleSignatureError",
     "OpaNotFoundError",
+    "PlatformPolicySource",
     "PolicyBundle",
+    "PolicySource",
+    "YamlPolicySource",
     "SignatureError",
     "PolicyDeniedError",
     "PolicyMode",

--- a/fortify/security/bundle.py
+++ b/fortify/security/bundle.py
@@ -231,8 +231,7 @@ class PolicyBundle:
         actual = hashlib.sha256(self.wasm_bytes).hexdigest()
         if actual != expected_wasm_hash:
             raise BundleIntegrityError(
-                f"wasm hash mismatch: manifest says {expected_wasm_hash}, "
-                f"got {actual}"
+                f"wasm hash mismatch: manifest says {expected_wasm_hash}, got {actual}"
             )
 
     # ---- Authenticity --------------------------------------------------
@@ -270,9 +269,20 @@ class PolicyBundle:
     # ---- Evaluation ----------------------------------------------------
 
     def policy(self) -> WasmPolicy:
-        """Return the cached WasmPolicy (instantiated on first call)."""
+        """Return the cached WasmPolicy (instantiated on first call).
+
+        Routes through :meth:`WasmPolicy.from_bytes_cached` so the
+        content-addressed cache actually fires in production. The hot
+        path the cache was designed for — ``refresh_policy()`` swaps
+        in a new bundle instance whose ``wasm_hash`` matches the
+        previous one (whitespace-only YAML edit, bundle-dir touch,
+        platform 304 fallthrough) — now reuses the existing wasmtime
+        store instead of paying ~50–100ms re-instantiation each turn.
+        """
         if self._wasm_policy is None:
-            self._wasm_policy = WasmPolicy.from_bytes(self.wasm_bytes)
+            self._wasm_policy = WasmPolicy.from_bytes_cached(
+                self.wasm_bytes, self.wasm_hash
+            )
         return self._wasm_policy
 
     def evaluate(
@@ -316,10 +326,10 @@ class SignedBundle:
     """
 
     rego_text: str
-    wasm_bytes: bytes | None        # None when compile_wasm=False (--no-wasm)
+    wasm_bytes: bytes | None  # None when compile_wasm=False (--no-wasm)
     manifest: dict
     manifest_bytes: bytes
-    signature: bytes | None         # None when no `sign` callback was given
+    signature: bytes | None  # None when no `sign` callback was given
 
     @property
     def source_hash(self) -> str | None:
@@ -375,9 +385,9 @@ def build_signed_bundle(
         "wasm_hash": wasm_hash,
     }
     # The one canonical serialization. Sign these exact bytes.
-    manifest_bytes = (
-        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
-    ).encode("utf-8")
+    manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(
+        "utf-8"
+    )
     signature = sign(manifest_bytes) if sign is not None else None
 
     return SignedBundle(

--- a/fortify/security/source.py
+++ b/fortify/security/source.py
@@ -1,0 +1,154 @@
+"""Policy sources — abstractions over "where the current policy lives."
+
+The runtime fetches a :class:`PolicyBundle` (or ``None``) from a source at
+every agent run; the source decides whether that's cheap or not. Today's
+implementation:
+
+  * :class:`PlatformPolicySource` — HTTP fetch with ``If-None-Match`` /
+    ``304 Not Modified``, so unchanged bundles cost one tiny round trip
+    instead of a full payload + signature verify + wasm re-instantiation.
+
+Phase 8b will add:
+
+  * ``BundleDirPolicySource`` — refresh a bundle directory on disk
+    (today's ``FORTIFY_LOCAL_POLICY=<dir>`` path, made stat-aware).
+  * ``YamlPolicySource`` — auto-recompile + re-sign a ``policy.yaml`` when
+    its mtime changes, so dev iteration matches the platform's hot-reload
+    UX without the platform in the loop.
+
+The common interface is :class:`PolicySource`; the agent runtime depends
+on the protocol, not on either concrete type.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from typing import TYPE_CHECKING, Protocol
+
+from fortify.security.bundle import (
+    BundleIntegrityError,
+    BundleSignatureError,
+    PolicyBundle,
+)
+
+if TYPE_CHECKING:
+    from fortify.cloud.client import FortifyClient
+
+
+logger = logging.getLogger("fortify.security.source")
+
+
+class PolicySource(Protocol):
+    """Produces a current :class:`PolicyBundle` (or ``None``) on demand.
+
+    Implementations are expected to be **cheap when nothing has changed**
+    — caching, ETags, or mtime checks — so the agent runtime can call
+    :meth:`fetch` at the top of every run without measurable cost.
+
+    A returned ``None`` means "no bundle is configured for this source"
+    (e.g. the platform served no compiled bundle). Callers fall back to
+    whatever they had before (pydantic engine on raw YAML).
+    """
+
+    def fetch(self) -> PolicyBundle | None: ...
+
+
+class PlatformPolicySource:
+    """Pull + verify a signed bundle from the platform, with ETag/304.
+
+    Holds the last seen bundle and its ``wasm_hash`` (the ETag the
+    platform serves). Each :meth:`fetch` sends ``If-None-Match`` and:
+
+      * ``304`` → returns the cached bundle without touching wasmtime or
+        the signature path.
+      * ``200`` → decodes + verifies the new payload, caches it, returns.
+      * payload with no bundle → returns ``None`` (the platform couldn't
+        compile, e.g. opa missing on the control plane — the SDK then
+        falls back to its pydantic engine).
+
+    Verification fails are fatal (a tampered platform bundle is never
+    silently downgraded). The signature is checked against the same
+    public key the SDK already trusts for biscuit verification.
+    """
+
+    def __init__(
+        self,
+        client: "FortifyClient",
+        agent_name: str,
+        *,
+        initial_bundle: PolicyBundle | None = None,
+        initial_etag: str | None = None,
+    ) -> None:
+        self._client = client
+        self._agent_name = agent_name
+        # Pre-seed when the caller already fetched + verified the bundle
+        # (typical at agent load time). Avoids a redundant 200 round-trip
+        # on the first refresh — that call will send If-None-Match and
+        # get a cheap 304.
+        self._cached_bundle: PolicyBundle | None = initial_bundle
+        self._cached_etag: str | None = initial_etag
+
+    def fetch(self) -> PolicyBundle | None:
+        payload, etag = self._client.get_agent(
+            self._agent_name, if_none_match=self._cached_etag
+        )
+        # 304 — nothing changed since last fetch. Cheap path.
+        if payload is None:
+            return self._cached_bundle
+
+        bundle = decode_and_verify_platform_bundle(
+            payload, self._client.public_key_bytes()
+        )
+        self._cached_bundle = bundle
+        # Server-supplied ETag wins; fall back to wasm_hash for when the
+        # response lacked an ETag header (older platform versions).
+        self._cached_etag = etag or (
+            f'"{bundle.wasm_hash}"'
+            if bundle is not None and bundle.wasm_hash
+            else None
+        )
+        return bundle
+
+
+def decode_and_verify_platform_bundle(
+    payload: dict, public_key_raw: bytes
+) -> PolicyBundle | None:
+    """Decode + verify the bundle in a platform :meth:`FortifyClient.get_agent`
+    response.
+
+    Returns ``None`` when the platform served no compiled bundle (the
+    bundle fields are null — e.g. opa wasn't available on the control
+    plane). Raises ``RuntimeError`` if a bundle WAS served but its
+    signature or integrity check fails: a bad signature is never
+    silently downgraded to the pydantic engine.
+    """
+    wasm_b64 = payload.get("bundle_wasm_b64")
+    manifest_text = payload.get("bundle_manifest")
+    sig_b64 = payload.get("bundle_signature_b64")
+    if not wasm_b64 or not manifest_text or not sig_b64:
+        return None
+
+    try:
+        wasm = base64.b64decode(wasm_b64)
+        signature = base64.b64decode(sig_b64)
+    except (ValueError, TypeError) as exc:
+        raise RuntimeError(
+            f"platform served a bundle but its base64 is malformed: {exc}"
+        ) from exc
+
+    bundle = PolicyBundle.from_parts(
+        wasm_bytes=wasm,
+        manifest_bytes=manifest_text.encode("utf-8"),
+        signature=signature,
+    )
+    try:
+        bundle.verify_signature(public_key_raw)
+        bundle.verify_integrity()
+    except (BundleSignatureError, BundleIntegrityError) as exc:
+        raise RuntimeError(
+            f"platform-served policy bundle failed verification: {exc}. "
+            "Refusing to run rather than silently downgrading to the "
+            "pydantic engine."
+        ) from exc
+    return bundle

--- a/fortify/security/source.py
+++ b/fortify/security/source.py
@@ -1,38 +1,41 @@
 """Policy sources — abstractions over "where the current policy lives."
 
 The runtime fetches a :class:`PolicyBundle` (or ``None``) from a source at
-every agent run; the source decides whether that's cheap or not. Today's
-implementation:
+every agent run; the source decides whether that's cheap or not. Three
+implementations cover the production + local-dev workflows:
 
   * :class:`PlatformPolicySource` — HTTP fetch with ``If-None-Match`` /
     ``304 Not Modified``, so unchanged bundles cost one tiny round trip
     instead of a full payload + signature verify + wasm re-instantiation.
-
-Phase 8b will add:
-
-  * ``BundleDirPolicySource`` — refresh a bundle directory on disk
-    (today's ``FORTIFY_LOCAL_POLICY=<dir>`` path, made stat-aware).
-  * ``YamlPolicySource`` — auto-recompile + re-sign a ``policy.yaml`` when
-    its mtime changes, so dev iteration matches the platform's hot-reload
-    UX without the platform in the loop.
+  * :class:`BundleDirPolicySource` — refresh a pre-built bundle directory
+    on disk (today's ``FORTIFY_LOCAL_POLICY=<dir>`` path, made mtime-aware
+    so a rebuild via ``fortify policy build`` takes effect on the next run).
+  * :class:`YamlPolicySource` — auto-recompile a ``policy.yaml`` when its
+    mtime changes. The dev edits → saves → runs loop matches the platform's
+    hot-reload UX without the platform in the loop.
 
 The common interface is :class:`PolicySource`; the agent runtime depends
-on the protocol, not on either concrete type.
+on the protocol, not on any concrete type.
 """
 
 from __future__ import annotations
 
 import base64
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
 from fortify.security.bundle import (
     BundleIntegrityError,
+    BundleLoadError,
     BundleSignatureError,
     PolicyBundle,
+    build_signed_bundle,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from fortify.cloud.client import FortifyClient
 
 
@@ -152,3 +155,193 @@ def decode_and_verify_platform_bundle(
             "pydantic engine."
         ) from exc
     return bundle
+
+
+# ---------------------------------------------------------------------------
+# Local sources — for FORTIFY_LOCAL_POLICY without a platform in the loop
+# ---------------------------------------------------------------------------
+
+
+class BundleDirPolicySource:
+    """Refresh a pre-built bundle directory on every fetch via mtime.
+
+    Wraps :meth:`PolicyBundle.from_disk` with two pieces of dev-loop polish:
+
+      * ``fetch()`` only reloads when the bundle manifest's mtime has
+        changed since the last load — so a quiet run pays one ``stat()``
+        and reuses the cached :class:`PolicyBundle` instance (identity
+        match → the agent runtime's refresh seam skips its swap).
+      * Verification (``verify_integrity`` + an optional
+        ``verify_signature``) runs on every reload, so a hand-edited
+        wasm/manifest pair never slips through.
+
+    Layout mirrors what ``fortify policy build`` emits — a directory
+    containing ``{stem}.yaml``, ``{stem}.rego``, ``{stem}.wasm``,
+    ``{stem}.bundle.json``, and optionally ``{stem}.bundle.json.sig``.
+    """
+
+    def __init__(
+        self,
+        directory: Path | str,
+        *,
+        verify_with: bytes | None = None,
+    ) -> None:
+        self._directory = Path(directory)
+        # When set, every reload's signature is verified against this raw
+        # Ed25519 public key. None disables the check (still enforces
+        # integrity — wasm matches the manifest's wasm_hash).
+        self._verify_with = verify_with
+        self._cached: PolicyBundle | None = None
+        self._cached_mtime_ns: int | None = None
+
+    def fetch(self) -> PolicyBundle | None:
+        manifest_path = self._locate_manifest()
+        try:
+            mtime_ns = manifest_path.stat().st_mtime_ns
+        except OSError as exc:
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY bundle at {self._directory} disappeared: {exc}"
+            ) from exc
+
+        if self._cached is not None and mtime_ns == self._cached_mtime_ns:
+            return self._cached
+
+        try:
+            bundle = PolicyBundle.from_disk(self._directory)
+            bundle.verify_integrity()
+        except (BundleLoadError, BundleIntegrityError) as exc:
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY bundle at {self._directory} failed to load: {exc}"
+            ) from exc
+
+        if self._verify_with is not None:
+            try:
+                bundle.verify_signature(self._verify_with)
+            except BundleSignatureError as exc:
+                raise RuntimeError(
+                    f"FORTIFY_LOCAL_POLICY bundle at {self._directory} failed "
+                    f"signature verification: {exc}"
+                ) from exc
+
+        self._cached = bundle
+        self._cached_mtime_ns = mtime_ns
+        return bundle
+
+    def _locate_manifest(self) -> Path:
+        """Find the single ``*.bundle.json`` we're refreshing against.
+
+        Same disambiguation rule as :meth:`PolicyBundle.from_disk`: one
+        manifest per directory; refuse rather than guess if there are
+        zero or multiple.
+        """
+        if not self._directory.is_dir():
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY={self._directory} is not a directory."
+            )
+        manifests = sorted(self._directory.glob("*.bundle.json"))
+        if not manifests:
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY={self._directory}: no *.bundle.json found. "
+                "Build with `fortify policy build` first."
+            )
+        if len(manifests) > 1:
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY={self._directory}: multiple bundle "
+                f"manifests {[m.name for m in manifests]} — pass an explicit "
+                "directory containing one."
+            )
+        return manifests[0]
+
+
+class YamlPolicySource:
+    """Recompile a ``policy.yaml`` into a bundle whenever the file changes.
+
+    Closes the dev iteration loop without a platform: edit the yaml,
+    save, re-run the agent → the new policy is live. Behaves like
+    :class:`PlatformPolicySource` from the runtime's perspective —
+    cached when nothing's changed, fresh instance when it has.
+
+    Recompilation shells out to ``opa`` via :func:`build_signed_bundle`
+    (same path the platform uses at save time), so the produced
+    :class:`PolicyBundle` is byte-for-byte what the platform would have
+    served — minus the platform's signature, unless ``sign`` is supplied.
+
+    The default unsigned mode is the happy path for dev. Production /
+    CI that requires authenticity should run against the platform
+    (PlatformPolicySource) or use a pre-built signed bundle directory
+    (BundleDirPolicySource) — local yaml signing is mostly noise since
+    the dev box holds the signing key.
+    """
+
+    def __init__(
+        self,
+        yaml_path: Path | str,
+        *,
+        sign: "Callable[[bytes], bytes] | None" = None,
+        opa_bin: str | None = None,
+    ) -> None:
+        self._yaml_path = Path(yaml_path)
+        self._sign = sign
+        self._opa_bin = opa_bin
+        self._cached: PolicyBundle | None = None
+        self._cached_mtime_ns: int | None = None
+
+    def fetch(self) -> PolicyBundle | None:
+        try:
+            mtime_ns = self._yaml_path.stat().st_mtime_ns
+        except OSError as exc:
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} disappeared: {exc}"
+            ) from exc
+
+        if self._cached is not None and mtime_ns == self._cached_mtime_ns:
+            return self._cached
+
+        try:
+            yaml_text = self._yaml_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} could not be "
+                f"read: {exc}"
+            ) from exc
+
+        try:
+            built = build_signed_bundle(
+                yaml_text,
+                source_name=self._yaml_path.name,
+                sign=self._sign,
+                opa_bin=self._opa_bin,
+            )
+        except Exception as exc:  # opa missing, malformed yaml, bad constraints
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} failed to "
+                f"compile: {exc}"
+            ) from exc
+
+        if built.wasm_bytes is None:
+            # build_signed_bundle returns wasm_bytes=None only with compile_wasm=False;
+            # we never set that, so this is paranoia for future-proofing.
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} compiled "
+                "without wasm — refusing to enforce a non-wasm bundle."
+            )
+
+        bundle = PolicyBundle.from_parts(
+            wasm_bytes=built.wasm_bytes,
+            manifest_bytes=built.manifest_bytes,
+            signature=built.signature,
+        )
+        # Integrity is trivially satisfied (we just produced both halves),
+        # but the check catches bugs in build_signed_bundle and keeps the
+        # invariant uniform across sources.
+        try:
+            bundle.verify_integrity()
+        except BundleIntegrityError as exc:
+            raise RuntimeError(
+                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path}: freshly "
+                f"built bundle failed integrity: {exc}"
+            ) from exc
+
+        self._cached = bundle
+        self._cached_mtime_ns = mtime_ns
+        return bundle

--- a/fortify/security/source.py
+++ b/fortify/security/source.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import base64
 import logging
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
@@ -91,27 +92,37 @@ class PlatformPolicySource:
         # get a cheap 304.
         self._cached_bundle: PolicyBundle | None = initial_bundle
         self._cached_etag: str | None = initial_etag
+        # Serialize the (read cached_etag → HTTP → write cached_*) cycle.
+        # Refresh runs on a to_thread worker, so two concurrent agent runs
+        # sharing one source could otherwise interleave a write to
+        # _cached_bundle with another's read of _cached_etag and pair the
+        # bundle from one response with the etag from another → a later
+        # spurious 200/304. The cost is serializing refreshes for shared
+        # sources, which is fine: refresh is best-effort and rare-ish per
+        # turn (most calls hit a cheap 304).
+        self._lock = threading.Lock()
 
     def fetch(self) -> PolicyBundle | None:
-        payload, etag = self._client.get_agent(
-            self._agent_name, if_none_match=self._cached_etag
-        )
-        # 304 — nothing changed since last fetch. Cheap path.
-        if payload is None:
-            return self._cached_bundle
+        with self._lock:
+            payload, etag = self._client.get_agent(
+                self._agent_name, if_none_match=self._cached_etag
+            )
+            # 304 — nothing changed since last fetch. Cheap path.
+            if payload is None:
+                return self._cached_bundle
 
-        bundle = decode_and_verify_platform_bundle(
-            payload, self._client.public_key_bytes()
-        )
-        self._cached_bundle = bundle
-        # Server-supplied ETag wins; fall back to wasm_hash for when the
-        # response lacked an ETag header (older platform versions).
-        self._cached_etag = etag or (
-            f'"{bundle.wasm_hash}"'
-            if bundle is not None and bundle.wasm_hash
-            else None
-        )
-        return bundle
+            bundle = decode_and_verify_platform_bundle(
+                payload, self._client.public_key_bytes()
+            )
+            self._cached_bundle = bundle
+            # Server-supplied ETag wins; fall back to wasm_hash for when the
+            # response lacked an ETag header (older platform versions).
+            self._cached_etag = etag or (
+                f'"{bundle.wasm_hash}"'
+                if bundle is not None and bundle.wasm_hash
+                else None
+            )
+            return bundle
 
 
 def decode_and_verify_platform_bundle(
@@ -193,6 +204,11 @@ class BundleDirPolicySource:
         self._verify_with = verify_with
         self._cached: PolicyBundle | None = None
         self._cached_mtime_ns: int | None = None
+        # Same concurrency guard as PlatformPolicySource — protect the
+        # (read cached_mtime → stat → maybe reload → write cached_*)
+        # cycle so two concurrent fetches can't pair an old mtime with a
+        # new bundle (or vice versa).
+        self._lock = threading.Lock()
 
     def fetch(self) -> PolicyBundle | None:
         manifest_path = self._locate_manifest()
@@ -203,29 +219,30 @@ class BundleDirPolicySource:
                 f"FORTIFY_LOCAL_POLICY bundle at {self._directory} disappeared: {exc}"
             ) from exc
 
-        if self._cached is not None and mtime_ns == self._cached_mtime_ns:
-            return self._cached
+        with self._lock:
+            if self._cached is not None and mtime_ns == self._cached_mtime_ns:
+                return self._cached
 
-        try:
-            bundle = PolicyBundle.from_disk(self._directory)
-            bundle.verify_integrity()
-        except (BundleLoadError, BundleIntegrityError) as exc:
-            raise RuntimeError(
-                f"FORTIFY_LOCAL_POLICY bundle at {self._directory} failed to load: {exc}"
-            ) from exc
-
-        if self._verify_with is not None:
             try:
-                bundle.verify_signature(self._verify_with)
-            except BundleSignatureError as exc:
+                bundle = PolicyBundle.from_disk(self._directory)
+                bundle.verify_integrity()
+            except (BundleLoadError, BundleIntegrityError) as exc:
                 raise RuntimeError(
-                    f"FORTIFY_LOCAL_POLICY bundle at {self._directory} failed "
-                    f"signature verification: {exc}"
+                    f"FORTIFY_LOCAL_POLICY bundle at {self._directory} failed to load: {exc}"
                 ) from exc
 
-        self._cached = bundle
-        self._cached_mtime_ns = mtime_ns
-        return bundle
+            if self._verify_with is not None:
+                try:
+                    bundle.verify_signature(self._verify_with)
+                except BundleSignatureError as exc:
+                    raise RuntimeError(
+                        f"FORTIFY_LOCAL_POLICY bundle at {self._directory} failed "
+                        f"signature verification: {exc}"
+                    ) from exc
+
+            self._cached = bundle
+            self._cached_mtime_ns = mtime_ns
+            return bundle
 
     def _locate_manifest(self) -> Path:
         """Find the single ``*.bundle.json`` we're refreshing against.
@@ -285,6 +302,13 @@ class YamlPolicySource:
         self._opa_bin = opa_bin
         self._cached: PolicyBundle | None = None
         self._cached_mtime_ns: int | None = None
+        # Same concurrency guard as the other sources. Note: compiling
+        # yaml under the lock means concurrent agent runs sharing this
+        # source serialize on every recompile — that's fine, OPA
+        # compilation is the slow step we already to_thread off the
+        # event loop, and the unchanged-mtime cheap path is lock-free
+        # in practice (the comparison itself is microseconds).
+        self._lock = threading.Lock()
 
     def fetch(self) -> PolicyBundle | None:
         try:
@@ -294,54 +318,55 @@ class YamlPolicySource:
                 f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} disappeared: {exc}"
             ) from exc
 
-        if self._cached is not None and mtime_ns == self._cached_mtime_ns:
-            return self._cached
+        with self._lock:
+            if self._cached is not None and mtime_ns == self._cached_mtime_ns:
+                return self._cached
 
-        try:
-            yaml_text = self._yaml_path.read_text(encoding="utf-8")
-        except OSError as exc:
-            raise RuntimeError(
-                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} could not be "
-                f"read: {exc}"
-            ) from exc
+            try:
+                yaml_text = self._yaml_path.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise RuntimeError(
+                    f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} could not be "
+                    f"read: {exc}"
+                ) from exc
 
-        try:
-            built = build_signed_bundle(
-                yaml_text,
-                source_name=self._yaml_path.name,
-                sign=self._sign,
-                opa_bin=self._opa_bin,
+            try:
+                built = build_signed_bundle(
+                    yaml_text,
+                    source_name=self._yaml_path.name,
+                    sign=self._sign,
+                    opa_bin=self._opa_bin,
+                )
+            except Exception as exc:  # opa missing, malformed yaml, bad constraints
+                raise RuntimeError(
+                    f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} failed to "
+                    f"compile: {exc}"
+                ) from exc
+
+            if built.wasm_bytes is None:
+                # build_signed_bundle returns wasm_bytes=None only with compile_wasm=False;
+                # we never set that, so this is paranoia for future-proofing.
+                raise RuntimeError(
+                    f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} compiled "
+                    "without wasm — refusing to enforce a non-wasm bundle."
+                )
+
+            bundle = PolicyBundle.from_parts(
+                wasm_bytes=built.wasm_bytes,
+                manifest_bytes=built.manifest_bytes,
+                signature=built.signature,
             )
-        except Exception as exc:  # opa missing, malformed yaml, bad constraints
-            raise RuntimeError(
-                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} failed to "
-                f"compile: {exc}"
-            ) from exc
+            # Integrity is trivially satisfied (we just produced both halves),
+            # but the check catches bugs in build_signed_bundle and keeps the
+            # invariant uniform across sources.
+            try:
+                bundle.verify_integrity()
+            except BundleIntegrityError as exc:
+                raise RuntimeError(
+                    f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path}: freshly "
+                    f"built bundle failed integrity: {exc}"
+                ) from exc
 
-        if built.wasm_bytes is None:
-            # build_signed_bundle returns wasm_bytes=None only with compile_wasm=False;
-            # we never set that, so this is paranoia for future-proofing.
-            raise RuntimeError(
-                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path} compiled "
-                "without wasm — refusing to enforce a non-wasm bundle."
-            )
-
-        bundle = PolicyBundle.from_parts(
-            wasm_bytes=built.wasm_bytes,
-            manifest_bytes=built.manifest_bytes,
-            signature=built.signature,
-        )
-        # Integrity is trivially satisfied (we just produced both halves),
-        # but the check catches bugs in build_signed_bundle and keeps the
-        # invariant uniform across sources.
-        try:
-            bundle.verify_integrity()
-        except BundleIntegrityError as exc:
-            raise RuntimeError(
-                f"FORTIFY_LOCAL_POLICY yaml at {self._yaml_path}: freshly "
-                f"built bundle failed integrity: {exc}"
-            ) from exc
-
-        self._cached = bundle
-        self._cached_mtime_ns = mtime_ns
-        return bundle
+            self._cached = bundle
+            self._cached_mtime_ns = mtime_ns
+            return bundle

--- a/fortify/security/wasm_engine.py
+++ b/fortify/security/wasm_engine.py
@@ -50,6 +50,8 @@ from __future__ import annotations
 
 import json
 import threading
+from collections import OrderedDict
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -161,6 +163,28 @@ class WasmPolicy:
             exports=exports,
             entrypoint_id=entrypoint_id,
             base_heap_ptr=base_heap_ptr,
+        )
+
+    @classmethod
+    def from_bytes_cached(
+        cls,
+        wasm: bytes,
+        wasm_hash: str,
+        *,
+        entrypoint: str = DEFAULT_ENTRYPOINT,
+    ) -> "WasmPolicy":
+        """Return a cached :class:`WasmPolicy` for ``wasm_hash``, instantiating
+        it (via :meth:`from_bytes`) on the first miss.
+
+        The hot path for policy refresh is "the bundle changed; the wasm
+        didn't" — most policy edits leave the wasm bytes alone or the dev
+        re-saves an identical policy. A content-addressed cache by
+        ``wasm_hash`` makes those refreshes ~free (no wasmtime
+        re-instantiation). The per-hash lock prevents N concurrent first-
+        loads from racing into N stores for the same hash.
+        """
+        return _wasm_policy_cache.get_or_load(
+            wasm_hash, lambda: cls.from_bytes(wasm, entrypoint=entrypoint)
         )
 
     @classmethod
@@ -396,3 +420,74 @@ def _parse_decision(raw: Any) -> RegoVerdict:
         requires_approval=bool(payload.get("requires_approval", False)),
         violations=list(payload.get("violations", []) or []),
     )
+
+
+# ---------------------------------------------------------------------------
+# Content-addressed WasmPolicy cache (used by from_bytes_cached)
+# ---------------------------------------------------------------------------
+
+
+class _WasmPolicyCache:
+    """Tiny LRU keyed by ``wasm_hash``.
+
+    Policy refreshes typically receive a bundle whose wasm bytes haven't
+    changed (the dev edited an unrelated field, the policy compiled to
+    the same module, or it's the same agent we already loaded once). The
+    cache makes that case ~free — a dict hit instead of a fresh wasmtime
+    instantiation (~50–100ms). Per-key locks prevent N concurrent first-
+    loads from racing into N stores for the same hash.
+
+    Memory bound: 16 entries × ~150 KB per ``WasmPolicy`` instance = a
+    handful of MB worst-case, plenty for any realistic agent count.
+    """
+
+    _MAX_ENTRIES = 16
+
+    def __init__(self) -> None:
+        self._policies: "OrderedDict[str, WasmPolicy]" = OrderedDict()
+        # One Lock for cache mutation, plus a per-hash Lock that prevents
+        # cache stampedes during the first concurrent load of a hash.
+        self._mutex = threading.Lock()
+        self._inflight: dict[str, threading.Lock] = {}
+
+    def get_or_load(
+        self, wasm_hash: str, loader: Callable[[], "WasmPolicy"]
+    ) -> "WasmPolicy":
+        # Fast path: already cached. Move-to-end to keep LRU semantics.
+        with self._mutex:
+            cached = self._policies.get(wasm_hash)
+            if cached is not None:
+                self._policies.move_to_end(wasm_hash)
+                return cached
+            # Reserve a per-hash lock so concurrent first-loads serialize.
+            slot = self._inflight.setdefault(wasm_hash, threading.Lock())
+
+        with slot:
+            # Re-check under the slot lock — another caller may have populated
+            # the cache while we waited.
+            with self._mutex:
+                cached = self._policies.get(wasm_hash)
+                if cached is not None:
+                    self._policies.move_to_end(wasm_hash)
+                    return cached
+
+            # Heavy work happens outside the global mutex so other hashes
+            # aren't blocked by this hash's wasmtime instantiation.
+            policy = loader()
+
+            with self._mutex:
+                self._policies[wasm_hash] = policy
+                self._policies.move_to_end(wasm_hash)
+                while len(self._policies) > self._MAX_ENTRIES:
+                    self._policies.popitem(last=False)
+                self._inflight.pop(wasm_hash, None)
+            return policy
+
+    def clear(self) -> None:
+        """Reset the cache. Mostly useful in tests."""
+        with self._mutex:
+            self._policies.clear()
+            self._inflight.clear()
+
+
+_wasm_policy_cache = _WasmPolicyCache()

--- a/platform/api/main.py
+++ b/platform/api/main.py
@@ -1,4 +1,5 @@
 import base64
+import hashlib
 from contextlib import asynccontextmanager
 
 from fastapi import (
@@ -322,13 +323,39 @@ def api_list_agent_manifests(
 def api_get_agent(
     project_id: str,
     name: str,
+    response: Response,
     session: Session = Depends(get_session),
+    if_none_match: str | None = Header(default=None, alias="If-None-Match"),
     _auth: None = Depends(optional_dev_token),
-) -> AgentRead:
+) -> AgentRead | Response:
+    """Return an agent's YAMLs + signed bundle.
+
+    Supports ETag-based conditional GETs: the response carries the
+    bundle's ``wasm_hash`` as an ``ETag`` header. A subsequent request
+    with ``If-None-Match: <wasm_hash>`` returns ``304 Not Modified``
+    when the bundle hasn't changed — so the SDK's per-run refresh costs
+    one short round-trip instead of base64-decoding the wasm again.
+    """
     ensure_default_project(session)
     agent = get_agent(session, project_id, name)
     if agent is None:
         raise HTTPException(status_code=404, detail="agent not found")
+
+    # ETag is a quoted opaque string per RFC 7232. We use the wasm_hash
+    # (a sha256 hex digest); falls back to None when no bundle is stored.
+    bundle_hash = (
+        hashlib.sha256(agent.compiled_wasm).hexdigest()
+        if agent.compiled_wasm is not None
+        else None
+    )
+    etag = f'"{bundle_hash}"' if bundle_hash else None
+
+    if etag and if_none_match and if_none_match.strip() == etag:
+        # 304 — no body, just the ETag so the client can re-confirm.
+        return Response(status_code=304, headers={"ETag": etag})
+
+    if etag:
+        response.headers["ETag"] = etag
     return _agent_read(agent)
 
 

--- a/platform/api/tests/test_bundle_signing.py
+++ b/platform/api/tests/test_bundle_signing.py
@@ -305,3 +305,62 @@ def test_platform_bundle_matches_pydantic(role, tool, args, expect_allow, signer
     assert wasm_allow == py_allow, (
         f"platform-bundle wasm disagrees with pydantic for {role}/{tool}/{args}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 8a — ETag / If-None-Match on the agent fetch endpoint
+# ---------------------------------------------------------------------------
+
+
+@needs_opa
+def test_get_agent_returns_etag_header_when_bundle_present() -> None:
+    """The endpoint exposes the bundle's wasm_hash as a quoted ETag so
+    the SDK can use it on subsequent conditional GETs."""
+    from fastapi.testclient import TestClient
+    import main
+
+    with TestClient(main.app) as c:
+        r = c.get("/v1/projects/support-bot/agents/default")
+        assert r.status_code == 200
+        etag = r.headers.get("etag")
+        assert etag and etag.startswith('"') and etag.endswith('"')
+        # Server-side ETag matches the wasm sha256 the SDK can compute.
+        body = r.json()
+        served_wasm = base64.b64decode(body["bundle_wasm_b64"])
+        assert etag == f'"{hashlib.sha256(served_wasm).hexdigest()}"'
+
+
+@needs_opa
+def test_if_none_match_returns_304_when_unchanged() -> None:
+    """A conditional GET with the prior ETag returns 304 + empty body —
+    the cheap path the per-run refresh leans on."""
+    from fastapi.testclient import TestClient
+    import main
+
+    with TestClient(main.app) as c:
+        r1 = c.get("/v1/projects/support-bot/agents/default")
+        etag = r1.headers["etag"]
+
+        r2 = c.get(
+            "/v1/projects/support-bot/agents/default",
+            headers={"If-None-Match": etag},
+        )
+        assert r2.status_code == 304
+        assert r2.content == b""
+        # ETag is echoed so the client can re-confirm the match.
+        assert r2.headers.get("etag") == etag
+
+
+@needs_opa
+def test_if_none_match_stale_etag_returns_fresh_200() -> None:
+    """A stale or wrong ETag → server resends the full body (200)."""
+    from fastapi.testclient import TestClient
+    import main
+
+    with TestClient(main.app) as c:
+        r = c.get(
+            "/v1/projects/support-bot/agents/default",
+            headers={"If-None-Match": '"obviously-stale"'},
+        )
+        assert r.status_code == 200
+        assert r.json().get("bundle_wasm_b64") is not None

--- a/platform/api/tests/test_bundle_signing.py
+++ b/platform/api/tests/test_bundle_signing.py
@@ -179,7 +179,6 @@ def test_backfill_signs_seeded_agents(session, signer) -> None:
     """Seeded agents start bundle-less; backfill compiles + signs them so
     they're served via WASM on the first request, not just after an edit."""
     from sqlmodel import select
-    from models import Agent
 
     sign, public_raw = signer
 

--- a/tests/adapters/openai/test_tools.py
+++ b/tests/adapters/openai/test_tools.py
@@ -8,7 +8,7 @@ import pytest
 from agents import FunctionTool
 
 from fortify.adapters.openai.tools import _parse_args, wrap_tool, wrap_tools
-from fortify.security import AgentPolicy, BaseToolPolicy, PolicySet
+from fortify.security import AgentPolicy, PolicySet
 from fortify.security.enforcer import PolicyEnforcer
 from fortify.security.policy_set import DEFAULT_ROLE_NAME
 

--- a/tests/agents/test_local_policy_override.py
+++ b/tests/agents/test_local_policy_override.py
@@ -123,12 +123,19 @@ def test_override_returns_none_when_env_unset(
 def test_override_loads_bundle_when_env_set(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Env var pointing at a fresh bundle yields a verified PolicyBundle."""
+    """Env var pointing at a fresh bundle yields (bundle, source).
+
+    Phase 8b returns both halves: the initial PolicyBundle for
+    enforce_policy and the PolicySource for per-run refresh.
+    """
     bundle_dir = _build_bundle_dir(tmp_path / "bundle")
     monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(bundle_dir))
 
-    bundle = loader._local_policy_override()
+    out = loader._local_policy_override()
+    assert out is not None
+    bundle, source = out
     assert bundle is not None
+    assert hasattr(source, "fetch")  # PolicySource protocol
     # The override prints a loud announcement to stderr.
     err = capsys.readouterr().err
     assert "FORTIFY_LOCAL_POLICY active" in err
@@ -137,9 +144,9 @@ def test_override_loads_bundle_when_env_set(
 def test_override_raises_for_missing_directory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Pointing at a non-existent directory fails loudly, not silently."""
+    """Pointing at a non-existent path fails loudly, not silently."""
     monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(tmp_path / "nope"))
-    with pytest.raises(RuntimeError, match="bundle could not be loaded"):
+    with pytest.raises(RuntimeError, match="expected a bundle"):
         loader._local_policy_override()
 
 
@@ -169,8 +176,11 @@ def test_load_builtin_agent_picks_up_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """``load_builtin_agent`` forwards the bundle to ``enforce_policy`` when
-    the env var is set, replacing the agent's own policy.yaml."""
+    the env var is set, replacing the agent's own policy.yaml, AND attaches
+    the local PolicySource so per-run refresh picks up later edits."""
+    import types
     from typing import Any
+
     from fortify.security import PolicyBundle
 
     bundle_dir = _build_bundle_dir(tmp_path / "bundle")
@@ -178,8 +188,9 @@ def test_load_builtin_agent_picks_up_override(
 
     captured: dict[str, Any] = {}
 
-    def fake_create_agent(**kwargs: Any) -> tuple[str, str]:
-        return "agent", "handler"
+    def fake_create_agent(**kwargs: Any) -> tuple[Any, str]:
+        # Return a namespace so the loader can set ._policy_source on it.
+        return types.SimpleNamespace(name="agent"), "handler"
 
     def fake_enforce_policy(_agent: Any, policy: Any, *, approval_handler: Any = None) -> Any:
         captured["policy"] = policy
@@ -188,11 +199,15 @@ def test_load_builtin_agent_picks_up_override(
     monkeypatch.setattr(loader, "create_agent", fake_create_agent)
     monkeypatch.setattr(loader, "enforce_policy", fake_enforce_policy)
 
-    loader.load_builtin_agent("researcher")
+    enforced, _handler = loader.load_builtin_agent("researcher")
     assert isinstance(captured["policy"], PolicyBundle), (
         "load_builtin_agent should have substituted the env-var bundle "
         f"for the on-disk policy.yaml; got {type(captured['policy'])}"
     )
+    # And the source rode along, so refresh_policy() will have something
+    # to call into on the next run.
+    assert hasattr(enforced, "_policy_source")
+    assert hasattr(enforced._policy_source, "fetch")
 
 
 @needs_opa
@@ -247,13 +262,19 @@ def test_unsigned_bundle_loads_with_warning_by_default(
 def test_unsigned_bundle_refused_when_signature_required(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """REQUIRE_SIGNATURE=true rejects an unsigned bundle at load time."""
+    """REQUIRE_SIGNATURE=true rejects an unsigned bundle at load time.
+
+    Phase 8b moved the check earlier: without a pubkey configured we
+    can't verify ANYTHING, so the loader refuses at construction time
+    with the pubkey-is-unset message rather than waiting to inspect
+    the (always-missing) signature on the bundle.
+    """
     _clear_signature_env(monkeypatch)
     bundle_dir = _build_bundle_dir(tmp_path / "bundle")
     monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(bundle_dir))
     monkeypatch.setenv("FORTIFY_BUNDLE_REQUIRE_SIGNATURE", "true")
 
-    with pytest.raises(RuntimeError, match="has no signature"):
+    with pytest.raises(RuntimeError, match="no key to verify"):
         loader._local_policy_override()
 
 
@@ -272,8 +293,10 @@ def test_signed_bundle_verifies_against_pubkey(
     monkeypatch.setenv("FORTIFY_BUNDLE_PUBKEY_PATH", str(pubkey_path))
     monkeypatch.setenv("FORTIFY_BUNDLE_REQUIRE_SIGNATURE", "true")
 
-    bundle = loader._local_policy_override()
-    assert bundle is not None and bundle.is_signed
+    out = loader._local_policy_override()
+    assert out is not None
+    bundle, _source = out
+    assert bundle.is_signed
     err = capsys.readouterr().err
     assert "signed" in err
 

--- a/tests/agents/test_platform_bundle.py
+++ b/tests/agents/test_platform_bundle.py
@@ -120,7 +120,9 @@ def test_platform_bundle_verifies_and_returns(monkeypatch) -> None:
     bundle = loader._platform_bundle(client.get_agent("default")[0], client)
     assert isinstance(bundle, PolicyBundle)
     assert bundle.is_signed
-    d = bundle.policy().decide(role="billing", tool="refund_order", args={"amount": 200})
+    d = bundle.policy().decide(
+        role="billing", tool="refund_order", args={"amount": 200}
+    )
     assert d.allow is True
 
 
@@ -212,7 +214,9 @@ def test_load_fortify_agent_uses_signed_bundle(_patched_loader) -> None:
     assert isinstance(captured["policy"], PolicyBundle)
 
 
-def test_load_fortify_agent_falls_back_to_pydantic_without_bundle(_patched_loader) -> None:
+def test_load_fortify_agent_falls_back_to_pydantic_without_bundle(
+    _patched_loader,
+) -> None:
     """No bundle served → enforce with the pydantic PolicySet, not a bundle."""
     from fortify.security.policy_set import PolicySet
 
@@ -302,9 +306,16 @@ def test_refresh_policy_skips_when_source_returns_same_instance() -> None:
 
 def test_refresh_policy_noop_without_source_or_enforcer() -> None:
     """Agents constructed programmatically without enforcement: refresh
-    is a quiet no-op, not a crash."""
+    is a quiet no-op, not a crash.
+
+    Bypasses ``__init__`` and sets the seam fields explicitly so the test
+    isn't dependent on the rest of ``FortifyAgent``'s required args
+    (model, graph, tools, ...). The contract we're pinning is just
+    ``refresh_policy() must not raise when both seam fields are None.``
+    """
     from fortify.agents.factory import FortifyAgent
 
     agent = FortifyAgent.__new__(FortifyAgent)
-    # Neither _enforcer nor _policy_source is set.
+    agent._enforcer = None
+    agent._policy_source = None
     agent.refresh_policy()  # must not raise

--- a/tests/agents/test_platform_bundle.py
+++ b/tests/agents/test_platform_bundle.py
@@ -88,14 +88,21 @@ def _signed_payload(private_raw: bytes) -> dict:
 
 
 class _FakeClient:
-    """Minimal stand-in for FortifyClient — just what the loader touches."""
+    """Minimal stand-in for FortifyClient — just what the loader touches.
+
+    Mirrors the Phase 8 ``get_agent(name, *, if_none_match=None) -> (payload, etag)``
+    signature, returning the payload unconditionally (no ETag tracking) —
+    callers that ignore the etag still work.
+    """
 
     def __init__(self, payload: dict, public_raw: bytes) -> None:
         self._payload = payload
         self._public_raw = public_raw
 
-    def get_agent(self, _name: str) -> dict:
-        return self._payload
+    def get_agent(
+        self, _name: str, *, if_none_match: str | None = None
+    ) -> tuple[dict, str | None]:
+        return self._payload, None
 
     def public_key_bytes(self) -> bytes:
         return self._public_raw
@@ -110,7 +117,7 @@ class _FakeClient:
 def test_platform_bundle_verifies_and_returns(monkeypatch) -> None:
     priv, pub = generate_keypair()
     client = _FakeClient(_signed_payload(priv), pub)
-    bundle = loader._platform_bundle(client.get_agent("default"), client)
+    bundle = loader._platform_bundle(client.get_agent("default")[0], client)
     assert isinstance(bundle, PolicyBundle)
     assert bundle.is_signed
     d = bundle.policy().decide(role="billing", tool="refund_order", args={"amount": 200})
@@ -122,7 +129,7 @@ def test_platform_bundle_none_when_no_bundle_served() -> None:
         {"agent_yaml": _AGENT_YAML, "policy_yaml": _POLICY_YAML, "system_md": ""},
         generate_keypair()[1],
     )
-    assert loader._platform_bundle(client.get_agent("default"), client) is None
+    assert loader._platform_bundle(client.get_agent("default")[0], client) is None
 
 
 @needs_opa
@@ -131,7 +138,7 @@ def test_platform_bundle_rejects_wrong_key() -> None:
     _, stranger_pub = generate_keypair()
     client = _FakeClient(_signed_payload(priv), stranger_pub)
     with pytest.raises(RuntimeError, match="failed verification"):
-        loader._platform_bundle(client.get_agent("default"), client)
+        loader._platform_bundle(client.get_agent("default")[0], client)
 
 
 @needs_opa
@@ -145,7 +152,7 @@ def test_platform_bundle_rejects_tampered_wasm() -> None:
     payload["bundle_wasm_b64"] = base64.b64encode(bytes(raw)).decode("ascii")
     client = _FakeClient(payload, pub)
     with pytest.raises(RuntimeError, match="failed verification"):
-        loader._platform_bundle(client.get_agent("default"), client)
+        loader._platform_bundle(client.get_agent("default")[0], client)
 
 
 # ---------------------------------------------------------------------------
@@ -237,3 +244,67 @@ def test_load_fortify_agent_require_signature_refuses_unsigned(
     monkeypatch.setenv("FORTIFY_BUNDLE_REQUIRE_SIGNATURE", "true")
     with pytest.raises(RuntimeError, match="served\\s+no signed bundle"):
         loader.load_fortify_agent("default")
+
+
+# ---------------------------------------------------------------------------
+# Phase 8a — refresh_policy swaps the enforcer's policy when the source
+# returns a new bundle.
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_policy_swaps_enforcer_policy_on_change() -> None:
+    """A source returning a new bundle → enforcer.policy is updated in
+    place. The shared enforcer means every guarded tool picks it up at the
+    next call, without re-wrapping the tools."""
+    from types import SimpleNamespace
+
+    from fortify.agents.factory import FortifyAgent
+
+    # Build the bare minimum of a FortifyAgent — the refresh_policy method
+    # only touches _enforcer and _policy_source, so we skip the heavy
+    # graph construction.
+    agent = FortifyAgent.__new__(FortifyAgent)
+    enforcer = SimpleNamespace(policy="initial")
+    agent._enforcer = enforcer  # type: ignore[attr-defined]
+
+    new_bundle = object()  # any new identity will do
+    fetched: list[object] = []
+
+    class _Source:
+        def fetch(self):
+            return new_bundle if not fetched else fetched.append("called") or new_bundle
+
+    agent._policy_source = _Source()  # type: ignore[attr-defined]
+    agent.refresh_policy()
+    assert enforcer.policy is new_bundle
+
+
+def test_refresh_policy_skips_when_source_returns_same_instance() -> None:
+    """Source returning the SAME object (e.g. PlatformPolicySource on 304)
+    → no-op. Verified by checking the policy attribute isn't even rewritten."""
+    from types import SimpleNamespace
+
+    from fortify.agents.factory import FortifyAgent
+
+    agent = FortifyAgent.__new__(FortifyAgent)
+    cached = object()
+    enforcer = SimpleNamespace(policy=cached)
+    agent._enforcer = enforcer  # type: ignore[attr-defined]
+
+    class _Source:
+        def fetch(self):
+            return cached  # same object every time
+
+    agent._policy_source = _Source()  # type: ignore[attr-defined]
+    agent.refresh_policy()
+    assert enforcer.policy is cached  # no swap happened
+
+
+def test_refresh_policy_noop_without_source_or_enforcer() -> None:
+    """Agents constructed programmatically without enforcement: refresh
+    is a quiet no-op, not a crash."""
+    from fortify.agents.factory import FortifyAgent
+
+    agent = FortifyAgent.__new__(FortifyAgent)
+    # Neither _enforcer nor _policy_source is set.
+    agent.refresh_policy()  # must not raise

--- a/tests/cloud/test_client.py
+++ b/tests/cloud/test_client.py
@@ -224,10 +224,14 @@ def test_client_verifies_on_first_call_then_caches(
     calls: list[tuple[str, bool]] = []
 
     def fake_raw_get(
-        self: FortifyClient, url: str, *, authorize: bool
-    ) -> dict[str, Any]:
+        self: FortifyClient,
+        url: str,
+        *,
+        authorize: bool,
+        if_none_match: str | None = None,
+    ) -> tuple[dict[str, Any] | None, str | None]:
         calls.append((url, authorize))
-        return _stub_get_agent_response()
+        return _stub_get_agent_response(), None
 
     monkeypatch.setattr(FortifyClient, "_raw_get", fake_raw_get)
 
@@ -306,14 +310,23 @@ def test_client_fetches_jwks_when_pubkey_unset(
     calls: list[tuple[str, bool]] = []
 
     def fake_raw_get(
-        self: FortifyClient, url: str, *, authorize: bool
-    ) -> dict[str, Any]:
+        self: FortifyClient,
+        url: str,
+        *,
+        authorize: bool,
+        if_none_match: str | None = None,
+    ) -> tuple[dict[str, Any] | None, str | None]:
         calls.append((url, authorize))
         if url.endswith("/.well-known/keys"):
-            return {
-                "keys": [{"x": _b64url(pub), "fingerprint": "sha256:abcdef0123456789"}]
-            }
-        return _stub_get_agent_response()
+            return (
+                {
+                    "keys": [
+                        {"x": _b64url(pub), "fingerprint": "sha256:abcdef0123456789"}
+                    ]
+                },
+                None,
+            )
+        return _stub_get_agent_response(), None
 
     monkeypatch.setattr(FortifyClient, "_raw_get", fake_raw_get)
 
@@ -344,7 +357,10 @@ def test_client_jwks_response_with_unexpected_shape_raises(
     monkeypatch.setattr(
         FortifyClient,
         "_raw_get",
-        lambda self, url, *, authorize: {"unexpected": "shape"},
+        lambda self, url, *, authorize, if_none_match=None: (
+            {"unexpected": "shape"},
+            None,
+        ),
     )
 
     with pytest.raises(FortifyError, match="unexpected JWKS shape"):

--- a/tests/runtime/test_user.py
+++ b/tests/runtime/test_user.py
@@ -54,13 +54,18 @@ def _client(priv: bytes, pub: bytes) -> FortifyClient:
 
 
 class _FakeAgent:
-    """A bare object the factory helpers can read attributes off."""
+    """A bare object the factory helpers can read attributes off.
+
+    Mirrors the real ``FortifyAgent``'s seam fields as first-class
+    attributes (set to ``None`` when not provided) so production code
+    can read them via direct attribute access without falling back to
+    ``getattr(agent, ..., None)``.
+    """
 
     def __init__(self, *, name: str | None = None, client: FortifyClient | None = None):
         self.name = name
         self.workspace = None
-        if client is not None:
-            self.fortify_client = client
+        self.fortify_client: FortifyClient | None = client
 
 
 # ---------------------------------------------------------------------------

--- a/tests/security/test_local_sources.py
+++ b/tests/security/test_local_sources.py
@@ -33,6 +33,14 @@ _OPA_AVAILABLE = shutil.which("opa") is not None
 needs_opa = pytest.mark.skipif(not _OPA_AVAILABLE, reason="opa not on PATH")
 
 
+def _permissive_sig_policy():
+    """A SignaturePolicy that doesn't refuse anything — for dispatch tests
+    that aren't exercising the signature matrix."""
+    from fortify.agents.loader import SignaturePolicy
+
+    return SignaturePolicy(verify_with=None, require_signature=False)
+
+
 _DEMO_YAML = """\
 version: 1
 roles:
@@ -262,7 +270,7 @@ def test_local_dispatch_routes_dir_to_bundle_dir_source(
     monkeypatch.delenv("FORTIFY_BUNDLE_PUBKEY_PATH", raising=False)
     monkeypatch.delenv("FORTIFY_BUNDLE_SIGN_KEY_PATH", raising=False)
 
-    src = _local_policy_source()
+    src = _local_policy_source(_permissive_sig_policy())
     assert isinstance(src, BundleDirPolicySource)
 
 
@@ -279,7 +287,7 @@ def test_local_dispatch_routes_yaml_to_yaml_source(
     monkeypatch.delenv("FORTIFY_BUNDLE_PUBKEY_PATH", raising=False)
     monkeypatch.delenv("FORTIFY_BUNDLE_SIGN_KEY_PATH", raising=False)
 
-    src = _local_policy_source()
+    src = _local_policy_source(_permissive_sig_policy())
     assert isinstance(src, YamlPolicySource)
 
 
@@ -287,7 +295,7 @@ def test_local_dispatch_unset_returns_none(monkeypatch: pytest.MonkeyPatch) -> N
     from fortify.agents.loader import _local_policy_source
 
     monkeypatch.delenv("FORTIFY_LOCAL_POLICY", raising=False)
-    assert _local_policy_source() is None
+    assert _local_policy_source(_permissive_sig_policy()) is None
 
 
 def test_local_dispatch_rejects_unknown_shape(
@@ -301,7 +309,7 @@ def test_local_dispatch_rejects_unknown_shape(
     target.write_text("not yaml", encoding="utf-8")
     monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(target))
     with pytest.raises(RuntimeError, match="expected a bundle"):
-        _local_policy_source()
+        _local_policy_source(_permissive_sig_policy())
 
 
 @needs_opa
@@ -348,5 +356,3 @@ def test_local_override_require_signature_rejects_unsigned_yaml(
         pytest.skip("opa not on PATH")
     with pytest.raises(RuntimeError, match="REQUIRE_SIGNATURE"):
         _local_policy_override()
-
-

--- a/tests/security/test_local_sources.py
+++ b/tests/security/test_local_sources.py
@@ -1,0 +1,352 @@
+"""Tests for the local policy sources (M2 phase 8b).
+
+The platform path (PlatformPolicySource) is covered in ``test_source.py``.
+These tests cover the two dev-loop sources:
+
+  * :class:`BundleDirPolicySource` — refresh a pre-built bundle dir
+    (output of ``fortify policy build``) by mtime.
+  * :class:`YamlPolicySource` — recompile a ``policy.yaml`` on save.
+
+Both need ``opa`` on PATH to actually compile a wasm module. Tests that
+need it are skipped on environments without opa, but the no-opa
+fallback path (graceful errors) is also exercised.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from fortify.security import (
+    BundleDirPolicySource,
+    PolicyBundle,
+    YamlPolicySource,
+    build_signed_bundle,
+    generate_keypair,
+    sign_bytes,
+)
+
+_OPA_AVAILABLE = shutil.which("opa") is not None
+needs_opa = pytest.mark.skipif(not _OPA_AVAILABLE, reason="opa not on PATH")
+
+
+_DEMO_YAML = """\
+version: 1
+roles:
+  default:
+    tools:
+      web_search: { mode: allow }
+  billing:
+    tools:
+      refund_order:
+        mode: allow
+        constraints:
+          - args.amount <= 500
+"""
+
+_NEXT_YAML = """\
+version: 1
+roles:
+  default:
+    tools:
+      web_search: { mode: allow }
+  billing:
+    tools:
+      refund_order:
+        mode: allow
+        constraints:
+          - args.amount <= 1000
+"""
+
+
+def _write_bundle_dir(yaml_text: str, target: Path, *, sign=None) -> Path:
+    """Materialize a ``fortify policy build``-shaped directory under ``target``.
+
+    We reuse the SDK's ``build_signed_bundle`` instead of shelling out so
+    these tests don't depend on the CLI; the on-disk layout is what
+    :meth:`PolicyBundle.from_disk` expects.
+    """
+    target.mkdir(parents=True, exist_ok=True)
+    built = build_signed_bundle(yaml_text, source_name="policy.yaml", sign=sign)
+    (target / "policy.yaml").write_text(yaml_text, encoding="utf-8")
+    (target / "policy.rego").write_text(built.rego_text, encoding="utf-8")
+    assert built.wasm_bytes is not None
+    (target / "policy.wasm").write_bytes(built.wasm_bytes)
+    (target / "policy.bundle.json").write_bytes(built.manifest_bytes)
+    if built.signature is not None:
+        (target / "policy.bundle.json.sig").write_bytes(built.signature)
+    return target / "policy.bundle.json"
+
+
+# ---------------------------------------------------------------------------
+# BundleDirPolicySource
+# ---------------------------------------------------------------------------
+
+
+@needs_opa
+def test_bundle_dir_source_loads_and_enforces(tmp_path: Path) -> None:
+    """A built directory loads + integrity-verifies + evaluates."""
+    _write_bundle_dir(_DEMO_YAML, tmp_path)
+    src = BundleDirPolicySource(tmp_path)
+    bundle = src.fetch()
+    assert isinstance(bundle, PolicyBundle)
+    d = bundle.policy().decide(
+        role="billing", tool="refund_order", args={"amount": 200}
+    )
+    assert d.allow is True
+
+
+@needs_opa
+def test_bundle_dir_source_reuses_instance_when_unchanged(tmp_path: Path) -> None:
+    """No mtime change → fetch returns the SAME object (identity match
+    means the runtime's refresh seam skips the swap)."""
+    _write_bundle_dir(_DEMO_YAML, tmp_path)
+    src = BundleDirPolicySource(tmp_path)
+    a = src.fetch()
+    b = src.fetch()
+    assert a is b
+
+
+@needs_opa
+def test_bundle_dir_source_reloads_when_manifest_changes(tmp_path: Path) -> None:
+    """Rewriting the bundle (e.g. fortify policy build again) → new instance."""
+    manifest = _write_bundle_dir(_DEMO_YAML, tmp_path)
+    src = BundleDirPolicySource(tmp_path)
+    first = src.fetch()
+
+    # Bump mtime explicitly so the test isn't sensitive to filesystem
+    # timestamp granularity (mtime_ns is precise; touch+sleep would work
+    # too, but is slower).
+    _write_bundle_dir(_NEXT_YAML, tmp_path)
+    future = manifest.stat().st_mtime_ns + 1_000_000_000  # +1s
+    os.utime(manifest, ns=(future, future))
+
+    second = src.fetch()
+    assert second is not first
+    assert second.wasm_hash != first.wasm_hash
+
+
+@needs_opa
+def test_bundle_dir_source_verifies_signature_when_pubkey_provided(
+    tmp_path: Path,
+) -> None:
+    """A signed bundle + the matching pubkey → verifies cleanly."""
+    priv, pub = generate_keypair()
+    _write_bundle_dir(_DEMO_YAML, tmp_path, sign=lambda b: sign_bytes(b, priv))
+    src = BundleDirPolicySource(tmp_path, verify_with=pub)
+    bundle = src.fetch()
+    assert bundle is not None and bundle.is_signed
+
+
+@needs_opa
+def test_bundle_dir_source_rejects_wrong_pubkey(tmp_path: Path) -> None:
+    """Signed bundle + a stranger's pubkey → fail loudly, no silent downgrade."""
+    priv, _ = generate_keypair()
+    _, stranger = generate_keypair()
+    _write_bundle_dir(_DEMO_YAML, tmp_path, sign=lambda b: sign_bytes(b, priv))
+    src = BundleDirPolicySource(tmp_path, verify_with=stranger)
+    with pytest.raises(RuntimeError, match="signature verification"):
+        src.fetch()
+
+
+def test_bundle_dir_source_rejects_missing_dir(tmp_path: Path) -> None:
+    src = BundleDirPolicySource(tmp_path / "nope")
+    with pytest.raises(RuntimeError, match="not a directory"):
+        src.fetch()
+
+
+def test_bundle_dir_source_rejects_empty_dir(tmp_path: Path) -> None:
+    src = BundleDirPolicySource(tmp_path)
+    with pytest.raises(RuntimeError, match="no \\*.bundle.json"):
+        src.fetch()
+
+
+# ---------------------------------------------------------------------------
+# YamlPolicySource
+# ---------------------------------------------------------------------------
+
+
+@needs_opa
+def test_yaml_source_compiles_and_enforces(tmp_path: Path) -> None:
+    """First fetch compiles the yaml → a usable PolicyBundle."""
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text(_DEMO_YAML, encoding="utf-8")
+    src = YamlPolicySource(yaml_path)
+    bundle = src.fetch()
+    assert isinstance(bundle, PolicyBundle)
+    assert not bundle.is_signed  # default: unsigned for dev loop
+    d = bundle.policy().decide(
+        role="billing", tool="refund_order", args={"amount": 100}
+    )
+    assert d.allow is True
+
+
+@needs_opa
+def test_yaml_source_reuses_instance_when_yaml_unchanged(tmp_path: Path) -> None:
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text(_DEMO_YAML, encoding="utf-8")
+    src = YamlPolicySource(yaml_path)
+    a = src.fetch()
+    b = src.fetch()
+    assert a is b
+
+
+@needs_opa
+def test_yaml_source_recompiles_on_save(tmp_path: Path) -> None:
+    """Edit policy.yaml + bump mtime → next fetch returns a new bundle
+    reflecting the new constraints."""
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text(_DEMO_YAML, encoding="utf-8")
+    src = YamlPolicySource(yaml_path)
+    first = src.fetch()
+    # Old policy denies 700.
+    assert (
+        first.policy()
+        .decide(role="billing", tool="refund_order", args={"amount": 700})
+        .allow
+        is False
+    )
+
+    yaml_path.write_text(_NEXT_YAML, encoding="utf-8")
+    future = yaml_path.stat().st_mtime_ns + 1_000_000_000
+    os.utime(yaml_path, ns=(future, future))
+
+    second = src.fetch()
+    assert second is not first
+    # New policy raised the cap to 1000 → 700 now allowed.
+    assert (
+        second.policy()
+        .decide(role="billing", tool="refund_order", args={"amount": 700})
+        .allow
+        is True
+    )
+
+
+@needs_opa
+def test_yaml_source_signs_when_sign_callable_provided(tmp_path: Path) -> None:
+    """When a ``sign`` callable is supplied the produced bundle is signed
+    (so callers that gate on ``is_signed`` see what they expect)."""
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text(_DEMO_YAML, encoding="utf-8")
+    priv, pub = generate_keypair()
+    src = YamlPolicySource(yaml_path, sign=lambda b: sign_bytes(b, priv))
+    bundle = src.fetch()
+    assert bundle is not None and bundle.is_signed
+    # And the signature is verifiable against the public half.
+    bundle.verify_signature(pub)
+
+
+def test_yaml_source_missing_file_raises(tmp_path: Path) -> None:
+    src = YamlPolicySource(tmp_path / "missing.yaml")
+    with pytest.raises(RuntimeError, match="disappeared|could not be read"):
+        src.fetch()
+
+
+# ---------------------------------------------------------------------------
+# loader dispatch — FORTIFY_LOCAL_POLICY shape-based routing
+# ---------------------------------------------------------------------------
+
+
+@needs_opa
+def test_local_dispatch_routes_dir_to_bundle_dir_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from fortify.agents.loader import _local_policy_source
+
+    _write_bundle_dir(_DEMO_YAML, tmp_path)
+    monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(tmp_path))
+    monkeypatch.delenv("FORTIFY_BUNDLE_REQUIRE_SIGNATURE", raising=False)
+    monkeypatch.delenv("FORTIFY_BUNDLE_PUBKEY_PATH", raising=False)
+    monkeypatch.delenv("FORTIFY_BUNDLE_SIGN_KEY_PATH", raising=False)
+
+    src = _local_policy_source()
+    assert isinstance(src, BundleDirPolicySource)
+
+
+@needs_opa
+def test_local_dispatch_routes_yaml_to_yaml_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from fortify.agents.loader import _local_policy_source
+
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text(_DEMO_YAML, encoding="utf-8")
+    monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(yaml_path))
+    monkeypatch.delenv("FORTIFY_BUNDLE_REQUIRE_SIGNATURE", raising=False)
+    monkeypatch.delenv("FORTIFY_BUNDLE_PUBKEY_PATH", raising=False)
+    monkeypatch.delenv("FORTIFY_BUNDLE_SIGN_KEY_PATH", raising=False)
+
+    src = _local_policy_source()
+    assert isinstance(src, YamlPolicySource)
+
+
+def test_local_dispatch_unset_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    from fortify.agents.loader import _local_policy_source
+
+    monkeypatch.delenv("FORTIFY_LOCAL_POLICY", raising=False)
+    assert _local_policy_source() is None
+
+
+def test_local_dispatch_rejects_unknown_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pointing the env var at a random file (not yaml, not a bundle dir)
+    is a configuration error, not a silent fallback."""
+    from fortify.agents.loader import _local_policy_source
+
+    target = tmp_path / "policy.txt"
+    target.write_text("not yaml", encoding="utf-8")
+    monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(target))
+    with pytest.raises(RuntimeError, match="expected a bundle"):
+        _local_policy_source()
+
+
+@needs_opa
+def test_local_override_returns_bundle_and_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The high-level helper returns BOTH the initial bundle (for
+    enforce_policy) and the source (for runtime refresh)."""
+    from fortify.agents.loader import _local_policy_override
+
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text(_DEMO_YAML, encoding="utf-8")
+    monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(yaml_path))
+    monkeypatch.delenv("FORTIFY_BUNDLE_REQUIRE_SIGNATURE", raising=False)
+
+    out = _local_policy_override()
+    assert out is not None
+    bundle, source = out
+    assert isinstance(bundle, PolicyBundle)
+    # Protocol check is structural — assert the contract instead of
+    # isinstance(PolicySource).
+    assert hasattr(source, "fetch") and callable(source.fetch)
+    # And the source returns the SAME bundle on a noop fetch.
+    assert source.fetch() is bundle
+
+
+def test_local_override_require_signature_rejects_unsigned_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """REQUIRE_SIGNATURE + yaml source without a sign-key → refuse,
+    don't sleepwalk into running unsigned policy."""
+    from fortify.agents.loader import _local_policy_override
+
+    yaml_path = tmp_path / "policy.yaml"
+    yaml_path.write_text(_DEMO_YAML, encoding="utf-8")
+    monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(yaml_path))
+    monkeypatch.setenv("FORTIFY_BUNDLE_REQUIRE_SIGNATURE", "true")
+    monkeypatch.delenv("FORTIFY_BUNDLE_SIGN_KEY_PATH", raising=False)
+
+    if not _OPA_AVAILABLE:
+        # Without opa we never even reach the signature check — the
+        # build inside YamlPolicySource will fail first. Skip rather
+        # than assert a misleading message.
+        pytest.skip("opa not on PATH")
+    with pytest.raises(RuntimeError, match="REQUIRE_SIGNATURE"):
+        _local_policy_override()
+
+

--- a/tests/security/test_source.py
+++ b/tests/security/test_source.py
@@ -1,0 +1,207 @@
+"""Tests for the policy source layer (M2 phase 8a).
+
+``PolicySource`` is the seam that lets the agent runtime refresh policy
+at every run without caring whether the bundle came from the platform or
+from disk. These tests cover :class:`PlatformPolicySource` (HTTP +
+``If-None-Match`` / 304) — local sources land in phase 8b.
+
+Each test uses a tiny in-memory ``FakeClient`` rather than spinning the
+real platform, so we control exactly what the platform "served" and on
+which call.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import shutil
+
+import pytest
+
+from fortify.security import (
+    PolicyBundle,
+    compile_to_rego,
+    compile_to_wasm,
+    generate_keypair,
+    sign_bytes,
+)
+from fortify.security.source import PlatformPolicySource
+
+
+_OPA_AVAILABLE = shutil.which("opa") is not None
+needs_opa = pytest.mark.skipif(not _OPA_AVAILABLE, reason="opa not on PATH")
+
+
+_POLICY_PAYLOAD = {
+    "version": 1,
+    "roles": {
+        "billing": {
+            "tools": {
+                "refund_order": {"mode": "allow", "constraints": ["args.amount <= 500"]}
+            }
+        }
+    },
+}
+
+
+def _bundle_response(private_raw: bytes, amount_cap: int = 500) -> dict:
+    """Build a get_agent-shaped response carrying a real signed bundle."""
+    payload = {
+        "version": 1,
+        "roles": {
+            "billing": {
+                "tools": {
+                    "refund_order": {
+                        "mode": "allow",
+                        "constraints": [f"args.amount <= {amount_cap}"],
+                    }
+                }
+            }
+        },
+    }
+    rego = compile_to_rego(payload)
+    wasm = compile_to_wasm(rego).wasm
+    manifest = {
+        "version": 1,
+        "source": "policy.yaml",
+        "source_hash": "0" * 64,
+        "rego_hash": hashlib.sha256(rego.encode("utf-8")).hexdigest(),
+        "wasm_hash": hashlib.sha256(wasm).hexdigest(),
+    }
+    manifest_text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    signature = sign_bytes(manifest_text.encode("utf-8"), private_raw)
+    return {
+        "bundle_wasm_b64": base64.b64encode(wasm).decode("ascii"),
+        "bundle_manifest": manifest_text,
+        "bundle_signature_b64": base64.b64encode(signature).decode("ascii"),
+    }
+
+
+class _FakeClient:
+    """Stand-in for FortifyClient that scripts a sequence of responses.
+
+    ``serve(...)`` queues the next answer the client should return; each
+    ``get_agent`` consumes one. The 304 path is triggered when the
+    incoming ``If-None-Match`` matches the previously-served etag.
+    """
+
+    def __init__(self, public_raw: bytes) -> None:
+        self._public_raw = public_raw
+        self._queued: list[tuple[dict | None, str | None]] = []
+        self.calls: list[str | None] = []
+
+    def serve(self, payload: dict | None, etag: str | None) -> None:
+        self._queued.append((payload, etag))
+
+    def serve_304(self, etag: str) -> None:
+        self._queued.append((None, etag))
+
+    def get_agent(
+        self, _name: str, *, if_none_match: str | None = None
+    ) -> tuple[dict | None, str | None]:
+        self.calls.append(if_none_match)
+        return self._queued.pop(0)
+
+    def public_key_bytes(self) -> bytes:
+        return self._public_raw
+
+
+# ---------------------------------------------------------------------------
+# PlatformPolicySource
+# ---------------------------------------------------------------------------
+
+
+@needs_opa
+def test_first_fetch_returns_verified_bundle() -> None:
+    """A 200 response builds, verifies, caches, and returns the bundle."""
+    priv, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve(_bundle_response(priv), etag='"abc123"')
+    src = PlatformPolicySource(fc, "default")
+
+    bundle = src.fetch()
+    assert isinstance(bundle, PolicyBundle)
+    assert bundle.is_signed
+    # First call has no etag to send.
+    assert fc.calls == [None]
+
+
+@needs_opa
+def test_second_fetch_sends_etag_and_304_reuses_cache() -> None:
+    """304 returns the SAME instance — no decode, no signature verify."""
+    priv, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    payload = _bundle_response(priv)
+    fc.serve(payload, etag='"abc123"')
+    fc.serve_304('"abc123"')
+
+    src = PlatformPolicySource(fc, "default")
+    first = src.fetch()
+    second = src.fetch()
+
+    assert first is second  # identity match — same Python object reused
+    # Second call sent the etag we got from the first.
+    assert fc.calls == [None, '"abc123"']
+
+
+@needs_opa
+def test_bundle_change_returns_new_instance() -> None:
+    """A different wasm_hash → new bundle returned + new etag tracked."""
+    priv, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve(_bundle_response(priv, amount_cap=500), etag='"hash-a"')
+    fc.serve(_bundle_response(priv, amount_cap=1000), etag='"hash-b"')
+
+    src = PlatformPolicySource(fc, "default")
+    first = src.fetch()
+    second = src.fetch()
+
+    assert first is not second
+    assert first.wasm_hash != second.wasm_hash
+    assert fc.calls == [None, '"hash-a"']  # second call sent first's etag
+
+
+def test_no_bundle_in_payload_returns_none() -> None:
+    """When the platform served no compiled bundle, fetch() → None."""
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve({"agent_yaml": "name: x\n", "policy_yaml": "version: 1\n"}, etag=None)
+
+    src = PlatformPolicySource(fc, "default")
+    assert src.fetch() is None
+
+
+@needs_opa
+def test_wrong_pubkey_raises() -> None:
+    """A bundle signed by one key, served with a stranger's pubkey on the
+    client, fails verification at fetch — never silently downgraded."""
+    priv, _ = generate_keypair()
+    _, stranger = generate_keypair()
+    fc = _FakeClient(stranger)
+    fc.serve(_bundle_response(priv), etag=None)
+
+    src = PlatformPolicySource(fc, "default")
+    with pytest.raises(RuntimeError, match="failed verification"):
+        src.fetch()
+
+
+@needs_opa
+def test_pre_seeded_source_skips_first_round_trip() -> None:
+    """When constructed with initial_bundle + initial_etag, the first
+    fetch sends If-None-Match and trivially hits 304."""
+    priv, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    # Pre-build a bundle the same way load_fortify_agent would have.
+    from fortify.security.source import decode_and_verify_platform_bundle
+
+    initial = decode_and_verify_platform_bundle(_bundle_response(priv), pub)
+    fc.serve_304(f'"{initial.wasm_hash}"')
+
+    src = PlatformPolicySource(
+        fc, "default", initial_bundle=initial, initial_etag=f'"{initial.wasm_hash}"'
+    )
+    result = src.fetch()
+
+    assert result is initial
+    assert fc.calls == [f'"{initial.wasm_hash}"']

--- a/tests/security/test_wasm_engine.py
+++ b/tests/security/test_wasm_engine.py
@@ -244,3 +244,48 @@ def test_unknown_entrypoint_raises_with_helpful_listing(demo_wasm: bytes) -> Non
         WasmPolicy.from_bytes(demo_wasm, entrypoint="fortify/policy/no_such_rule")
     # The error names what *is* available so the caller can self-correct.
     assert "fortify/policy/decision" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# from_bytes_cached — content-addressed cache by wasm_hash (Phase 8a)
+# ---------------------------------------------------------------------------
+
+
+@needs_opa
+def test_from_bytes_cached_reuses_instance_on_same_hash(demo_wasm: bytes) -> None:
+    """Two loads of the same hash reuse one wasmtime store — the whole point.
+
+    Without this, every policy refresh would re-instantiate wasmtime even
+    when the bundle hadn't actually changed.
+    """
+    import hashlib
+    from fortify.security.wasm_engine import _wasm_policy_cache
+
+    _wasm_policy_cache.clear()
+    h = hashlib.sha256(demo_wasm).hexdigest()
+    a = WasmPolicy.from_bytes_cached(demo_wasm, h)
+    b = WasmPolicy.from_bytes_cached(demo_wasm, h)
+    assert a is b
+    # And the cached instance still evaluates correctly.
+    assert a.decide(role="billing", tool="web_search", args={}).allow is True
+
+
+@needs_opa
+def test_from_bytes_cached_distinguishes_hashes(demo_wasm: bytes) -> None:
+    """Different hash → different cached instance (no false collisions)."""
+    import hashlib
+    from fortify.security import compile_to_rego, compile_to_wasm
+    from fortify.security.wasm_engine import _wasm_policy_cache
+
+    _wasm_policy_cache.clear()
+    other_rego = compile_to_rego(
+        {"version": 1, "roles": {"default": {"tools": {"fetch": {"mode": "allow"}}}}}
+    )
+    other_wasm = compile_to_wasm(other_rego).wasm
+
+    h1 = hashlib.sha256(demo_wasm).hexdigest()
+    h2 = hashlib.sha256(other_wasm).hexdigest()
+    p1 = WasmPolicy.from_bytes_cached(demo_wasm, h1)
+    p2 = WasmPolicy.from_bytes_cached(other_wasm, h2)
+    assert p1 is not p2
+    assert h1 != h2


### PR DESCRIPTION
# Policy hot-reload: refresh-on-every-run for platform + local sources

Policy used to load once at agent boot. After this PR, the runtime consults a `PolicySource` at the top of **every** agent run — so a YAML edit in the dashboard, or a `policy.yaml` saved on disk, takes effect on the next chat message. No restart, no tool re-wrap, no rebuild step in between.

## What changed

**`PolicySource` protocol** — one tiny interface, three implementations:

| Source | Wakes up on | Cheap path |
|---|---|---|
| `PlatformPolicySource` | `FORTIFY_KEY` set | `If-None-Match` → `304 Not Modified`, cached `PolicyBundle` reused |
| `BundleDirPolicySource` | `FORTIFY_LOCAL_POLICY=<dir>` | `stat()` the manifest; identity-reuse when mtime unchanged |
| `YamlPolicySource` | `FORTIFY_LOCAL_POLICY=*.yaml` | `stat()` the yaml; recompile only when mtime changed |

**Runtime seam** — `FortifyAgent.refresh_policy()` swaps `PolicyEnforcer.policy` in place when the source returns a new bundle instance. Tools hold a reference to the enforcer, not the bundle, so one update covers every guarded tool with zero re-wrapping. `invoke_agent` / `stream_agent_raw` call it via `asyncio.to_thread` and swallow refresh failures (a flaky source never kills a turn).

**Content-addressed WASM cache** — `WasmPolicy.from_bytes_cached(wasm, wasm_hash)` shares wasmtime stores across loads of the same hash. Refresh that didn't actually change → no wasmtime re-instantiation. LRU(16) with per-hash locks against stampede.

**Platform endpoint** — `GET /v1/projects/{p}/agents/{a}` now sets `ETag: "<wasm_hash>"` and returns `304` with empty body when `If-None-Match` matches.

**Dev signing** — `FORTIFY_BUNDLE_SIGN_KEY_PATH=<*.private>` opts a YAML source into signing each recompile, so downstream gates that check `bundle.is_signed` see what they expect.

## Dev-facing surface

Zero new code in user-land. The whole story:

```bash
# Production: edit YAML in the dashboard, next chat picks it up
export FORTIFY_KEY=fty_test_...

# Tight dev loop: edit policy.yaml in $EDITOR, save, next chat sees the new policy
export FORTIFY_LOCAL_POLICY=./policy.yaml

# Production-shaped local testing: rebuild between turns
fortify policy build policy.yaml --out ./bundle
export FORTIFY_LOCAL_POLICY=./bundle/
```

Same `User(role=...)` scope around the call, same `enforce_policy` wrapping, same everything else.

## Tests

- **SDK 694/694 green**, **platform 70/70 green**, lint clean.
- New: `tests/security/test_local_sources.py` (18), `tests/security/test_source.py` (7), 3 wasm-cache tests, 3 platform ETag/304 tests, 3 `refresh_policy` seam tests, 4 parity-with-old-API tests in `test_local_policy_override.py`.

## Out of scope

- Policy hot-reload during a single agent turn — refresh is at turn boundaries, not mid-tool-call.
- Approval handler hot-reload — only the policy swaps; handlers wired into `enforce_policy(...)` stay where they were.

## Commits

- `377f214` — phase 8a: platform ETag/304 + WASM cache + `refresh_policy` seam
- `d43e9d0` — phase 8b: local yaml + bundle-dir sources
- `95faa9a` — README: build-an-agent walkthrough, drop stale `before_action` section
