### PR TITLE
Add start_date and end_date to audit API

### DIFF
--- a/platform/api/audit.py
+++ b/platform/api/audit.py
@@ -12,11 +12,14 @@ HTTP-agnostic — exceptions map to status codes in main.py.
 from __future__ import annotations
 
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 
 from clickhouse_connect.driver.client import Client
 
 from schemas import DecisionEvent
+
+_log = logging.getLogger(__name__)
 
 
 class AuditPayloadTooLarge(Exception):
@@ -132,22 +135,40 @@ def insert_decision(
 # Dashboard windows → hours; 90d is the 90-day TTL ceiling.
 WINDOW_HOURS: dict[str, int] = {"24h": 24, "7d": 24 * 7, "30d": 24 * 30, "90d": 24 * 90}
 
-# Bucket size per window (~24-90 points): 24h→hourly, 7d→6h, 30d/90d→daily.
-_WINDOW_BUCKET_MINUTES: dict[str, int] = {
-    "24h": 60,
-    "7d": 360,
-    "30d": 1440,
-    "90d": 1440,
-}
 
+def bucket_minutes_for_timedelta(delta: timedelta) -> int:
+    """Bucket size (minutes) for a free-form date range.
 
-def bucket_minutes_for(window: str) -> int:
-    """Bucket size (minutes) for a window key (KeyError on unknown window)."""
-    return _WINDOW_BUCKET_MINUTES[window]
+    ≤30min→1min, ≤1h→5min, ≤6h→15min, ≤12h→30min, ≤24h→60min, ≤7d→360min, else→1440min.
+    """
+    if delta <= timedelta(minutes=30):
+        return 1
+    elif delta <= timedelta(hours=1):
+        return 5
+    elif delta <= timedelta(hours=6):
+        return 15
+    elif delta <= timedelta(hours=12):
+        return 30
+    elif delta <= timedelta(hours=24):
+        return 60
+    elif delta <= timedelta(days=7):
+        return 360
+    else:
+        return 1440
 
 
 def _zero_counts() -> dict[str, int]:
     return {"all": 0, "allow": 0, "deny": 0, "needs_approval": 0}
+
+
+def _date_range_valid(start: datetime | None, end: datetime | None) -> bool:
+    """True if both dates are present and start <= end."""
+    if not (start and end):
+        return False
+    if start > end:
+        _log.warning(f"Date range invalid, start > end: {start} > {end}")
+        return False
+    return True
 
 
 def _scope(
@@ -157,14 +178,24 @@ def _scope(
     agent: str | None = None,
     role: str | None = None,
     tool: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
 ) -> tuple[list[str], dict[str, object]]:
     """Shared WHERE + params for the scope filters (project/window/agent/role/
     tool) that all reads narrow by. Pass role="" for the no-role bucket."""
     where = [
         "project_id = {pid:String}",
-        "occurred_at >= now() - INTERVAL {hrs:UInt32} HOUR",
     ]
-    params: dict[str, object] = {"pid": project_id, "hrs": since_hours}
+    params: dict[str, object] = {"pid": project_id}
+    if _date_range_valid(start_date, end_date):
+        where.append(
+            "occurred_at >= {start_date:DateTime} AND occurred_at <= {end_date:DateTime}"
+        )
+        params["start_date"] = start_date
+        params["end_date"] = end_date
+    else:
+        params["hrs"] = since_hours
+        where.append("occurred_at >= now() - INTERVAL {hrs:UInt32} HOUR")
     if agent:
         where.append("agent_name = {agent:String}")
         params["agent"] = agent
@@ -194,13 +225,23 @@ def summarize(
     agent: str | None = None,
     role: str | None = None,
     tool: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
 ) -> dict:
     """Totals + breakdowns for the scoped slice. Returns ``{totals, by_agent,
     by_role, by_tool}``; each breakdown is ``{key, all, allow, deny,
     needs_approval}`` sorted by ``all`` desc. An empty role keeps its raw
     ``""`` key — labelling it ("(none)") is the dashboard's concern, so no
     string is reserved on the wire."""
-    where, params = _scope(project_id, since_hours, agent=agent, role=role, tool=tool)
+    where, params = _scope(
+        project_id,
+        since_hours,
+        agent=agent,
+        role=role,
+        tool=tool,
+        start_date=start_date,
+        end_date=end_date,
+    )
     where_sql = " AND ".join(where)
     summary_sql = (
         "SELECT agent_name, role, tool_name, outcome, "
@@ -265,14 +306,27 @@ def timeseries(
     *,
     project_id: str,
     since_hours: int,
-    bucket_minutes: int,
     agent: str | None = None,
     role: str | None = None,
     tool: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
 ) -> list[dict]:
     """Per-bucket outcome counts, ordered by bucket. Sparse: empty buckets are
     omitted. Returns ``[{bucket, allow, deny, needs_approval}]``."""
-    where, params = _scope(project_id, since_hours, agent=agent, role=role, tool=tool)
+    where, params = _scope(
+        project_id,
+        since_hours,
+        agent=agent,
+        role=role,
+        tool=tool,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    if "start_date" in params:
+        bucket_minutes = bucket_minutes_for_timedelta(end_date - start_date)
+    else:
+        bucket_minutes = bucket_minutes_for_timedelta(timedelta(hours=since_hours))
     params["bucket"] = bucket_minutes
     where_sql = " AND ".join(where)
     ts_sql = (
@@ -320,11 +374,21 @@ def list_decisions(
     session_id: str | None = None,
     limit: int = 25,
     offset: int = 0,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
 ) -> dict:
     """Detail rows for the events table, newest first. Scope filters plus
     table-only ``outcome``/``session_id``. Returns ``{rows, total, limit,
     offset}`` with ``total`` the unpaginated match count."""
-    where, params = _scope(project_id, since_hours, agent=agent, role=role, tool=tool)
+    where, params = _scope(
+        project_id,
+        since_hours,
+        agent=agent,
+        role=role,
+        tool=tool,
+        start_date=start_date,
+        end_date=end_date,
+    )
     if outcome:
         where.append("outcome = {outcome:String}")
         params["outcome"] = outcome
@@ -365,3 +429,26 @@ def list_decisions(
         )
 
     return {"rows": rows, "total": total, "limit": limit, "offset": offset}
+
+
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def prepare_date_range(
+    start_date: datetime | None, end_date: datetime | None
+) -> tuple[datetime | None, datetime | None]:
+    start_date = _ensure_utc(start_date)
+    end_date = _ensure_utc(end_date)
+
+    if end_date:
+        end_date = min(end_date, datetime.now(timezone.utc) + CLOCK_SKEW_FUTURE)
+
+    if start_date and end_date:
+        start_date = max(start_date, end_date - RETENTION_WINDOW)
+
+    return start_date, end_date

--- a/platform/api/main.py
+++ b/platform/api/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+from datetime import datetime
 import hashlib
 import logging
 from contextlib import asynccontextmanager
@@ -34,7 +35,7 @@ from audit import (
     WINDOW_HOURS,
     AuditEventOutOfWindow,
     AuditPayloadTooLarge,
-    bucket_minutes_for,
+    prepare_date_range,
     insert_decision,
     list_decisions,
     summarize,
@@ -1109,8 +1110,11 @@ async def api_audit_summary(
     agent: str | None = None,
     role: str | None = None,
     tool: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
     clickhouse_client=Depends(require_clickhouse),
 ) -> AuditSummary:
+    start_date, end_date = prepare_date_range(start_date, end_date)
     try:
         # The clickhouse_connect client is sync — run it off the event loop
         # so a slow aggregation can't stall every other in-flight request.
@@ -1122,6 +1126,8 @@ async def api_audit_summary(
             agent=agent,
             role=role,
             tool=tool,
+            start_date=start_date,
+            end_date=end_date,
         )
     except ClickHouseError:
         raise _audit_unavailable()
@@ -1140,18 +1146,22 @@ async def api_audit_timeseries(
     agent: str | None = None,
     role: str | None = None,
     tool: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
     clickhouse_client=Depends(require_clickhouse),
 ) -> list[AuditTimeseriesPoint]:
+    start_date, end_date = prepare_date_range(start_date, end_date)
     try:
         return await asyncio.to_thread(
             timeseries,
             clickhouse_client,
             project_id=project_id,
             since_hours=WINDOW_HOURS[window],
-            bucket_minutes=bucket_minutes_for(window),
             agent=agent,
             role=role,
             tool=tool,
+            start_date=start_date,
+            end_date=end_date,
         )
     except ClickHouseError:
         raise _audit_unavailable()
@@ -1173,8 +1183,11 @@ async def api_audit_decisions(
     session_id: str | None = None,
     limit: int = 25,
     offset: int = 0,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
     clickhouse_client=Depends(require_clickhouse),
 ) -> AuditDecisionPage:
+    start_date, end_date = prepare_date_range(start_date, end_date)
     try:
         page = await asyncio.to_thread(
             list_decisions,
@@ -1188,6 +1201,8 @@ async def api_audit_decisions(
             session_id=session_id,
             limit=max(1, min(limit, 200)),
             offset=max(0, offset),
+            start_date=start_date,
+            end_date=end_date,
         )
     except ClickHouseError:
         raise _audit_unavailable()

--- a/platform/api/tests/test_audit.py
+++ b/platform/api/tests/test_audit.py
@@ -21,7 +21,7 @@ from pydantic import ValidationError
 
 import audit
 import main
-from audit import list_decisions, summarize
+from audit import CLOCK_SKEW_FUTURE, list_decisions, summarize
 from keystore import FileKeyStore
 from main import (
     app,
@@ -33,6 +33,7 @@ from main import (
 )
 from schemas import DecisionEvent
 
+from audit import prepare_date_range
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -330,6 +331,82 @@ def test_scope_all_filters() -> None:
     # Every dynamic value travels as a bound parameter, never spliced into
     # the SQL string — the injection-shape invariant for this module.
     assert all("{" in clause and ":" in clause for clause in where)
+
+
+_START = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+_END = datetime(2025, 1, 7, 23, 59, 59, tzinfo=timezone.utc)
+
+
+def test_scope_appends_date_range_clause_when_both_dates_provided() -> None:
+    where, params = audit._scope("p1", 24, start_date=_START, end_date=_END)
+
+    expected_clauses = [
+        "project_id = {pid:String}",
+        "occurred_at >= {start_date:DateTime} AND occurred_at <= {end_date:DateTime}",
+    ]
+
+    assert where == expected_clauses
+    assert params == {"pid": "p1", "start_date": _START, "end_date": _END}
+
+
+def test_scope_falls_back_to_since_hours_when_one_date_missing() -> None:
+    where_only_start, params = audit._scope("p1", 24, start_date=_START)
+    assert where_only_start == _BASE_WHERE
+    assert "start_date" not in params and "end_date" not in params
+
+    where_only_end, params = audit._scope("p1", 24, end_date=_END)
+    assert where_only_end == _BASE_WHERE
+    assert "start_date" not in params and "end_date" not in params
+
+
+def test_scope_falls_back_to_since_hours_when_start_date_is_after_end_date() -> None:
+    where, params = audit._scope("p1", 24, start_date=_END, end_date=_START)
+    assert where == _BASE_WHERE
+    assert "start_date" not in params and "end_date" not in params
+
+
+# ---------------------------------------------------------------------------
+# bucket_minutes_for_timedelta() — granularity thresholds
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_minutes_for_timedelta_thresholds() -> None:
+    f = audit.bucket_minutes_for_timedelta
+    assert f(timedelta(minutes=30)) == 1
+    assert f(timedelta(hours=1)) == 5
+    assert f(timedelta(hours=6)) == 15
+    assert f(timedelta(hours=12)) == 30
+    assert f(timedelta(hours=24)) == 60
+    assert f(timedelta(days=7)) == 360
+    assert f(timedelta(days=30)) == 1440
+    assert f(timedelta(days=90)) == 1440
+
+
+# ---------------------------------------------------------------------------
+# timeseries() — bucket param derived from date range vs since_hours
+# ---------------------------------------------------------------------------
+
+
+def _timeseries_client() -> MagicMock:
+    client = MagicMock()
+    client.query.return_value.result_rows = []
+    return client
+
+
+def test_timeseries_bucket_uses_date_range_when_dates_provided() -> None:
+    # _END - _START ≈ 7 days → 360-minute buckets
+    client = _timeseries_client()
+    audit.timeseries(
+        client, project_id="p1", since_hours=24, start_date=_START, end_date=_END
+    )
+    assert client.query.call_args.kwargs["parameters"]["bucket"] == 360
+
+
+def test_timeseries_bucket_uses_since_hours_when_no_dates() -> None:
+    # since_hours=24 → 60-minute buckets
+    client = _timeseries_client()
+    audit.timeseries(client, project_id="p1", since_hours=24)
+    assert client.query.call_args.kwargs["parameters"]["bucket"] == 60
 
 
 # ---------------------------------------------------------------------------
@@ -691,3 +768,56 @@ def test_real_clickhouse_round_trip() -> None:
             "ALTER TABLE policy_decision DELETE WHERE project_id = {pid:String}",
             parameters={"pid": project_id},
         )
+
+
+# ---------------------------------------------------------------------------
+# _prepare_date_range() — UTC normalization + 90-day retention clamping
+# ---------------------------------------------------------------------------
+
+
+def test_when_both_inputs_are_none_then_returns_none_none() -> None:
+    start, end = prepare_date_range(None, None)
+    assert start is None
+    assert end is None
+
+
+def test_when_naive_datetimes_provided_then_utc_is_attached() -> None:
+    naive_start = datetime(2025, 1, 1, 0, 0, 0)
+    naive_end = datetime(2025, 1, 7, 0, 0, 0)
+    start, end = prepare_date_range(naive_start, naive_end)
+    assert start.tzinfo == timezone.utc
+    assert end.tzinfo == timezone.utc
+
+
+def test_when_window_is_within_90d_then_start_date_is_unchanged() -> None:
+    start, end = prepare_date_range(_START, _END)  # 7-day window
+    assert start == _START
+    assert end == _END
+
+
+def test_when_window_exceeds_90d_then_start_date_is_clamped_to_end_minus_retention() -> (
+    None
+):
+    far_start = datetime(2024, 9, 1, tzinfo=timezone.utc)  # >90d before _END
+    start, _ = prepare_date_range(far_start, _END)
+    assert start == _END - audit.RETENTION_WINDOW
+
+
+def test_when_only_start_date_provided_then_no_clamping_occurs() -> None:
+    start, end = prepare_date_range(_START, None)
+    assert start == _START
+    assert end is None
+
+
+def test_when_start_date_is_after_end_date_then_no_clamping_occurs() -> None:
+    # start > end: max(start, end - 90d) always returns start unchanged.
+    # _date_range_valid handles the invalid pair downstream.
+    start, end = prepare_date_range(_END, _START)
+    assert start == _END
+    assert end == _START
+
+
+def test_when_end_date_is_in_the_future_then_end_date_is_clamped_to_now() -> None:
+    future_end = datetime(2099, 12, 31, tzinfo=timezone.utc)
+    _, end = prepare_date_range(None, future_end)
+    assert end <= datetime.now(timezone.utc) + CLOCK_SKEW_FUTURE


### PR DESCRIPTION
## Rev 2
- add `_ensure_utc` and `_prepare_date_range` functions to pre-process datetimes objects
- add corresponding unit tests


## What is changing
To filter decisions by time range in the audit window, we need to query the backend with a time range. Hence `start_date` and `end_date` are added to the audit API GET endpoints that allow filtering by date.
If these parameters are not passed, the date is filtered using the `since_hours` parameter, like it did before.

[Notion task](https://app.notion.com/p/Modify-backend-to-enable-start-date-end-date-filters-383fb45dbae28074b01bdc394054d47d?v=337fb45dbae2800ca10e000c2073872d&source=copy_link)

## Tests
- unit tests: `make platform-api-test`
- integration test: `uv run pytest -m integration tests/test_audit.py::test_real_clickhouse_round_trip -v`
- manual tests: tested that the UI correctly shows the graph for all fixed existing time ranges (24h, 7d, 30d, 90d):

<img width="1447" height="1115" alt="Screenshot 2026-06-19 at 12 14 19" src="https://github.com/user-attachments/assets/2b915440-0d56-49b9-b53e-0f14cad08646" />
