### PR TITLE
chore: sync pyproject.toml version to 0.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 # 2014 by an unrelated abandoned project, so we publish under the brand
 # name and let import-time keep the existing identifier.
 name = "hexgate"
-version = "0.1.0"
+version = "0.1.1"
 description = "HexaGate Fortify — authorization infrastructure for AI agents (agent runtime + cloud client)."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1446,7 +1446,7 @@ wheels = [
 
 [[package]]
 name = "hexgate"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "bashlex" },


### PR DESCRIPTION
PyPI has `hexgate==0.1.1` published (from a previous release-workflow run whose publish step succeeded but commit-back was rejected by the old `main` branch-protection rule). main's pyproject.toml stayed at `0.1.0`, so any subsequent `uv version --bump patch` would re-derive `0.1.1` and the publish would 400 on "file already exists" — exactly what happened on the 15:00 / 15:06 / 15:48 runs of June 8.

Bumping main to match PyPI reality so the next `--bump patch` ratchets forward to `0.1.2` instead of colliding.

Tag follow-up: after this merges, add `v0.1.1` on the merge commit so the git history has an anchor for the version PyPI is already serving.