### PR TITLE
feat(dashboard): wire start_date and end_date into audit scope

### DIFF
--- a/platform/dashboard/src/components/audit/pieces.tsx
+++ b/platform/dashboard/src/components/audit/pieces.tsx
@@ -133,7 +133,7 @@ export function ActiveChips({ f, setF }: { f: Filters; setF: SetFilters }) {
           </button>
         </Badge>
       ))}
-      <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => setF((p) => ({ agent: '', role: '', tool: '', outcome: '', range: p.range }))}>
+      <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => setF((p) => ({ agent: '', role: '', tool: '', outcome: '', range: p.range, start_date: null, end_date: null }))}>
         Clear all
       </Button>
     </div>

--- a/platform/dashboard/src/lib/api.ts
+++ b/platform/dashboard/src/lib/api.ts
@@ -252,6 +252,8 @@ export interface AuditScope {
   agent?: string
   role?: string
   tool?: string
+  start_date?: string
+  end_date?: string
 }
 
 /** List filters: scope + table-only outcome/session_id + paging. */

--- a/platform/dashboard/src/lib/audit-filters.ts
+++ b/platform/dashboard/src/lib/audit-filters.ts
@@ -22,6 +22,8 @@ export interface AuditFilters {
   tool: string
   outcome: '' | AuditOutcome
   range: '24h' | '7d' | '30d' | '90d'
+  start_date: Date | null
+  end_date: Date | null
 }
 
 export type SetAuditFilters = (
@@ -34,6 +36,8 @@ export const EMPTY_AUDIT_FILTERS: AuditFilters = {
   tool: '',
   outcome: '',
   range: '30d',
+  start_date: null,
+  end_date: null,
 }
 
 const PAGE_SIZE = 40

--- a/platform/dashboard/src/routes/Audit.tsx
+++ b/platform/dashboard/src/routes/Audit.tsx
@@ -194,6 +194,8 @@ export function AuditPage() {
     agent: f.agent || undefined,
     role: f.role === NO_VALUE_LABEL ? '' : f.role || undefined,
     tool: f.tool || undefined,
+    start_date: f.start_date ? f.start_date.toISOString() : undefined,
+    end_date: f.end_date ? f.end_date.toISOString() : undefined,
   }
 
   // Range-only (unscoped) summary: filter dropdown options + the "X of Y"


### PR DESCRIPTION
## What is changing?
The frontend is modified to accept `start_date` and `end_date` to its GET requests, now that the backend accepts them.

## Tests
**Manual test**: on the locally running Hexgate at address http://localhost:5173/, opened developer tools, and typed in the console the following request to fetch the `summary`, `timeseries` and `decisions` endpoints with data from last month:

- summary:
```
const u = new URL('/v1/projects/00000000-0000-0000-0000-000000000003/audit/summary', location.origin)
u.searchParams.set('start_date', '2026-05-01T00:00:00Z')
u.searchParams.set('end_date', '2026-05-31T00:00:00Z')
fetch(u, {credentials: 'include'}).then(r => r.json()).then(console.log)
```

Got: 
```
[Log] Object

by_agent: [Object] (1)

by_role: [Object] (1)

by_tool: [Object, Object, Object, Object] (4)

totals: {all: 304, allow: 258, deny: 21, needs_approval: 25}

Object Prototype

```


- timeseries:
```
const u = new URL('/v1/projects/00000000-0000-0000-0000-000000000003/audit/timeseries', location.origin)
u.searchParams.set('start_date', '2026-05-01T00:00:00Z')
u.searchParams.set('end_date', '2026-05-31T00:00:00Z')
fetch(u, {credentials: 'include'}).then(r => r.json()).then(console.log)
```

Got:
```
[Log] Array (11)
0
{bucket: "2026-05-20T00:00:00", allow: 17, deny: 1, needs_approval: 5}
1
{bucket: "2026-05-21T00:00:00", allow: 29, deny: 4, needs_approval: 2}
2
{bucket: "2026-05-22T00:00:00", allow: 16, deny: 2, needs_approval: 5}
3
{bucket: "2026-05-23T00:00:00", allow: 20, deny: 2, needs_approval: 1}
4
{bucket: "2026-05-24T00:00:00", allow: 33, deny: 3, needs_approval: 2}
5
{bucket: "2026-05-25T00:00:00", allow: 27, deny: 0, needs_approval: 1}
6
{bucket: "2026-05-26T00:00:00", allow: 28, deny: 3, needs_approval: 2}
7
{bucket: "2026-05-27T00:00:00", allow: 22, deny: 2, needs_approval: 2}
8
{bucket: "2026-05-28T00:00:00", allow: 23, deny: 1, needs_approval: 0}
9
{bucket: "2026-05-29T00:00:00", allow: 22, deny: 2, needs_approval: 4}
10
{bucket: "2026-05-30T00:00:00", allow: 21, deny: 1, needs_approval: 1}

Array Prototype
```

- decisions:
```
const u = new URL('/v1/projects/00000000-0000-0000-0000-000000000003/audit/decisions', location.origin)
u.searchParams.set('start_date', '2026-05-01T00:00:00Z')
u.searchParams.set('end_date', '2026-05-31T00:00:00Z')
fetch(u, {credentials: 'include'}).then(r => r.json()).then(console.log)
```

Got:
```
[Log] Object

limit: 25

offset: 0

rows: [Object, Object, Object, Object, Object, Object, Object, Object, Object, Object, …] (25)

total: 304

Object Prototype

```
