### PR TITLE
fix(serve): attach PolicySource so dashboard policy edits land mid-serve

### DIFF
--- a/hexgate/cli/_common.py
+++ b/hexgate/cli/_common.py
@@ -209,13 +209,11 @@ def build_runtime_from_local_agent(
     """
     import os
 
-    import yaml
-
     from hexgate.agents.factory import enforce_policy
     from hexgate.cli.register.manifest import create_manifest
     from hexgate.cli.register.register import post_manifest
     from hexgate.cloud.client import HexgateClient, HexgateConfig
-    from hexgate.security.policy_set import load_policy_set_from_dict
+    from hexgate.security.binding import platform_policy_from_payload
     from hexgate.tracing.langfuse import get_langfuse_handler
 
     manifest = create_manifest(agent_obj, description=description)
@@ -239,7 +237,7 @@ def build_runtime_from_local_agent(
 
     config = HexgateConfig.from_env()
     client = HexgateClient(config)
-    payload, _etag = client.get_agent(agent_name)
+    payload, initial_etag = client.get_agent(agent_name)
     if payload is None:
         # Invariant: no If-None-Match was sent, so a 304 is impossible.
         # Raise so `python -O` can't strip the check.
@@ -248,10 +246,22 @@ def build_runtime_from_local_agent(
             "on initial fetch (no If-None-Match was sent)"
         )
 
-    policy_payload = yaml.safe_load(payload["policy_yaml"]) or {}
-    policy = load_policy_set_from_dict(policy_payload)
+    # platform_policy_from_payload returns the canonical (engine, source)
+    # pair: handles signed-bundle vs pydantic fallback, and seeds the
+    # PlatformPolicySource with the bundle + ETag so the next refresh is
+    # a 304 unless policy changed. Without the source kwarg, refresh_policy()
+    # at the top of every stream_agent() is a no-op and dashboard edits
+    # only land at the next `hexgate serve` restart.
+    policy, refresh_source = platform_policy_from_payload(
+        client, agent_name, payload, initial_etag
+    )
 
-    enforced = enforce_policy(agent_obj, policy, approval_handler=approval_handler)
+    enforced = enforce_policy(
+        agent_obj,
+        policy,
+        approval_handler=approval_handler,
+        source=refresh_source,
+    )
 
     # Fresh handler for the streaming layer. The user's create_agent() call
     # built its own handler but discarded it; we make a new one bound to

--- a/platform/api/uv.lock
+++ b/platform/api/uv.lock
@@ -908,7 +908,7 @@ wheels = [
 
 [[package]]
 name = "hexgate"
-version = "0.2.1"
+version = "0.2.3"
 source = { editable = "../../" }
 dependencies = [
     { name = "bashlex" },

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -382,14 +382,23 @@ def _patched_runtime_deps(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
                 # Minimal payload with a parseable policy_yaml. The
                 # roles map gives load_policy_set_from_dict something
                 # to chew on without needing real role inheritance.
+                # No bundle_* fields → decode_and_verify_platform_bundle
+                # returns None, so the pydantic engine path applies.
                 {
                     "policy_yaml": (
                         "version: 1\nroles:\n  default:\n    "
                         "default_policy:\n      mode: allow\n"
                     )
                 },
-                None,
+                "etag-abc",
             )
+
+        def public_key_bytes(self) -> bytes:
+            # Never consulted on the bundle-less path (the payload above
+            # omits the bundle fields, so decode_and_verify_platform_bundle
+            # returns before touching this key). 32 zero bytes are enough
+            # to satisfy the type contract.
+            return b"\x00" * 32
 
     def fake_enforce_policy(agent_obj: Any, policy: Any, **kw: Any):
         captured["enforced_agent"] = agent_obj
@@ -512,3 +521,40 @@ def test_build_runtime_applies_fetched_policy_to_local_agent(
     assert captured["enforced_agent"] is user_agent
     # The fetched policy_yaml had the ``default`` role declared.
     assert "default" in captured["enforced_policy"].roles
+
+
+def test_build_runtime_attaches_platform_policy_source_for_per_turn_refresh(
+    _patched_runtime_deps: dict[str, Any],
+) -> None:
+    """Regression: serve must attach a PolicySource so dashboard edits land
+    at the next chat turn, not only at the next ``hexgate serve`` restart.
+
+    The previous implementation parsed ``policy_yaml`` straight into a
+    PolicySet and called ``enforce_policy(agent, policy, approval_handler=...)``
+    with no ``source=`` kwarg, leaving the binding's source as ``None``
+    and the per-turn ``refresh_policy()`` a no-op. The canonical helper
+    ``platform_policy_from_payload`` returns both the engine AND a
+    pre-seeded :class:`PlatformPolicySource` — wiring the source through
+    is the difference between "policy reloads on next turn" and "policy
+    only reloads on serve restart".
+    """
+    from hexgate.security.source import PlatformPolicySource
+
+    captured = _patched_runtime_deps
+
+    build_runtime_from_local_agent(
+        _stub_settings(),
+        agent_obj=object(),
+        description=None,
+        approval_handler=None,
+        auto_register=True,
+        console=Console(),
+    )
+
+    kwargs = captured["enforce_kwargs"]
+    assert "source" in kwargs, (
+        "enforce_policy must be called with source= so per-turn refresh works"
+    )
+    assert isinstance(kwargs["source"], PlatformPolicySource), (
+        f"expected PlatformPolicySource, got {type(kwargs['source']).__name__}"
+    )


### PR DESCRIPTION
## The bug

After running \`hexgate serve\`, edits to a policy in the dashboard's \`/policies\` page were **not** taking effect until the operator restarted \`hexgate serve\`. The README + audit-pipeline docs both promise turn-level refresh ("your edits take effect on the next chat message without a restart") — that contract was broken.

## Root cause

\`build_runtime_from_local_agent\` in [hexgate/cli/_common.py](asianf/hexgate/cli/_common.py) was parsing the platform's \`policy_yaml\` straight into a \`PolicySet\` and calling:

\`\`\`python
enforce_policy(agent_obj, policy, approval_handler=approval_handler)
\`\`\`

— with **no \`source=\` kwarg**. The resulting binding had \`source=None\`, so \`refresh_policy()\` (which \`HexgateAgent.ainvoke\` / \`astream_events\` run at the top of every turn) was a no-op. The serve loop's own docstring even says "the attached PolicySource sends If-None-Match and reuses the cached bundle on 304" — but there was no attached source.

Meanwhile \`load_hexgate_agent\` (the other platform path) was correctly using the canonical helper \`platform_policy_from_payload\` which returns both the engine AND a pre-seeded \`PlatformPolicySource\`.

## The fix

Route \`build_runtime_from_local_agent\` through the same canonical helper:

\`\`\`python
policy, refresh_source = platform_policy_from_payload(
    client, agent_name, payload, initial_etag
)
enforced = enforce_policy(
    agent_obj,
    policy,
    approval_handler=approval_handler,
    source=refresh_source,                      # ← was missing
)
\`\`\`

Side benefit: the local-code-+-platform-policy path now correctly decodes signed WASM bundles too (the old manual yaml parse always fell back to the pydantic engine even when a signed bundle was available).

## Regression test

Added \`test_build_runtime_attaches_platform_policy_source_for_per_turn_refresh\` in [tests/cli/test_serve.py](asianf/tests/cli/test_serve.py) that asserts \`enforce_policy\` is called with a \`source\` kwarg that's a \`PlatformPolicySource\` instance.

## Test plan

- [x] \`uv run pytest tests/cli/test_serve.py\` — 18/18 pass (17 existing + 1 new)
- [x] \`make check\` — 829 passed, 2 skipped
- [x] **Manual smoke test on this PR:** \`hexgate serve examples.customer_bot:agent\` → edit a tool from \`allow\` to \`deny\` in the dashboard → next chat turn should reflect the change without restart