### PR TITLE
fix(langchain): correct astream_events streaming + User scope teardown

### DIFF
--- a/hexgate/adapters/langchain/agent.py
+++ b/hexgate/adapters/langchain/agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator
+from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Literal
 
 from langchain_core.runnables import RunnableConfig
 from langfuse import get_client, propagate_attributes
@@ -134,10 +134,10 @@ class HexgateLangchainAgent:
     async def astream_events(
         self,
         input: dict[str, Any],
-        version: str,
         *,
         user: User,
         config: RunnableConfig | None = None,
+        version: Literal["v1", "v2"] = "v2",
         **kwargs: Any,
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream the agent events asynchronously inside a User scope."""
@@ -145,7 +145,10 @@ class HexgateLangchainAgent:
         async with user:
             with propagate_attributes(**self._propagate_kwargs(user, "astream_events")):
                 async for event in self._agent.astream_events(
-                    input, version, config=self._with_callbacks(config), **kwargs
+                    input,
+                    config=self._with_callbacks(config),
+                    version=version,
+                    **kwargs,
                 ):
                     yield event
 

--- a/hexgate/runtime/context.py
+++ b/hexgate/runtime/context.py
@@ -9,7 +9,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
 from dataclasses import dataclass
-from typing import Any
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr
 
@@ -96,26 +95,30 @@ class User(BaseModel):
     session_id: str | None = None
     ttl_seconds: int | None = None
 
-    # Stack so the same User instance survives nested ``async with`` blocks.
-    _tokens: list[Any] = PrivateAttr(default_factory=list)
+    # Stack of shadowed values (supports nested scopes). We save/restore via
+    # set() rather than reset(token): async-generator finalizers run __aexit__
+    # in a different Context, where a token reset would raise — set() doesn't.
+    _saved: list["User | None"] = PrivateAttr(default_factory=list)
 
     async def __aenter__(self) -> "User":
-        self._tokens.append(_CURRENT_USER.set(self))
+        self._saved.append(_CURRENT_USER.get())
+        _CURRENT_USER.set(self)
         return self
 
     async def __aexit__(self, *_: object) -> None:
-        if self._tokens:
-            _CURRENT_USER.reset(self._tokens.pop())
+        if self._saved:
+            _CURRENT_USER.set(self._saved.pop())
 
     @contextmanager
     def sync_scope(self) -> Iterator["User"]:
         """Sync mirror of ``async with self`` for sync entry points."""
-        self._tokens.append(_CURRENT_USER.set(self))
+        self._saved.append(_CURRENT_USER.get())
+        _CURRENT_USER.set(self)
         try:
             yield self
         finally:
-            if self._tokens:
-                _CURRENT_USER.reset(self._tokens.pop())
+            if self._saved:
+                _CURRENT_USER.set(self._saved.pop())
 
 
 _CURRENT_USER: ContextVar[User | None] = ContextVar(

--- a/tests/adapters/langchain/test_agent.py
+++ b/tests/adapters/langchain/test_agent.py
@@ -69,12 +69,16 @@ class _RecordingGraph:
     async def astream_events(
         self,
         payload: dict[str, Any],
-        version: str,
+        config: Any = None,
         *,
-        config: Any,
+        version: str = "v2",
         **_kwargs: Any,
     ) -> AsyncIterator[dict[str, Any]]:
-        """Async-yield two events, also recording the requested version."""
+        """Async-yield two events, also recording the requested version.
+
+        Mirrors langgraph's real signature — ``config`` positional, ``version``
+        keyword-only — so forwarding ``version`` positionally (the original
+        bug) would bind it to ``config`` and fail this test."""
         snapshot = self._snapshot(payload, config)
         snapshot["version"] = version
         self.astream_events_calls.append(snapshot)
@@ -193,14 +197,28 @@ async def test_astream_events_forwards_version_and_opens_scope() -> None:
     user = _user()
 
     events = [
-        evt async for evt in proxy.astream_events({"input": "hi"}, "v2", user=user)
+        evt
+        async for evt in proxy.astream_events({"input": "hi"}, version="v2", user=user)
     ]
 
     assert events == [{"event": "start"}, {"event": "end"}]
     [call] = graph.astream_events_calls
     assert call["version"] == "v2"
+    assert call["config"] is not None  # version did not leak into the config slot
     assert call["user"] is user
     assert get_current_user() is None
+
+
+@pytest.mark.asyncio
+async def test_astream_events_defaults_version_to_v2() -> None:
+    """version is keyword-only with a 'v2' default, mirroring base langchain."""
+    graph = _RecordingGraph()
+    proxy = HexgateLangchainAgent(agent=graph, api_key="k", tool_names=["echo"])
+
+    _ = [evt async for evt in proxy.astream_events({"input": "hi"}, user=_user())]
+
+    [call] = graph.astream_events_calls
+    assert call["version"] == "v2"
 
 
 def test_user_scope_is_unwound_when_invoke_raises() -> None:

--- a/tests/runtime/test_user.py
+++ b/tests/runtime/test_user.py
@@ -13,6 +13,7 @@ context-resolution helper to confirm the right facts arrive at the runtime.
 from __future__ import annotations
 
 import asyncio
+import contextvars
 
 import pytest
 from biscuit_auth import BiscuitBuilder, KeyPair
@@ -117,6 +118,41 @@ async def test_user_defaults_keep_optional_fields_unset() -> None:
         assert u.role is None
         assert u.session_id is None
         assert u.ttl_seconds is None
+
+
+def test_sync_scope_exit_survives_foreign_context() -> None:
+    """Exiting in a different Context than entry must not raise.
+
+    A sync generator holding ``sync_scope()`` across a yield can be GC-finalized
+    in a foreign Context; with the old token-based reset that raised "Token was
+    created in a different Context". Save/restore via set() works in any Context.
+
+    Enter and exit each run in their own copied Context so neither touches the
+    test's real context (and the distinct contexts are what reproduce the bug).
+    """
+    user = User(user_id="alice")
+    cm = user.sync_scope()
+    contextvars.copy_context().run(cm.__enter__)  # set in context A
+    contextvars.copy_context().run(cm.__exit__, None, None, None)  # exit in B: no raise
+    assert get_current_user() is None  # test's own context never polluted
+
+
+@pytest.mark.asyncio
+async def test_async_scope_exit_survives_foreign_context() -> None:
+    """async __aexit__ in a foreign Context must not raise (astream_events
+    aclose() runs in the event loop's finalizer task). __aexit__ does no real
+    awaiting, so a single send() drives it to completion."""
+    user = User(user_id="alice")
+
+    def _drive(coro: object) -> None:
+        try:
+            coro.send(None)  # type: ignore[attr-defined]
+        except StopIteration:
+            pass
+
+    contextvars.copy_context().run(_drive, user.__aenter__())  # enter in context A
+    contextvars.copy_context().run(_drive, user.__aexit__(None, None, None))  # B: no raise
+    assert get_current_user() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two related fixes for streaming through the LangChain proxy (`HexgateLangchainAgent`). Both surfaced via the HexUI agent-server `/stream` route.

## 1. `astream_events` signature + forwarding

`astream_events` raised `TypeError: got multiple values for argument 'config'` on every call. The proxy exposed `version` as a positional 2nd arg and forwarded it positionally, but the wrapped graph's signature is `astream_events(input, config=None, *, version='v2', ...)` — `version` is keyword-only and the 2nd positional is `config`, so `version` bound to `config` and collided with the explicit `config=`.

Fix: make the proxy's `version` keyword-only with a `"v2"` default (matching base langchain and the sibling `ainvoke`/`astream` methods), and forward `config`/`version`/`**kwargs` by keyword. The recording-graph test stub now mirrors langgraph's real signature so a positional-`version` regression fails the test.

## 2. `User` scope teardown across Contexts

After (1), streaming surfaced `ValueError: Token was created in a different Context` as an unretrieved task exception. `User` set `_CURRENT_USER` via a `ContextVar` token and reset it on exit — but a token can only be reset in the Context it was created in, and async-generator finalizers (a consumer breaking early, then `aclose()` running in the event loop's finalizer task) run `__aexit__` in a different Context.

Fix: save/restore the previous value instead of using a token. `set()` carries no Context binding, so the foreign-context exit is harmless; for this var (default `None`) it's equivalent to a token reset, and nesting/normal completion are unchanged. Added regression tests that enter and exit in distinct copied Contexts (both fail on the token-based code).

## Verification
- 644 tests pass across runtime/adapters/agents/security/audit/streaming; ruff clean.
- Standalone repro streams cleanly; the "Token was created in a different Context" / unretrieved-task-exception noise is gone.

> Based on `gp/fix/audit_emition_loop`; merge after that lands (or retarget to `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)