### PR TITLE
fix(hexgate/audit): deliver events emitted from executor threads

### DIFF
--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -149,7 +149,13 @@ class AuditSender:
         # latch onto the first loop that drives them and reject any other
         # (e.g. a second asyncio.run()). Build them eagerly so configure()
         # stays sync, but track the loop and rebuild if it rotates.
-        self._loop: asyncio.AbstractEventLoop | None = None
+        #
+        # Capture the build-time loop so emit() can reach it from an executor
+        # thread (a sync tool under run_in_executor has no loop of its own).
+        try:
+            self._loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
         self._semaphore = asyncio.Semaphore(max_in_flight)
         self._client: httpx.AsyncClient | None = self._new_client()
         self._tasks: set[asyncio.Task[None]] = set()
@@ -182,11 +188,31 @@ class AuditSender:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            if not self._warned_no_loop:
-                _log.warning("audit emit called without a running event loop; skipping")
-                self._warned_no_loop = True
+            # Called off-loop (sync tool on a run_in_executor thread): route
+            # to the build-time loop instead of dropping the event.
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                if not self._warned_no_loop:
+                    _log.warning(
+                        "audit emit called with no running loop and no live "
+                        "bound loop; skipping"
+                    )
+                    self._warned_no_loop = True
+                return
+            try:
+                loop.call_soon_threadsafe(self._spawn_send, event)
+            except RuntimeError:
+                pass  # loop torn down between the is_closed() check and the call
             return
         self._ensure_loop_state(loop)
+        self._spawn_send(event)
+
+    def _spawn_send(self, event: AuditEvent) -> None:
+        """Create the send task. MUST run on the bound loop's thread —
+        ``create_task`` and the loop-bound semaphore require the running loop.
+        Reached on-loop from :meth:`emit`, or via ``call_soon_threadsafe``."""
+        if self._closing or self._client is None:
+            return
         if self._semaphore.locked():
             self._dropped += 1
             if self._dropped % 100 == 1:

--- a/tests/audit/test_sender.py
+++ b/tests/audit/test_sender.py
@@ -114,17 +114,41 @@ async def test_network_error_logged_not_raised(
 
 
 def test_no_running_loop_skips_silently(caplog: "logging.LogCaptureFixture") -> None:
-    """Sync caller with no event loop: emit no-ops with a one-time warning."""
+    """No running loop and no bound loop (built outside any loop): emit
+    no-ops with a one-time warning."""
     sender = AuditSender("http://x/y", "k")
+    assert sender._loop is None
     with caplog.at_level(logging.WARNING, logger="hexgate.audit"):
         sender.emit(_event())
         sender.emit(_event())  # second call: silent
     assert len(sender._tasks) == 0
     assert sender._warned_no_loop is True
     no_loop_warnings = [
-        r for r in caplog.records if "without a running event loop" in r.message
+        r for r in caplog.records if "no live bound loop" in r.message
     ]
     assert len(no_loop_warnings) == 1
+
+
+async def test_emit_from_executor_thread_routes_to_bound_loop() -> None:
+    """Off-loop emit (sync tool on a run_in_executor thread) routes to the
+    build-time loop instead of being dropped."""
+    sender = AuditSender("http://x/y", "k")
+    sender._client = _stub_client()
+    assert sender._loop is asyncio.get_running_loop()  # captured at construction
+
+    loop = asyncio.get_running_loop()
+    # Emit from a worker thread, exactly as BaseTool.ainvoke runs a sync tool.
+    await loop.run_in_executor(None, sender.emit, _event())
+    # Pump the loop until the send runs. The task self-discards on completion,
+    # so the durable signal is the POST, not a transient _tasks count.
+    for _ in range(100):
+        if sender._client.post.await_count:
+            break
+        await asyncio.sleep(0)
+
+    assert sender._warned_no_loop is False  # routed, not dropped
+    await asyncio.gather(*sender._tasks)
+    sender._client.post.assert_called_once()
 
 
 def test_rebuilds_loop_bound_state_across_event_loops() -> None:

--- a/tests/audit/test_sender.py
+++ b/tests/audit/test_sender.py
@@ -123,9 +123,7 @@ def test_no_running_loop_skips_silently(caplog: "logging.LogCaptureFixture") -> 
         sender.emit(_event())  # second call: silent
     assert len(sender._tasks) == 0
     assert sender._warned_no_loop is True
-    no_loop_warnings = [
-        r for r in caplog.records if "no live bound loop" in r.message
-    ]
+    no_loop_warnings = [r for r in caplog.records if "no live bound loop" in r.message]
     assert len(no_loop_warnings) == 1
 
 


### PR DESCRIPTION
  ## What
  `AuditSender.emit()` dropped events when called from a thread with no running
  loop. Sync LangChain tools run their policy decision (and the audit emit) on a
  `run_in_executor` worker thread under `ainvoke`, so every audit event from a
  sync-tool agent was silently lost.
 
  ## Fix
  - Capture the build-time loop in `__init__` (adapters build the sender inside
    the caller's async context).
  - When `emit()` is called off-loop, route the send to that loop via
    `loop.call_soon_threadsafe` instead of dropping it.

  On-loop behavior (async tools, OpenAI/Google runners) is unchanged.
  
  ## Test
  Added a regression test that emits via `run_in_executor` (as `BaseTool.ainvoke`
  runs a sync tool) and asserts the event reaches the wire. Verified end-to-end
  through deepagents: a sync tool under `ainvoke` now audits correctly.