### PR TITLE
fix(adapters): propagate user scope to tool execution in OpenAI streaming and Google ADK sync runs

### DIFF
--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -79,16 +79,32 @@ class HexgateRunner:
         user: User,
         **kwargs: Any,
     ) -> Generator[Any, None, None]:
-        """Run the Google ADK agent synchronously, yielding events."""
+        """Run the Google ADK agent synchronously, yielding events.
+
+        ADK's ``Runner.run`` drives the agent loop in a worker thread whose
+        context cannot see our :class:`User` scope, so the tools' enforcers
+        lose the active role. We drive ``run_async`` inline on a per-call loop
+        instead, keeping execution in this scoped thread.
+        """
         self._setup_observability()
         self._binding.refresh()  # per-run policy pull; 304 when unchanged
         with user.sync_scope(), self._propagate(user):
-            yield from self._runner.run(
+            agen = self._runner.run_async(
                 user_id=user.user_id,
                 session_id=user.session_id,
                 new_message=new_message,
                 **kwargs,
             )
+            loop = asyncio.new_event_loop()
+            try:
+                while True:
+                    try:
+                        yield loop.run_until_complete(agen.__anext__())
+                    except StopAsyncIteration:
+                        break
+            finally:
+                loop.run_until_complete(agen.aclose())
+                loop.close()
 
     async def run_async(
         self,

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -134,21 +134,22 @@ class HexgateRunner:
     ) -> RunResultStreaming:
         """Stream the OpenAI agent inside a User scope.
 
-        ``Runner.run_streamed`` returns sync; tools only run during
-        ``stream_events`` iteration. The User scope is opened inside the
-        wrapped iterator. Langfuse propagation runs during setup so the
-        trace span attaches. The policy refresh runs in the setup body —
-        the wrap is fixed before tools fire during stream_events.
+        ``Runner.run_streamed`` returns sync but spawns the agent loop as a
+        background task that snapshots the current contextvars at creation;
+        tools fire there, not in ``stream_events``. So the User scope must be
+        active around the ``run_streamed`` call for the task to inherit it —
+        the wrapped iterator re-opens it for exit/audit semantics.
         """
         self._setup_observability()
         binding = self._binding_for(agent)
         binding.refresh()  # must precede the wrap + setup
         wrapped_agent = wrap_openai_agent(agent, enforcer=binding.enforcer)
 
-        with self._propagate(user, agent.name):
-            result = Runner.run_streamed(
-                wrapped_agent, input, run_config=run_config, **kwargs
-            )
+        with user.sync_scope():
+            with self._propagate(user, agent.name):
+                result = Runner.run_streamed(
+                    wrapped_agent, input, run_config=run_config, **kwargs
+                )
 
         original_stream_events = result.stream_events
 

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -197,10 +197,11 @@ def test_constructor_builds_underlying_runner_once(
 # ---------------------------------------------------------------------------
 
 
-def test_run_opens_user_scope_and_yields_events(
+def test_run_drives_run_async_inline_under_user_scope(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """run() opens a User scope around the underlying Runner.run."""
+    """run() drives the underlying Runner.run_async inline (not ADK's threaded
+    Runner.run, whose worker thread cannot see our scope) under a live User."""
     setup_counts = _silence_observability(monkeypatch)
     fake = _install_fake_runner(monkeypatch)
 
@@ -217,7 +218,9 @@ def test_run_opens_user_scope_and_yields_events(
     assert events == [{"event": "first"}, {"event": "second"}]
     assert setup_counts["setup"] == 1
     [fake_runner] = fake.instances
-    [run_call] = fake_runner.run_calls
+    # The threaded sync path is bypassed; the async path carries the scope.
+    assert fake_runner.run_calls == []
+    [run_call] = fake_runner.run_async_calls
     assert run_call == {
         "user_id": "u-1",
         "session_id": "s-1",
@@ -227,6 +230,39 @@ def test_run_opens_user_scope_and_yields_events(
     [active] = fake_runner.active_users
     assert active is user
     # Scope unwound after the call.
+    assert get_current_user() is None
+
+
+def test_run_keeps_scope_visible_across_awaits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The inline drive must keep the User visible across the agent loop's
+    await points — where tools actually fire — not just at entry."""
+    import asyncio
+
+    _silence_observability(monkeypatch)
+    _install_fake_runner(monkeypatch)
+
+    runner = HexgateRunner(
+        agent=_make_agent(),
+        app_name="my-app",
+        session_service=InMemorySessionService(),
+        api_key="k",
+    )
+    user = _user()
+    seen: list[Any] = []
+
+    async def run_async(**_kwargs: Any) -> Any:
+        await asyncio.sleep(0)
+        seen.append(get_current_user())  # post-await: a tool-call point
+        yield {"event": "only"}
+
+    runner._runner.run_async = run_async  # type: ignore[attr-defined]
+
+    events = list(runner.run(new_message="hi", user=user))
+
+    assert events == [{"event": "only"}]
+    assert seen == [user]
     assert get_current_user() is None
 
 

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -250,6 +250,34 @@ async def test_run_streamed_wraps_stream_events_to_re_enter_scope_and_propagatio
 
 
 @pytest.mark.asyncio
+async def test_run_streamed_opens_user_scope_around_run_streamed_call(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The User must be active when Runner.run_streamed spawns its loop task —
+    that task snapshots contextvars at creation, where tools later resolve it."""
+    _silence_observability(monkeypatch)
+
+    captured: dict[str, Any] = {}
+
+    def fake_run_streamed(*_args: Any, **_kwargs: Any) -> _FakeStreamingResult:
+        captured["active_user"] = get_current_user()
+        return _FakeStreamingResult()
+
+    monkeypatch.setattr(
+        "hexgate.adapters.openai.runner.Runner.run_streamed",
+        staticmethod(fake_run_streamed),
+    )
+
+    runner = HexgateRunner(api_key="k")
+    user = _user()
+
+    runner.run_streamed(_make_agent(), "hello", user=user)
+
+    assert captured["active_user"] is user
+    assert get_current_user() is None
+
+
+@pytest.mark.asyncio
 async def test_run_propagates_user_identity_to_langfuse(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Fix: propagate User scope to tool execution in OpenAI streaming and Google ADK sync runs

  **Problem**

  Both adapters lost the User context var (_CURRENT_USER) at the point tools actually execute, so enforcers fell back to no active role:

  - OpenAI run_streamed — Runner.run_streamed synchronously spawns the agent loop as a background asyncio.Task (which snapshots context at creation via
  copy_context()). The scope was only opened later inside the stream_events() wrapper, so the task — where tools fire — captured _CURRENT_USER = None.
  - Google ADK sync run — ADK's Runner.run drives the agent loop in a separate OS thread (threading.Thread + asyncio.run). Context vars don't cross thread
  boundaries, so user.sync_scope() in the calling thread was invisible to the tools running in the worker thread.

  **Fix**

  Align the execution context with the scope in both adapters:

  - OpenAI: wrap the Runner.run_streamed(...) call itself in user.sync_scope() so the spawned background task inherits _CURRENT_USER in its context
  snapshot. The existing stream_events wrapper is kept for consumer-side scope / exit semantics.
  - Google: drive Runner.run_async inline on a per-call event loop (instead of ADK's threaded Runner.run), keeping tool execution in the scoped calling
  thread. Matches ADK's per-call-loop sync semantics and cleans up via aclose().

  run/run_sync/run_async paths that already held the scope across execution were unaffected.

  **Tests**

  - OpenAI: assert the User is active at the moment Runner.run_streamed is invoked (the task's context-snapshot point).
  - Google: assert sync run delegates to run_async under a live scope, and that the User stays visible across await points (the actual tool-call sites).
  Both new Google tests were verified to fail on the old implementation and pass on the fix.

  Full adapter suite green (16 OpenAI + 14 Google).

  **Note**

  Calling Google's sync run from within an already-running event loop now raises (can't nest loops on one thread) — an anti-pattern that ADK documents
  sync run as not intended for ("local testing and convenience only").