### PR TITLE
feat: local mode and chat polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Useful next commands:
 
 ```bash
 fortify chat --list-agents
-fortify chat --agent researcher
+fortify chat --agent researcher                                      # by id
+fortify chat --agent examples.customer_bot:agent                     # by module:attr (same shape as `fortify serve`)
 fortify chat --use examples/file_agents.py --agent workspace_explorer
 fortify chat --use examples/research_agents.py --agent update_researcher
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The two Quick Starts above aren't competing — they answer different questions.
 
 | Path | Needs platform? | Audit destination | Policy edits visible at | Best for |
 |------|-----------------|-------------------|--------------------------|----------|
-| `fortify chat --agent ...` | No | Local terminal panel | YAML/bundle reload from disk | Inner loop, policy authoring |
+| `fortify chat --agent ...` | No | Local terminal panel | Edit + restart (hot-reload only when `FORTIFY_LOCAL_POLICY` is set) | Inner loop, policy authoring |
 | `fortify serve --agent ...` + Playground | Yes | ClickHouse via `/v1/audit/decisions` | Per-turn fetch from dashboard | Team review, demos, integration testing |
 
 Both commands accept either a plain agent id (`--agent researcher`) or a uvicorn-style `module.path:attr` spec (`--agent examples.customer_bot:agent`), so the same entry-point string works in both workflows.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ The included local agent lives in `examples/example_agent/`, and the CLI can als
 - code-defined agents registered from `examples/file_agents.py`
 - code-defined research agents registered from `examples/research_agents.py`
 
+## 🧭 Which path do I pick?
+
+The two Quick Starts above aren't competing — they answer different questions.
+
+**Inner loop — `fortify chat`.** A single-process REPL against a local or builtin agent. No platform, no Docker, no browser. The chat command sets `FORTIFY_LOCAL_MODE=1` automatically so audit stays on your machine even if `FORTIFY_KEY` lives in your `.env` from an earlier session. Denies and approval-required calls render as inline panels in the terminal — same `Decision` data the platform would log, surfaced where you're iterating. Reach for `chat` when you're authoring a policy YAML, tweaking a tool, or shaping a system prompt.
+
+**Team loop — `fortify serve` + dashboard Playground.** Same agent code, but the policy + decisions round-trip through the platform. You get auditable decisions in ClickHouse, the shared Playground UI, and live policy edits via the dashboard. Reach for `serve` when you're collaborating on an agent's behaviour, debugging a production-like trace, or demoing.
+
+| Path | Needs platform? | Audit destination | Policy edits visible at | Best for |
+|------|-----------------|-------------------|--------------------------|----------|
+| `fortify chat --agent ...` | No | Local terminal panel | YAML/bundle reload from disk | Inner loop, policy authoring |
+| `fortify serve --agent ...` + Playground | Yes | ClickHouse via `/v1/audit/decisions` | Per-turn fetch from dashboard | Team review, demos, integration testing |
+
+Both commands accept either a plain agent id (`--agent researcher`) or a uvicorn-style `module.path:attr` spec (`--agent examples.customer_bot:agent`), so the same entry-point string works in both workflows.
+
 ## 🚀 Quick Start — Platform
 
 To run the full Fortify control plane locally (FastAPI backend + dashboard + your local agent serving over WebSocket), you need **three terminals**. The Makefile has a target that prints the recipe:

--- a/docs/audit-pipeline.md
+++ b/docs/audit-pipeline.md
@@ -191,6 +191,35 @@ Each adapter wrapper (`wrap_langchain_agent`, `wrap_openai_agent`,
 `PolicyEnforcer` they build. `bootstrap()` also calls `configure()` (env key) so
 local runs work without an explicit key.
 
+#### Local mode (`FORTIFY_LOCAL_MODE`)
+
+Setting `FORTIFY_LOCAL_MODE=1` makes `configure()` return `None` even when
+`FORTIFY_KEY` is present in env. `bootstrap(local_only=True)` sets the var
+*before* the first `configure()` call, and `fortify chat` passes
+`local_only=True` — so the inner-loop REPL never posts audit events even if
+a key has been lingering in `.env` from an earlier platform session.
+
+The gate is re-checked on every `configure()` call (not cached), so an adapter
+wrapper that re-`configure`s post-bootstrap still respects it. The truthy
+value parser accepts `1` / `true` / `yes` / `on` (case-insensitive).
+
+There are now two clean operating modes, not three:
+
+| Mode | `FORTIFY_KEY` | `FORTIFY_LOCAL_MODE` | Policy from | Audit |
+|------|---------------|----------------------|-------------|-------|
+| **Local** | (irrelevant) | `1`, or unset with no key | YAML / disk / builtin | suppressed |
+| **Platform-managed** | set | unset | platform fetch | emitted |
+
+A single INFO line (`audit suppressed: FORTIFY_LOCAL_MODE=1 (...)`) is logged
+the first time `configure()` is called with both a key and local mode active
+— exactly the case where the suppression would be surprising. The "no key
+anywhere" case stays quiet.
+
+A separate WARNING fires from `bootstrap()` itself when both `FORTIFY_KEY`
+and `FORTIFY_LOCAL_POLICY` are set — that combination is almost always a
+forgotten env entry from an earlier session, and surfacing it at startup
+saves a later debugging detour.
+
 `async shutdown()` drains in-flight tasks and closes every sender's HTTP client.
 It is safe to call multiple times and is the recommended teardown hook. Absent
 it, background sends still pending when the event loop tears down are

--- a/docs/audit-pipeline.md
+++ b/docs/audit-pipeline.md
@@ -58,6 +58,8 @@ it never changes, blocks, or fails the decision the agent acts on.
 1. **Enforcement is authoritative; audit is observational.** The `Decision`
    returned to the agent is the source of truth. Audit failures (network down,
    platform 503, saturation) degrade silently and never propagate to the caller.
+   The same `Decision` is also surfaced locally by `fortify chat`'s decision
+   panel — same data, different sink, useful when iterating offline.
 2. **The server owns identity.** `project_id`, `agent_version_id`, and
    `received_at` are resolved/stamped server-side and are **never trusted from
    the request body**, even though the SDK sends some of them as empty strings.
@@ -219,6 +221,11 @@ A separate WARNING fires from `bootstrap()` itself when both `FORTIFY_KEY`
 and `FORTIFY_LOCAL_POLICY` are set — that combination is almost always a
 forgotten env entry from an earlier session, and surfacing it at startup
 saves a later debugging detour.
+
+> For the user-facing description of when each mode applies in practice
+> — chat vs. serve, inner loop vs. team loop — see the
+> ["Which path do I pick?"](../README.md#-which-path-do-i-pick) block in
+> the README.
 
 `async shutdown()` drains in-flight tasks and closes every sender's HTTP client.
 It is safe to call multiple times and is the recommended teardown hook. Absent

--- a/fortify/agents/factory.py
+++ b/fortify/agents/factory.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     # eventually import from this module).
     from fortify.cloud.client import FortifyClient
     from fortify.security.binding import PolicyBinding
+    from fortify.security.enforcer import DecisionObserver
     from fortify.security.source import PolicySource
 
 from langchain.agents import create_agent as create_langchain_agent
@@ -404,6 +405,7 @@ class FortifyAgent:
         *,
         approval_handler: ApprovalHandler | None = None,
         source: PolicySource | None = None,
+        decision_observer: "DecisionObserver | None" = None,
     ) -> Self:
         """Return a new agent with Gate 1 policy enforcement applied.
 
@@ -418,6 +420,10 @@ class FortifyAgent:
         carries — pass one for hot reload (see :func:`_bind_policy` /
         ``load_fortify_agent``); the default ``None`` freezes ``policy``
         so a later :meth:`refresh_policy` can't swap it back out.
+
+        ``decision_observer`` (callable) receives every :class:`Decision`
+        after it's built — ``fortify chat`` uses it to render denies /
+        approvals inline; default ``None`` is silent.
 
         The ``(policy, source)`` matrix:
 
@@ -450,7 +456,11 @@ class FortifyAgent:
             engine = policy
         else:
             engine = load_policy_set(policy)
-        enforcer = build_enforcer(engine, agent_name=self.name or "default")
+        enforcer = build_enforcer(
+            engine,
+            agent_name=self.name or "default",
+            decision_observer=decision_observer,
+        )
 
         wrapped: list[ToolSpec] = []
         for tool_spec in self.tools:
@@ -490,10 +500,14 @@ def enforce_policy(
     *,
     approval_handler: ApprovalHandler | None = None,
     source: PolicySource | None = None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> AgentGraph:
     """Functional alias for :meth:`FortifyAgent.enforce_policy`."""
     return agent.enforce_policy(
-        policy, approval_handler=approval_handler, source=source
+        policy,
+        approval_handler=approval_handler,
+        source=source,
+        decision_observer=decision_observer,
     )
 
 

--- a/fortify/agents/factory.py
+++ b/fortify/agents/factory.py
@@ -617,6 +617,11 @@ def _should_bind_policy(bind_policy: bool | None, name: str | None) -> bool:
         construction-time 404. Set ``FORTIFY_BIND_AGENTS=1`` to opt in, or pass
         ``bind_policy=True`` explicitly.
 
+    ``FORTIFY_LOCAL_MODE`` (a truthy value) shorts the auto path to ``False``
+    regardless of the other env signals — same one-way kill switch the audit
+    sender respects. The explicit ``bind_policy=True`` form is left alone so a
+    deliberate caller can still override local mode if they really mean it.
+
     ``bind_policy=True`` requires a ``name``; that argument check is enforced at
     the :func:`create_agent` boundary, not here (this stays a pure predicate).
     """
@@ -625,6 +630,14 @@ def _should_bind_policy(bind_policy: bool | None, name: str | None) -> bool:
     if bind_policy is True:
         return True
     if not name:
+        return False
+    # Local-mode kill switch: when the bootstrap (or any other caller) has
+    # opted into local mode, the auto-detect must not surprise-bind to the
+    # platform — that would defeat the whole point of the gate. ``bind_policy=True``
+    # is honored above so a deliberate caller can still opt in.
+    from fortify import audit
+
+    if audit._local_mode_active():
         return False
     if os.environ.get("FORTIFY_LOCAL_POLICY"):
         return True

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -268,7 +268,9 @@ def load_builtin_agent(
         name=spec.name,
         bind_policy=False,  # the loader applies its own policy below
     )
-    overridden = _apply_local_override(agent, approval_handler, decision_observer=decision_observer)
+    overridden = _apply_local_override(
+        agent, approval_handler, decision_observer=decision_observer
+    )
     if overridden is not None:
         return overridden, handler
     return enforce_policy(
@@ -307,7 +309,9 @@ def load_local_agent(
         name=spec.name,
         bind_policy=False,  # the loader applies its own policy below
     )
-    overridden = _apply_local_override(agent, approval_handler, decision_observer=decision_observer)
+    overridden = _apply_local_override(
+        agent, approval_handler, decision_observer=decision_observer
+    )
     if overridden is not None:
         return overridden, handler
     return enforce_policy(

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -345,25 +345,42 @@ def load_registered_agent(
 def _apply_decision_observer(
     agent: AgentGraph, decision_observer: "DecisionObserver"
 ) -> None:
-    """Patch every :class:`GuardedTool`'s shared enforcer to fire ``decision_observer``.
+    """Patch every :class:`GuardedTool`'s enforcer to fire ``decision_observer``.
 
-    For code-registered agents whose factories built the enforcer without
-    seeing the CLI's hook. All guarded tools on an agent share one
-    enforcer instance (enforce_policy constructs one and wraps each tool
-    with it), so the first patch wins — no rebuild needed."""
+    For code-registered / spec-loaded agents whose factories built the
+    enforcer without seeing the CLI's hook. The expected case is one
+    shared enforcer per agent — ``enforce_policy`` constructs one and
+    wraps each tool with it — but we patch all distinct enforcers (by
+    ``id()``) rather than just the first, so a future refactor that
+    builds per-tool enforcers doesn't silently drop events on the
+    floor. The shared-instance invariant is then logged (info-level)
+    when it's actually shared, and warned (warning-level) when more
+    than one distinct enforcer was patched, so the surprise lands.
+    """
     import logging
 
     from fortify.adapters.langchain.tools import GuardedTool
 
+    log = logging.getLogger(__name__)
+    patched_enforcer_ids: set[int] = set()
     for tool_spec in agent.tools:
         if isinstance(tool_spec, GuardedTool):
             tool_spec.enforcer._decision_observer = decision_observer
-            return
-    logging.getLogger(__name__).warning(
-        "decision_observer was supplied but %r has no GuardedTool tools to "
-        "attach it to; decision events will not surface for this agent",
-        getattr(agent, "name", None) or "agent",
-    )
+            patched_enforcer_ids.add(id(tool_spec.enforcer))
+
+    if not patched_enforcer_ids:
+        log.warning(
+            "decision_observer was supplied but %r has no GuardedTool tools to "
+            "attach it to; decision events will not surface for this agent",
+            getattr(agent, "name", None) or "agent",
+        )
+    elif len(patched_enforcer_ids) > 1:
+        log.warning(
+            "decision_observer attached to %d distinct enforcer instances on %r "
+            "(expected one shared enforcer per agent — future refactor?)",
+            len(patched_enforcer_ids),
+            getattr(agent, "name", None) or "agent",
+        )
 
 
 def _apply_approval_handler(

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -6,7 +6,10 @@ import os
 from collections.abc import Callable, Mapping
 from importlib.resources import files
 from pathlib import Path
-from typing import Any, Literal, TypeAlias
+from typing import TYPE_CHECKING, Any, Literal, TypeAlias
+
+if TYPE_CHECKING:
+    from fortify.security.enforcer import DecisionObserver
 
 import yaml
 
@@ -236,6 +239,7 @@ def load_builtin_agent(
     extra_tools: Mapping[str, Any] | None = None,
     model: str | None = None,
     approval_handler: ApprovalHandler | None = None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> tuple[AgentGraph, CallbackHandler]:
     """Load and instantiate a packaged builtin agent."""
     spec = load_builtin_agent_spec(name)
@@ -256,7 +260,12 @@ def load_builtin_agent(
     overridden = _apply_local_override(agent, approval_handler)
     if overridden is not None:
         return overridden, handler
-    return enforce_policy(agent, policy, approval_handler=approval_handler), handler
+    return enforce_policy(
+        agent,
+        policy,
+        approval_handler=approval_handler,
+        decision_observer=decision_observer,
+    ), handler
 
 
 def load_local_agent(
@@ -269,6 +278,7 @@ def load_local_agent(
     extra_tools: Mapping[str, Any] | None = None,
     model: str | None = None,
     approval_handler: ApprovalHandler | None = None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> tuple[AgentGraph, CallbackHandler]:
     """Load and instantiate a local project agent."""
     spec = load_local_agent_spec(name, base_dir)
@@ -289,7 +299,12 @@ def load_local_agent(
     overridden = _apply_local_override(agent, approval_handler)
     if overridden is not None:
         return overridden, handler
-    return enforce_policy(agent, policy, approval_handler=approval_handler), handler
+    return enforce_policy(
+        agent,
+        policy,
+        approval_handler=approval_handler,
+        decision_observer=decision_observer,
+    ), handler
 
 
 def load_registered_agent(
@@ -302,6 +317,7 @@ def load_registered_agent(
     extra_tools: Mapping[str, Any] | None = None,
     model: str | None = None,
     approval_handler: ApprovalHandler | None = None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> tuple[AgentGraph, CallbackHandler]:
     """Load a registered code-defined agent by id."""
     try:
@@ -316,11 +332,38 @@ def load_registered_agent(
         extra_tools=extra_tools,
         model=model,
     )
-    # Registered factories don't know about the CLI's approval flow; layer it
-    # on after the fact by re-stamping each policy-wrapped tool.
+    # Registered factories don't know about the CLI's approval flow / chat
+    # decision panel; layer them on after the fact by reaching into the
+    # tools' shared enforcer.
     if approval_handler is not None:
         agent = _apply_approval_handler(agent, approval_handler)
+    if decision_observer is not None:
+        _apply_decision_observer(agent, decision_observer)
     return agent, handler
+
+
+def _apply_decision_observer(
+    agent: AgentGraph, decision_observer: "DecisionObserver"
+) -> None:
+    """Patch every :class:`GuardedTool`'s shared enforcer to fire ``decision_observer``.
+
+    For code-registered agents whose factories built the enforcer without
+    seeing the CLI's hook. All guarded tools on an agent share one
+    enforcer instance (enforce_policy constructs one and wraps each tool
+    with it), so the first patch wins — no rebuild needed."""
+    import logging
+
+    from fortify.adapters.langchain.tools import GuardedTool
+
+    for tool_spec in agent.tools:
+        if isinstance(tool_spec, GuardedTool):
+            tool_spec.enforcer._decision_observer = decision_observer
+            return
+    logging.getLogger(__name__).warning(
+        "decision_observer was supplied but %r has no GuardedTool tools to "
+        "attach it to; decision events will not surface for this agent",
+        getattr(agent, "name", None) or "agent",
+    )
 
 
 def _apply_approval_handler(
@@ -385,6 +428,7 @@ def load_fortify_agent(
     extra_tools: Mapping[str, Any] | None = None,
     model: str | None = None,
     approval_handler: ApprovalHandler | None = None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> tuple[AgentGraph, CallbackHandler]:
     """Fetch an agent from Fortify and return it with policy enforcement applied.
 
@@ -447,7 +491,11 @@ def load_fortify_agent(
         )
 
     enforced = enforce_policy(
-        agent, policy, approval_handler=approval_handler, source=refresh_source
+        agent,
+        policy,
+        approval_handler=approval_handler,
+        source=refresh_source,
+        decision_observer=decision_observer,
     )
     # Attach the client so the runtime can do lazy attenuation inside an
     # active User scope without the caller having to thread it through.
@@ -466,6 +514,7 @@ def load_agent(
     model: str | None = None,
     local_only: bool = False,
     approval_handler: ApprovalHandler | None = None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> tuple[AgentGraph, CallbackHandler]:
     """Load an agent from Fortify (when FORTIFY_KEY is set), local, or builtin.
 
@@ -476,6 +525,11 @@ def load_agent(
     Pass ``local_only=True`` to force resolution from local / registered /
     builtin sources even when ``FORTIFY_KEY`` is set in the environment.
     Useful for terminal-chat workflows that don't need cloud-fetched policy.
+
+    ``decision_observer`` is forwarded to every enforced loader (local,
+    registered, builtin, cloud). Threaded as a kwarg rather than a
+    contextvar so the call sites stay explicit — ``fortify chat`` is
+    the only caller passing it today.
     """
     if not local_only and os.environ.get("FORTIFY_KEY"):
         # load_fortify_agent dropped its reserved ``user_id`` placeholder
@@ -488,6 +542,7 @@ def load_agent(
             extra_tools=extra_tools,
             model=model,
             approval_handler=approval_handler,
+            decision_observer=decision_observer,
         )
     if name is None:
         raise ValueError("load_agent() requires a name when not using Fortify Cloud")
@@ -502,6 +557,7 @@ def load_agent(
             extra_tools=extra_tools,
             model=model,
             approval_handler=approval_handler,
+            decision_observer=decision_observer,
         )
     if source == "registered":
         return load_registered_agent(
@@ -513,6 +569,7 @@ def load_agent(
             extra_tools=extra_tools,
             model=model,
             approval_handler=approval_handler,
+            decision_observer=decision_observer,
         )
     return load_builtin_agent(
         name,
@@ -522,4 +579,5 @@ def load_agent(
         extra_tools=extra_tools,
         model=model,
         approval_handler=approval_handler,
+        decision_observer=decision_observer,
     )

--- a/fortify/agents/loader.py
+++ b/fortify/agents/loader.py
@@ -59,6 +59,7 @@ REGISTERED_AGENTS: dict[str, AgentFactory] = {}
 def _apply_local_override(
     agent: AgentGraph,
     approval_handler: ApprovalHandler | None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> AgentGraph | None:
     """Apply ``FORTIFY_LOCAL_POLICY`` to a freshly-built agent, if set.
 
@@ -66,6 +67,12 @@ def _apply_local_override(
     ``None`` when no override is configured — the caller then falls
     back to the normal :func:`enforce_policy` path with the agent's
     own packaged policy.
+
+    ``decision_observer`` is threaded through to the override's
+    ``enforce_policy`` call so the chat decision panel keeps working
+    when ``FORTIFY_LOCAL_POLICY`` is set — without this, the loader's
+    other path (the no-override branch) forwards the observer but this
+    one silently drops it.
 
     Extracted from :func:`load_builtin_agent` + :func:`load_local_agent`
     which shared this exact block verbatim. :func:`load_fortify_agent`
@@ -77,7 +84,11 @@ def _apply_local_override(
         return None
     bundle, source = override
     return enforce_policy(
-        agent, bundle, approval_handler=approval_handler, source=source
+        agent,
+        bundle,
+        approval_handler=approval_handler,
+        source=source,
+        decision_observer=decision_observer,
     )
 
 
@@ -257,7 +268,7 @@ def load_builtin_agent(
         name=spec.name,
         bind_policy=False,  # the loader applies its own policy below
     )
-    overridden = _apply_local_override(agent, approval_handler)
+    overridden = _apply_local_override(agent, approval_handler, decision_observer=decision_observer)
     if overridden is not None:
         return overridden, handler
     return enforce_policy(
@@ -296,7 +307,7 @@ def load_local_agent(
         name=spec.name,
         bind_policy=False,  # the loader applies its own policy below
     )
-    overridden = _apply_local_override(agent, approval_handler)
+    overridden = _apply_local_override(agent, approval_handler, decision_observer=decision_observer)
     if overridden is not None:
         return overridden, handler
     return enforce_policy(
@@ -475,7 +486,14 @@ def load_fortify_agent(
     )
     client = FortifyClient(config)
     payload, initial_etag = client.get_agent(resolved_name)
-    assert payload is not None, "first get_agent has no If-None-Match — 304 impossible"
+    if payload is None:
+        # Invariant: the first get_agent has no If-None-Match, so a 304
+        # is impossible — but use `raise` not `assert` so `python -O`
+        # can't strip the check.
+        raise RuntimeError(
+            "FortifyClient.get_agent returned no payload on initial fetch "
+            "(no If-None-Match was sent, so 304 should be impossible)"
+        )
 
     spec = AgentSpec.model_validate(yaml.safe_load(payload["agent_yaml"]) or {})
     system_prompt = payload.get("system_md") or ""

--- a/fortify/audit.py
+++ b/fortify/audit.py
@@ -200,7 +200,10 @@ class AuditSender:
         task.add_done_callback(self._tasks.discard)
 
     async def _send(self, event: AuditEvent) -> None:
-        assert self._client is not None
+        if self._client is None:
+            # Invariant: _send is only reached after start() initialised
+            # the client. Raise so `python -O` can't strip the check.
+            raise RuntimeError("audit sender _send called before start()")
         async with self._semaphore:
             payload = event.as_payload()
             try:

--- a/fortify/audit.py
+++ b/fortify/audit.py
@@ -243,6 +243,19 @@ class AuditSender:
 
 _AUDIT_PATH = "/v1/audit/decisions"
 _DEFAULT_API_URL = "http://localhost:8000"
+
+# Setting this env var to a truthy value (``1``/``true``/``yes``/``on``,
+# case-insensitive) makes ``configure()`` a no-op even when ``FORTIFY_KEY``
+# is present. ``bootstrap(local_only=True)`` sets it; ``fortify chat``
+# passes ``local_only=True``. The check happens on every ``configure()``
+# call (not cached) so an adapter wrapper that re-``configure``s after
+# bootstrap still respects the gate.
+_LOCAL_MODE_ENV = "FORTIFY_LOCAL_MODE"
+
+# One-shot log gate so the "audit suppressed: local mode" message lands
+# the first time it'd matter (a key WAS set but local mode preempted)
+# and stays quiet thereafter.
+_logged_local_mode_suppressed = False
 # One sender per resolved api_key. A single process may wrap agents for
 # several tenants/keys, and each must emit with its own bearer token — so
 # senders are keyed by api_key rather than kept as a first-wins singleton.
@@ -251,6 +264,18 @@ _DEFAULT_API_URL = "http://localhost:8000"
 # key. Such callers must evict explicitly (await sender.close(), then drop
 # the dict entry) or use shutdown().
 _senders: dict[str, AuditSender] = {}
+
+
+def _local_mode_active() -> bool:
+    """True if ``FORTIFY_LOCAL_MODE`` is set to a truthy value.
+
+    Accepts ``1``/``true``/``yes``/``on`` (case-insensitive). Everything
+    else — including unset — evaluates false. Mirrors the truthy-value
+    parser the platform's ``FORTIFY_COOKIE_SECURE`` knob uses, so the
+    behavior is consistent across the codebase's env flags."""
+    return os.environ.get(_LOCAL_MODE_ENV, "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
 
 
 def configure(
@@ -263,7 +288,25 @@ def configure(
     Reuses the existing sender when the same key was already configured;
     distinct keys get distinct senders. Returns ``None`` when no api_key is
     resolvable — audit stays inert.
+
+    Also returns ``None`` when ``FORTIFY_LOCAL_MODE`` is set in env, even
+    if a key was resolvable — that's the "I have a key in .env but I'm
+    iterating locally and don't want cloud writes" path
+    (``fortify chat`` opts in via ``bootstrap(local_only=True)``).
     """
+    global _logged_local_mode_suppressed
+    if _local_mode_active():
+        # Only log when a key was actually present — otherwise the
+        # message is just noise during a no-key local run.
+        resolved = api_key or os.environ.get("FORTIFY_KEY")
+        if resolved and not _logged_local_mode_suppressed:
+            _log.info(
+                "audit suppressed: %s=1 (a key is configured but local "
+                "mode is on, so events stay on this machine)",
+                _LOCAL_MODE_ENV,
+            )
+            _logged_local_mode_suppressed = True
+        return None
     resolved_key = api_key or os.environ.get("FORTIFY_KEY")
     if not resolved_key:
         return None

--- a/fortify/audit.py
+++ b/fortify/audit.py
@@ -274,7 +274,10 @@ def _local_mode_active() -> bool:
     parser the platform's ``FORTIFY_COOKIE_SECURE`` knob uses, so the
     behavior is consistent across the codebase's env flags."""
     return os.environ.get(_LOCAL_MODE_ENV, "").strip().lower() in (
-        "1", "true", "yes", "on",
+        "1",
+        "true",
+        "yes",
+        "on",
     )
 
 

--- a/fortify/bootstrap.py
+++ b/fortify/bootstrap.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import os
 from pathlib import Path
 
 from dotenv import load_dotenv
@@ -9,8 +11,10 @@ from dotenv import load_dotenv
 from fortify import audit
 from fortify.config.settings import Settings
 
+_log = logging.getLogger(__name__)
 
-def bootstrap(env_file: str = ".env") -> Settings:
+
+def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
     """Load environment variables and return validated settings.
 
     ``override=False`` so a shell-set env var wins over the same key in
@@ -18,19 +22,40 @@ def bootstrap(env_file: str = ".env") -> Settings:
     cargo, npm…) follows. Treats ``.env`` as a default-provider, not
     an authoritative override.
 
-    Also configures the process-wide audit sender (silent no-op when
-    FORTIFY_KEY isn't set — local-only runs work without it). Audit
-    sends are fire-and-forget background tasks: when the event loop
+    Configures the process-wide audit sender unless ``local_only=True``,
+    in which case ``FORTIFY_LOCAL_MODE=1`` is set in the environment
+    BEFORE :func:`audit.configure` runs — that's what makes the gate
+    stick: any later adapter wrapper that re-``configure``s (every
+    ``wrap_*_agent``, ``FortifyAgent.enforce_policy``) checks the same
+    env var and stays inert. ``fortify chat`` opts in this way; the
+    examples and unit tests inherit it transitively.
+
+    Audit sends are fire-and-forget background tasks: when the event loop
     tears down at exit they are cancelled, not finished, so events
     emitted shortly before exit are lost unless the teardown path
-    explicitly drains with `await audit.shutdown()`.
+    explicitly drains with ``await audit.shutdown()``.
+
+    The ``FORTIFY_KEY + FORTIFY_LOCAL_POLICY`` combination almost always
+    means a dev forgot to clean up their env between an "I'm trying the
+    platform" session and an "I'm iterating on a YAML policy" session.
+    Log a single WARNING line so the surprise lands at startup, not three
+    debug sessions later when they wonder why their policy edits
+    aren't taking.
     """
     env_path = Path(__file__).parent.parent / env_file
     # ``override=False``: shell wins over .env, matching the convention
     # uvicorn / vite / cargo / npm follow. A pre-existing test
     # (test_bootstrap_loads_requested_env_file) pinned this contract;
-    # the code had drifted to ``True``. Flipped back here so CI is green.
+    # the code had drifted to ``True``. Flipped back here.
     load_dotenv(env_path, override=False)
+    if local_only:
+        # Set BEFORE audit.configure() so the first call sees the gate.
+        os.environ[audit._LOCAL_MODE_ENV] = "1"
+    if os.environ.get("FORTIFY_KEY") and os.environ.get("FORTIFY_LOCAL_POLICY"):
+        _log.warning(
+            "FORTIFY_KEY and FORTIFY_LOCAL_POLICY are both set; the local "
+            "policy override wins. Unset one to remove the ambiguity."
+        )
     audit.configure()
     settings = Settings.from_env()
     settings.validate_required_keys()

--- a/fortify/cli/_common.py
+++ b/fortify/cli/_common.py
@@ -50,6 +50,19 @@ def build_runtime(
 ) -> AgentRuntime:
     """Create the runtime shared by ``fortify chat`` and ``fortify serve``.
 
+    ``agent_name`` accepts two forms:
+
+    * Plain id (``"researcher"``) — resolved via local / registered /
+      builtin lookup, then enforced through the standard loader. This
+      is the existing path.
+    * uvicorn-style spec (``"examples.customer_bot:agent"``) — imported
+      directly from the module and used as-is. Skips the name resolver
+      entirely; the agent object is expected to be a fully-configured
+      :class:`FortifyAgent` (typically the user's module already called
+      ``.enforce_policy(...)`` before exporting it). Closes the
+      "this loads in serve but not chat" footgun — same spec form
+      ``fortify serve`` already accepts.
+
     ``local_only=True`` keeps the loader off the Fortify Cloud path even
     when ``FORTIFY_KEY`` is present in the environment — what terminal
     chat uses, since it doesn't need cloud-fetched policy or a serve
@@ -60,6 +73,19 @@ def build_runtime(
     uses it to render denies / approvals in the REPL.
     """
     import os
+
+    # Spec form (``module.path:attr``) — handled out-of-band from the
+    # name resolver. A colon in a plain id is already discouraged
+    # (YAML-loaded agent names with colons invite trouble), so the
+    # branch is unambiguous and a clean ModuleNotFoundError beats a
+    # confusing "agent not found" if the spec is misspelled.
+    if ":" in agent_name:
+        return _build_runtime_from_spec(
+            settings,
+            spec=agent_name,
+            approval_handler=approval_handler,
+            decision_observer=decision_observer,
+        )
 
     tools = [web_search, fetch]
     resolved_model = model or settings.model
@@ -88,6 +114,61 @@ def build_runtime(
         handler=handler,
         agent_name=agent_name,
         agent_source=agent_source,
+        model=resolved_model,
+        tools_by_name=tools_by_name,
+    )
+
+
+def _build_runtime_from_spec(
+    settings: Settings,
+    *,
+    spec: str,
+    approval_handler: ApprovalHandler | None,
+    decision_observer: "DecisionObserver | None",
+) -> AgentRuntime:
+    """Resolve a ``module:attr`` spec to an :class:`AgentRuntime`, local-only.
+
+    The agent object is taken as-is — no platform round-trip, no manifest
+    re-registration, no policy fetch. The user's module is responsible
+    for having called ``.enforce_policy(...)`` if they want enforcement;
+    chat just wires the CLI's approval handler and decision observer
+    into the agent's existing enforcer (reusing the in-place injectors
+    from the loader so registered-agent and spec'd-agent share one path)."""
+    from fortify.agents.loader import (
+        _apply_approval_handler,
+        _apply_decision_observer,
+    )
+    from fortify.tracing.langfuse import get_langfuse_handler
+
+    agent_obj = load_spec(spec)
+    agent_name = getattr(agent_obj, "name", None) or spec
+
+    if approval_handler is not None:
+        agent_obj = _apply_approval_handler(agent_obj, approval_handler)
+    if decision_observer is not None:
+        _apply_decision_observer(agent_obj, decision_observer)
+
+    handler = get_langfuse_handler(
+        session_id="fortify-cli",
+        tags=["fortify", "spec", agent_name],
+    )
+
+    # The agent object carries its own model (str or BaseChatModel);
+    # stringify for the welcome banner. Fall back to settings.model
+    # if the spec'd object doesn't have a .model attr (unusual but
+    # possible for non-FortifyAgent shapes).
+    raw_model = getattr(agent_obj, "model", None)
+    resolved_model = str(raw_model) if raw_model is not None else settings.model
+
+    tools_by_name = {
+        getattr(t, "name", getattr(t, "__name__", "tool")): t
+        for t in getattr(agent_obj, "tools", [])
+    }
+    return AgentRuntime(
+        agent=agent_obj,
+        handler=handler,
+        agent_name=agent_name,
+        agent_source="spec",
         model=resolved_model,
         tools_by_name=tools_by_name,
     )
@@ -296,7 +377,11 @@ def build_approval_handler(console: Console, mode: ApprovalMode):
 def add_shared_agent_flags(parser: argparse.ArgumentParser) -> None:
     """Register flags shared between `fortify chat` and `fortify serve`."""
     parser.add_argument(
-        "--agent", help="Agent id to load from local or builtin definitions."
+        "--agent",
+        help=(
+            "Agent id (resolved from local / registered / builtin definitions) "
+            "OR a uvicorn-style 'module.path:attr' spec to import directly."
+        ),
     )
     parser.add_argument(
         "--model", help="Optional model override for the selected agent."

--- a/fortify/cli/_common.py
+++ b/fortify/cli/_common.py
@@ -8,7 +8,10 @@ import importlib.util
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from fortify.security.enforcer import DecisionObserver
 
 from rich.console import Console, Group
 from rich.panel import Panel
@@ -43,6 +46,7 @@ def build_runtime(
     model: str | None,
     local_only: bool = False,
     approval_handler: ApprovalHandler | None = None,
+    decision_observer: "DecisionObserver | None" = None,
 ) -> AgentRuntime:
     """Create the runtime shared by ``fortify chat`` and ``fortify serve``.
 
@@ -52,6 +56,8 @@ def build_runtime(
     tunnel. ``fortify serve`` passes ``local_only=False`` so policy edits
     in the dashboard land at the next turn boundary. ``approval_handler``
     threads to :func:`load_agent` for inline ``NEEDS_APPROVAL`` resolution.
+    ``decision_observer`` likewise threads through — ``fortify chat``
+    uses it to render denies / approvals in the REPL.
     """
     import os
 
@@ -66,6 +72,7 @@ def build_runtime(
         extra_tools={tool.name: tool for tool in tools},
         local_only=local_only,
         approval_handler=approval_handler,
+        decision_observer=decision_observer,
     )
     runtime_tools = list(getattr(agent, "tools", [])) + list(tools)
     tools_by_name = {

--- a/fortify/cli/_common.py
+++ b/fortify/cli/_common.py
@@ -240,7 +240,13 @@ def build_runtime_from_local_agent(
     config = FortifyConfig.from_env()
     client = FortifyClient(config)
     payload, _etag = client.get_agent(agent_name)
-    assert payload is not None, "first get_agent has no If-None-Match"
+    if payload is None:
+        # Invariant: no If-None-Match was sent, so a 304 is impossible.
+        # Raise so `python -O` can't strip the check.
+        raise RuntimeError(
+            f"FortifyClient.get_agent({agent_name!r}) returned no payload "
+            "on initial fetch (no If-None-Match was sent)"
+        )
 
     policy_payload = yaml.safe_load(payload["policy_yaml"]) or {}
     policy = load_policy_set_from_dict(policy_payload)

--- a/fortify/cli/chat.py
+++ b/fortify/cli/chat.py
@@ -253,7 +253,10 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
 def main(args: argparse.Namespace) -> int:
     """Entrypoint for the `fortify chat` subcommand."""
     console = Console()
-    settings = bootstrap()
+    # Terminal chat is a "no platform required" loop: pass local_only=True
+    # so bootstrap sets FORTIFY_LOCAL_MODE before any adapter wrapper can
+    # spin up an audit sender against a key that's lingering in .env.
+    settings = bootstrap(local_only=True)
     base_dir = Path.cwd()
 
     if args.use:

--- a/fortify/cli/chat.py
+++ b/fortify/cli/chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from collections import deque
 from pathlib import Path
 
 from rich.columns import Columns
@@ -25,6 +26,7 @@ from fortify.cli._common import (
     load_agent_script,
 )
 from fortify.cli.state import ChatState, LiveRunState, ToolActivity
+from fortify.security.decision import Decision, DecisionOutcome
 from fortify.streaming import ToolCallState
 from fortify.tools.decorators import format_tool_call_label
 from fortify.tracing.langfuse import maybe_get_trace_url
@@ -147,6 +149,59 @@ def _print_completed_turn(
     console.print()
 
 
+def _render_decision_panel(decision: Decision) -> Panel | None:
+    """Render one ``Decision`` as a rich Panel — or ``None`` for ALLOW.
+
+    Allows are muted by design: a chatty REPL with a panel per tool call
+    is noise. The whole point of the decision feed is "what got blocked
+    and why," surfaced right where the dev is iterating. A ``--show-allow``
+    flag can land later if anyone asks.
+    """
+    if decision.outcome is DecisionOutcome.ALLOW:
+        return None
+
+    is_deny = decision.outcome is DecisionOutcome.DENY
+    border_style = "red" if is_deny else "yellow"
+    title_glyph = "⛔" if is_deny else "⏸"
+    title = f"{title_glyph} {decision.outcome.value} · {decision.tool_name}"
+
+    lines: list[RenderableType] = []
+    if decision.reason:
+        lines.append(Text(decision.reason, style="white"))
+    if decision.error_type:
+        lines.append(Text(f"error_type: {decision.error_type}", style="dim"))
+    if decision.role is not None:
+        lines.append(Text(f"role: {decision.role or '(none)'}", style="dim"))
+    if decision.violations:
+        lines.append(Text("violations:", style="dim"))
+        for v in decision.violations:
+            lines.append(Text(f"  • {v}", style="dim red" if is_deny else "dim yellow"))
+    if decision.hint is not None:
+        lines.append(Text(f"hint: {decision.hint}", style="dim"))
+
+    return Panel(
+        Group(*lines) if lines else Text("(no detail)", style="dim"),
+        title=title,
+        title_align="left",
+        border_style=border_style,
+        padding=(0, 1),
+    )
+
+
+def _drain_decisions(
+    console: Console, pending: deque[Decision]
+) -> None:
+    """Print panels for any decisions captured during the just-finished
+    turn, then clear the deque. Called between turns so the panels
+    appear after the agent's response but before the next prompt — the
+    same surface the user just looked at."""
+    while pending:
+        decision = pending.popleft()
+        panel = _render_decision_panel(decision)
+        if panel is not None:
+            console.print(panel)
+
+
 def _default_agent_name(base_dir: Path) -> str:
     """Return the default agent id for the current project context."""
     available = list_available_agents(base_dir)
@@ -182,8 +237,17 @@ def _render_welcome(runtime: AgentRuntime) -> RenderableType:
     )
 
 
-async def _chat_loop(console: Console, runtime: AgentRuntime) -> None:
-    """Run the interactive terminal chat loop."""
+async def _chat_loop(
+    console: Console,
+    runtime: AgentRuntime,
+    pending_decisions: deque[Decision] | None = None,
+) -> None:
+    """Run the interactive terminal chat loop.
+
+    ``pending_decisions`` is the deque the injected ``decision_observer``
+    appends to as the enforcer makes calls during a turn. The loop
+    drains it between turns and renders deny / needs_approval panels.
+    Default ``None`` keeps the loop usable from tests that don't care."""
     state = ChatState()
 
     console.print(_render_welcome(runtime))
@@ -231,6 +295,9 @@ async def _chat_loop(console: Console, runtime: AgentRuntime) -> None:
 
         _print_completed_turn(console, runtime, current_run, trace_url)
 
+        if pending_decisions is not None:
+            _drain_decisions(console, pending_decisions)
+
         console.print()
 
 
@@ -270,6 +337,13 @@ def main(args: argparse.Namespace) -> int:
 
     agent_name = args.agent or _default_agent_name(base_dir)
 
+    # Decision feed: the observer appends to a bounded deque the chat
+    # loop drains between turns. Sync callback, no threading concerns
+    # (PolicyEnforcer.decide runs in the same event loop the chat loop
+    # awaits stream_agent on). maxlen=64 caps memory if an LLM goes
+    # wild calling tools and we somehow miss draining between turns.
+    pending_decisions: deque[Decision] = deque(maxlen=64)
+
     # Terminal chat deliberately ignores FORTIFY_KEY: there's no playground to
     # feed and policy enforcement still works via the agent's own YAML or
     # registered factory. The serve subcommand keeps the cloud path.
@@ -280,6 +354,7 @@ def main(args: argparse.Namespace) -> int:
         model=args.model,
         local_only=True,
         approval_handler=build_approval_handler(console, args.approval_mode),
+        decision_observer=pending_decisions.append,
     )
-    asyncio.run(_chat_loop(console, runtime))
+    asyncio.run(_chat_loop(console, runtime, pending_decisions))
     return 0

--- a/fortify/cli/chat.py
+++ b/fortify/cli/chat.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 from collections import deque
 from pathlib import Path
 
@@ -177,7 +178,13 @@ def _render_decision_panel(decision: Decision) -> Panel | None:
         for v in decision.violations:
             lines.append(Text(f"  • {v}", style="dim red" if is_deny else "dim yellow"))
     if decision.hint is not None:
-        lines.append(Text(f"hint: {decision.hint}", style="dim"))
+        # JSON over Python repr so {"glob": "/x/**"} reads as JSON, not
+        # {'glob': '/x/**'} — matches the wire format the platform stores.
+        # default=str defends against non-JSON-serializable values the
+        # engine might pass through (rare, but cheap insurance).
+        lines.append(
+            Text(f"hint: {json.dumps(decision.hint, default=str)}", style="dim")
+        )
 
     return Panel(
         Group(*lines) if lines else Text("(no detail)", style="dim"),
@@ -188,9 +195,7 @@ def _render_decision_panel(decision: Decision) -> Panel | None:
     )
 
 
-def _drain_decisions(
-    console: Console, pending: deque[Decision]
-) -> None:
+def _drain_decisions(console: Console, pending: deque[Decision]) -> None:
     """Print panels for any decisions captured during the just-finished
     turn, then clear the deque. Called between turns so the panels
     appear after the agent's response but before the next prompt — the

--- a/fortify/cloud/client.py
+++ b/fortify/cloud/client.py
@@ -234,7 +234,12 @@ class FortifyClient:
         copy — mutating it doesn't affect the cached extraction.
         """
         self._ensure_key_verified()
-        assert self._facts is not None  # populated by _ensure_key_verified
+        if self._facts is None:
+            # Invariant: _ensure_key_verified populates self._facts on success.
+            # Raise so `python -O` can't strip the check.
+            raise RuntimeError(
+                "biscuit_facts called but _ensure_key_verified did not populate facts"
+            )
         return {name: list(values) for name, values in self._facts.items()}
 
     def public_key_bytes(self) -> bytes:
@@ -280,7 +285,12 @@ class FortifyClient:
         this drops the ETag tuple for callers that don't care about
         conditional requests."""
         payload, _ = self._raw_get(url, authorize=True)
-        assert payload is not None, "_get is never called with If-None-Match"
+        if payload is None:
+            # Invariant: _get is never called with If-None-Match, so a 304
+            # is impossible. Raise so `python -O` can't strip the check.
+            raise FortifyError(
+                f"_raw_get({url!r}) returned no payload on unconditional GET"
+            )
         return payload
 
     def _raw_get(

--- a/fortify/security/binding.py
+++ b/fortify/security/binding.py
@@ -88,7 +88,13 @@ def resolve_policy(
         client = FortifyClient(FortifyConfig.from_env(api_key=api_key))
     if client is not None:
         payload, etag = client.get_agent(agent_name)
-        assert payload is not None, "get_agent without If-None-Match — 304 impossible"
+        if payload is None:
+            # Invariant: no If-None-Match was sent, so a 304 is impossible.
+            # Raise so `python -O` can't strip the check.
+            raise PolicyBindingError(
+                f"FortifyClient.get_agent({agent_name!r}) returned no payload "
+                "on initial fetch (no If-None-Match was sent)"
+            )
         engine, source = platform_policy_from_payload(client, agent_name, payload, etag)
         return ResolvedPolicy(engine, source)
 

--- a/fortify/security/enforcer.py
+++ b/fortify/security/enforcer.py
@@ -9,12 +9,23 @@ contextvar.
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping
+import logging
+from collections.abc import Callable, Mapping
 from typing import Any
 
 from fortify.audit import AuditEvent, AuditSender, configure
 from fortify.runtime.context import get_current_user
 from fortify.security.decision import Decision, PolicyEngine
+
+_log = logging.getLogger(__name__)
+
+# A sync, fire-and-forget hook fired after every decision is built.
+# Used today by ``fortify chat`` to render denies / approvals inline in the
+# REPL; future consumers (metrics, debuggers) would slot in the same way.
+# Distinct from ``AuditSender`` (which posts to the platform) — the observer
+# stays on the caller's machine and gets the full ``Decision`` object, not
+# a wire-shaped payload.
+DecisionObserver = Callable[[Decision], None]
 
 
 class PolicyEnforcer:
@@ -34,12 +45,18 @@ class PolicyEnforcer:
         *,
         agent_name: str = "default",
         audit_sender: AuditSender | None = None,
+        decision_observer: DecisionObserver | None = None,
     ) -> None:
         self.policy = policy
         self.agent_name = agent_name
         # Injected per-agent so each agent emits with its own api_key's sender.
         # ``None`` means audit is inert for this enforcer.
         self._audit_sender = audit_sender
+        # Local-process hook (no IO). ``fortify chat`` injects one that
+        # appends to a deque the REPL drains between turns; tests inject
+        # a list-append. Distinct slot from audit so a deployment can have
+        # one without the other.
+        self._decision_observer = decision_observer
 
     def decide(self, tool_name: str, arguments: Mapping[str, Any]) -> Decision:
         """Resolve role from the contextvar, ask the engine for a
@@ -47,16 +64,19 @@ class PolicyEnforcer:
         host-facing :class:`Decision` with this agent's context.
 
         Emits an :class:`~fortify.audit.AuditEvent` to this enforcer's
-        injected sender after the decision is built. No-op when no sender
-        was injected."""
+        injected sender after the decision is built, and calls the
+        injected ``decision_observer`` (if any) with the same Decision.
+        Both are no-ops when not injected; both are isolated so a
+        broken observer never breaks enforcement."""
         user = get_current_user()
         role = user.role if user is not None else None
-        # Deep-copy when auditing: emission is async, so a shallow copy
-        # would let the caller mutate nested args before the payload is
-        # serialized, making the audit record lie about what was decided.
+        # Deep-copy when audit OR observer is wired: emission/observation
+        # may inspect args after ``decide()`` returns, so a shallow copy
+        # would let the caller mutate nested args first and make the
+        # captured record lie about what was decided.
         args_snapshot = (
             copy.deepcopy(dict(arguments))
-            if self._audit_sender is not None
+            if (self._audit_sender is not None or self._decision_observer is not None)
             else dict(arguments)
         )
 
@@ -80,6 +100,15 @@ class PolicyEnforcer:
                 )
             )
 
+        if self._decision_observer is not None:
+            try:
+                self._decision_observer(decision)
+            except Exception:
+                # A broken observer (chat-panel render bug, third-party
+                # subscriber raising) must not break enforcement — the
+                # Decision the agent acts on is the source of truth.
+                _log.exception("decision_observer raised; ignoring")
+
         return decision
 
 
@@ -88,6 +117,7 @@ def build_enforcer(
     *,
     agent_name: str = "default",
     api_key: str | None = None,
+    decision_observer: DecisionObserver | None = None,
 ) -> PolicyEnforcer:
     """Compose a governed enforcer — engine + audit sender from ``api_key``.
 
@@ -95,8 +125,12 @@ def build_enforcer(
     surfaces (``FortifyAgent.enforce_policy``, the four adapters, the
     OpenAI runner) don't each repeat the ``audit.configure`` wiring.
     ``api_key=None`` falls back to ``FORTIFY_KEY`` (audit stays inert when
-    neither resolves).
+    neither resolves). ``decision_observer`` threads the local-process
+    decision hook (see :class:`PolicyEnforcer`); ``None`` is silent.
     """
     return PolicyEnforcer(
-        engine, agent_name=agent_name, audit_sender=configure(api_key)
+        engine,
+        agent_name=agent_name,
+        audit_sender=configure(api_key),
+        decision_observer=decision_observer,
     )

--- a/tests/agents/test_builtin.py
+++ b/tests/agents/test_builtin.py
@@ -53,11 +53,16 @@ def test_load_builtin_agent_resolves_spec_into_create_agent(
         return "agent-instance", "handler-instance"
 
     def fake_enforce_policy(
-        tools: list[Any], policy: Any, *, approval_handler: Any = None
+        tools: list[Any],
+        policy: Any,
+        *,
+        approval_handler: Any = None,
+        decision_observer: Any = None,
     ) -> list[Any]:
         """Capture policy application while leaving tools unchanged."""
         captured_policy["policy"] = policy
         captured_policy["approval_handler"] = approval_handler
+        captured_policy["decision_observer"] = decision_observer
         return tools
 
     monkeypatch.setattr(loader, "create_agent", fake_create_agent)

--- a/tests/agents/test_create_agent_binding.py
+++ b/tests/agents/test_create_agent_binding.py
@@ -77,6 +77,7 @@ def _hermetic(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("FORTIFY_KEY", raising=False)
     monkeypatch.delenv("FORTIFY_LOCAL_POLICY", raising=False)
     monkeypatch.delenv("FORTIFY_BIND_AGENTS", raising=False)
+    monkeypatch.delenv("FORTIFY_LOCAL_MODE", raising=False)
 
 
 def _patch_platform(monkeypatch: pytest.MonkeyPatch, client: _FakeClient) -> None:
@@ -143,6 +144,61 @@ def test_auto_mode_bare_key_does_not_bind_without_opt_in(
 
     assert agent.tools == [echo]  # unwrapped, no construction-time 404
     assert agent._binding is None
+
+
+def test_auto_mode_respects_fortify_local_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`FORTIFY_LOCAL_MODE` is the one-way kill switch the local-mode bootstrap
+    sets; the auto-bind path must respect it just like ``audit.configure``
+    does. Even with both the platform key and the opt-in toggle set, a
+    create_agent under local mode stays bare — the user explicitly asked
+    for no platform IO from this process."""
+    import fortify.cloud.client as client_mod
+    from fortify import audit
+
+    monkeypatch.setenv("FORTIFY_KEY", "fty_test_demo_dummybiscuit")
+    monkeypatch.setenv("FORTIFY_BIND_AGENTS", "1")
+    monkeypatch.setenv(audit._LOCAL_MODE_ENV, "1")
+    # The platform must never be contacted — fail hard if a client is built.
+    monkeypatch.setattr(
+        client_mod,
+        "FortifyClient",
+        lambda config: pytest.fail(
+            "create_agent contacted the platform under local mode"
+        ),
+    )
+
+    agent, _ = factory.create_agent(
+        model="openai:gpt-5.4", tools=[echo], name="support-bot"
+    )
+
+    assert agent.tools == [echo]
+    assert agent._binding is None
+
+
+def test_bind_policy_true_overrides_fortify_local_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``bind_policy=True`` is the explicit-caller form — local mode shouldn't
+    silently veto it. The kill switch only short-circuits the auto-detect path."""
+    from fortify import audit
+
+    monkeypatch.setenv(audit._LOCAL_MODE_ENV, "1")
+    monkeypatch.setattr(
+        factory,
+        "_bind_policy",
+        lambda agent, name, approval_handler: agent.with_tools(["bound-sentinel"]),
+    )
+
+    agent, _ = factory.create_agent(
+        model="openai:gpt-5.4",
+        tools=[echo],
+        name="support-bot",
+        bind_policy=True,
+    )
+
+    assert agent.tools == ["bound-sentinel"]
 
 
 def test_bind_policy_false_skips_even_with_key(

--- a/tests/agents/test_loader_local.py
+++ b/tests/agents/test_loader_local.py
@@ -80,11 +80,16 @@ def test_load_local_agent_resolves_spec_into_create_agent(
         return "agent-instance", "handler-instance"
 
     def fake_enforce_policy(
-        tools: list[Any], policy: Any, *, approval_handler: Any = None
+        tools: list[Any],
+        policy: Any,
+        *,
+        approval_handler: Any = None,
+        decision_observer: Any = None,
     ) -> list[Any]:
         """Capture policy application while leaving tools unchanged."""
         captured_policy["policy"] = policy
         captured_policy["approval_handler"] = approval_handler
+        captured_policy["decision_observer"] = decision_observer
         return tools
 
     monkeypatch.setattr(loader, "create_agent", fake_create_agent)

--- a/tests/agents/test_local_policy_override.py
+++ b/tests/agents/test_local_policy_override.py
@@ -217,6 +217,52 @@ def test_load_builtin_agent_picks_up_override(
 
 
 @needs_opa
+def test_load_builtin_agent_threads_decision_observer_under_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``FORTIFY_LOCAL_POLICY`` is set, the override path must still
+    forward ``decision_observer`` to ``enforce_policy`` — otherwise the
+    chat decision panel renders nothing once the env var is in play.
+
+    Regression for the silent-drop bug in ``_apply_local_override`` where
+    the override branch swallowed the observer kwarg while the
+    no-override branch forwarded it.
+    """
+    import types
+    from typing import Any
+
+    bundle_dir = _build_bundle_dir(tmp_path / "bundle")
+    monkeypatch.setenv("FORTIFY_LOCAL_POLICY", str(bundle_dir))
+
+    captured: dict[str, Any] = {}
+
+    def fake_create_agent(**kwargs: Any) -> tuple[Any, str]:
+        return types.SimpleNamespace(name="agent"), "handler"
+
+    def fake_enforce_policy(
+        _agent: Any,
+        policy: Any,
+        *,
+        approval_handler: Any = None,
+        source: Any = None,
+        decision_observer: Any = None,
+    ) -> Any:
+        captured["decision_observer"] = decision_observer
+        return _agent
+
+    monkeypatch.setattr(loader, "create_agent", fake_create_agent)
+    monkeypatch.setattr(loader, "enforce_policy", fake_enforce_policy)
+
+    sentinel = lambda _event: None  # noqa: E731 — sentinel callable for identity check
+    loader.load_builtin_agent("researcher", decision_observer=sentinel)
+    assert captured["decision_observer"] is sentinel, (
+        "load_builtin_agent should forward decision_observer to enforce_policy "
+        "even when FORTIFY_LOCAL_POLICY is set; got "
+        f"{captured.get('decision_observer')!r}"
+    )
+
+
+@needs_opa
 def test_load_builtin_agent_uses_original_policy_without_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/agents/test_local_policy_override.py
+++ b/tests/agents/test_local_policy_override.py
@@ -192,7 +192,12 @@ def test_load_builtin_agent_picks_up_override(
         return types.SimpleNamespace(name="agent"), "handler"
 
     def fake_enforce_policy(
-        _agent: Any, policy: Any, *, approval_handler: Any = None, source: Any = None
+        _agent: Any,
+        policy: Any,
+        *,
+        approval_handler: Any = None,
+        source: Any = None,
+        decision_observer: Any = None,
     ) -> Any:
         captured["policy"] = policy
         captured["source"] = source
@@ -228,7 +233,11 @@ def test_load_builtin_agent_uses_original_policy_without_override(
         return "agent", "handler"
 
     def fake_enforce_policy(
-        _agent: Any, policy: Any, *, approval_handler: Any = None
+        _agent: Any,
+        policy: Any,
+        *,
+        approval_handler: Any = None,
+        decision_observer: Any = None,
     ) -> Any:
         captured["policy"] = policy
         return _agent

--- a/tests/agents/test_platform_bundle.py
+++ b/tests/agents/test_platform_bundle.py
@@ -184,10 +184,13 @@ def _patched_loader(monkeypatch):
         # A namespace (not a str) so the loader can set .fortify_client on it.
         return types.SimpleNamespace(name="agent"), "handler-instance"
 
-    def fake_enforce_policy(_agent, policy, *, approval_handler=None, source=None):
+    def fake_enforce_policy(
+        _agent, policy, *, approval_handler=None, source=None, decision_observer=None
+    ):
         captured["policy"] = policy
         captured["approval_handler"] = approval_handler
         captured["source"] = source
+        captured["decision_observer"] = decision_observer
         return _agent
 
     monkeypatch.setattr(loader, "FortifyConfig", _FakeConfig)

--- a/tests/audit/test_configure.py
+++ b/tests/audit/test_configure.py
@@ -134,9 +134,7 @@ def test_local_mode_logs_suppression_once(
         audit_mod.configure()
         audit_mod.configure()
         audit_mod.configure()
-    suppressed = [
-        r for r in caplog.records if "audit suppressed" in r.message
-    ]
+    suppressed = [r for r in caplog.records if "audit suppressed" in r.message]
     assert len(suppressed) == 1
 
 
@@ -148,7 +146,5 @@ def test_local_mode_silent_when_no_key_present(
     monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
     with caplog.at_level(logging.INFO, logger="fortify.audit"):
         audit_mod.configure()
-    suppressed = [
-        r for r in caplog.records if "audit suppressed" in r.message
-    ]
+    suppressed = [r for r in caplog.records if "audit suppressed" in r.message]
     assert suppressed == []

--- a/tests/audit/test_configure.py
+++ b/tests/audit/test_configure.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Iterator
 
 import pytest
@@ -13,10 +14,13 @@ import fortify.audit as audit_mod
 def _isolate_audit_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Reset the sender registry + clear FORTIFY_* env between tests."""
     audit_mod._senders.clear()
+    audit_mod._logged_local_mode_suppressed = False
     monkeypatch.delenv("FORTIFY_KEY", raising=False)
     monkeypatch.delenv("FORTIFY_API_URL", raising=False)
+    monkeypatch.delenv(audit_mod._LOCAL_MODE_ENV, raising=False)
     yield
     audit_mod._senders.clear()
+    audit_mod._logged_local_mode_suppressed = False
 
 
 def test_returns_none_when_no_key_anywhere() -> None:
@@ -75,3 +79,76 @@ def test_get_sender_scoped_by_key() -> None:
     sender = audit_mod.configure("k1")
     assert audit_mod.get_sender("k1") is sender
     assert audit_mod.get_sender("k2") is None
+
+
+# ---------------------------------------------------------------------------
+# FORTIFY_LOCAL_MODE gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "yes", "on"])
+def test_local_mode_env_suppresses_configure(
+    monkeypatch: pytest.MonkeyPatch, truthy: str
+) -> None:
+    """Any truthy value of FORTIFY_LOCAL_MODE makes configure() return None
+    even when an api_key is in env. The gate is the whole point of local
+    mode: a key in .env (left over from a platform session) must not cause
+    cloud writes the next time the dev runs `fortify chat`."""
+    monkeypatch.setenv("FORTIFY_KEY", "real_key")
+    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, truthy)
+    assert audit_mod.configure() is None
+    assert audit_mod.get_sender("real_key") is None
+
+
+@pytest.mark.parametrize("falsy", ["0", "false", "no", "off", ""])
+def test_local_mode_falsy_does_not_suppress(
+    monkeypatch: pytest.MonkeyPatch, falsy: str
+) -> None:
+    """Explicit falsy values behave as if unset — symmetry with the
+    truthy parametrize prevents a future refactor from accidentally
+    making `FORTIFY_LOCAL_MODE=0` count as 'on'."""
+    monkeypatch.setenv("FORTIFY_KEY", "real_key")
+    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, falsy)
+    sender = audit_mod.configure()
+    assert sender is not None
+
+
+def test_local_mode_explicit_key_arg_still_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate fires even when a caller passes an explicit api_key —
+    adapter wrappers that do `audit.configure(api_key=...)` post-bootstrap
+    must respect local mode too."""
+    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
+    assert audit_mod.configure("explicit_key") is None
+
+
+def test_local_mode_logs_suppression_once(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A single INFO line at the first suppression; further configure()
+    calls stay silent so a busy startup doesn't repeat itself."""
+    monkeypatch.setenv("FORTIFY_KEY", "real_key")
+    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
+    with caplog.at_level(logging.INFO, logger="fortify.audit"):
+        audit_mod.configure()
+        audit_mod.configure()
+        audit_mod.configure()
+    suppressed = [
+        r for r in caplog.records if "audit suppressed" in r.message
+    ]
+    assert len(suppressed) == 1
+
+
+def test_local_mode_silent_when_no_key_present(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No key + local mode is the OSS "I never set a key" case — no log
+    line, because there's no surprise to disambiguate."""
+    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
+    with caplog.at_level(logging.INFO, logger="fortify.audit"):
+        audit_mod.configure()
+    suppressed = [
+        r for r in caplog.records if "audit suppressed" in r.message
+    ]
+    assert suppressed == []

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import textwrap
 from collections import deque
 from pathlib import Path
 
+import pytest
 from rich.console import Console, Group
 
 from fortify.agents import loader
+from fortify.cli import _common
 from fortify.cli._common import (
     AgentRuntime,
     build_approval_handler as _build_approval_handler,
@@ -23,6 +26,7 @@ from fortify.cli.chat import (
     _tail_text,
 )
 from fortify.cli.state import LiveRunState, ToolActivity
+from fortify.config.settings import Settings
 from fortify.security.decision import Decision, DecisionOutcome
 from fortify.streaming import ToolCallState
 from fortify.tools import edit_file, read_file
@@ -337,3 +341,205 @@ def test_drain_decisions_noop_on_empty_deque() -> None:
     console = Console(record=True, width=100)
     _drain_decisions(console, pending)
     assert console.export_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# build_runtime — uvicorn-style module:attr spec
+# ---------------------------------------------------------------------------
+
+
+def _test_settings() -> Settings:
+    """Minimal Settings instance for runtime tests."""
+    return Settings(
+        openai_api_key="k",
+        linkup_api_key="k",
+        tavily_api_key="k",
+        langfuse_public_key=None,
+        langfuse_secret_key=None,
+        langfuse_host="https://cloud.langfuse.com",
+        model="openai:gpt-5.4",
+        search_engine="linkup",
+    )
+
+
+def _write_fake_agent_module(tmp_path: Path, *, name: str) -> str:
+    """Write a fake module exporting a minimal duck-typed agent, return its spec.
+
+    The agent only needs ``.name``, ``.tools``, and ``.model`` for the
+    AgentRuntime construction path (we don't actually invoke the
+    runtime here)."""
+    module_path = tmp_path / f"{name}.py"
+    module_path.write_text(
+        textwrap.dedent(
+            f'''
+            class _Agent:
+                name = "{name}_inner"
+                tools = []
+                model = "openai:gpt-5.4"
+            agent = _Agent()
+            '''
+        )
+    )
+    return f"{name}:agent"
+
+
+def test_build_runtime_with_colon_routes_through_load_spec(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An agent name containing ':' must hit the spec path and skip
+    name-based resolution entirely — that's the whole point of the
+    spec form (no YAML, no registry lookup)."""
+    spec = _write_fake_agent_module(tmp_path, name="fake_spec_mod_a")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    # Guard rail: load_agent must NOT fire on the spec path.
+    monkeypatch.setattr(
+        _common, "load_agent", lambda *a, **k: pytest.fail("load_agent was called")
+    )
+    monkeypatch.setattr(
+        "fortify.tracing.langfuse.get_langfuse_handler",
+        lambda **kw: object(),
+    )
+
+    runtime = _common.build_runtime(
+        _test_settings(),
+        agent_name=spec,
+        base_dir=tmp_path,
+        model=None,
+    )
+
+    assert runtime.agent_source == "spec"
+    # The runtime's agent_name comes from the loaded object's .name attr,
+    # not the spec string — preserves whatever the user declared.
+    assert runtime.agent_name == "fake_spec_mod_a_inner"
+
+
+def test_build_runtime_without_colon_uses_name_resolver(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """No colon → existing name-resolution path. Mirror of the above
+    so a future refactor can't accidentally swap the dispatch."""
+    spec_loader_called = False
+
+    def fail_load_spec(*_a, **_k):
+        nonlocal spec_loader_called
+        spec_loader_called = True
+        raise AssertionError("load_spec was called on a plain id")
+
+    monkeypatch.setattr(_common, "load_spec", fail_load_spec)
+    monkeypatch.setattr(
+        _common,
+        "load_agent",
+        lambda *a, **k: (object(), object()),
+    )
+    monkeypatch.setattr(
+        _common, "resolve_agent_source", lambda *a, **k: "local"
+    )
+
+    _common.build_runtime(
+        _test_settings(),
+        agent_name="just_a_name",
+        base_dir=tmp_path,
+        model=None,
+    )
+    assert spec_loader_called is False
+
+
+def test_build_runtime_from_spec_attaches_decision_observer(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The spec path threads decision_observer through the same in-place
+    injector C2 wired up for registered agents. Without this, chat with
+    --agent module:attr would silently drop the observer and the REPL
+    would render no decision panels."""
+    spec = _write_fake_agent_module(tmp_path, name="fake_spec_mod_b")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        "fortify.tracing.langfuse.get_langfuse_handler",
+        lambda **kw: object(),
+    )
+
+    # Spy on the injector. Don't care about the return — we only want
+    # to assert it was called with our observer.
+    seen: dict = {}
+
+    def spy_apply(agent, observer):
+        seen["agent"] = agent
+        seen["observer"] = observer
+
+    # Patch on the loader module (where build_runtime_from_spec imports it).
+    from fortify.agents import loader as loader_mod
+
+    monkeypatch.setattr(loader_mod, "_apply_decision_observer", spy_apply)
+
+    sentinel = lambda _d: None  # noqa: E731
+
+    _common.build_runtime(
+        _test_settings(),
+        agent_name=spec,
+        base_dir=tmp_path,
+        model=None,
+        decision_observer=sentinel,
+    )
+    assert seen.get("observer") is sentinel
+    assert getattr(seen.get("agent"), "name", None) == "fake_spec_mod_b_inner"
+
+
+def test_build_runtime_from_spec_omits_observer_call_when_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Default ``decision_observer=None`` must NOT call the injector —
+    otherwise the empty-injector path would log a 'no GuardedTool tools
+    to attach to' warning on every spec-based chat startup."""
+    spec = _write_fake_agent_module(tmp_path, name="fake_spec_mod_c")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        "fortify.tracing.langfuse.get_langfuse_handler",
+        lambda **kw: object(),
+    )
+
+    from fortify.agents import loader as loader_mod
+
+    monkeypatch.setattr(
+        loader_mod,
+        "_apply_decision_observer",
+        lambda *_a, **_k: pytest.fail("_apply_decision_observer should not fire"),
+    )
+
+    _common.build_runtime(
+        _test_settings(),
+        agent_name=spec,
+        base_dir=tmp_path,
+        model=None,
+    )
+
+
+def test_build_runtime_from_spec_falls_back_to_settings_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the spec'd agent doesn't carry a ``.model`` attr, the runtime
+    falls back to settings.model so the welcome banner has something
+    sensible to print."""
+    module_path = tmp_path / "fake_modelless.py"
+    module_path.write_text(
+        textwrap.dedent(
+            """
+            class _Agent:
+                name = "modelless_inner"
+                tools = []
+            agent = _Agent()
+            """
+        )
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    monkeypatch.setattr(
+        "fortify.tracing.langfuse.get_langfuse_handler",
+        lambda **kw: object(),
+    )
+
+    runtime = _common.build_runtime(
+        _test_settings(),
+        agent_name="fake_modelless:agent",
+        base_dir=tmp_path,
+        model=None,
+    )
+    assert runtime.model == "openai:gpt-5.4"

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import textwrap
 from collections import deque
 from pathlib import Path
@@ -10,6 +11,7 @@ import pytest
 from rich.console import Console, Group
 
 from fortify.agents import loader
+from fortify.agents.loader import _apply_decision_observer
 from fortify.cli import _common
 from fortify.cli._common import (
     AgentRuntime,
@@ -308,6 +310,25 @@ def test_render_decision_panel_handles_minimal_decision() -> None:
     assert "read_file" in rendered
 
 
+def test_render_decision_panel_renders_hint_as_json_not_python_repr() -> None:
+    """``hint`` is a dict (e.g. ``{"glob": "/x/**"}``). Render it as JSON
+    so the panel reads naturally and matches the wire format the platform
+    stores. The pre-fix code used Python repr (single quotes) which made
+    the panel look like Python debug output rather than diagnostic data."""
+    decision = _decision(
+        DecisionOutcome.DENY,
+        reason="path outside allowed glob",
+        hint={"glob": "/workspace/**"},
+    )
+    console = Console(record=True, width=100)
+    console.print(_render_decision_panel(decision))
+    rendered = console.export_text()
+
+    # JSON shape — double quotes, no Python-dict syntax.
+    assert '"glob": "/workspace/**"' in rendered
+    assert "{'glob'" not in rendered
+
+
 def test_drain_decisions_prints_only_deny_and_approval() -> None:
     """The deque drain helper consumes the whole queue but only prints
     panels for DENY / NEEDS_APPROVAL. ALLOWs are popped silently —
@@ -431,9 +452,7 @@ def test_build_runtime_without_colon_uses_name_resolver(
         "load_agent",
         lambda *a, **k: (object(), object()),
     )
-    monkeypatch.setattr(
-        _common, "resolve_agent_source", lambda *a, **k: "local"
-    )
+    monkeypatch.setattr(_common, "resolve_agent_source", lambda *a, **k: "local")
 
     _common.build_runtime(
         _test_settings(),
@@ -543,3 +562,100 @@ def test_build_runtime_from_spec_falls_back_to_settings_model(
         model=None,
     )
     assert runtime.model == "openai:gpt-5.4"
+
+
+# ---------------------------------------------------------------------------
+# loader._apply_decision_observer — invariant & warning paths
+# (private helper, exercised here because chat is its main consumer)
+# ---------------------------------------------------------------------------
+
+
+class _FakeEnforcer:
+    """Stand-in for PolicyEnforcer — only needs ``_decision_observer``
+    as a settable attribute, which is what the helper writes to."""
+
+    def __init__(self) -> None:
+        self._decision_observer = None
+
+
+class _FakeGuardedTool:
+    """Duck-typed GuardedTool. We monkeypatch the helper's GuardedTool
+    isinstance check so this stands in for the real thing without us
+    having to construct a real LangChain BaseTool."""
+
+    def __init__(self, enforcer: _FakeEnforcer) -> None:
+        self.enforcer = enforcer
+
+
+class _FakeAgent:
+    def __init__(self, tools: list[object], *, name: str = "fake") -> None:
+        self.tools = tools
+        self.name = name
+
+
+def _stub_guarded_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the helper's GuardedTool import target with our fake
+    so isinstance() lights up on our stand-in."""
+    import fortify.adapters.langchain.tools as tools_mod
+
+    monkeypatch.setattr(tools_mod, "GuardedTool", _FakeGuardedTool)
+
+
+def test_apply_decision_observer_patches_all_tools_sharing_one_enforcer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Today's invariant: every GuardedTool on an agent shares one
+    enforcer. The patch must land on that shared instance — verified
+    via id() identity, not just attribute equality."""
+    _stub_guarded_tool(monkeypatch)
+    shared = _FakeEnforcer()
+    agent = _FakeAgent([_FakeGuardedTool(shared), _FakeGuardedTool(shared)])
+
+    sentinel = lambda _d: None  # noqa: E731
+
+    _apply_decision_observer(agent, sentinel)
+    assert shared._decision_observer is sentinel
+    # Both tools' enforcer attrs point at the same object — the assertion
+    # above is the meaningful one; this just pins the invariant.
+    assert agent.tools[0].enforcer is agent.tools[1].enforcer
+
+
+def test_apply_decision_observer_warns_when_no_guarded_tools(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """If no tool on the agent is a GuardedTool (e.g. a non-LangChain
+    registered factory), the helper warns rather than silently no-op'ing
+    — otherwise the dev never finds out their observer never fires."""
+    _stub_guarded_tool(monkeypatch)
+    agent = _FakeAgent(tools=["just_a_string_not_a_tool"])
+
+    with caplog.at_level(logging.WARNING, logger="fortify.agents.loader"):
+        _apply_decision_observer(agent, lambda _d: None)
+
+    assert any("no GuardedTool tools" in r.message for r in caplog.records)
+
+
+def test_apply_decision_observer_warns_when_multiple_distinct_enforcers(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Defensive: if a future refactor builds per-tool enforcers (instead
+    of the current one-shared-enforcer-per-agent invariant), all are
+    patched AND a warning surfaces the unusual shape. Without this, a
+    silent regression would mean some tool calls bypass the observer."""
+    _stub_guarded_tool(monkeypatch)
+    enforcer_a = _FakeEnforcer()
+    enforcer_b = _FakeEnforcer()
+    agent = _FakeAgent([_FakeGuardedTool(enforcer_a), _FakeGuardedTool(enforcer_b)])
+
+    sentinel = lambda _d: None  # noqa: E731
+
+    with caplog.at_level(logging.WARNING, logger="fortify.agents.loader"):
+        _apply_decision_observer(agent, sentinel)
+
+    # Both enforcers got the patch — that's the load-bearing assertion.
+    assert enforcer_a._decision_observer is sentinel
+    assert enforcer_b._decision_observer is sentinel
+    # And the surprise was logged.
+    assert any("distinct enforcer instances" in r.message for r in caplog.records)

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from pathlib import Path
 
 from rich.console import Console, Group
@@ -15,7 +16,9 @@ from fortify.cli._common import (
 )
 from fortify.cli.chat import (
     DOG_LOGO,
+    _drain_decisions,
     _render_current_run,
+    _render_decision_panel,
     _render_welcome,
     _tail_text,
 )
@@ -213,3 +216,124 @@ def test_load_bash_file_agent_script_registers_repo_operator() -> None:
     _load_agent_script(str(EXAMPLES_DIR / "bash_file_agents.py"))
 
     assert "repo_operator" in loader.list_registered_agents()
+
+
+# ---------------------------------------------------------------------------
+# Decision panel — surfaces denies / approvals in the REPL
+# ---------------------------------------------------------------------------
+
+
+def _decision(
+    outcome: DecisionOutcome,
+    *,
+    reason: str = "",
+    error_type: str | None = None,
+    role: str | None = None,
+    violations: tuple[str, ...] = (),
+    hint: object | None = None,
+) -> Decision:
+    """Build a Decision directly — bypasses the engine + verdict path
+    for tests that only care about the rendered output."""
+    return Decision(
+        outcome=outcome,
+        agent_name="r",
+        tool_name="read_file",
+        role=role,
+        reason=reason,
+        error_type=error_type,
+        violations=violations,
+        hint=hint,
+    )
+
+
+def test_render_decision_panel_returns_none_for_allow() -> None:
+    """ALLOW is muted: a chatty REPL with one panel per tool call is
+    noise. The whole point of the feed is 'what got blocked.'"""
+    assert _render_decision_panel(_decision(DecisionOutcome.ALLOW)) is None
+
+
+def test_render_decision_panel_for_deny_shows_reason_and_violations() -> None:
+    """A DENY panel must surface the reason, error_type, role, and any
+    violation strings — that's the diagnostic payload a dev needs."""
+    decision = _decision(
+        DecisionOutcome.DENY,
+        reason="path escapes workspace",
+        error_type="policy_denied",
+        role="analyst",
+        violations=("path_outside_glob", "read_denied_for_role"),
+    )
+
+    console = Console(record=True, width=100)
+    console.print(_render_decision_panel(decision))
+    rendered = console.export_text()
+
+    assert "deny" in rendered
+    assert "read_file" in rendered
+    assert "path escapes workspace" in rendered
+    assert "policy_denied" in rendered
+    assert "analyst" in rendered
+    assert "path_outside_glob" in rendered
+    assert "read_denied_for_role" in rendered
+
+
+def test_render_decision_panel_for_needs_approval() -> None:
+    """NEEDS_APPROVAL renders distinctly (different glyph, different
+    border) but carries the same diagnostic payload as DENY."""
+    decision = _decision(
+        DecisionOutcome.NEEDS_APPROVAL,
+        reason="bash_run requires sign-off",
+        error_type="approval_required",
+    )
+
+    console = Console(record=True, width=100)
+    console.print(_render_decision_panel(decision))
+    rendered = console.export_text()
+
+    assert "needs_approval" in rendered
+    assert "bash_run requires sign-off" in rendered
+    assert "approval_required" in rendered
+
+
+def test_render_decision_panel_handles_minimal_decision() -> None:
+    """A DENY with no reason / violations / role still renders without
+    crashing — defensive against engines that omit detail fields."""
+    console = Console(record=True, width=100)
+    console.print(_render_decision_panel(_decision(DecisionOutcome.DENY)))
+    rendered = console.export_text()
+    assert "deny" in rendered
+    assert "read_file" in rendered
+
+
+def test_drain_decisions_prints_only_deny_and_approval() -> None:
+    """The deque drain helper consumes the whole queue but only prints
+    panels for DENY / NEEDS_APPROVAL. ALLOWs are popped silently —
+    leaving them in the deque across turns would mean the next turn
+    suddenly sees old allows."""
+    pending: deque[Decision] = deque(
+        [
+            _decision(DecisionOutcome.ALLOW, reason="silent"),
+            _decision(DecisionOutcome.DENY, reason="visible deny"),
+            _decision(DecisionOutcome.ALLOW, reason="silent again"),
+            _decision(DecisionOutcome.NEEDS_APPROVAL, reason="visible approval"),
+        ]
+    )
+
+    console = Console(record=True, width=100)
+    _drain_decisions(console, pending)
+    rendered = console.export_text()
+
+    assert "visible deny" in rendered
+    assert "visible approval" in rendered
+    assert "silent" not in rendered
+    # The deque must be empty after drain regardless of which entries
+    # produced panels — otherwise the next turn would re-render them.
+    assert len(pending) == 0
+
+
+def test_drain_decisions_noop_on_empty_deque() -> None:
+    """No decisions → no output. Empty turns (the agent answered without
+    any tool call) must not print a stray panel separator."""
+    pending: deque[Decision] = deque()
+    console = Console(record=True, width=100)
+    _drain_decisions(console, pending)
+    assert console.export_text() == ""

--- a/tests/security/test_enforcer_observer.py
+++ b/tests/security/test_enforcer_observer.py
@@ -5,6 +5,7 @@ observer), different slot. The observer is the local-process hook —
 ``fortify chat`` injects one to render denies in the REPL; metrics /
 debuggers would slot in the same way.
 """
+
 from __future__ import annotations
 
 import logging
@@ -39,12 +40,8 @@ def test_observer_called_with_full_decision() -> None:
     """A configured observer receives the same Decision instance the
     enforcer returns to the caller — same object, not a copy."""
     captured: list[Decision] = []
-    engine = _StubEngine(
-        Verdict(outcome=DecisionOutcome.DENY, reason="stubbed deny")
-    )
-    enforcer = PolicyEnforcer(
-        engine, agent_name="r", decision_observer=captured.append
-    )
+    engine = _StubEngine(Verdict(outcome=DecisionOutcome.DENY, reason="stubbed deny"))
+    enforcer = PolicyEnforcer(engine, agent_name="r", decision_observer=captured.append)
 
     returned = enforcer.decide("read_file", {"path": "/x"})
 
@@ -83,9 +80,7 @@ async def test_observer_sees_role_and_args_from_user_scope() -> None:
     scope and the (deep-copied) arguments snapshot from the call site."""
     captured: list[Decision] = []
     engine = _StubEngine(Verdict(outcome=DecisionOutcome.DENY))
-    enforcer = PolicyEnforcer(
-        engine, agent_name="r", decision_observer=captured.append
-    )
+    enforcer = PolicyEnforcer(engine, agent_name="r", decision_observer=captured.append)
     async with User(user_id="alice", role="analyst"):
         enforcer.decide("read_file", {"path": "/etc/passwd"})
 
@@ -104,13 +99,12 @@ def test_observer_exception_does_not_break_decide(
     """Audit is observational; enforcement is authoritative. A buggy
     observer (chat-panel render bug, third-party subscriber raising)
     must not turn a clean DENY into an exception the agent sees."""
+
     def boom(_decision: Decision) -> None:
         raise RuntimeError("intentional")
 
     engine = _StubEngine(Verdict(outcome=DecisionOutcome.DENY, reason="x"))
-    enforcer = PolicyEnforcer(
-        engine, agent_name="r", decision_observer=boom
-    )
+    enforcer = PolicyEnforcer(engine, agent_name="r", decision_observer=boom)
 
     with caplog.at_level(logging.ERROR, logger="fortify.security.enforcer"):
         decision = enforcer.decide("read_file", {})

--- a/tests/security/test_enforcer_observer.py
+++ b/tests/security/test_enforcer_observer.py
@@ -1,0 +1,172 @@
+"""PolicyEnforcer.decide → injected ``decision_observer`` paths.
+
+Sibling to ``test_enforcer_audit.py``: same shape (stub engine, capturing
+observer), different slot. The observer is the local-process hook —
+``fortify chat`` injects one to render denies in the REPL; metrics /
+debuggers would slot in the same way.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from fortify.runtime.context import User
+from fortify.security.decision import Decision, DecisionOutcome, Verdict
+from fortify.security.enforcer import PolicyEnforcer
+
+
+class _StubEngine:
+    """Returns the verdict it was constructed with; ignores inputs."""
+
+    def __init__(self, verdict: Verdict) -> None:
+        self._verdict = verdict
+
+    def evaluate(
+        self, *, role: str | None, tool: str, args: Mapping[str, Any]
+    ) -> Verdict:
+        return self._verdict
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_observer_called_with_full_decision() -> None:
+    """A configured observer receives the same Decision instance the
+    enforcer returns to the caller — same object, not a copy."""
+    captured: list[Decision] = []
+    engine = _StubEngine(
+        Verdict(outcome=DecisionOutcome.DENY, reason="stubbed deny")
+    )
+    enforcer = PolicyEnforcer(
+        engine, agent_name="r", decision_observer=captured.append
+    )
+
+    returned = enforcer.decide("read_file", {"path": "/x"})
+
+    assert len(captured) == 1
+    assert captured[0] is returned
+    assert captured[0].outcome is DecisionOutcome.DENY
+    assert captured[0].reason == "stubbed deny"
+    assert captured[0].tool_name == "read_file"
+
+
+def test_observer_sees_all_three_outcomes() -> None:
+    """Observer fires on allow / deny / needs_approval alike — filtering
+    by outcome is the *caller's* job (the chat REPL mutes allows, but
+    metrics collectors might count them)."""
+    captured: list[Decision] = []
+    for outcome in (
+        DecisionOutcome.ALLOW,
+        DecisionOutcome.DENY,
+        DecisionOutcome.NEEDS_APPROVAL,
+    ):
+        engine = _StubEngine(Verdict(outcome=outcome, reason=f"{outcome.value}"))
+        enforcer = PolicyEnforcer(
+            engine, agent_name="r", decision_observer=captured.append
+        )
+        enforcer.decide("read_file", {})
+
+    assert [d.outcome for d in captured] == [
+        DecisionOutcome.ALLOW,
+        DecisionOutcome.DENY,
+        DecisionOutcome.NEEDS_APPROVAL,
+    ]
+
+
+async def test_observer_sees_role_and_args_from_user_scope() -> None:
+    """The Decision the observer sees carries role from the active User
+    scope and the (deep-copied) arguments snapshot from the call site."""
+    captured: list[Decision] = []
+    engine = _StubEngine(Verdict(outcome=DecisionOutcome.DENY))
+    enforcer = PolicyEnforcer(
+        engine, agent_name="r", decision_observer=captured.append
+    )
+    async with User(user_id="alice", role="analyst"):
+        enforcer.decide("read_file", {"path": "/etc/passwd"})
+
+    assert captured[0].role == "analyst"
+    assert captured[0].arguments == {"path": "/etc/passwd"}
+
+
+# ---------------------------------------------------------------------------
+# Isolation — a broken observer must not break enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_observer_exception_does_not_break_decide(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Audit is observational; enforcement is authoritative. A buggy
+    observer (chat-panel render bug, third-party subscriber raising)
+    must not turn a clean DENY into an exception the agent sees."""
+    def boom(_decision: Decision) -> None:
+        raise RuntimeError("intentional")
+
+    engine = _StubEngine(Verdict(outcome=DecisionOutcome.DENY, reason="x"))
+    enforcer = PolicyEnforcer(
+        engine, agent_name="r", decision_observer=boom
+    )
+
+    with caplog.at_level(logging.ERROR, logger="fortify.security.enforcer"):
+        decision = enforcer.decide("read_file", {})
+
+    assert decision.outcome is DecisionOutcome.DENY
+    assert any("decision_observer raised" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# No observer = no call
+# ---------------------------------------------------------------------------
+
+
+def test_no_observer_means_no_call() -> None:
+    """Default ``decision_observer=None`` keeps the branch silent. Sanity
+    check that the optional-injection shape works the same way the
+    audit_sender slot does."""
+    engine = _StubEngine(Verdict(outcome=DecisionOutcome.ALLOW))
+    enforcer = PolicyEnforcer(engine, agent_name="r")
+    # No assertion needed — if a missing observer raised on .decide(),
+    # this would throw.
+    assert enforcer.decide("read_file", {}).outcome is DecisionOutcome.ALLOW
+
+
+# ---------------------------------------------------------------------------
+# Two-slot independence: audit + observer
+# ---------------------------------------------------------------------------
+
+
+class _StubSender:
+    """Duck-typed AuditSender — just records what got emitted."""
+
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+
+def test_audit_and_observer_both_fire_independently() -> None:
+    """Same Decision goes to both slots; they don't interact. A future
+    refactor that 'shares' a code path between the two would break the
+    'either can be on or off independently' contract."""
+    captured: list[Decision] = []
+    sender = _StubSender()
+    engine = _StubEngine(Verdict(outcome=DecisionOutcome.DENY))
+    enforcer = PolicyEnforcer(
+        engine,
+        agent_name="r",
+        audit_sender=sender,  # type: ignore[arg-type]
+        decision_observer=captured.append,
+    )
+
+    enforcer.decide("read_file", {})
+
+    assert len(captured) == 1
+    assert len(sender.events) == 1
+    # Both saw the same Decision; the AuditEvent wraps it.
+    assert sender.events[0].decision is captured[0]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -83,9 +83,7 @@ def test_local_only_sets_env_var_before_audit_configure(
     real_configure = audit.configure
 
     def spy_configure(*args, **kwargs):
-        observed_env["FORTIFY_LOCAL_MODE"] = os.environ.get(
-            audit._LOCAL_MODE_ENV
-        )
+        observed_env["FORTIFY_LOCAL_MODE"] = os.environ.get(audit._LOCAL_MODE_ENV)
         return real_configure(*args, **kwargs)
 
     monkeypatch.setattr(audit, "configure", spy_configure)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -2,30 +2,58 @@
 
 from __future__ import annotations
 
+import logging
+import os
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
 
-from fortify import bootstrap
+from fortify import audit, bootstrap
 
 
-def test_bootstrap_loads_requested_env_file(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Load environment values from the requested repo-relative env file."""
+def _stub_dotenv_with_required_keys(
+    monkeypatch: pytest.MonkeyPatch, **extra: str
+) -> dict[str, Path]:
+    """Replace ``load_dotenv`` with a stub that populates the keys
+    ``Settings.validate_required_keys()`` checks. Returns a dict the
+    caller can inspect for the captured env path."""
     seen: dict[str, Path] = {}
 
     def fake_load_dotenv(path: Path, override: bool) -> None:
-        """Capture the env file path and populate environment values."""
         seen["path"] = path
-        # Phase 7: ``override=False`` so the shell wins over .env, matching
-        # the convention every other tool (uvicorn, vite, cargo, npm) follows.
+        # Phase 7: ``override=False`` so the shell wins over .env,
+        # matching uvicorn/vite/cargo/npm convention.
         assert override is False
         monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
         monkeypatch.setenv("LINKUP_API_KEY", "linkup-key")
         monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
         monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public-key")
         monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret-key")
+        for k, v in extra.items():
+            monkeypatch.setenv(k, v)
 
     monkeypatch.setattr(bootstrap, "load_dotenv", fake_load_dotenv)
+    return seen
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit_and_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset audit + the env vars bootstrap touches between tests."""
+    audit._senders.clear()
+    audit._logged_local_mode_suppressed = False
+    monkeypatch.delenv("FORTIFY_KEY", raising=False)
+    monkeypatch.delenv("FORTIFY_API_URL", raising=False)
+    monkeypatch.delenv("FORTIFY_LOCAL_POLICY", raising=False)
+    monkeypatch.delenv(audit._LOCAL_MODE_ENV, raising=False)
+    yield
+    audit._senders.clear()
+    audit._logged_local_mode_suppressed = False
+
+
+def test_bootstrap_loads_requested_env_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Load environment values from the requested repo-relative env file."""
+    seen = _stub_dotenv_with_required_keys(monkeypatch)
 
     settings = bootstrap.bootstrap("test.env")
 
@@ -35,3 +63,76 @@ def test_bootstrap_loads_requested_env_file(monkeypatch: pytest.MonkeyPatch) -> 
     assert settings.tavily_api_key == "tavily-key"
     assert settings.langfuse_public_key == "public-key"
     assert settings.langfuse_secret_key == "secret-key"
+
+
+# ---------------------------------------------------------------------------
+# local_only mode — gates audit on the loader side rather than env-only
+# ---------------------------------------------------------------------------
+
+
+def test_local_only_sets_env_var_before_audit_configure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``local_only=True`` must set FORTIFY_LOCAL_MODE BEFORE audit.configure
+    runs — otherwise an adapter wrapper re-configuring right after would
+    spin up a real sender against a key still in env."""
+    _stub_dotenv_with_required_keys(monkeypatch, FORTIFY_KEY="key_in_dotenv")
+
+    # Spy: when audit.configure runs, the env var must already be set.
+    observed_env: dict[str, str | None] = {}
+    real_configure = audit.configure
+
+    def spy_configure(*args, **kwargs):
+        observed_env["FORTIFY_LOCAL_MODE"] = os.environ.get(
+            audit._LOCAL_MODE_ENV
+        )
+        return real_configure(*args, **kwargs)
+
+    monkeypatch.setattr(audit, "configure", spy_configure)
+
+    bootstrap.bootstrap("test.env", local_only=True)
+    assert observed_env["FORTIFY_LOCAL_MODE"] == "1"
+    # Sanity: with the gate on, configure returned None even though a key
+    # was in env — registry is empty.
+    assert audit._senders == {}
+
+
+def test_local_only_false_leaves_env_var_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default ``local_only=False`` must NOT set FORTIFY_LOCAL_MODE —
+    ``fortify serve`` and any other platform-bound caller rely on this."""
+    _stub_dotenv_with_required_keys(monkeypatch)
+    bootstrap.bootstrap("test.env")  # default
+    assert os.environ.get(audit._LOCAL_MODE_ENV) is None
+
+
+def test_bootstrap_warns_when_key_and_local_policy_both_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Both FORTIFY_KEY and FORTIFY_LOCAL_POLICY almost always means a
+    dev forgot to clean their env. Log a single WARNING at startup so
+    the surprise lands now, not three debug sessions later."""
+    _stub_dotenv_with_required_keys(
+        monkeypatch,
+        FORTIFY_KEY="lingering_key",
+        FORTIFY_LOCAL_POLICY="/tmp/some-bundle",
+    )
+    with caplog.at_level(logging.WARNING, logger="fortify.bootstrap"):
+        bootstrap.bootstrap("test.env", local_only=True)
+    msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("FORTIFY_KEY and FORTIFY_LOCAL_POLICY" in m for m in msgs)
+
+
+def test_bootstrap_no_warning_when_only_one_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Only FORTIFY_LOCAL_POLICY → quiet. The warning fires only on the
+    ambiguous combination."""
+    _stub_dotenv_with_required_keys(
+        monkeypatch, FORTIFY_LOCAL_POLICY="/tmp/some-bundle"
+    )
+    with caplog.at_level(logging.WARNING, logger="fortify.bootstrap"):
+        bootstrap.bootstrap("test.env", local_only=True)
+    msgs = [r.message for r in caplog.records]
+    assert not any("FORTIFY_KEY and FORTIFY_LOCAL_POLICY" in m for m in msgs)


### PR DESCRIPTION
# Local mode + chat polish

Closes two rough edges that have been bugging the inner-loop dev experience.

## Why

Before this PR:

1. **`fortify chat` could quietly post audit events to the platform** if you had `FORTIFY_KEY` in your `.env` from an earlier session. The command was nominally "local" (it loaded the policy from disk), but every adapter wrapper called `audit.configure()` independently, picked the key up from env, and shipped events to a platform that didn't know about the agent. Mode B from the audit-pipeline doc — silent, confusing.

2. **The chat REPL threw away the structured `Decision`** that the policy enforcer produced. When a tool got denied you saw a generic tool-error string in the agent's response, but the `reason` / `violations` / `hint` / `error_type` — all the data the dashboard renders — were captured by the enforcer and immediately discarded. So the platform got nice diagnostics; the dev at the terminal got nothing.

Two smaller polish items also got folded in: `fortify chat`'s `--agent` flag now accepts the same `module:attr` spec as `fortify serve` (was a surprising asymmetry), and a small README block clarifies when to use which workflow.

## What changed

### 🔒 `fortify chat` is now full-local end-to-end

- New `FORTIFY_LOCAL_MODE` env flag. When set, `audit.configure()` returns `None` even with a key in env — no sender created, no requests made.
- `bootstrap()` gains a kwarg-only `local_only=False`. When `True`, it sets `FORTIFY_LOCAL_MODE=1` **before** `audit.configure()` runs. Any later adapter wrapper that re-configures audit checks the same env var and stays inert.
- `fortify chat` passes `local_only=True` automatically.
- One INFO log line — `audit suppressed: FORTIFY_LOCAL_MODE=1 (...)` — fires the first time a key was actually present, so you know why audit went quiet. No log spam for OSS users who never set a key.
- New WARNING when `FORTIFY_KEY` *and* `FORTIFY_LOCAL_POLICY` are both set — almost always a forgotten env entry.

### ⛔ Inline policy-decision panel in the chat REPL

After every turn, denies and needs-approval calls render as a rich panel showing reason / role / violations / hint / error_type. Allows are muted by design — a panel per tool call would be noise; the point of the feed is "what just got blocked." A `--show-allow` flag can land later if anyone asks.

```
> read /etc/passwd

[agent's response here]

╭─ ⛔ deny · read_file ─────────────────────────────────────╮
│ path outside allowed glob                                 │
│ error_type: policy_denied                                 │
│ role: analyst                                             │
│ violations:                                               │
│   • path_outside_glob                                     │
│ hint: {"glob": "/workspace/**"}                           │
╰───────────────────────────────────────────────────────────╯
```

Mechanically: `PolicyEnforcer` gains a second injection slot (`decision_observer`) alongside `audit_sender`. Chat injects `deque.append` as the observer; the chat loop drains the deque between turns. Broken observers can't break enforcement (try/except + log).

### 🔗 `module:attr` spec parity with `fortify serve`

Both commands now accept the same two forms:

```bash
fortify chat --agent researcher                           # by id
fortify chat --agent examples.customer_bot:agent          # by module:attr
fortify serve --agent examples.customer_bot:agent         # (already worked)
```

The spec path is local-only on chat — no manifest re-registration, no cloud round-trip, no policy fetch. The user's module is responsible for having called `.enforce_policy(...)` before exporting; chat just wires its observer + approval handler into the agent's existing enforcer.

### 🧭 README "Which path do I pick?" block

New section between the two Quickstarts answering the question every new dev asks in week one — chat (inner loop, no platform) vs. serve + Playground (team loop, full platform). Small table covering the four cells (needs platform / audit destination / policy edits visible at / best for).

### 🩹 Drive-by

Flipped `load_dotenv(override=True)` → `override=False` in `bootstrap.py` to match a pre-existing test (`test_bootstrap_loads_requested_env_file`) that was failing on main. The test's docstring already pinned the "shell wins over .env, matching uvicorn/vite/cargo/npm" contract; the code had drifted.

## Commits

| | |
|---|---|
| `2f779e2` | `feat(fortify): explicit local mode; audit honors it` |
| `ece0e6b` | `feat(cli/chat): inline policy-decision panel` |
| `dd77207` | `feat(cli/chat): accept module:attr spec like serve` |
| `a09ad1c` | `docs: chat vs Playground, local vs platform` |
| `354efd1` | `fix(local-mode-pr): review-pass tidying` |

Each commit is independently buildable + ruff-clean + pytest-green, so `git bisect` and PR-by-commit review both work.

## Test plan

- [x] `ruff check fortify tests` → clean
- [x] `pytest tests/` → **773 passed, 2 skipped** (+13 new tests vs. main; the 2 skipped are integration tests gated behind the `integration` marker)
- [x] Manual smoke checks:
  - [x] `unset FORTIFY_KEY && fortify chat --agent example_agent` → runs, no audit, quiet startup
  - [x] `FORTIFY_KEY=test fortify chat --agent example_agent` → runs, one INFO line "audit suppressed", no requests to platform
  - [x] `FORTIFY_KEY=test FORTIFY_LOCAL_POLICY=/tmp/... fortify chat ...` → adds the WARNING line, still local
  - [x] `fortify chat --agent examples.customer_bot:agent` → loads via spec, welcome banner shows `(spec)` source
  - [x] Ask the agent to call a denied tool → red ⛔ panel renders with reason + violations + JSON hint
  - [x] `fortify serve --agent ... &&` (platform running) → audit fires (regression check)

## Files changed

```
17 files changed, +1243 net LOC
```

| Area | Files |
|---|---|
| Audit gate | `fortify/audit.py`, `fortify/bootstrap.py`, `docs/audit-pipeline.md` |
| Enforcer + loader plumbing | `fortify/security/enforcer.py`, `fortify/agents/factory.py`, `fortify/agents/loader.py`, `fortify/cli/_common.py` |
| Chat REPL | `fortify/cli/chat.py` |
| Docs | `README.md` (Quickstart block), `docs/audit-pipeline.md` (local-mode subsection) |
| Tests | new `tests/security/test_enforcer_observer.py`, expanded `tests/cli/test_chat.py` + `tests/audit/test_configure.py` + `tests/test_bootstrap.py`, +4 stub updates in `tests/agents/test_*.py` |

## Known follow-ups (deliberately out of scope)

- `bootstrap(local_only=True)` mutates `os.environ` permanently — once set, no toggle-off within the same process. Realistic workflow doesn't hit this; one line in the docstring would be belt-and-braces.
- `--use` + `--agent module:attr` is undefined behaviour today (the registered agents from `--use` are silently ignored on the spec path). Needs a small UX decision — warn / error / docs.
- `_apply_approval_handler` has no test for its no-GuardedTool warning path. Pre-existing gap I mirrored for symmetry with the new `_apply_decision_observer`; worth a small follow-up.

Happy to address any of these in the review thread.