### PR TITLE
build(dashboard): add prettier formatter and format entire codebase

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm lint
           pnpm typecheck
+          pnpm format:check
           pnpm test
 
       # --------------------------------------------------------------

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Sync platform-api deps
         run: cd platform/api && uv sync --group dev
 
+      - name: Lint
+        run: cd platform/api && uv run ruff check .
+
       - name: Tests
         run: make platform-api-test
 
@@ -120,6 +123,9 @@ jobs:
 
       - name: Typecheck
         run: pnpm typecheck
+
+      - name: Format check
+        run: pnpm format:check
 
       - name: Tests
         run: pnpm test

--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,19 @@ lint-fix: ## Apply ruff autofixes
 	$(UV) ruff check --fix hexgate tests
 
 .PHONY: fmt
-fmt: ## Format with ruff
-	$(UV) ruff format hexgate tests
+fmt: ## Format with ruff (SDK + platform/api)
+	$(UV) ruff format hexgate tests platform/api
 
 .PHONY: fmt-check
 fmt-check: ## Check formatting without writing changes
-	$(UV) ruff format --check hexgate tests
+	$(UV) ruff format --check hexgate tests platform/api
 
 .PHONY: check
-check: lint fmt-check test ## All static + dynamic checks (CI parity)
+check: lint fmt-check test ## Python CI parity: lint + fmt-check + test
+
+.PHONY: check-all
+check-all: check dashboard-lint dashboard-typecheck dashboard-fmt-check ## Full stack check: Python + dashboard lint, typecheck, fmt, tests
+	cd platform/dashboard && pnpm test --run
 
 # -------- Policy / M2 demo helpers --------
 
@@ -163,6 +167,22 @@ dashboard-install: ## Install dashboard JS deps (first time)
 .PHONY: dashboard
 dashboard: ## Run the dashboard dev server (Vite on :5173)
 	cd platform/dashboard && pnpm dev
+
+.PHONY: dashboard-fmt
+dashboard-fmt: ## Format dashboard TypeScript with prettier
+	cd platform/dashboard && pnpm format
+
+.PHONY: dashboard-fmt-check
+dashboard-fmt-check: ## Check dashboard TypeScript formatting (prettier)
+	cd platform/dashboard && pnpm format:check
+
+.PHONY: dashboard-lint
+dashboard-lint: ## Lint dashboard TypeScript with eslint
+	cd platform/dashboard && pnpm lint
+
+.PHONY: dashboard-typecheck
+dashboard-typecheck: ## Typecheck dashboard TypeScript
+	cd platform/dashboard && pnpm typecheck
 
 # -------- SDK → platform bridge --------
 

--- a/platform/dashboard/README.md
+++ b/platform/dashboard/README.md
@@ -1,73 +1,36 @@
-# React + TypeScript + Vite
+# Hexgate Dashboard
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+React + TypeScript + Vite frontend for the Hexgate control plane. Proxies `/v1/*` to the platform API on `:8000`.
 
-Currently, two official plugins are available:
+## Setup
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
-
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+# Run from the repo root
+make dashboard-install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Dev server
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+```bash
+# Run from the repo root
+make dashboard  # starts Vite on :5173
+```
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Code quality
+
+```bash
+# Run from the repo root
+make dashboard-fmt        # Prettier auto-fix
+make dashboard-fmt-check  # Prettier check only
+
+# Run from platform/dashboard/
+pnpm lint  # ESLint
+```
+
+## Tests
+
+```bash
+# Run from platform/dashboard/
+pnpm test        # single run
+pnpm test:watch  # watch mode (reruns on file save)
 ```

--- a/platform/dashboard/package.json
+++ b/platform/dashboard/package.json
@@ -10,7 +10,9 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc -b --noEmit"
+    "typecheck": "tsc -b --noEmit",
+    "format": "prettier --write src",
+    "format:check": "prettier --check src"
   },
   "dependencies": {
     "@codemirror/lang-yaml": "^6.1.3",
@@ -64,6 +66,7 @@
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.2",
     "vite": "^8.0.10",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "prettier": "^3.0.0"
   }
 }

--- a/platform/dashboard/pnpm-lock.yaml
+++ b/platform/dashboard/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
+      prettier:
+        specifier: ^3.0.0
+        version: 3.8.4
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -1365,6 +1368,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
@@ -2449,6 +2453,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -5604,6 +5613,8 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.8.4: {}
 
   pretty-format@27.5.1:
     dependencies:

--- a/platform/dashboard/src/App.tsx
+++ b/platform/dashboard/src/App.tsx
@@ -1,23 +1,23 @@
-import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
-import { AppShell } from '@/components/AppShell'
-import { ProtectedRoute } from '@/components/ProtectedRoute'
-import { AcceptInvitationPage } from '@/routes/AcceptInvitation'
-import { AgentsPage } from '@/routes/Agents'
-import { AuditPage } from '@/routes/Audit'
-import { ForgotPasswordPage } from '@/routes/ForgotPassword'
-import { GraphPage } from '@/routes/Graph'
-import { OrgMembersPage } from '@/routes/OrgMembers'
-import { OrgSettingsPage } from '@/routes/OrgSettings'
-import { OrgsPage } from '@/routes/Orgs'
-import { PlaygroundPage } from '@/routes/Playground'
-import { PoliciesPage } from '@/routes/Policies'
-import { ResetPasswordPage } from '@/routes/ResetPassword'
-import { SettingsPage } from '@/routes/Settings'
-import { SignInPage } from '@/routes/SignIn'
-import { SignUpPage } from '@/routes/SignUp'
-import { TokensPage } from '@/routes/Tokens'
-import { VerifyEmailPage } from '@/routes/VerifyEmail'
+import { AppShell } from "@/components/AppShell";
+import { ProtectedRoute } from "@/components/ProtectedRoute";
+import { AcceptInvitationPage } from "@/routes/AcceptInvitation";
+import { AgentsPage } from "@/routes/Agents";
+import { AuditPage } from "@/routes/Audit";
+import { ForgotPasswordPage } from "@/routes/ForgotPassword";
+import { GraphPage } from "@/routes/Graph";
+import { OrgMembersPage } from "@/routes/OrgMembers";
+import { OrgSettingsPage } from "@/routes/OrgSettings";
+import { OrgsPage } from "@/routes/Orgs";
+import { PlaygroundPage } from "@/routes/Playground";
+import { PoliciesPage } from "@/routes/Policies";
+import { ResetPasswordPage } from "@/routes/ResetPassword";
+import { SettingsPage } from "@/routes/Settings";
+import { SignInPage } from "@/routes/SignIn";
+import { SignUpPage } from "@/routes/SignUp";
+import { TokensPage } from "@/routes/Tokens";
+import { VerifyEmailPage } from "@/routes/VerifyEmail";
 
 export default function App() {
   return (
@@ -68,5 +68,5 @@ export default function App() {
         </Route>
       </Routes>
     </BrowserRouter>
-  )
+  );
 }

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react'
-import { useNavigate, NavLink, Outlet } from 'react-router-dom'
+import { useEffect } from "react";
+import { useNavigate, NavLink, Outlet } from "react-router-dom";
 import {
   Building2,
   FileCode,
@@ -13,16 +13,16 @@ import {
   Settings2,
   ShieldCheck,
   type LucideIcon,
-} from 'lucide-react'
+} from "lucide-react";
 
-import { Button } from '@/components/ui/button'
-import { OrgProjectSwitcher } from '@/components/OrgProjectSwitcher'
-import { VerifyEmailBanner } from '@/components/VerifyEmailBanner'
-import { useActive } from '@/lib/active'
-import { useLogout, useUser } from '@/lib/auth'
-import { useOrgs } from '@/lib/orgs'
-import { useProjects } from '@/lib/projects'
-import { cn } from '@/lib/utils'
+import { Button } from "@/components/ui/button";
+import { OrgProjectSwitcher } from "@/components/OrgProjectSwitcher";
+import { VerifyEmailBanner } from "@/components/VerifyEmailBanner";
+import { useActive } from "@/lib/active";
+import { useLogout, useUser } from "@/lib/auth";
+import { useOrgs } from "@/lib/orgs";
+import { useProjects } from "@/lib/projects";
+import { cn } from "@/lib/utils";
 
 /**
  * Bootstrap effect — runs on every AppShell mount.
@@ -37,42 +37,42 @@ import { cn } from '@/lib/utils'
  */
 function useActiveBootstrap(): void {
   const { activeOrgId, activeProjectId, setActiveOrg, setActiveProject } =
-    useActive()
-  const orgsQuery = useOrgs()
-  const projectsQuery = useProjects(activeOrgId)
+    useActive();
+  const orgsQuery = useOrgs();
+  const projectsQuery = useProjects(activeOrgId);
 
   // First-org bootstrap. Don't run while orgs are loading — we'd
   // briefly set null and flicker the switcher label.
   useEffect(() => {
-    if (orgsQuery.isLoading || !orgsQuery.data) return
+    if (orgsQuery.isLoading || !orgsQuery.data) return;
     if (activeOrgId === null) {
-      const first = orgsQuery.data[0]
-      if (first) setActiveOrg(first.id)
-      return
+      const first = orgsQuery.data[0];
+      if (first) setActiveOrg(first.id);
+      return;
     }
     // Stale-org cleanup: the persisted activeOrgId refers to an org
     // the user no longer belongs to (e.g., they got removed). Reset
     // to the first remaining one.
     if (!orgsQuery.data.some((o) => o.id === activeOrgId)) {
-      const fallback = orgsQuery.data[0] ?? null
-      setActiveOrg(fallback?.id ?? null)
+      const fallback = orgsQuery.data[0] ?? null;
+      setActiveOrg(fallback?.id ?? null);
     }
-  }, [orgsQuery.isLoading, orgsQuery.data, activeOrgId, setActiveOrg])
+  }, [orgsQuery.isLoading, orgsQuery.data, activeOrgId, setActiveOrg]);
 
   // First-project bootstrap, scoped to the active org. setActiveOrg
   // clears activeProjectId in the store so we'll always come through
   // here after an org change.
   useEffect(() => {
-    if (!activeOrgId || projectsQuery.isLoading || !projectsQuery.data) return
+    if (!activeOrgId || projectsQuery.isLoading || !projectsQuery.data) return;
     if (activeProjectId === null) {
-      const first = projectsQuery.data[0]
-      if (first) setActiveProject(first.id)
-      return
+      const first = projectsQuery.data[0];
+      if (first) setActiveProject(first.id);
+      return;
     }
     // Stale-project cleanup (e.g., project deleted in another tab).
     if (!projectsQuery.data.some((p) => p.id === activeProjectId)) {
-      const fallback = projectsQuery.data[0] ?? null
-      setActiveProject(fallback?.id ?? null)
+      const fallback = projectsQuery.data[0] ?? null;
+      setActiveProject(fallback?.id ?? null);
     }
   }, [
     activeOrgId,
@@ -80,24 +80,24 @@ function useActiveBootstrap(): void {
     projectsQuery.isLoading,
     projectsQuery.data,
     setActiveProject,
-  ])
+  ]);
 }
 
 const workspaceLinks = [
-  { to: '/agents', label: 'Agents', icon: FileCode },
-  { to: '/policies', label: 'Policies', icon: ShieldCheck },
-  { to: '/graph', label: 'Graph', icon: Network },
-  { to: '/playground', label: 'Playground', icon: MessageSquareCode },
-  { to: '/audit', label: 'Audit', icon: ScrollText },
-  { to: '/tokens', label: 'Tokens', icon: KeyRound },
-  { to: '/orgs', label: 'Organizations', icon: Building2 },
-  { to: '/settings', label: 'Settings', icon: Settings2 },
-]
+  { to: "/agents", label: "Agents", icon: FileCode },
+  { to: "/policies", label: "Policies", icon: ShieldCheck },
+  { to: "/graph", label: "Graph", icon: Network },
+  { to: "/playground", label: "Playground", icon: MessageSquareCode },
+  { to: "/audit", label: "Audit", icon: ScrollText },
+  { to: "/tokens", label: "Tokens", icon: KeyRound },
+  { to: "/orgs", label: "Organizations", icon: Building2 },
+  { to: "/settings", label: "Settings", icon: Settings2 },
+];
 
 const environmentLinks = [
-  { to: '/control-plane', label: 'Control plane', icon: Server, status: 'OK' },
-  { to: '/signing-key', label: 'Signing key', icon: Fingerprint },
-]
+  { to: "/control-plane", label: "Control plane", icon: Server, status: "OK" },
+  { to: "/signing-key", label: "Signing key", icon: Fingerprint },
+];
 
 function NavItem({
   to,
@@ -107,12 +107,12 @@ function NavItem({
   badge,
   status,
 }: {
-  to: string
-  label: string
-  icon: LucideIcon
-  end?: boolean
-  badge?: string
-  status?: string
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  end?: boolean;
+  badge?: string;
+  status?: string;
 }) {
   return (
     <NavLink
@@ -120,10 +120,10 @@ function NavItem({
       end={end}
       className={({ isActive }) =>
         cn(
-          'flex h-9 items-center justify-between rounded-md px-3 text-sm transition-colors',
+          "flex h-9 items-center justify-between rounded-md px-3 text-sm transition-colors",
           isActive
-            ? 'bg-primary/15 text-primary font-medium'
-            : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+            ? "bg-primary/15 text-primary font-medium"
+            : "text-muted-foreground hover:bg-accent hover:text-foreground",
         )
       }
     >
@@ -131,21 +131,23 @@ function NavItem({
         <Icon className="size-4" />
         {label}
       </span>
-      {badge && <span className="text-[11px] text-muted-foreground">{badge}</span>}
+      {badge && (
+        <span className="text-[11px] text-muted-foreground">{badge}</span>
+      )}
       {status && (
         <span className="rounded-full bg-allow/15 px-1.5 py-0.5 text-[10px] font-medium text-allow">
           {status}
         </span>
       )}
     </NavLink>
-  )
+  );
 }
 
 export function AppShell() {
   // Pick a default active org + project on first load so the switcher
   // shows something usable instead of "Pick an organization" empty
   // state. Idempotent — won't overwrite an existing valid selection.
-  useActiveBootstrap()
+  useActiveBootstrap();
 
   return (
     <div className="flex h-screen bg-background text-foreground">
@@ -207,20 +209,20 @@ export function AppShell() {
         </main>
       </div>
     </div>
-  )
+  );
 }
 
 /** Top-right corner: shows the signed-in user's initial + a sign-out
  * button. Phase 5 will replace this with a proper dropdown menu (and
  * an org switcher next to it); for now a flat layout is enough. */
 function UserMenu() {
-  const { user } = useUser()
-  const logout = useLogout()
-  const navigate = useNavigate()
+  const { user } = useUser();
+  const logout = useLogout();
+  const navigate = useNavigate();
 
-  if (!user) return null
+  if (!user) return null;
 
-  const initial = user.email.slice(0, 1).toUpperCase()
+  const initial = user.email.slice(0, 1).toUpperCase();
 
   return (
     <div className="flex items-center gap-3 text-muted-foreground">
@@ -238,12 +240,12 @@ function UserMenu() {
         title="Sign out"
         disabled={logout.isPending}
         onClick={async () => {
-          await logout.mutateAsync().catch(() => undefined)
-          navigate('/sign-in', { replace: true })
+          await logout.mutateAsync().catch(() => undefined);
+          navigate("/sign-in", { replace: true });
         }}
       >
         <LogOut className="h-4 w-4" />
       </Button>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/components/ConfirmDialog.tsx
+++ b/platform/dashboard/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@/components/ui/button'
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -6,40 +6,40 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog'
+} from "@/components/ui/dialog";
 
 interface ConfirmDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 
   /** Title displayed in the header — should be a clear question, e.g.
    * "Leave Acme Inc?" or "Remove alice@example.com?" */
-  title: string
+  title: string;
 
   /** One-line description of what happens. Surfaces real consequences
    * (loss of access, mailed cancellation, etc.) so the user isn't
    * confirming blind. */
-  description: string
+  description: string;
 
   /** Label for the confirming button — defaults to "Confirm". Set to
    * a verb that matches the action ("Leave organization", "Remove",
    * "Delete") so the user reads the same word they're committing to. */
-  confirmLabel?: string
+  confirmLabel?: string;
 
   /** Variant of the confirming button. ``destructive`` is the right
    * default for the actions this dialog covers (leave / remove /
    * cancel) — the red colour reinforces irreversibility. */
-  confirmVariant?: 'default' | 'destructive'
+  confirmVariant?: "default" | "destructive";
 
   /** Async handler. Awaited before the dialog closes so the button
    * can show its pending state. The handler is responsible for
    * surfacing errors (typically a toast) — this dialog stays focused
    * on the user choosing. */
-  onConfirm: () => Promise<void> | void
+  onConfirm: () => Promise<void> | void;
 
   /** Pending-state flag from the underlying mutation. When true, the
    * confirm button shows a spinner / "Working…" label and disables. */
-  pending?: boolean
+  pending?: boolean;
 }
 
 /**
@@ -56,8 +56,8 @@ export function ConfirmDialog({
   onOpenChange,
   title,
   description,
-  confirmLabel = 'Confirm',
-  confirmVariant = 'destructive',
+  confirmLabel = "Confirm",
+  confirmVariant = "destructive",
   onConfirm,
   pending = false,
 }: ConfirmDialogProps) {
@@ -84,10 +84,10 @@ export function ConfirmDialog({
             disabled={pending}
             onClick={() => void onConfirm()}
           >
-            {pending ? 'Working…' : confirmLabel}
+            {pending ? "Working…" : confirmLabel}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/platform/dashboard/src/components/CreateOrgDialog.tsx
+++ b/platform/dashboard/src/components/CreateOrgDialog.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -12,39 +12,39 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { useActive } from '@/lib/active'
-import { useCreateOrg } from '@/lib/orgs'
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useActive } from "@/lib/active";
+import { useCreateOrg } from "@/lib/orgs";
 
 /** Mirror of the backend slug regex (schemas.OrgCreate). DNS-label
  * shape — lowercase letters/digits/hyphens, must start with a letter,
  * can't end with hyphen, 1-32 chars. Single letter accepted. */
-const SLUG_REGEX = /^([a-z]|[a-z][a-z0-9-]*[a-z0-9])$/
+const SLUG_REGEX = /^([a-z]|[a-z][a-z0-9-]*[a-z0-9])$/;
 
 const CreateOrgSchema = z.object({
-  name: z.string().min(1, 'Required').max(64, 'Max 64 characters'),
+  name: z.string().min(1, "Required").max(64, "Max 64 characters"),
   // Empty string is allowed at the form layer (means "let the server
   // derive it from the name"); we strip it before submitting.
   slug: z
     .string()
-    .max(32, 'Max 32 characters')
-    .refine((v) => v === '' || SLUG_REGEX.test(v), {
-      message: 'Lowercase letters, digits, hyphens. Must start with a letter.',
+    .max(32, "Max 32 characters")
+    .refine((v) => v === "" || SLUG_REGEX.test(v), {
+      message: "Lowercase letters, digits, hyphens. Must start with a letter.",
     })
     .optional(),
-})
+});
 
-type CreateOrgValues = z.infer<typeof CreateOrgSchema>
+type CreateOrgValues = z.infer<typeof CreateOrgSchema>;
 
 interface CreateOrgDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   /** Optional callback after a successful create — receives the new
    * org id so the caller can navigate or set it active. The dialog
    * itself sets it active automatically (the most common UX). */
-  onCreated?: (orgId: string) => void
+  onCreated?: (orgId: string) => void;
 }
 
 export function CreateOrgDialog({
@@ -52,43 +52,43 @@ export function CreateOrgDialog({
   onOpenChange,
   onCreated,
 }: CreateOrgDialogProps) {
-  const create = useCreateOrg()
-  const setActiveOrg = useActive((s) => s.setActiveOrg)
+  const create = useCreateOrg();
+  const setActiveOrg = useActive((s) => s.setActiveOrg);
 
   const form = useForm<CreateOrgValues>({
     resolver: zodResolver(CreateOrgSchema),
-    defaultValues: { name: '', slug: '' },
-  })
+    defaultValues: { name: "", slug: "" },
+  });
 
   // Reset the form + mutation error each time the dialog opens. Without
   // this, closing the dialog mid-error and reopening shows stale state.
   useEffect(() => {
     if (open) {
-      form.reset({ name: '', slug: '' })
-      create.reset()
+      form.reset({ name: "", slug: "" });
+      create.reset();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open])
+  }, [open]);
 
   async function onSubmit(values: CreateOrgValues) {
     try {
       const org = await create.mutateAsync({
         name: values.name,
         slug: values.slug || undefined,
-      })
+      });
       // The brand-new org becomes the active one — the user's intent
       // when creating is to use it next.
-      setActiveOrg(org.id)
-      onCreated?.(org.id)
-      onOpenChange(false)
+      setActiveOrg(org.id);
+      onCreated?.(org.id);
+      onOpenChange(false);
     } catch {
       // surfaces via create.error
     }
   }
 
-  const error = create.error
-  const detailText = extractDetail(error)
-  const slugTaken = detailText.toLowerCase().includes('taken')
+  const error = create.error;
+  const detailText = extractDetail(error);
+  const slugTaken = detailText.toLowerCase().includes("taken");
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -96,8 +96,8 @@ export function CreateOrgDialog({
         <DialogHeader>
           <DialogTitle>Create organization</DialogTitle>
           <DialogDescription>
-            Teams in Hexgate live inside an organization. You'll be its
-            first owner.
+            Teams in Hexgate live inside an organization. You'll be its first
+            owner.
           </DialogDescription>
         </DialogHeader>
 
@@ -110,8 +110,8 @@ export function CreateOrgDialog({
             <Alert variant="destructive">
               <AlertDescription>
                 {slugTaken
-                  ? 'That slug is already taken. Pick a different one.'
-                  : detailText || 'Could not create the organization.'}
+                  ? "That slug is already taken. Pick a different one."
+                  : detailText || "Could not create the organization."}
               </AlertDescription>
             </Alert>
           )}
@@ -122,7 +122,7 @@ export function CreateOrgDialog({
               id="org-name"
               placeholder="Acme Inc"
               autoComplete="off"
-              {...form.register('name')}
+              {...form.register("name")}
             />
             {form.formState.errors.name && (
               <p className="text-xs text-destructive">
@@ -133,7 +133,7 @@ export function CreateOrgDialog({
 
           <div className="space-y-2">
             <Label htmlFor="org-slug">
-              Slug{' '}
+              Slug{" "}
               <span className="text-xs font-normal text-muted-foreground">
                 (optional — we'll generate one if blank)
               </span>
@@ -142,7 +142,7 @@ export function CreateOrgDialog({
               id="org-slug"
               placeholder="acme"
               autoComplete="off"
-              {...form.register('slug')}
+              {...form.register("slug")}
             />
             {form.formState.errors.slug && (
               <p className="text-xs text-destructive">
@@ -166,22 +166,22 @@ export function CreateOrgDialog({
             form="create-org-form"
             disabled={create.isPending}
           >
-            {create.isPending ? 'Creating…' : 'Create organization'}
+            {create.isPending ? "Creating…" : "Create organization"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 function extractDetail(err: unknown): string {
-  if (err && typeof err === 'object' && 'detail' in err) {
-    const d = (err as { detail: unknown }).detail
-    if (typeof d === 'string') return d
-    if (typeof d === 'object' && d !== null && 'detail' in d) {
-      const inner = (d as { detail: unknown }).detail
-      if (typeof inner === 'string') return inner
+  if (err && typeof err === "object" && "detail" in err) {
+    const d = (err as { detail: unknown }).detail;
+    if (typeof d === "string") return d;
+    if (typeof d === "object" && d !== null && "detail" in d) {
+      const inner = (d as { detail: unknown }).detail;
+      if (typeof inner === "string") return inner;
     }
   }
-  return ''
+  return "";
 }

--- a/platform/dashboard/src/components/CreateProjectDialog.tsx
+++ b/platform/dashboard/src/components/CreateProjectDialog.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from 'react'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -12,26 +12,26 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { useActive } from '@/lib/active'
-import { useCreateProject } from '@/lib/projects'
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useActive } from "@/lib/active";
+import { useCreateProject } from "@/lib/projects";
 
 const CreateProjectSchema = z.object({
-  name: z.string().min(1, 'Required').max(64, 'Max 64 characters'),
-})
+  name: z.string().min(1, "Required").max(64, "Max 64 characters"),
+});
 
-type CreateProjectValues = z.infer<typeof CreateProjectSchema>
+type CreateProjectValues = z.infer<typeof CreateProjectSchema>;
 
 interface CreateProjectDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   /** Override the org to create in. Defaults to the currently-active
    * org from the store. Useful for "Create project in Acme" from the
    * org list page where the active org might be elsewhere. */
-  orgId?: string
-  onCreated?: (projectId: string) => void
+  orgId?: string;
+  onCreated?: (projectId: string) => void;
 }
 
 export function CreateProjectDialog({
@@ -40,45 +40,45 @@ export function CreateProjectDialog({
   orgId,
   onCreated,
 }: CreateProjectDialogProps) {
-  const activeOrgId = useActive((s) => s.activeOrgId)
-  const setActiveProject = useActive((s) => s.setActiveProject)
-  const create = useCreateProject()
-  const targetOrgId = orgId ?? activeOrgId
+  const activeOrgId = useActive((s) => s.activeOrgId);
+  const setActiveProject = useActive((s) => s.setActiveProject);
+  const create = useCreateProject();
+  const targetOrgId = orgId ?? activeOrgId;
 
   const form = useForm<CreateProjectValues>({
     resolver: zodResolver(CreateProjectSchema),
-    defaultValues: { name: '' },
-  })
+    defaultValues: { name: "" },
+  });
 
   useEffect(() => {
     if (open) {
-      form.reset({ name: '' })
-      create.reset()
+      form.reset({ name: "" });
+      create.reset();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open])
+  }, [open]);
 
   async function onSubmit(values: CreateProjectValues) {
-    if (!targetOrgId) return  // shouldn't happen: button is hidden when no org
+    if (!targetOrgId) return; // shouldn't happen: button is hidden when no org
     try {
       const project = await create.mutateAsync({
         orgId: targetOrgId,
         name: values.name,
-      })
+      });
       // New project becomes active in the current org. If the user is
       // creating cross-org from the orgs list, this implicitly moves
       // them into that org's project list — usually what they want.
-      setActiveProject(project.id)
-      onCreated?.(project.id)
-      onOpenChange(false)
+      setActiveProject(project.id);
+      onCreated?.(project.id);
+      onOpenChange(false);
     } catch {
       // surfaces via create.error
     }
   }
 
-  const error = create.error
-  const detailText = extractDetail(error)
-  const nameTaken = detailText.toLowerCase().includes('already exists')
+  const error = create.error;
+  const detailText = extractDetail(error);
+  const nameTaken = detailText.toLowerCase().includes("already exists");
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -86,8 +86,8 @@ export function CreateProjectDialog({
         <DialogHeader>
           <DialogTitle>Create project</DialogTitle>
           <DialogDescription>
-            Projects hold agents and the tokens that authenticate them.
-            Names are unique within an organization.
+            Projects hold agents and the tokens that authenticate them. Names
+            are unique within an organization.
           </DialogDescription>
         </DialogHeader>
 
@@ -100,8 +100,8 @@ export function CreateProjectDialog({
             <Alert variant="destructive">
               <AlertDescription>
                 {nameTaken
-                  ? 'A project with that name already exists in this organization.'
-                  : detailText || 'Could not create the project.'}
+                  ? "A project with that name already exists in this organization."
+                  : detailText || "Could not create the project."}
               </AlertDescription>
             </Alert>
           )}
@@ -112,7 +112,7 @@ export function CreateProjectDialog({
               id="project-name"
               placeholder="customer-bot"
               autoComplete="off"
-              {...form.register('name')}
+              {...form.register("name")}
             />
             {form.formState.errors.name && (
               <p className="text-xs text-destructive">
@@ -136,22 +136,22 @@ export function CreateProjectDialog({
             form="create-project-form"
             disabled={create.isPending || !targetOrgId}
           >
-            {create.isPending ? 'Creating…' : 'Create project'}
+            {create.isPending ? "Creating…" : "Create project"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 function extractDetail(err: unknown): string {
-  if (err && typeof err === 'object' && 'detail' in err) {
-    const d = (err as { detail: unknown }).detail
-    if (typeof d === 'string') return d
-    if (typeof d === 'object' && d !== null && 'detail' in d) {
-      const inner = (d as { detail: unknown }).detail
-      if (typeof inner === 'string') return inner
+  if (err && typeof err === "object" && "detail" in err) {
+    const d = (err as { detail: unknown }).detail;
+    if (typeof d === "string") return d;
+    if (typeof d === "object" && d !== null && "detail" in d) {
+      const inner = (d as { detail: unknown }).detail;
+      if (typeof inner === "string") return inner;
     }
   }
-  return ''
+  return "";
 }

--- a/platform/dashboard/src/components/InviteMemberDialog.test.tsx
+++ b/platform/dashboard/src/components/InviteMemberDialog.test.tsx
@@ -13,95 +13,95 @@
  * happening in the component (verified by manual smoke).
  */
 
-import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { InviteMemberDialog } from '@/components/InviteMemberDialog'
-import { renderWithProviders } from '@/test/render'
+import { InviteMemberDialog } from "@/components/InviteMemberDialog";
+import { renderWithProviders } from "@/test/render";
 
-describe('InviteMemberDialog', () => {
+describe("InviteMemberDialog", () => {
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('POSTs email + role to /v1/orgs/{id}/invites on submit', async () => {
-    let captured: { url: string; body: unknown } | null = null
-    vi.spyOn(window, 'fetch').mockImplementation(
+  it("POSTs email + role to /v1/orgs/{id}/invites on submit", async () => {
+    let captured: { url: string; body: unknown } | null = null;
+    vi.spyOn(window, "fetch").mockImplementation(
       async (input: RequestInfo | URL, init?: RequestInit) => {
-        const url = typeof input === 'string' ? input : input.toString()
-        if (init?.method === 'POST' && url.includes('/invites')) {
-          const body = init.body ? JSON.parse(init.body as string) : null
-          captured = { url, body }
+        const url = typeof input === "string" ? input : input.toString();
+        if (init?.method === "POST" && url.includes("/invites")) {
+          const body = init.body ? JSON.parse(init.body as string) : null;
+          captured = { url, body };
           return new Response(
             JSON.stringify({
-              id: 'new-invite',
-              email: 'alice@example.com',
-              role: 'admin',
-              invited_by_email: 'me@example.com',
-              expires_at: '2030-01-01T00:00:00Z',
-              created_at: '2026-06-01T00:00:00Z',
+              id: "new-invite",
+              email: "alice@example.com",
+              role: "admin",
+              invited_by_email: "me@example.com",
+              expires_at: "2030-01-01T00:00:00Z",
+              created_at: "2026-06-01T00:00:00Z",
             }),
             { status: 201 },
-          )
+          );
         }
-        return new Response('{}', { status: 200 })
+        return new Response("{}", { status: 200 });
       },
-    )
+    );
 
-    const user = userEvent.setup()
-    const onOpenChange = vi.fn()
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
     renderWithProviders(
       <InviteMemberDialog
         open={true}
         onOpenChange={onOpenChange}
         orgId="org-1"
       />,
-    )
+    );
 
-    await user.type(
-      screen.getByLabelText('Email'),
-      'alice@example.com',
-    )
-    await user.click(screen.getByText('Send invitation'))
+    await user.type(screen.getByLabelText("Email"), "alice@example.com");
+    await user.click(screen.getByText("Send invitation"));
 
     await waitFor(() => {
-      expect(captured).not.toBeNull()
-    })
-    expect(captured!.url).toContain('/v1/orgs/org-1/invites')
-    expect(captured!.body).toEqual({ email: 'alice@example.com', role: 'member' })
+      expect(captured).not.toBeNull();
+    });
+    expect(captured!.url).toContain("/v1/orgs/org-1/invites");
+    expect(captured!.body).toEqual({
+      email: "alice@example.com",
+      role: "member",
+    });
     // After success, the dialog asks to close.
     await waitFor(() => {
-      expect(onOpenChange).toHaveBeenCalledWith(false)
-    })
-  })
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
 
-  it('client-side validation rejects an invalid email', async () => {
-    const fetchSpy = vi.spyOn(window, 'fetch')
+  it("client-side validation rejects an invalid email", async () => {
+    const fetchSpy = vi.spyOn(window, "fetch");
 
-    const user = userEvent.setup()
+    const user = userEvent.setup();
     renderWithProviders(
       <InviteMemberDialog
         open={true}
         onOpenChange={() => undefined}
         orgId="org-1"
       />,
-    )
+    );
 
-    await user.type(screen.getByLabelText('Email'), 'not-an-email')
-    await user.click(screen.getByText('Send invitation'))
+    await user.type(screen.getByLabelText("Email"), "not-an-email");
+    await user.click(screen.getByText("Send invitation"));
 
     // The load-bearing assertion: invalid form → no API call. The
     // exact error message text varies by zod version (custom message
     // in zod 3, default in zod 4), so we don't pin specific copy.
-    await new Promise((r) => setTimeout(r, 50))  // let validation settle
+    await new Promise((r) => setTimeout(r, 50)); // let validation settle
     const inviteCalls = fetchSpy.mock.calls.filter(([url, init]) => {
-      const u = typeof url === 'string' ? url : url.toString()
+      const u = typeof url === "string" ? url : url.toString();
       return (
-        u.includes('/invites') &&
-        (init as RequestInit | undefined)?.method === 'POST'
-      )
-    })
-    expect(inviteCalls).toHaveLength(0)
-  })
-})
+        u.includes("/invites") &&
+        (init as RequestInit | undefined)?.method === "POST"
+      );
+    });
+    expect(inviteCalls).toHaveLength(0);
+  });
+});

--- a/platform/dashboard/src/components/InviteMemberDialog.tsx
+++ b/platform/dashboard/src/components/InviteMemberDialog.tsx
@@ -1,11 +1,11 @@
-import { useEffect } from 'react'
-import { useForm, Controller } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
-import { toast } from 'sonner'
+import { useEffect } from "react";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -13,35 +13,35 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select'
-import { ApiError } from '@/lib/api'
-import { useCreateInvitation } from '@/lib/invites'
-import { ROLES } from '@/lib/orgs'
+} from "@/components/ui/select";
+import { ApiError } from "@/lib/api";
+import { useCreateInvitation } from "@/lib/invites";
+import { ROLES } from "@/lib/orgs";
 
 const InviteSchema = z.object({
-  email: z.string().email('Enter a valid email'),
+  email: z.string().email("Enter a valid email"),
   role: z.enum(ROLES),
-})
+});
 
-type InviteValues = z.infer<typeof InviteSchema>
+type InviteValues = z.infer<typeof InviteSchema>;
 
 interface InviteMemberDialogProps {
-  open: boolean
-  onOpenChange: (open: boolean) => void
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   /** Org the invite is for. The dialog ALWAYS targets the explicitly-
    * passed org — never reads from the active store. Lets the caller
    * surface "Invite to Acme Inc" copy even when the user is sitting
    * on a different org's page. */
-  orgId: string
+  orgId: string;
 }
 
 /**
@@ -55,20 +55,20 @@ export function InviteMemberDialog({
   onOpenChange,
   orgId,
 }: InviteMemberDialogProps) {
-  const invite = useCreateInvitation()
+  const invite = useCreateInvitation();
 
   const form = useForm<InviteValues>({
     resolver: zodResolver(InviteSchema),
-    defaultValues: { email: '', role: 'member' },
-  })
+    defaultValues: { email: "", role: "member" },
+  });
 
   useEffect(() => {
     if (open) {
-      form.reset({ email: '', role: 'member' })
-      invite.reset()
+      form.reset({ email: "", role: "member" });
+      invite.reset();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open])
+  }, [open]);
 
   async function onSubmit(values: InviteValues): Promise<void> {
     try {
@@ -76,17 +76,17 @@ export function InviteMemberDialog({
         orgId,
         email: values.email,
         role: values.role,
-      })
-      toast.success(`Invitation sent to ${values.email}`)
-      onOpenChange(false)
+      });
+      toast.success(`Invitation sent to ${values.email}`);
+      onOpenChange(false);
     } catch (err) {
-      const detail = err instanceof ApiError ? String(err.message) : ''
-      const roleEscalation = detail.toLowerCase().includes('cannot invite')
+      const detail = err instanceof ApiError ? String(err.message) : "";
+      const roleEscalation = detail.toLowerCase().includes("cannot invite");
       toast.error(
         roleEscalation
           ? `You can't invite at the ${values.role} level (your role is below that).`
-          : 'Could not send the invitation. Check the email and try again.',
-      )
+          : "Could not send the invitation. Check the email and try again.",
+      );
     }
   }
 
@@ -108,8 +108,8 @@ export function InviteMemberDialog({
           {invite.isError && !invite.isPending && (
             <Alert variant="destructive">
               <AlertDescription>
-                Could not send the invitation. The address might already
-                belong to this organization.
+                Could not send the invitation. The address might already belong
+                to this organization.
               </AlertDescription>
             </Alert>
           )}
@@ -121,7 +121,7 @@ export function InviteMemberDialog({
               type="email"
               placeholder="alice@example.com"
               autoComplete="off"
-              {...form.register('email')}
+              {...form.register("email")}
             />
             {form.formState.errors.email && (
               <p className="text-xs text-destructive">
@@ -155,8 +155,8 @@ export function InviteMemberDialog({
               )}
             />
             <p className="text-xs text-muted-foreground">
-              Only owners can invite other owners. Admins can invite
-              admins and members.
+              Only owners can invite other owners. Admins can invite admins and
+              members.
             </p>
           </div>
         </form>
@@ -175,10 +175,10 @@ export function InviteMemberDialog({
             form="invite-member-form"
             disabled={invite.isPending}
           >
-            {invite.isPending ? 'Sending…' : 'Send invitation'}
+            {invite.isPending ? "Sending…" : "Send invitation"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }

--- a/platform/dashboard/src/components/NoProjectEmptyState.test.tsx
+++ b/platform/dashboard/src/components/NoProjectEmptyState.test.tsx
@@ -9,42 +9,38 @@
  *      switcher dropdown).
  */
 
-import { screen } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
-import { renderWithProviders } from '@/test/render'
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { renderWithProviders } from "@/test/render";
 
-describe('NoProjectEmptyState', () => {
+describe("NoProjectEmptyState", () => {
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('interpolates the resource name into the help copy', () => {
-    renderWithProviders(<NoProjectEmptyState resource="tokens" />)
-    expect(screen.getByText(/No project selected/i)).toBeInTheDocument()
+  it("interpolates the resource name into the help copy", () => {
+    renderWithProviders(<NoProjectEmptyState resource="tokens" />);
+    expect(screen.getByText(/No project selected/i)).toBeInTheDocument();
     // Mentions the resource so the user knows which page they're on.
-    expect(
-      screen.getByText(/organization's tokens/i),
-    ).toBeInTheDocument()
-  })
+    expect(screen.getByText(/organization's tokens/i)).toBeInTheDocument();
+  });
 
   it("'Create project' button opens the CreateProjectDialog", async () => {
-    const user = userEvent.setup()
-    renderWithProviders(<NoProjectEmptyState resource="agents" />)
+    const user = userEvent.setup();
+    renderWithProviders(<NoProjectEmptyState resource="agents" />);
 
     // Dialog isn't mounted until the button is clicked. The dialog
     // title duplicates the button label, so we check the dialog's
     // unique description copy instead.
-    expect(
-      screen.queryByText(/Projects hold agents/i),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/Projects hold agents/i)).not.toBeInTheDocument();
 
-    await user.click(screen.getByText('Create project'))
+    await user.click(screen.getByText("Create project"));
 
     expect(
       await screen.findByText(/Projects hold agents/i),
-    ).toBeInTheDocument()
-  })
-})
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/dashboard/src/components/NoProjectEmptyState.tsx
+++ b/platform/dashboard/src/components/NoProjectEmptyState.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
-import { FolderOpen, FolderPlus } from 'lucide-react'
+import { useState } from "react";
+import { FolderOpen, FolderPlus } from "lucide-react";
 
-import { CreateProjectDialog } from '@/components/CreateProjectDialog'
-import { Button } from '@/components/ui/button'
+import { CreateProjectDialog } from "@/components/CreateProjectDialog";
+import { Button } from "@/components/ui/button";
 
 /**
  * Rendered by project-scoped pages when ``useProjectScoped`` returns
@@ -18,11 +18,11 @@ import { Button } from '@/components/ui/button'
 interface NoProjectEmptyStateProps {
   /** Short noun naming the page's content — used in the help copy
    * ("…to view tokens", "…to view agents"). */
-  resource: string
+  resource: string;
 }
 
 export function NoProjectEmptyState({ resource }: NoProjectEmptyStateProps) {
-  const [createOpen, setCreateOpen] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false);
 
   return (
     <div className="mx-auto flex max-w-md flex-col items-center gap-4 py-16 text-center">
@@ -32,8 +32,8 @@ export function NoProjectEmptyState({ resource }: NoProjectEmptyStateProps) {
       <div className="space-y-1.5">
         <h2 className="text-base font-medium">No project selected</h2>
         <p className="text-sm text-muted-foreground">
-          Pick a project from the switcher above, or create one to view
-          this organization's {resource}.
+          Pick a project from the switcher above, or create one to view this
+          organization's {resource}.
         </p>
       </div>
       <Button onClick={() => setCreateOpen(true)} className="gap-2">
@@ -41,10 +41,7 @@ export function NoProjectEmptyState({ resource }: NoProjectEmptyStateProps) {
         Create project
       </Button>
 
-      <CreateProjectDialog
-        open={createOpen}
-        onOpenChange={setCreateOpen}
-      />
+      <CreateProjectDialog open={createOpen} onOpenChange={setCreateOpen} />
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/components/OrgProjectSwitcher.test.tsx
+++ b/platform/dashboard/src/components/OrgProjectSwitcher.test.tsx
@@ -11,116 +11,116 @@
  *   3. The "New organization" footer action opens the create dialog.
  */
 
-import { act, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { OrgProjectSwitcher } from '@/components/OrgProjectSwitcher'
-import { useActive } from '@/lib/active'
-import { renderWithProviders } from '@/test/render'
+import { OrgProjectSwitcher } from "@/components/OrgProjectSwitcher";
+import { useActive } from "@/lib/active";
+import { renderWithProviders } from "@/test/render";
 
 /** Stub fetch with canned responses keyed by URL. Returns 404 for
  * unknown paths so a missed wiring shows up as an obvious failure. */
 function stubFetch(routes: Record<string, unknown>): void {
-  vi.spyOn(window, 'fetch').mockImplementation(
+  vi.spyOn(window, "fetch").mockImplementation(
     async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input.toString()
+      const url = typeof input === "string" ? input : input.toString();
       // Allow `/v1/orgs?foo=bar` style matches.
-      const path = url.split('?')[0]
+      const path = url.split("?")[0];
       if (path in routes) {
         return new Response(JSON.stringify(routes[path]), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+          headers: { "Content-Type": "application/json" },
+        });
       }
-      return new Response('not found', { status: 404 })
+      return new Response("not found", { status: 404 });
     },
-  )
+  );
 }
 
 const ORG_A = {
-  id: 'org-a',
-  slug: 'org-a',
-  name: 'Org Alpha',
-  created_at: '2026-01-01T00:00:00Z',
-  role: 'owner' as const,
-}
+  id: "org-a",
+  slug: "org-a",
+  name: "Org Alpha",
+  created_at: "2026-01-01T00:00:00Z",
+  role: "owner" as const,
+};
 const ORG_B = {
-  id: 'org-b',
-  slug: 'org-b',
-  name: 'Org Beta',
-  created_at: '2026-01-02T00:00:00Z',
-  role: 'member' as const,
-}
+  id: "org-b",
+  slug: "org-b",
+  name: "Org Beta",
+  created_at: "2026-01-02T00:00:00Z",
+  role: "member" as const,
+};
 
-describe('OrgProjectSwitcher', () => {
+describe("OrgProjectSwitcher", () => {
   beforeEach(() => {
     act(() => {
-      useActive.setState({ activeOrgId: ORG_A.id, activeProjectId: null })
-    })
+      useActive.setState({ activeOrgId: ORG_A.id, activeProjectId: null });
+    });
     stubFetch({
-      '/v1/orgs': [ORG_A, ORG_B],
-      '/v1/orgs/org-a/projects': [],
-      '/v1/orgs/org-b/projects': [],
-    })
-  })
+      "/v1/orgs": [ORG_A, ORG_B],
+      "/v1/orgs/org-a/projects": [],
+      "/v1/orgs/org-b/projects": [],
+    });
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('shows the active org name in the trigger', async () => {
-    renderWithProviders(<OrgProjectSwitcher />)
+  it("shows the active org name in the trigger", async () => {
+    renderWithProviders(<OrgProjectSwitcher />);
     await waitFor(() => {
-      expect(screen.getByText('Org Alpha')).toBeInTheDocument()
-    })
-  })
+      expect(screen.getByText("Org Alpha")).toBeInTheDocument();
+    });
+  });
 
-  it('switching org updates the store and clears the active project', async () => {
+  it("switching org updates the store and clears the active project", async () => {
     // Seed an active project so we can assert it gets cleared.
     act(() => {
       useActive.setState({
         activeOrgId: ORG_A.id,
-        activeProjectId: 'stale-project',
-      })
-    })
+        activeProjectId: "stale-project",
+      });
+    });
 
-    const user = userEvent.setup()
-    renderWithProviders(<OrgProjectSwitcher />)
+    const user = userEvent.setup();
+    renderWithProviders(<OrgProjectSwitcher />);
 
     // Open the dropdown.
     await waitFor(() => {
-      expect(screen.getByText('Org Alpha')).toBeInTheDocument()
-    })
-    await user.click(screen.getAllByText('Org Alpha')[0]!)
+      expect(screen.getByText("Org Alpha")).toBeInTheDocument();
+    });
+    await user.click(screen.getAllByText("Org Alpha")[0]!);
 
     // Click Org Beta in the dropdown.
-    const betaItem = await screen.findByText('Org Beta')
-    await user.click(betaItem)
+    const betaItem = await screen.findByText("Org Beta");
+    await user.click(betaItem);
 
-    expect(useActive.getState().activeOrgId).toBe(ORG_B.id)
+    expect(useActive.getState().activeOrgId).toBe(ORG_B.id);
     // Clearing the stale project across org switches is the load-bearing
     // invariant — see active.ts comments.
-    expect(useActive.getState().activeProjectId).toBeNull()
-  })
+    expect(useActive.getState().activeProjectId).toBeNull();
+  });
 
   it('"New organization" opens the create dialog', async () => {
-    const user = userEvent.setup()
-    renderWithProviders(<OrgProjectSwitcher />)
+    const user = userEvent.setup();
+    renderWithProviders(<OrgProjectSwitcher />);
 
     await waitFor(() => {
-      expect(screen.getByText('Org Alpha')).toBeInTheDocument()
-    })
-    await user.click(screen.getAllByText('Org Alpha')[0]!)
+      expect(screen.getByText("Org Alpha")).toBeInTheDocument();
+    });
+    await user.click(screen.getAllByText("Org Alpha")[0]!);
 
-    const newOrgItem = await screen.findByText('New organization')
-    await user.click(newOrgItem)
+    const newOrgItem = await screen.findByText("New organization");
+    await user.click(newOrgItem);
 
     // CreateOrgDialog renders both a title and a submit button with
     // the text "Create organization" — assert on something unique to
     // the dialog body to avoid the multi-match getByText error.
     expect(
       await screen.findByText(/Teams in Hexgate live inside/i),
-    ).toBeInTheDocument()
-  })
-})
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/dashboard/src/components/OrgProjectSwitcher.tsx
+++ b/platform/dashboard/src/components/OrgProjectSwitcher.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react'
+import { useState } from "react";
 import {
   Building2,
   Check,
   ChevronsUpDown,
   FolderPlus,
   Plus,
-} from 'lucide-react'
+} from "lucide-react";
 
-import { CreateOrgDialog } from '@/components/CreateOrgDialog'
-import { CreateProjectDialog } from '@/components/CreateProjectDialog'
+import { CreateOrgDialog } from "@/components/CreateOrgDialog";
+import { CreateProjectDialog } from "@/components/CreateProjectDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -16,11 +16,11 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
-import { useActive } from '@/lib/active'
-import { useOrgs, type OrgWithRole } from '@/lib/orgs'
-import { useProjects, type ProjectRead } from '@/lib/projects'
-import { cn } from '@/lib/utils'
+} from "@/components/ui/dropdown-menu";
+import { useActive } from "@/lib/active";
+import { useOrgs, type OrgWithRole } from "@/lib/orgs";
+import { useProjects, type ProjectRead } from "@/lib/projects";
+import { cn } from "@/lib/utils";
 
 /**
  * The pill that lives in the AppShell header. Reads the active org +
@@ -37,17 +37,17 @@ import { cn } from '@/lib/utils'
  */
 export function OrgProjectSwitcher() {
   const { activeOrgId, activeProjectId, setActiveOrg, setActiveProject } =
-    useActive()
-  const orgsQuery = useOrgs()
-  const projectsQuery = useProjects(activeOrgId)
+    useActive();
+  const orgsQuery = useOrgs();
+  const projectsQuery = useProjects(activeOrgId);
 
-  const [createOrgOpen, setCreateOrgOpen] = useState(false)
-  const [createProjectOpen, setCreateProjectOpen] = useState(false)
+  const [createOrgOpen, setCreateOrgOpen] = useState(false);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
 
-  const orgs: OrgWithRole[] = orgsQuery.data ?? []
-  const projects: ProjectRead[] = projectsQuery.data ?? []
-  const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? null
-  const activeProject = projects.find((p) => p.id === activeProjectId) ?? null
+  const orgs: OrgWithRole[] = orgsQuery.data ?? [];
+  const projects: ProjectRead[] = projectsQuery.data ?? [];
+  const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? null;
+  const activeProject = projects.find((p) => p.id === activeProjectId) ?? null;
 
   return (
     <>
@@ -56,9 +56,9 @@ export function OrgProjectSwitcher() {
           <button
             type="button"
             className={cn(
-              'inline-flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1 text-xs',
-              'transition-colors hover:border-primary hover:bg-primary/5',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+              "inline-flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1 text-xs",
+              "transition-colors hover:border-primary hover:bg-primary/5",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             )}
           >
             <Building2 className="h-3.5 w-3.5 text-primary" />
@@ -98,7 +98,7 @@ export function OrgProjectSwitcher() {
           <DropdownMenuSeparator />
 
           <DropdownMenuLabel>
-            Projects{activeOrg ? ` in ${activeOrg.name}` : ''}
+            Projects{activeOrg ? ` in ${activeOrg.name}` : ""}
           </DropdownMenuLabel>
           {activeOrgId === null ? (
             <div className="px-2 py-3 text-xs text-muted-foreground">
@@ -145,22 +145,19 @@ export function OrgProjectSwitcher() {
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <CreateOrgDialog
-        open={createOrgOpen}
-        onOpenChange={setCreateOrgOpen}
-      />
+      <CreateOrgDialog open={createOrgOpen} onOpenChange={setCreateOrgOpen} />
       <CreateProjectDialog
         open={createProjectOpen}
         onOpenChange={setCreateProjectOpen}
       />
     </>
-  )
+  );
 }
 
 interface SwitcherLabelProps {
-  activeOrg: OrgWithRole | null
-  activeProject: ProjectRead | null
-  loading: boolean
+  activeOrg: OrgWithRole | null;
+  activeProject: ProjectRead | null;
+  loading: boolean;
 }
 
 function SwitcherLabel({
@@ -169,10 +166,10 @@ function SwitcherLabel({
   loading,
 }: SwitcherLabelProps) {
   if (loading) {
-    return <span className="text-muted-foreground">Loading…</span>
+    return <span className="text-muted-foreground">Loading…</span>;
   }
   if (!activeOrg) {
-    return <span className="text-muted-foreground">Pick an organization</span>
+    return <span className="text-muted-foreground">Pick an organization</span>;
   }
   return (
     <span className="flex items-center gap-1.5">
@@ -180,12 +177,14 @@ function SwitcherLabel({
       {activeProject && (
         <>
           <span className="text-muted-foreground">/</span>
-          <span className="font-mono text-foreground">{activeProject.name}</span>
+          <span className="font-mono text-foreground">
+            {activeProject.name}
+          </span>
         </>
       )}
       {!activeProject && (
         <span className="text-muted-foreground">· no project</span>
       )}
     </span>
-  )
+  );
 }

--- a/platform/dashboard/src/components/PolicyEditor/PolicyEditor.test.tsx
+++ b/platform/dashboard/src/components/PolicyEditor/PolicyEditor.test.tsx
@@ -9,38 +9,38 @@
  * is a one-line passthrough to `<CodeMirror onChange={onChange} />`,
  * which @uiw/react-codemirror tests on its own.
  */
-import { describe, expect, it } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
 
-import { PolicyEditor } from './PolicyEditor'
+import { PolicyEditor } from "./PolicyEditor";
 
-describe('PolicyEditor', () => {
-  it('renders the initial value into the editor surface', () => {
+describe("PolicyEditor", () => {
+  it("renders the initial value into the editor surface", () => {
     const { container } = render(
-      <PolicyEditor value={'version: 1\nroles: {}'} onChange={() => {}} />,
-    )
+      <PolicyEditor value={"version: 1\nroles: {}"} onChange={() => {}} />,
+    );
     // CodeMirror tokenises into spans inside `.cm-content`. We don't care
     // about the exact DOM shape — only that the text reaches the document.
-    expect(container.textContent).toContain('version: 1')
-    expect(container.textContent).toContain('roles: {}')
-  })
+    expect(container.textContent).toContain("version: 1");
+    expect(container.textContent).toContain("roles: {}");
+  });
 
-  it('renders the lint gutter so diagnostics have somewhere to anchor', () => {
+  it("renders the lint gutter so diagnostics have somewhere to anchor", () => {
     const { container } = render(
       <PolicyEditor
-        value={'a: 1\n'}
+        value={"a: 1\n"}
         onChange={() => {}}
-        diagnostics={[{ line: 1, role: null, message: 'bad' }]}
+        diagnostics={[{ line: 1, role: null, message: "bad" }]}
       />,
-    )
+    );
     // `.cm-gutter-lint` is the gutter class that `lintGutter()` adds.
-    expect(container.querySelector('.cm-gutter-lint')).not.toBeNull()
-  })
+    expect(container.querySelector(".cm-gutter-lint")).not.toBeNull();
+  });
 
-  it('respects readOnly by exposing aria-readonly on the editor', () => {
+  it("respects readOnly by exposing aria-readonly on the editor", () => {
     const { container } = render(
       <PolicyEditor value="a: 1" onChange={() => {}} readOnly />,
-    )
-    expect(container.querySelector('[aria-readonly="true"]')).not.toBeNull()
-  })
-})
+    );
+    expect(container.querySelector('[aria-readonly="true"]')).not.toBeNull();
+  });
+});

--- a/platform/dashboard/src/components/PolicyEditor/PolicyEditor.tsx
+++ b/platform/dashboard/src/components/PolicyEditor/PolicyEditor.tsx
@@ -14,15 +14,15 @@
  * rendering surface for diagnostics — the source of truth is the
  * platform's `/policies/validate` endpoint.
  */
-import { useEffect, useRef } from 'react'
-import CodeMirror, { type ReactCodeMirrorRef } from '@uiw/react-codemirror'
-import { yaml } from '@codemirror/lang-yaml'
-import { lintGutter, setDiagnostics } from '@codemirror/lint'
+import { useEffect, useRef } from "react";
+import CodeMirror, { type ReactCodeMirrorRef } from "@uiw/react-codemirror";
+import { yaml } from "@codemirror/lang-yaml";
+import { lintGutter, setDiagnostics } from "@codemirror/lint";
 
-import type { PolicyValidationError } from '@/lib/api'
-import { policyModeDecorations } from './decorations'
-import { toCodemirrorDiagnostics } from './diagnostics'
-import { policyEditorTheme } from './theme'
+import type { PolicyValidationError } from "@/lib/api";
+import { policyModeDecorations } from "./decorations";
+import { toCodemirrorDiagnostics } from "./diagnostics";
+import { policyEditorTheme } from "./theme";
 
 // @uiw/react-codemirror dispatches `StateEffect.reconfigure` whenever
 // `extensions`, `basicSetup`, `onChange`, etc. change reference. Defining
@@ -34,7 +34,7 @@ import { policyEditorTheme } from './theme'
 // `setDiagnostics` (used in the effect below) writes into the lint state
 // field that `lintGutter()` installs, so we don't need a `linter()` source
 // callback — the imperative push is the only signal the gutter needs.
-const EXTENSIONS = [yaml(), lintGutter(), policyModeDecorations]
+const EXTENSIONS = [yaml(), lintGutter(), policyModeDecorations];
 
 const BASIC_SETUP = {
   lineNumbers: true,
@@ -48,19 +48,19 @@ const BASIC_SETUP = {
   bracketMatching: false,
   closeBrackets: false,
   searchKeymap: true,
-} as const
+} as const;
 
 export interface PolicyEditorProps {
-  value: string
-  onChange: (next: string) => void
+  value: string;
+  onChange: (next: string) => void;
   /**
    * Server-side validation errors. Line-anchored ones render as gutter
    * markers; role-only errors (no line) are dropped here — the parent's
    * error list surfaces them above the editor instead.
    */
-  diagnostics?: PolicyValidationError[] | null
-  readOnly?: boolean
-  className?: string
+  diagnostics?: PolicyValidationError[] | null;
+  readOnly?: boolean;
+  className?: string;
 }
 
 export function PolicyEditor({
@@ -70,7 +70,7 @@ export function PolicyEditor({
   readOnly = false,
   className,
 }: PolicyEditorProps) {
-  const ref = useRef<ReactCodeMirrorRef>(null)
+  const ref = useRef<ReactCodeMirrorRef>(null);
 
   // Push the latest validation results into the lint state. Empty list
   // when `diagnostics` is null/empty clears the gutter markers. The view
@@ -78,13 +78,13 @@ export function PolicyEditor({
   // effect ordering), so `ref.current.view` is populated by this point on
   // initial mount; the `if (!view) return` is a defensive backstop.
   useEffect(() => {
-    const view = ref.current?.view
-    if (!view) return
+    const view = ref.current?.view;
+    if (!view) return;
     const next = diagnostics
       ? toCodemirrorDiagnostics(view.state, diagnostics)
-      : []
-    view.dispatch(setDiagnostics(view.state, next))
-  }, [diagnostics])
+      : [];
+    view.dispatch(setDiagnostics(view.state, next));
+  }, [diagnostics]);
 
   return (
     <CodeMirror
@@ -98,5 +98,5 @@ export function PolicyEditor({
       className={className}
       height="100%"
     />
-  )
+  );
 }

--- a/platform/dashboard/src/components/PolicyEditor/decorations.test.ts
+++ b/platform/dashboard/src/components/PolicyEditor/decorations.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it } from 'vitest'
-import { EditorState } from '@codemirror/state'
-import { EditorView } from '@codemirror/view'
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
 
-import { policyModeDecorations } from './decorations'
+import { policyModeDecorations } from "./decorations";
 
 /**
  * Build a real EditorView, run the ViewPlugin, return the ranges it
@@ -13,79 +13,81 @@ import { policyModeDecorations } from './decorations'
 function decoratedRanges(doc: string): Array<[number, number, string]> {
   const view = new EditorView({
     state: EditorState.create({ doc, extensions: [policyModeDecorations] }),
-  })
-  const plugin = view.plugin(policyModeDecorations)
-  const out: Array<[number, number, string]> = []
+  });
+  const plugin = view.plugin(policyModeDecorations);
+  const out: Array<[number, number, string]> = [];
   // The plugin's decoration set carries one mark per match; iterate
   // via the public RangeSet cursor.
-  const cursor = plugin?.decorations?.iter()
+  const cursor = plugin?.decorations?.iter();
   while (cursor?.value) {
     // `Decoration.mark({ class })` stores spec in `value.spec`.
-    const cls = (cursor.value.spec as { class?: string }).class ?? ''
-    out.push([cursor.from, cursor.to, cls])
-    cursor.next()
+    const cls = (cursor.value.spec as { class?: string }).class ?? "";
+    out.push([cursor.from, cursor.to, cls]);
+    cursor.next();
   }
-  view.destroy()
-  return out
+  view.destroy();
+  return out;
 }
 
-describe('policyModeDecorations', () => {
-  it('decorates `mode: deny` with cm-policy-deny', () => {
-    const doc = 'default_policy:\n  mode: deny\n'
-    const ranges = decoratedRanges(doc)
-    expect(ranges).toHaveLength(1)
-    const [from, to, cls] = ranges[0]
-    expect(doc.slice(from, to)).toBe('deny')
-    expect(cls).toBe('cm-policy-deny')
-  })
+describe("policyModeDecorations", () => {
+  it("decorates `mode: deny` with cm-policy-deny", () => {
+    const doc = "default_policy:\n  mode: deny\n";
+    const ranges = decoratedRanges(doc);
+    expect(ranges).toHaveLength(1);
+    const [from, to, cls] = ranges[0];
+    expect(doc.slice(from, to)).toBe("deny");
+    expect(cls).toBe("cm-policy-deny");
+  });
 
-  it('decorates `mode: allow` with cm-policy-allow', () => {
-    const ranges = decoratedRanges('tools:\n  refund_order:\n    mode: allow\n')
-    expect(ranges).toHaveLength(1)
-    expect(ranges[0][2]).toBe('cm-policy-allow')
-  })
+  it("decorates `mode: allow` with cm-policy-allow", () => {
+    const ranges = decoratedRanges(
+      "tools:\n  refund_order:\n    mode: allow\n",
+    );
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0][2]).toBe("cm-policy-allow");
+  });
 
-  it('decorates `mode: approval_required` with cm-policy-approval', () => {
-    const ranges = decoratedRanges('  mode: approval_required\n')
-    expect(ranges).toHaveLength(1)
-    expect(ranges[0][2]).toBe('cm-policy-approval')
-  })
+  it("decorates `mode: approval_required` with cm-policy-approval", () => {
+    const ranges = decoratedRanges("  mode: approval_required\n");
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0][2]).toBe("cm-policy-approval");
+  });
 
-  it('produces one decoration per matching line', () => {
+  it("produces one decoration per matching line", () => {
     const doc = [
-      'default_policy:',
-      '  mode: deny',
-      'tools:',
-      '  read_file:',
-      '    mode: allow',
-      '  write_file:',
-      '    mode: approval_required',
-      '',
-    ].join('\n')
-    const ranges = decoratedRanges(doc)
+      "default_policy:",
+      "  mode: deny",
+      "tools:",
+      "  read_file:",
+      "    mode: allow",
+      "  write_file:",
+      "    mode: approval_required",
+      "",
+    ].join("\n");
+    const ranges = decoratedRanges(doc);
     expect(ranges.map((r) => r[2])).toEqual([
-      'cm-policy-deny',
-      'cm-policy-allow',
-      'cm-policy-approval',
-    ])
-  })
+      "cm-policy-deny",
+      "cm-policy-allow",
+      "cm-policy-approval",
+    ]);
+  });
 
-  it('ignores `mode:` followed by an unknown value', () => {
+  it("ignores `mode:` followed by an unknown value", () => {
     // The validator catches unknown modes; the editor doesn't try to
     // semantic-color them. Plain foreground is the right "I don't know
     // what this is" fallback.
-    expect(decoratedRanges('  mode: maybe\n')).toEqual([])
-  })
+    expect(decoratedRanges("  mode: maybe\n")).toEqual([]);
+  });
 
-  it('ignores `mode:` lines that lack a value', () => {
-    expect(decoratedRanges('  mode:\n  mode:    \n')).toEqual([])
-  })
+  it("ignores `mode:` lines that lack a value", () => {
+    expect(decoratedRanges("  mode:\n  mode:    \n")).toEqual([]);
+  });
 
-  it('does not match values used outside a `mode:` key', () => {
+  it("does not match values used outside a `mode:` key", () => {
     // The word `allow` appears inside a comment / quoted string here —
     // neither is a YAML key-value pair on its own line, so the regex
     // anchored to ^...mode:...$ correctly leaves them alone.
-    const doc = '# the allow path\ndescription: "allow refunds"\n'
-    expect(decoratedRanges(doc)).toEqual([])
-  })
-})
+    const doc = '# the allow path\ndescription: "allow refunds"\n';
+    expect(decoratedRanges(doc)).toEqual([]);
+  });
+});

--- a/platform/dashboard/src/components/PolicyEditor/decorations.ts
+++ b/platform/dashboard/src/components/PolicyEditor/decorations.ts
@@ -18,61 +18,60 @@
  * and the inline-flow form still has `mode: deny` on a key-value pair
  * the regex matches inside the braces).
  */
-import { RangeSetBuilder } from '@codemirror/state'
+import { RangeSetBuilder } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
   type EditorView,
   ViewPlugin,
   type ViewUpdate,
-} from '@codemirror/view'
+} from "@codemirror/view";
 
 const CLASS_FOR_VALUE: Record<string, string> = {
-  allow: 'cm-policy-allow',
-  deny: 'cm-policy-deny',
-  approval_required: 'cm-policy-approval',
-}
+  allow: "cm-policy-allow",
+  deny: "cm-policy-deny",
+  approval_required: "cm-policy-approval",
+};
 
 // `mode: deny`, `  mode: allow`, `    mode:    approval_required`, etc.
 // Captured group is the value; we use match.index + leading-text length
 // to compute its absolute position.
-const MODE_LINE = /^(\s*mode:\s+)(allow|deny|approval_required)\b/gm
+const MODE_LINE = /^(\s*mode:\s+)(allow|deny|approval_required)\b/gm;
 
 function buildDecorations(view: EditorView): DecorationSet {
-  const builder = new RangeSetBuilder<Decoration>()
-  const doc = view.state.doc.toString()
+  const builder = new RangeSetBuilder<Decoration>();
+  const doc = view.state.doc.toString();
   // Reset stateful regex between calls (`g` flag keeps lastIndex).
-  MODE_LINE.lastIndex = 0
-  let match: RegExpExecArray | null
+  MODE_LINE.lastIndex = 0;
+  let match: RegExpExecArray | null;
   while ((match = MODE_LINE.exec(doc)) !== null) {
-    const [, prefix, value] = match
-    const from = match.index + prefix.length
-    const to = from + value.length
-    const className = CLASS_FOR_VALUE[value]
+    const [, prefix, value] = match;
+    const from = match.index + prefix.length;
+    const to = from + value.length;
+    const className = CLASS_FOR_VALUE[value];
     if (className) {
-      builder.add(from, to, Decoration.mark({ class: className }))
+      builder.add(from, to, Decoration.mark({ class: className }));
     }
   }
-  return builder.finish()
+  return builder.finish();
 }
 
 export const policyModeDecorations = ViewPlugin.fromClass(
   class {
-    decorations: DecorationSet
+    decorations: DecorationSet;
     constructor(view: EditorView) {
-      this.decorations = buildDecorations(view)
+      this.decorations = buildDecorations(view);
     }
     update(update: ViewUpdate) {
       // Rebuild only when content changed — viewport scrolls don't move
       // ranges. (For our doc sizes this is cheap; viewport-aware logic
       // would matter past ~10k lines.)
       if (update.docChanged) {
-        this.decorations = buildDecorations(update.view)
+        this.decorations = buildDecorations(update.view);
       }
     }
   },
   {
     decorations: (instance) => instance.decorations,
   },
-)
-
+);

--- a/platform/dashboard/src/components/PolicyEditor/diagnostics.test.ts
+++ b/platform/dashboard/src/components/PolicyEditor/diagnostics.test.ts
@@ -1,60 +1,60 @@
-import { describe, expect, it } from 'vitest'
-import { EditorState } from '@codemirror/state'
+import { describe, expect, it } from "vitest";
+import { EditorState } from "@codemirror/state";
 
-import { toCodemirrorDiagnostics } from './diagnostics'
+import { toCodemirrorDiagnostics } from "./diagnostics";
 
-const stateFor = (doc: string) => EditorState.create({ doc })
+const stateFor = (doc: string) => EditorState.create({ doc });
 
-describe('toCodemirrorDiagnostics', () => {
-  it('maps a line-anchored error onto the correct character range', () => {
-    const state = stateFor('a: 1\nb: 2\nc: 3')
+describe("toCodemirrorDiagnostics", () => {
+  it("maps a line-anchored error onto the correct character range", () => {
+    const state = stateFor("a: 1\nb: 2\nc: 3");
     const diagnostics = toCodemirrorDiagnostics(state, [
-      { line: 2, role: null, message: 'bad value' },
-    ])
-    expect(diagnostics).toHaveLength(1)
+      { line: 2, role: null, message: "bad value" },
+    ]);
+    expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0]).toMatchObject({
-      severity: 'error',
-      message: 'bad value',
+      severity: "error",
+      message: "bad value",
       from: 5, // start of line 2 ("b")
       to: 9, // end of line 2 ("2")
-    })
-  })
+    });
+  });
 
-  it('prefixes role-scoped errors with the role name', () => {
-    const state = stateFor('roles:\n  support: {}\n')
+  it("prefixes role-scoped errors with the role name", () => {
+    const state = stateFor("roles:\n  support: {}\n");
     const [d] = toCodemirrorDiagnostics(state, [
-      { line: 2, role: 'support', message: 'must have at least one tool' },
-    ])
-    expect(d.message).toBe('support: must have at least one tool')
-  })
+      { line: 2, role: "support", message: "must have at least one tool" },
+    ]);
+    expect(d.message).toBe("support: must have at least one tool");
+  });
 
-  it('drops errors without a line number (role-level / whole-document)', () => {
-    const state = stateFor('a: 1')
+  it("drops errors without a line number (role-level / whole-document)", () => {
+    const state = stateFor("a: 1");
     const diagnostics = toCodemirrorDiagnostics(state, [
-      { line: null, role: 'support', message: 'role not referenced' },
-      { line: null, role: null, message: 'missing default_policy' },
-    ])
-    expect(diagnostics).toEqual([])
-  })
+      { line: null, role: "support", message: "role not referenced" },
+      { line: null, role: null, message: "missing default_policy" },
+    ]);
+    expect(diagnostics).toEqual([]);
+  });
 
-  it('clamps a line number past the doc end to the last line', () => {
+  it("clamps a line number past the doc end to the last line", () => {
     // Validator may report a line that no longer exists if the user typed
     // since — clamp instead of throwing on `doc.line(out_of_range)`. No
     // trailing newline here so `doc.lines === 1` and the clamp lands on
     // a non-empty line we can assert range-of-text on.
-    const state = stateFor('only one line')
+    const state = stateFor("only one line");
     const [d] = toCodemirrorDiagnostics(state, [
-      { line: 99, role: null, message: 'phantom' },
-    ])
-    expect(d.from).toBe(0)
-    expect(d.to).toBe('only one line'.length)
-  })
+      { line: 99, role: null, message: "phantom" },
+    ]);
+    expect(d.from).toBe(0);
+    expect(d.to).toBe("only one line".length);
+  });
 
-  it('ignores errors with line=0 (1-indexed lines per server contract)', () => {
-    const state = stateFor('a: 1\n')
+  it("ignores errors with line=0 (1-indexed lines per server contract)", () => {
+    const state = stateFor("a: 1\n");
     const diagnostics = toCodemirrorDiagnostics(state, [
-      { line: 0, role: null, message: 'should not happen' },
-    ])
-    expect(diagnostics).toEqual([])
-  })
-})
+      { line: 0, role: null, message: "should not happen" },
+    ]);
+    expect(diagnostics).toEqual([]);
+  });
+});

--- a/platform/dashboard/src/components/PolicyEditor/diagnostics.ts
+++ b/platform/dashboard/src/components/PolicyEditor/diagnostics.ts
@@ -8,31 +8,31 @@
  * can't be anchored to a position in the editor; we drop them here and
  * leave the existing error list above the editor to surface them.
  */
-import type { Diagnostic } from '@codemirror/lint'
-import type { EditorState } from '@codemirror/state'
+import type { Diagnostic } from "@codemirror/lint";
+import type { EditorState } from "@codemirror/state";
 
-import type { PolicyValidationError } from '@/lib/api'
+import type { PolicyValidationError } from "@/lib/api";
 
 export function toCodemirrorDiagnostics(
   state: EditorState,
   errors: PolicyValidationError[],
 ): Diagnostic[] {
-  const total = state.doc.lines
+  const total = state.doc.lines;
   return errors
     .filter(
       (e): e is PolicyValidationError & { line: number } =>
-        typeof e.line === 'number' && e.line >= 1,
+        typeof e.line === "number" && e.line >= 1,
     )
     .map((err) => {
       // Clamp out-of-range lines (validator may return a line that no
       // longer exists if the user typed since) to the last line.
-      const lineNo = Math.min(err.line, total)
-      const line = state.doc.line(lineNo)
+      const lineNo = Math.min(err.line, total);
+      const line = state.doc.line(lineNo);
       return {
         from: line.from,
         to: line.to,
-        severity: 'error',
+        severity: "error",
         message: err.role ? `${err.role}: ${err.message}` : err.message,
-      } satisfies Diagnostic
-    })
+      } satisfies Diagnostic;
+    });
 }

--- a/platform/dashboard/src/components/PolicyEditor/index.ts
+++ b/platform/dashboard/src/components/PolicyEditor/index.ts
@@ -1,1 +1,1 @@
-export { PolicyEditor, type PolicyEditorProps } from './PolicyEditor'
+export { PolicyEditor, type PolicyEditorProps } from "./PolicyEditor";

--- a/platform/dashboard/src/components/PolicyEditor/theme.ts
+++ b/platform/dashboard/src/components/PolicyEditor/theme.ts
@@ -21,23 +21,23 @@
  * via `tokyoNightStormInit({ settings: { background: 'hsl(...)' } })`
  * later if we want them to match exactly.
  */
-import { EditorView } from '@codemirror/view'
-import { tokyoNightStormInit } from '@uiw/codemirror-theme-tokyo-night-storm'
+import { EditorView } from "@codemirror/view";
+import { tokyoNightStormInit } from "@uiw/codemirror-theme-tokyo-night-storm";
 
 const tokyoNight = tokyoNightStormInit({
   settings: {
     // Mono face — Tokyo Night Storm's default is a stack we don't use.
-    fontFamily: 'var(--font-mono)',
+    fontFamily: "var(--font-mono)",
     // Match the dashboard's text-sm (14px).
-    fontSize: '14px',
+    fontSize: "14px",
     // Blend the editor into the dashboard surface — Tokyo Night Storm's
     // default `#24283b` was slightly bluer than `--background`; using
     // the dashboard var instead means no seam between the editor and the
     // surrounding chrome.
-    background: 'hsl(var(--background))',
-    gutterBackground: 'hsl(var(--background))',
+    background: "hsl(var(--background))",
+    gutterBackground: "hsl(var(--background))",
   },
-})
+});
 
 /**
  * Editor chrome + semantic decoration colors. Kept here (in
@@ -45,23 +45,23 @@ const tokyoNight = tokyoNightStormInit({
  * styling is self-contained.
  */
 const chromeAndDecorationsTheme = EditorView.theme({
-  '.cm-content': { padding: '12px 16px' },
-  '.cm-scroller': { fontFamily: 'var(--font-mono)' },
+  ".cm-content": { padding: "12px 16px" },
+  ".cm-scroller": { fontFamily: "var(--font-mono)" },
   // Semantic mode-value coloring — applied by the ViewPlugin in
   // `./decorations.ts`. Colors come from `--semantic-*` CSS vars so the
   // editor matches the dashboard badges and audit-decision colors.
-  '.cm-policy-allow': {
-    color: 'hsl(var(--semantic-allow))',
-    fontWeight: '600',
+  ".cm-policy-allow": {
+    color: "hsl(var(--semantic-allow))",
+    fontWeight: "600",
   },
-  '.cm-policy-deny': {
-    color: 'hsl(var(--semantic-deny))',
-    fontWeight: '600',
+  ".cm-policy-deny": {
+    color: "hsl(var(--semantic-deny))",
+    fontWeight: "600",
   },
-  '.cm-policy-approval': {
-    color: 'hsl(var(--semantic-approval))',
-    fontWeight: '600',
+  ".cm-policy-approval": {
+    color: "hsl(var(--semantic-approval))",
+    fontWeight: "600",
   },
-})
+});
 
-export const policyEditorTheme = [tokyoNight, chromeAndDecorationsTheme]
+export const policyEditorTheme = [tokyoNight, chromeAndDecorationsTheme];

--- a/platform/dashboard/src/components/ProtectedRoute.tsx
+++ b/platform/dashboard/src/components/ProtectedRoute.tsx
@@ -1,9 +1,9 @@
-import { Navigate, useLocation } from 'react-router-dom'
+import { Navigate, useLocation } from "react-router-dom";
 
-import { useUser } from '@/lib/auth'
+import { useUser } from "@/lib/auth";
 
 interface ProtectedRouteProps {
-  children: React.ReactNode
+  children: React.ReactNode;
 }
 
 /**
@@ -19,15 +19,15 @@ interface ProtectedRouteProps {
  *     /sign-in entries when the user clicks back.
  */
 export function ProtectedRoute({ children }: ProtectedRouteProps) {
-  const { user, loading } = useUser()
-  const location = useLocation()
+  const { user, loading } = useUser();
+  const location = useLocation();
 
   if (loading) {
     return (
       <div className="flex h-screen items-center justify-center">
         <div className="text-sm text-muted-foreground">Loading…</div>
       </div>
-    )
+    );
   }
 
   if (!user) {
@@ -37,8 +37,8 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
         replace
         state={{ from: location.pathname + location.search }}
       />
-    )
+    );
   }
 
-  return <>{children}</>
+  return <>{children}</>;
 }

--- a/platform/dashboard/src/components/RoleSelect.tsx
+++ b/platform/dashboard/src/components/RoleSelect.tsx
@@ -4,19 +4,19 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select'
-import { ROLES, type Role } from '@/lib/orgs'
+} from "@/components/ui/select";
+import { ROLES, type Role } from "@/lib/orgs";
 
 interface RoleSelectProps {
-  value: Role
+  value: Role;
   /** Called with the new role string. The consumer is responsible
    * for the mutation + toast / error handling — this component
    * stays display-only. */
-  onChange: (role: Role) => void
+  onChange: (role: Role) => void;
   /** Greys out the trigger + makes it un-clickable. Used while the
    * underlying mutation is in flight, or to render in static mode
    * for plain members who can see roles but not change them. */
-  disabled?: boolean
+  disabled?: boolean;
 }
 
 /**
@@ -49,5 +49,5 @@ export function RoleSelect({ value, onChange, disabled }: RoleSelectProps) {
         ))}
       </SelectContent>
     </Select>
-  )
+  );
 }

--- a/platform/dashboard/src/components/VerifyEmailBanner.tsx
+++ b/platform/dashboard/src/components/VerifyEmailBanner.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react'
-import { MailWarning } from 'lucide-react'
+import { useState } from "react";
+import { MailWarning } from "lucide-react";
 
-import { Button } from '@/components/ui/button'
-import { useRequestVerify, useUser } from '@/lib/auth'
+import { Button } from "@/components/ui/button";
+import { useRequestVerify, useUser } from "@/lib/auth";
 
 /**
  * Soft banner shown to logged-in but unverified users. Non-blocking —
@@ -14,11 +14,11 @@ import { useRequestVerify, useUser } from '@/lib/auth'
  * actually tries to mint a token. For now, a header strip is enough.
  */
 export function VerifyEmailBanner() {
-  const { user } = useUser()
-  const requestVerify = useRequestVerify()
-  const [resent, setResent] = useState(false)
+  const { user } = useUser();
+  const requestVerify = useRequestVerify();
+  const [resent, setResent] = useState(false);
 
-  if (!user || user.is_verified) return null
+  if (!user || user.is_verified) return null;
 
   return (
     <div className="flex items-center gap-3 border-b border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm">
@@ -36,17 +36,17 @@ export function VerifyEmailBanner() {
           disabled={requestVerify.isPending}
           onClick={async () => {
             try {
-              await requestVerify.mutateAsync(user.email)
-              setResent(true)
+              await requestVerify.mutateAsync(user.email);
+              setResent(true);
             } catch {
               // 202 is the success path; anything else we just leave
               // the button armed — the banner already conveys the state.
             }
           }}
         >
-          {requestVerify.isPending ? 'Sending…' : 'Resend email'}
+          {requestVerify.isPending ? "Sending…" : "Resend email"}
         </Button>
       )}
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/components/audit/chart-tokens.ts
+++ b/platform/dashboard/src/components/audit/chart-tokens.ts
@@ -1,40 +1,58 @@
-import type { AuditOutcome } from '@/lib/api'
-import type { ChartSeries } from '@/components/ui/charts'
+import type { AuditOutcome } from "@/lib/api";
+import type { ChartSeries } from "@/components/ui/charts";
 
 // Shared palette (--semantic-* tokens). Separate module so charts.tsx exports
 // only components (react-refresh).
 export const CHART_COLORS = {
-  allow: 'hsl(var(--semantic-allow))',
-  deny: 'hsl(var(--semantic-deny))',
-  needs_approval: 'hsl(var(--semantic-approval))',
-  primary: 'hsl(var(--primary))',
-  grid: 'hsl(var(--border))',
-  muted: 'hsl(var(--muted-foreground))',
-} as const
+  allow: "hsl(var(--semantic-allow))",
+  deny: "hsl(var(--semantic-deny))",
+  needs_approval: "hsl(var(--semantic-approval))",
+  primary: "hsl(var(--primary))",
+  grid: "hsl(var(--border))",
+  muted: "hsl(var(--muted-foreground))",
+} as const;
 
 export const OUT_LABEL: Record<AuditOutcome, string> = {
-  allow: 'allow',
-  deny: 'deny',
-  needs_approval: 'approval',
-}
+  allow: "allow",
+  deny: "deny",
+  needs_approval: "approval",
+};
 
 // Legend-swatch background classes. Static map — Tailwind's scanner can't
 // see interpolated class names like `bg-${k}`.
 export const OUT_SWATCH: Record<AuditOutcome, string> = {
-  allow: 'bg-allow',
-  deny: 'bg-deny',
-  needs_approval: 'bg-approval',
-}
+  allow: "bg-allow",
+  deny: "bg-deny",
+  needs_approval: "bg-approval",
+};
 
 // Display label for the empty-role bucket. Local to the dashboard — the
 // wire carries the raw "" key (and `role=` filters it), so the stored data
 // and API never reserve this string. A role literally named "(none)" would
 // be display-ambiguous here, but its data stays intact and queryable.
-export const NO_VALUE_LABEL = '(none)'
+export const NO_VALUE_LABEL = "(none)";
 
 // The outcome stack, in render order, for the generic ui/charts primitives.
 export const OUTCOME_SERIES: ChartSeries[] = [
-  { key: 'allow', label: OUT_LABEL.allow, color: CHART_COLORS.allow, swatchClass: OUT_SWATCH.allow, fillOpacity: 0.16 },
-  { key: 'needs_approval', label: OUT_LABEL.needs_approval, color: CHART_COLORS.needs_approval, swatchClass: OUT_SWATCH.needs_approval, fillOpacity: 0.4 },
-  { key: 'deny', label: OUT_LABEL.deny, color: CHART_COLORS.deny, swatchClass: OUT_SWATCH.deny, fillOpacity: 0.55 },
-]
+  {
+    key: "allow",
+    label: OUT_LABEL.allow,
+    color: CHART_COLORS.allow,
+    swatchClass: OUT_SWATCH.allow,
+    fillOpacity: 0.16,
+  },
+  {
+    key: "needs_approval",
+    label: OUT_LABEL.needs_approval,
+    color: CHART_COLORS.needs_approval,
+    swatchClass: OUT_SWATCH.needs_approval,
+    fillOpacity: 0.4,
+  },
+  {
+    key: "deny",
+    label: OUT_LABEL.deny,
+    color: CHART_COLORS.deny,
+    swatchClass: OUT_SWATCH.deny,
+    fillOpacity: 0.55,
+  },
+];

--- a/platform/dashboard/src/components/audit/charts.tsx
+++ b/platform/dashboard/src/components/audit/charts.tsx
@@ -4,30 +4,30 @@
  * is bound to the allow/deny/needs_approval outcome domain.
  */
 
-import { Check, CircleDashed, X } from 'lucide-react'
-import type { AuditOutcome } from '@/lib/api'
-import { Badge } from '@/components/ui/badge'
-import { OUT_LABEL } from './chart-tokens'
+import { Check, CircleDashed, X } from "lucide-react";
+import type { AuditOutcome } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { OUT_LABEL } from "./chart-tokens";
 
 export interface Counts {
-  allow: number
-  deny: number
-  needs_approval: number
-  total: number
+  allow: number;
+  deny: number;
+  needs_approval: number;
+  total: number;
 }
 
 export interface BreakdownDatum extends Counts {
-  key: string
+  key: string;
 }
 
 export function DecisionBadge({ d }: { d: AuditOutcome }) {
-  const OutcomeIcon = d === 'allow' ? Check : d === 'deny' ? X : CircleDashed
+  const OutcomeIcon = d === "allow" ? Check : d === "deny" ? X : CircleDashed;
   return (
-    <Badge variant={d === 'needs_approval' ? 'approval' : d}>
+    <Badge variant={d === "needs_approval" ? "approval" : d}>
       <OutcomeIcon className="size-3" strokeWidth={2} />
       {OUT_LABEL[d]}
     </Badge>
-  )
+  );
 }
 
 // ——— Stacked breakdown bar row (allow/approval/deny, deny emphasised) ———
@@ -38,23 +38,25 @@ export function BreakdownBar({
   onClick,
   active,
 }: {
-  label: string
-  row: BreakdownDatum
-  max: number
-  onClick?: () => void
-  active?: boolean
+  label: string;
+  row: BreakdownDatum;
+  max: number;
+  onClick?: () => void;
+  active?: boolean;
 }) {
-  const seg = (k: AuditOutcome) => (row.total ? (row[k] / row.total) * 100 : 0)
-  const widthPct = max ? (row.total / max) * 100 : 0
+  const seg = (k: AuditOutcome) => (row.total ? (row[k] / row.total) * 100 : 0);
+  const widthPct = max ? (row.total / max) * 100 : 0;
   return (
     <div
       onClick={onClick}
-      className={`mb-[11px] transition-opacity ${onClick ? 'cursor-pointer' : ''} ${active === false ? 'opacity-45' : ''}`}
+      className={`mb-[11px] transition-opacity ${onClick ? "cursor-pointer" : ""} ${active === false ? "opacity-45" : ""}`}
     >
       <div className="mb-1 flex justify-between gap-2 text-[12.5px]">
         <span className="truncate font-mono">{label}</span>
         <span className="shrink-0 text-muted-foreground">
-          {row.deny > 0 && <span className="mr-2 text-deny">{row.deny} denied</span>}
+          {row.deny > 0 && (
+            <span className="mr-2 text-deny">{row.deny} denied</span>
+          )}
           <span className="text-foreground">{row.total.toLocaleString()}</span>
         </span>
       </div>
@@ -62,10 +64,13 @@ export function BreakdownBar({
         className="flex h-1.5 min-w-6 overflow-hidden rounded-[3px] bg-secondary"
         style={{ width: `${Math.max(widthPct, 4)}%` }}
       >
-        <div className="bg-allow" style={{ width: `${seg('allow')}%` }} />
-        <div className="bg-approval" style={{ width: `${seg('needs_approval')}%` }} />
-        <div className="bg-deny" style={{ width: `${seg('deny')}%` }} />
+        <div className="bg-allow" style={{ width: `${seg("allow")}%` }} />
+        <div
+          className="bg-approval"
+          style={{ width: `${seg("needs_approval")}%` }}
+        />
+        <div className="bg-deny" style={{ width: `${seg("deny")}%` }} />
       </div>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/components/audit/pieces.tsx
+++ b/platform/dashboard/src/components/audit/pieces.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ComponentType } from 'react'
+import { useMemo, useState, type ComponentType } from "react";
 import {
   Check,
   ChevronRight,
@@ -6,26 +6,26 @@ import {
   Download,
   List,
   X,
-} from 'lucide-react'
+} from "lucide-react";
 import type {
   AuditBreakdownRow,
   AuditDecisionRow,
   AuditOutcome,
-} from '@/lib/api'
+} from "@/lib/api";
 import type {
   AuditFilters as Filters,
   SetAuditFilters as SetFilters,
-} from '@/lib/audit-filters'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
+} from "@/lib/audit-filters";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select'
+} from "@/components/ui/select";
 import {
   Table,
   TableBody,
@@ -33,17 +33,24 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
-import { Sparkline } from '@/components/ui/charts'
-import { BreakdownBar, type BreakdownDatum, DecisionBadge } from './charts'
-import { OUTCOME_SERIES } from './chart-tokens'
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Sparkline } from "@/components/ui/charts";
+import { BreakdownBar, type BreakdownDatum, DecisionBadge } from "./charts";
+import { OUTCOME_SERIES } from "./chart-tokens";
 
 const fmtTs = (d: Date) =>
-  d.toLocaleString('en-US', {
-    month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
-  }) + '.' + String(d.getMilliseconds()).padStart(3, '0')
+  d.toLocaleString("en-US", {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }) +
+  "." +
+  String(d.getMilliseconds()).padStart(3, "0");
 
 // Map a server breakdown row ({key, all, ...}) to the chart datum ({total, ...}).
 const toDatum = (r: AuditBreakdownRow): BreakdownDatum => ({
@@ -52,73 +59,138 @@ const toDatum = (r: AuditBreakdownRow): BreakdownDatum => ({
   allow: r.allow,
   deny: r.deny,
   needs_approval: r.needs_approval,
-})
+});
 
 // Radix Select items can't carry value="" — UI-local stand-in for "all".
-const ALL = '__all__'
+const ALL = "__all__";
 
 // Module-level (not re-created per render).
-function FilterSelect({ value, all, opts, onChange }: { value: string; all: string; opts: string[]; onChange: (v: string) => void }) {
+function FilterSelect({
+  value,
+  all,
+  opts,
+  onChange,
+}: {
+  value: string;
+  all: string;
+  opts: string[];
+  onChange: (v: string) => void;
+}) {
   return (
-    <Select value={value || ALL} onValueChange={(v) => onChange(v === ALL ? '' : v)}>
+    <Select
+      value={value || ALL}
+      onValueChange={(v) => onChange(v === ALL ? "" : v)}
+    >
       <SelectTrigger className="h-8 w-auto min-w-32 gap-1.5 text-[13px]">
         <SelectValue />
       </SelectTrigger>
       <SelectContent>
         <SelectItem value={ALL}>{all}</SelectItem>
-        {opts.map((o) => <SelectItem key={o} value={o} className="font-mono text-xs">{o}</SelectItem>)}
+        {opts.map((o) => (
+          <SelectItem key={o} value={o} className="font-mono text-xs">
+            {o}
+          </SelectItem>
+        ))}
       </SelectContent>
     </Select>
-  )
+  );
 }
 
 // ————————————————————————————————————————————— Filter bar
 export function FilterBar({
-  f, setF, shown, total, agents, roles, tools,
+  f,
+  setF,
+  shown,
+  total,
+  agents,
+  roles,
+  tools,
 }: {
-  f: Filters
-  setF: SetFilters
-  shown: number
-  total: number
-  agents: string[]
-  roles: string[]
-  tools: string[]
+  f: Filters;
+  setF: SetFilters;
+  shown: number;
+  total: number;
+  agents: string[];
+  roles: string[];
+  tools: string[];
 }) {
-  const set = <K extends keyof Filters>(k: K, v: Filters[K]) => setF((p) => ({ ...p, [k]: v }))
+  const set = <K extends keyof Filters>(k: K, v: Filters[K]) =>
+    setF((p) => ({ ...p, [k]: v }));
   return (
     <div className="mb-3.5 flex flex-wrap items-center gap-2">
-      <FilterSelect value={f.agent} all="All agents" opts={agents} onChange={(v) => set('agent', v)} />
-      <FilterSelect value={f.role} all="All roles" opts={roles} onChange={(v) => set('role', v)} />
-      <FilterSelect value={f.tool} all="All tools" opts={tools} onChange={(v) => set('tool', v)} />
+      <FilterSelect
+        value={f.agent}
+        all="All agents"
+        opts={agents}
+        onChange={(v) => set("agent", v)}
+      />
+      <FilterSelect
+        value={f.role}
+        all="All roles"
+        opts={roles}
+        onChange={(v) => set("role", v)}
+      />
+      <FilterSelect
+        value={f.tool}
+        all="All tools"
+        opts={tools}
+        onChange={(v) => set("tool", v)}
+      />
       <span className="ml-1 text-xs text-muted-foreground">Outcome</span>
       <ToggleGroup
         type="single"
         value={f.outcome || ALL}
-        onValueChange={(v) => set('outcome', !v || v === ALL ? '' : (v as AuditOutcome))}
+        onValueChange={(v) =>
+          set("outcome", !v || v === ALL ? "" : (v as AuditOutcome))
+        }
       >
-        <ToggleGroupItem value={ALL}><List className="size-3" />All</ToggleGroupItem>
-        <ToggleGroupItem value="allow" className="text-allow data-[state=on]:bg-allow/15 data-[state=on]:text-allow">
-          <Check className="size-3" strokeWidth={2} />allow
+        <ToggleGroupItem value={ALL}>
+          <List className="size-3" />
+          All
         </ToggleGroupItem>
-        <ToggleGroupItem value="deny" className="text-deny data-[state=on]:bg-deny/15 data-[state=on]:text-deny">
-          <X className="size-3" strokeWidth={2} />deny
+        <ToggleGroupItem
+          value="allow"
+          className="text-allow data-[state=on]:bg-allow/15 data-[state=on]:text-allow"
+        >
+          <Check className="size-3" strokeWidth={2} />
+          allow
         </ToggleGroupItem>
-        <ToggleGroupItem value="needs_approval" className="text-approval data-[state=on]:bg-approval/15 data-[state=on]:text-approval">
-          <CircleDashed className="size-3" strokeWidth={2} />approval
+        <ToggleGroupItem
+          value="deny"
+          className="text-deny data-[state=on]:bg-deny/15 data-[state=on]:text-deny"
+        >
+          <X className="size-3" strokeWidth={2} />
+          deny
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          value="needs_approval"
+          className="text-approval data-[state=on]:bg-approval/15 data-[state=on]:text-approval"
+        >
+          <CircleDashed className="size-3" strokeWidth={2} />
+          approval
         </ToggleGroupItem>
       </ToggleGroup>
       <span className="ml-auto whitespace-nowrap text-xs text-muted-foreground">
-        <span className="text-foreground">{shown.toLocaleString()}</span> of <span className="font-mono">{total.toLocaleString()}</span> decisions
+        <span className="text-foreground">{shown.toLocaleString()}</span> of{" "}
+        <span className="font-mono">{total.toLocaleString()}</span> decisions
       </span>
     </div>
-  )
+  );
 }
 
 export function ActiveChips({ f, setF }: { f: Filters; setF: SetFilters }) {
-  const set = <K extends keyof Filters>(k: K, v: Filters[K]) => setF((p) => ({ ...p, [k]: v }))
-  const lbl: Record<string, string> = { agent: 'agent', role: 'role', tool: 'tool', outcome: 'outcome' }
-  const chips = (['agent', 'role', 'tool', 'outcome'] as const).filter((k) => f[k])
-  if (!chips.length) return null
+  const set = <K extends keyof Filters>(k: K, v: Filters[K]) =>
+    setF((p) => ({ ...p, [k]: v }));
+  const lbl: Record<string, string> = {
+    agent: "agent",
+    role: "role",
+    tool: "tool",
+    outcome: "outcome",
+  };
+  const chips = (["agent", "role", "tool", "outcome"] as const).filter(
+    (k) => f[k],
+  );
+  if (!chips.length) return null;
   return (
     <div className="mb-4 flex flex-wrap items-center gap-1.5">
       <span className="text-[11.5px] text-muted-foreground">Filters</span>
@@ -126,83 +198,122 @@ export function ActiveChips({ f, setF }: { f: Filters; setF: SetFilters }) {
         <Badge key={k} className="gap-1 pr-1 text-muted-foreground">
           {lbl[k]}: <span className="font-mono text-foreground">{f[k]}</span>
           <button
-            onClick={() => set(k, '')}
+            onClick={() => set(k, "")}
             className="inline-flex cursor-pointer text-muted-foreground hover:text-foreground"
           >
             <X className="size-3" />
           </button>
         </Badge>
       ))}
-      <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={() => setF((p) => ({ agent: '', role: '', tool: '', outcome: '', range: p.range, start_date: null, end_date: null }))}>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 px-2 text-xs"
+        onClick={() =>
+          setF((p) => ({
+            agent: "",
+            role: "",
+            tool: "",
+            outcome: "",
+            range: p.range,
+            start_date: null,
+            end_date: null,
+          }))
+        }
+      >
         Clear all
       </Button>
     </div>
-  )
+  );
 }
 
 // ————————————————————————————————————————————— KPI tile
 export function KpiCard({
-  label, icon: KpiIcon, value, sub, color, spark, sparkColor, showSpark, onClick, active,
+  label,
+  icon: KpiIcon,
+  value,
+  sub,
+  color,
+  spark,
+  sparkColor,
+  showSpark,
+  onClick,
+  active,
 }: {
-  label: string
-  icon: ComponentType<{ className?: string }>
-  value: string
-  sub: string
-  color?: 'allow' | 'deny' | 'approval'
-  spark?: number[]
-  sparkColor?: string
-  showSpark?: boolean
-  onClick?: () => void
-  active?: boolean
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  value: string;
+  sub: string;
+  color?: "allow" | "deny" | "approval";
+  spark?: number[];
+  sparkColor?: string;
+  showSpark?: boolean;
+  onClick?: () => void;
+  active?: boolean;
 }) {
   // Static map — Tailwind's scanner can't see interpolated class names.
-  const valColor = { allow: 'text-allow', deny: 'text-deny', approval: 'text-approval' }
+  const valColor = {
+    allow: "text-allow",
+    deny: "text-deny",
+    approval: "text-approval",
+  };
   return (
     <Card
       onClick={onClick}
-      className={`p-5 transition-colors ${onClick ? 'cursor-pointer' : ''} ${active ? 'border-primary/50' : ''}`}
+      className={`p-5 transition-colors ${onClick ? "cursor-pointer" : ""} ${active ? "border-primary/50" : ""}`}
     >
       <div className="flex flex-col gap-1.5">
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <KpiIcon className="size-3.5" />
           <span>{label}</span>
         </div>
-        <div className={`text-[28px] font-semibold leading-tight tracking-tight ${color ? valColor[color] : ''}`}>
+        <div
+          className={`text-[28px] font-semibold leading-tight tracking-tight ${color ? valColor[color] : ""}`}
+        >
           {value}
         </div>
         <div className="text-[11.5px] text-muted-foreground">{sub}</div>
-        {showSpark && spark && <div className="mt-1.5"><Sparkline data={spark} color={sparkColor} width={170} /></div>}
+        {showSpark && spark && (
+          <div className="mt-1.5">
+            <Sparkline data={spark} color={sparkColor} width={170} />
+          </div>
+        )}
       </div>
     </Card>
-  )
+  );
 }
 
 // ————————————————————————————————————————————— Breakdown card
 const DIMS = [
-  { id: 'tool' as const, label: 'Tools', fkey: 'tool' as const },
-  { id: 'agent' as const, label: 'Agents', fkey: 'agent' as const },
-  { id: 'role' as const, label: 'Roles', fkey: 'role' as const },
-]
+  { id: "tool" as const, label: "Tools", fkey: "tool" as const },
+  { id: "agent" as const, label: "Agents", fkey: "agent" as const },
+  { id: "role" as const, label: "Roles", fkey: "role" as const },
+];
 
 export function BreakdownCard({
-  byTool, byAgent, byRole, f, setF,
+  byTool,
+  byAgent,
+  byRole,
+  f,
+  setF,
 }: {
-  byTool: AuditBreakdownRow[]
-  byAgent: AuditBreakdownRow[]
-  byRole: AuditBreakdownRow[]
-  f: Filters
-  setF: SetFilters
+  byTool: AuditBreakdownRow[];
+  byAgent: AuditBreakdownRow[];
+  byRole: AuditBreakdownRow[];
+  f: Filters;
+  setF: SetFilters;
 }) {
-  const [dim, setDim] = useState<'tool' | 'agent' | 'role'>('tool')
-  const [sort, setSort] = useState<'volume' | 'denials'>('volume')
-  const source = dim === 'tool' ? byTool : dim === 'agent' ? byAgent : byRole
+  const [dim, setDim] = useState<"tool" | "agent" | "role">("tool");
+  const [sort, setSort] = useState<"volume" | "denials">("volume");
+  const source = dim === "tool" ? byTool : dim === "agent" ? byAgent : byRole;
   const data = useMemo(() => {
-    let d = source.map(toDatum)
-    if (sort === 'denials') d = d.slice().sort((a, b) => b.deny - a.deny || b.total - a.total)
-    return d.slice(0, 10)
-  }, [source, sort])
-  const max = Math.max(...data.map((d) => d.total), 1)
-  const fkey = dim
+    let d = source.map(toDatum);
+    if (sort === "denials")
+      d = d.slice().sort((a, b) => b.deny - a.deny || b.total - a.total);
+    return d.slice(0, 10);
+  }, [source, sort]);
+  const max = Math.max(...data.map((d) => d.total), 1);
+  const fkey = dim;
 
   return (
     <Card className="flex flex-col p-6">
@@ -210,11 +321,16 @@ export function BreakdownCard({
         <Tabs value={dim} onValueChange={(v) => setDim(v as typeof dim)}>
           <TabsList>
             {DIMS.map((d) => (
-              <TabsTrigger key={d.id} value={d.id}>{d.label}</TabsTrigger>
+              <TabsTrigger key={d.id} value={d.id}>
+                {d.label}
+              </TabsTrigger>
             ))}
           </TabsList>
         </Tabs>
-        <Select value={sort} onValueChange={(v) => setSort(v as 'volume' | 'denials')}>
+        <Select
+          value={sort}
+          onValueChange={(v) => setSort(v as "volume" | "denials")}
+        >
           <SelectTrigger className="h-7 w-auto gap-1.5 text-xs">
             <SelectValue />
           </SelectTrigger>
@@ -226,45 +342,71 @@ export function BreakdownCard({
       </div>
       <div className="grid flex-1 grid-cols-2 gap-x-8">
         {data.map((row) => (
-          <BreakdownBar key={row.key} label={row.key} row={row} max={max}
+          <BreakdownBar
+            key={row.key}
+            label={row.key}
+            row={row}
+            max={max}
             active={!f[fkey] || f[fkey] === row.key}
-            onClick={() => setF((p) => ({ ...p, [fkey]: p[fkey] === row.key ? '' : row.key }))} />
+            onClick={() =>
+              setF((p) => ({
+                ...p,
+                [fkey]: p[fkey] === row.key ? "" : row.key,
+              }))
+            }
+          />
         ))}
-        {!data.length && <div className="py-2 text-[12.5px] text-muted-foreground">No decisions match.</div>}
+        {!data.length && (
+          <div className="py-2 text-[12.5px] text-muted-foreground">
+            No decisions match.
+          </div>
+        )}
       </div>
       <div className="mt-1 flex gap-3.5 border-t border-border pt-3 text-[11px] text-muted-foreground">
         {OUTCOME_SERIES.map((s) => (
           <span key={s.key} className="flex items-center gap-1.5">
-            <span className={`size-2 rounded-sm ${s.swatchClass}`} />{s.label}
+            <span className={`size-2 rounded-sm ${s.swatchClass}`} />
+            {s.label}
           </span>
         ))}
         <span className="ml-auto">click a bar to filter →</span>
       </div>
     </Card>
-  )
+  );
 }
 
 // ————————————————————————————————————————————— Events table
 export function EventsTable({
-  rows, total, onSelect, selectedId, onLoadMore, loadingMore, onExport,
+  rows,
+  total,
+  onSelect,
+  selectedId,
+  onLoadMore,
+  loadingMore,
+  onExport,
 }: {
-  rows: AuditDecisionRow[]
-  total: number
-  onSelect: (e: AuditDecisionRow) => void
-  selectedId?: string | null
-  onLoadMore: () => void
-  loadingMore?: boolean
-  onExport?: () => void
+  rows: AuditDecisionRow[];
+  total: number;
+  onSelect: (e: AuditDecisionRow) => void;
+  selectedId?: string | null;
+  onLoadMore: () => void;
+  loadingMore?: boolean;
+  onExport?: () => void;
 }) {
   return (
     <Card className="overflow-hidden p-0">
       <div className="flex items-center justify-between border-b border-border px-5 py-4">
         <div>
           <div className="text-[15px] font-semibold">Decisions</div>
-          <div className="mt-0.5 text-xs text-muted-foreground">Newest first · ordered by <span className="font-mono">occurred_at</span>. Click a row to inspect.</div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            Newest first · ordered by{" "}
+            <span className="font-mono">occurred_at</span>. Click a row to
+            inspect.
+          </div>
         </div>
         <Button variant="ghost" onClick={onExport} disabled={!onExport}>
-          <Download className="size-3.5" />Export JSONL
+          <Download className="size-3.5" />
+          Export JSONL
         </Button>
       </div>
       <div className="overflow-x-auto">
@@ -285,20 +427,39 @@ export function EventsTable({
               <TableRow
                 key={e.event_id}
                 onClick={() => onSelect(e)}
-                className={`cursor-pointer ${selectedId === e.event_id ? 'bg-primary/10 hover:bg-primary/10' : ''}`}
+                className={`cursor-pointer ${selectedId === e.event_id ? "bg-primary/10 hover:bg-primary/10" : ""}`}
               >
-                <TableCell className="font-mono text-xs text-muted-foreground">{fmtTs(new Date(e.occurred_at))}</TableCell>
-                <TableCell className="font-mono text-[12.5px]">{e.agent_name}</TableCell>
-                <TableCell className={e.role ? '' : 'text-muted-foreground'}>{e.role || '—'}</TableCell>
-                <TableCell className="font-mono text-[12.5px]">{e.tool_name}</TableCell>
-                <TableCell><DecisionBadge d={e.outcome} /></TableCell>
-                <TableCell className="max-w-80 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] text-muted-foreground">{e.reason || '—'}</TableCell>
-                <TableCell><ChevronRight className="size-3.5 text-muted-foreground" /></TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  {fmtTs(new Date(e.occurred_at))}
+                </TableCell>
+                <TableCell className="font-mono text-[12.5px]">
+                  {e.agent_name}
+                </TableCell>
+                <TableCell className={e.role ? "" : "text-muted-foreground"}>
+                  {e.role || "—"}
+                </TableCell>
+                <TableCell className="font-mono text-[12.5px]">
+                  {e.tool_name}
+                </TableCell>
+                <TableCell>
+                  <DecisionBadge d={e.outcome} />
+                </TableCell>
+                <TableCell className="max-w-80 overflow-hidden text-ellipsis whitespace-nowrap text-[12.5px] text-muted-foreground">
+                  {e.reason || "—"}
+                </TableCell>
+                <TableCell>
+                  <ChevronRight className="size-3.5 text-muted-foreground" />
+                </TableCell>
               </TableRow>
             ))}
             {!rows.length && (
               <TableRow>
-                <TableCell colSpan={7} className="py-8 text-center text-muted-foreground">No decisions match the current filters.</TableCell>
+                <TableCell
+                  colSpan={7}
+                  className="py-8 text-center text-muted-foreground"
+                >
+                  No decisions match the current filters.
+                </TableCell>
               </TableRow>
             )}
           </TableBody>
@@ -306,11 +467,18 @@ export function EventsTable({
       </div>
       {rows.length < total && (
         <div className="border-t border-border px-5 py-3 text-center">
-          <Button variant="secondary" size="sm" onClick={onLoadMore} disabled={loadingMore}>
-            {loadingMore ? 'Loading…' : `Load 40 more · ${(total - rows.length).toLocaleString()} remaining`}
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+          >
+            {loadingMore
+              ? "Loading…"
+              : `Load 40 more · ${(total - rows.length).toLocaleString()} remaining`}
           </Button>
         </div>
       )}
     </Card>
-  )
+  );
 }

--- a/platform/dashboard/src/components/graph/nodes.tsx
+++ b/platform/dashboard/src/components/graph/nodes.tsx
@@ -1,110 +1,137 @@
-import { Handle, Position, type NodeProps } from '@xyflow/react'
-import { Users, Bot, Wrench } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { Users, Bot, Wrench } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface RoleData {
-  label: string
-  muted?: boolean
-  [key: string]: unknown
+  label: string;
+  muted?: boolean;
+  [key: string]: unknown;
 }
 
 interface AgentData {
-  name: string
-  model?: string
-  toolCount?: number
-  [key: string]: unknown
+  name: string;
+  model?: string;
+  toolCount?: number;
+  [key: string]: unknown;
 }
 
 interface ToolData {
-  name: string
-  mode?: 'allow' | 'deny' | 'approval_required' | 'default'
-  [key: string]: unknown
+  name: string;
+  mode?: "allow" | "deny" | "approval_required" | "default";
+  [key: string]: unknown;
 }
 
 const MODE_STRIP: Record<string, string> = {
-  allow: 'bg-allow',
-  deny: 'bg-deny',
-  approval_required: 'bg-approval',
-  default: 'bg-muted-foreground',
-}
+  allow: "bg-allow",
+  deny: "bg-deny",
+  approval_required: "bg-approval",
+  default: "bg-muted-foreground",
+};
 
 export function RoleNode({ data, selected }: NodeProps) {
-  const d = data as RoleData
+  const d = data as RoleData;
   return (
     <div
       className={cn(
-        'relative flex items-center gap-2.5 rounded-md border px-3 py-2 min-w-[160px] transition-colors',
+        "relative flex items-center gap-2.5 rounded-md border px-3 py-2 min-w-[160px] transition-colors",
         selected
-          ? 'border-primary bg-primary/10'
+          ? "border-primary bg-primary/10"
           : d.muted
-            ? 'border-border bg-card text-muted-foreground'
-            : 'border-border bg-card',
+            ? "border-border bg-card text-muted-foreground"
+            : "border-border bg-card",
       )}
     >
-      <Users className={cn('size-4', d.muted ? 'text-muted-foreground' : 'text-primary')} />
+      <Users
+        className={cn(
+          "size-4",
+          d.muted ? "text-muted-foreground" : "text-primary",
+        )}
+      />
       <div>
         <div className="text-sm font-medium text-foreground">{d.label}</div>
-        {d.muted && <div className="text-[10px] text-muted-foreground">default</div>}
+        {d.muted && (
+          <div className="text-[10px] text-muted-foreground">default</div>
+        )}
       </div>
-      <Handle type="source" position={Position.Right} className="!bg-border !border-0" />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!bg-border !border-0"
+      />
     </div>
-  )
+  );
 }
 
 export function AgentNode({ data, selected }: NodeProps) {
-  const d = data as AgentData
+  const d = data as AgentData;
   return (
     <div
       className={cn(
-        'relative flex items-start gap-2.5 rounded-md border px-3 py-2 min-w-[180px] transition-colors',
-        selected ? 'border-primary bg-primary/10' : 'border-border bg-card',
+        "relative flex items-start gap-2.5 rounded-md border px-3 py-2 min-w-[180px] transition-colors",
+        selected ? "border-primary bg-primary/10" : "border-border bg-card",
       )}
     >
       <Bot className="size-4 mt-0.5 text-foreground" />
       <div className="flex-1 min-w-0">
-        <div className="text-sm font-medium text-foreground truncate">{d.name}</div>
+        <div className="text-sm font-medium text-foreground truncate">
+          {d.name}
+        </div>
         <div className="flex items-center gap-1.5 text-[10px] text-muted-foreground">
           {d.model && <span className="font-mono">{d.model}</span>}
-          {typeof d.toolCount === 'number' && (
+          {typeof d.toolCount === "number" && (
             <>
               <span>·</span>
               <span>
-                {d.toolCount} tool{d.toolCount === 1 ? '' : 's'}
+                {d.toolCount} tool{d.toolCount === 1 ? "" : "s"}
               </span>
             </>
           )}
         </div>
       </div>
-      <Handle type="target" position={Position.Left} className="!bg-border !border-0" />
-      <Handle type="source" position={Position.Right} className="!bg-border !border-0" />
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!bg-border !border-0"
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!bg-border !border-0"
+      />
     </div>
-  )
+  );
 }
 
 export function ToolNode({ data, selected }: NodeProps) {
-  const d = data as ToolData
+  const d = data as ToolData;
   return (
     <div
       className={cn(
-        'relative flex items-center gap-2 rounded-md border px-3 py-2 min-w-[160px] transition-colors overflow-hidden',
-        selected ? 'border-primary bg-primary/10' : 'border-border bg-card',
+        "relative flex items-center gap-2 rounded-md border px-3 py-2 min-w-[160px] transition-colors overflow-hidden",
+        selected ? "border-primary bg-primary/10" : "border-border bg-card",
       )}
     >
       <span
         className={cn(
-          'absolute left-0 top-0 bottom-0 w-[3px]',
-          MODE_STRIP[d.mode ?? 'default'],
+          "absolute left-0 top-0 bottom-0 w-[3px]",
+          MODE_STRIP[d.mode ?? "default"],
         )}
       />
       <Wrench className="size-4 text-muted-foreground ml-1.5" />
-      <div className="text-sm font-medium text-foreground font-mono">{d.name}</div>
-      <Handle type="target" position={Position.Left} className="!bg-border !border-0" />
+      <div className="text-sm font-medium text-foreground font-mono">
+        {d.name}
+      </div>
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!bg-border !border-0"
+      />
     </div>
-  )
+  );
 }
 
 export const nodeTypes = {
   role: RoleNode,
   agent: AgentNode,
   tool: ToolNode,
-}
+};

--- a/platform/dashboard/src/components/ui/alert.tsx
+++ b/platform/dashboard/src/components/ui/alert.tsx
@@ -1,20 +1,20 @@
-import * as React from 'react'
-import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
-  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4',
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4",
   {
     variants: {
       variant: {
-        default: 'bg-background text-foreground border-border',
+        default: "bg-background text-foreground border-border",
         destructive:
-          'border-destructive/50 text-destructive [&>svg]:text-destructive bg-destructive/5',
+          "border-destructive/50 text-destructive [&>svg]:text-destructive bg-destructive/5",
       },
     },
-    defaultVariants: { variant: 'default' },
+    defaultVariants: { variant: "default" },
   },
-)
+);
 
 const Alert = React.forwardRef<
   HTMLDivElement,
@@ -26,19 +26,20 @@ const Alert = React.forwardRef<
     className={cn(alertVariants({ variant }), className)}
     {...props}
   />
-))
-Alert.displayName = 'Alert'
+));
+Alert.displayName = "Alert";
 
-const AlertTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h5
-      ref={ref}
-      className={cn('mb-1 font-medium leading-none tracking-tight', className)}
-      {...props}
-    />
-  ),
-)
-AlertTitle.displayName = 'AlertTitle'
+const AlertTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -46,10 +47,10 @@ const AlertDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('text-sm [&_p]:leading-relaxed', className)}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />
-))
-AlertDescription.displayName = 'AlertDescription'
+));
+AlertDescription.displayName = "AlertDescription";
 
-export { Alert, AlertTitle, AlertDescription }
+export { Alert, AlertTitle, AlertDescription };

--- a/platform/dashboard/src/components/ui/badge.tsx
+++ b/platform/dashboard/src/components/ui/badge.tsx
@@ -1,32 +1,35 @@
-import * as React from 'react'
-import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium transition-colors',
+  "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium transition-colors",
   {
     variants: {
       variant: {
-        default: 'bg-secondary text-secondary-foreground',
-        outline: 'border border-border text-muted-foreground',
-        allow: 'bg-allow/15 text-allow',
-        deny: 'bg-deny/15 text-deny',
-        approval: 'bg-approval/15 text-approval',
-        primary: 'bg-primary/15 text-primary',
+        default: "bg-secondary text-secondary-foreground",
+        outline: "border border-border text-muted-foreground",
+        allow: "bg-allow/15 text-allow",
+        deny: "bg-deny/15 text-deny",
+        approval: "bg-approval/15 text-approval",
+        primary: "bg-primary/15 text-primary",
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: "default",
     },
   },
-)
+);
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLSpanElement>,
+  extends
+    React.HTMLAttributes<HTMLSpanElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {
-  return <span className={cn(badgeVariants({ variant }), className)} {...props} />
+  return (
+    <span className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/platform/dashboard/src/components/ui/button.tsx
+++ b/platform/dashboard/src/components/ui/button.tsx
@@ -1,48 +1,56 @@
-import * as React from 'react'
-import { Slot } from '@radix-ui/react-slot'
-import { cva, type VariantProps } from 'class-variance-authority'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-border bg-transparent hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-border bg-transparent hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-6',
-        icon: 'h-9 w-9',
+        default: "h-9 px-4 py-2",
+        sm: "h-8 rounded-md px-3 text-xs",
+        lg: "h-10 rounded-md px-6",
+        icon: "h-9 w-9",
       },
     },
     defaultVariants: {
-      variant: 'default',
-      size: 'default',
+      variant: "default",
+      size: "default",
     },
   },
-)
+);
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button'
+    const Comp = asChild ? Slot : "button";
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-    )
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
   },
-)
-Button.displayName = 'Button'
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/platform/dashboard/src/components/ui/card.tsx
+++ b/platform/dashboard/src/components/ui/card.tsx
@@ -1,58 +1,85 @@
-import * as React from 'react'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
-const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn(
-        'rounded-lg border border-border bg-card text-card-foreground shadow-sm',
-        className,
-      )}
-      {...props}
-    />
-  ),
-)
-Card.displayName = 'Card'
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-border bg-card text-card-foreground shadow-sm",
+      className,
+    )}
+    {...props}
+  />
+));
+Card.displayName = "Card";
 
-const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
-  ),
-)
-CardHeader.displayName = 'CardHeader'
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
 
-const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
-  ({ className, ...props }, ref) => (
-    <h3
-      ref={ref}
-      className={cn('text-2xl font-semibold leading-none tracking-tight', className)}
-      {...props}
-    />
-  ),
-)
-CardTitle.displayName = 'CardTitle'
+const CardTitle = React.forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
 
 const CardDescription = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, ...props }, ref) => (
-  <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
-))
-CardDescription.displayName = 'CardDescription'
+  <p
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
 
-const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
-  ),
-)
-CardContent.displayName = 'CardContent'
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
 
-const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
-  ),
-)
-CardFooter.displayName = 'CardFooter'
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }
+export {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+  CardFooter,
+};

--- a/platform/dashboard/src/components/ui/charts.tsx
+++ b/platform/dashboard/src/components/ui/charts.tsx
@@ -6,113 +6,155 @@
  * outcome stack) and pass per-bucket values keyed by ``series.key``.
  */
 
-import { useLayoutEffect, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from "react";
 
 /** One stacked series: colours for SVG strokes/fills plus the Tailwind
  * class used for legend swatches. */
 export interface ChartSeries {
-  key: string
-  label: string
+  key: string;
+  label: string;
   /** CSS colour for SVG stroke/fill attributes. */
-  color: string
+  color: string;
   /** Tailwind background class for legend dots (static — the scanner
    * can't see interpolated class names). */
-  swatchClass: string
+  swatchClass: string;
   /** Stacked-area layer fill opacity (default 0.3). */
-  fillOpacity?: number
+  fillOpacity?: number;
 }
 
 /** One x-axis bucket; ``values`` is keyed by ``ChartSeries.key``. */
 export interface ChartBucket {
-  label: Date
-  mode: 'hour' | 'day'
-  values: Record<string, number>
-  total: number
+  label: Date;
+  mode: "hour" | "day";
+  values: Record<string, number>;
+  total: number;
 }
 
 function useMeasure() {
-  const ref = useRef<HTMLDivElement>(null)
-  const [w, setW] = useState(0)
+  const ref = useRef<HTMLDivElement>(null);
+  const [w, setW] = useState(0);
   useLayoutEffect(() => {
-    if (!ref.current) return
-    const ro = new ResizeObserver((ents) => setW(ents[0].contentRect.width))
-    ro.observe(ref.current)
-    setW(ref.current.clientWidth)
-    return () => ro.disconnect()
-  }, [])
-  return [ref, w] as const
+    if (!ref.current) return;
+    const ro = new ResizeObserver((ents) => setW(ents[0].contentRect.width));
+    ro.observe(ref.current);
+    setW(ref.current.clientWidth);
+    return () => ro.disconnect();
+  }, []);
+  return [ref, w] as const;
 }
 
 // ——— Sparkline (single series area) ———
 export function Sparkline({
   data,
-  color = 'hsl(var(--primary))',
+  color = "hsl(var(--primary))",
   height = 34,
   width = 150,
 }: {
-  data: number[]
-  color?: string
-  height?: number
-  width?: number
+  data: number[];
+  color?: string;
+  height?: number;
+  width?: number;
 }) {
-  if (!data.length) return null
-  const max = Math.max(...data, 1)
+  if (!data.length) return null;
+  const max = Math.max(...data, 1);
   const pts = data.map((v, i) => {
-    const x = (i / Math.max(data.length - 1, 1)) * width
-    const y = height - (v / max) * (height - 3) - 1.5
-    return [x, y] as const
-  })
-  const line = pts.map((p) => p.join(',')).join(' ')
-  const area = `0,${height} ${line} ${width},${height}`
+    const x = (i / Math.max(data.length - 1, 1)) * width;
+    const y = height - (v / max) * (height - 3) - 1.5;
+    return [x, y] as const;
+  });
+  const line = pts.map((p) => p.join(",")).join(" ");
+  const area = `0,${height} ${line} ${width},${height}`;
   return (
     <svg width={width} height={height} className="block overflow-visible">
       <polygon points={area} fill={color} opacity="0.12" />
-      <polyline points={line} fill="none" stroke={color} strokeWidth="1.5" strokeLinejoin="round" strokeLinecap="round" />
-      <circle cx={pts[pts.length - 1][0]} cy={pts[pts.length - 1][1]} r="2" fill={color} />
+      <polyline
+        points={line}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle
+        cx={pts[pts.length - 1][0]}
+        cy={pts[pts.length - 1][1]}
+        r="2"
+        fill={color}
+      />
     </svg>
-  )
+  );
 }
 
 // ——— Stacked area chart with hover tooltip ———
-export function AreaChart({ buckets, series, height = 240 }: { buckets: ChartBucket[]; series: ChartSeries[]; height?: number }) {
-  const [ref, w] = useMeasure()
-  const [hover, setHover] = useState<number | null>(null)
-  const padL = 8, padR = 8, padT = 14, padB = 26
-  const W = Math.max(w, 320)
-  const innerW = W - padL - padR
-  const innerH = height - padT - padB
-  const maxTotal = Math.max(...buckets.map((d) => d.total), 1)
-  const x = (i: number) => padL + (i / Math.max(buckets.length - 1, 1)) * innerW
-  const y = (v: number) => padT + innerH - (v / maxTotal) * innerH
+export function AreaChart({
+  buckets,
+  series,
+  height = 240,
+}: {
+  buckets: ChartBucket[];
+  series: ChartSeries[];
+  height?: number;
+}) {
+  const [ref, w] = useMeasure();
+  const [hover, setHover] = useState<number | null>(null);
+  const padL = 8,
+    padR = 8,
+    padT = 14,
+    padB = 26;
+  const W = Math.max(w, 320);
+  const innerW = W - padL - padR;
+  const innerH = height - padT - padB;
+  const maxTotal = Math.max(...buckets.map((d) => d.total), 1);
+  const x = (i: number) =>
+    padL + (i / Math.max(buckets.length - 1, 1)) * innerW;
+  const y = (v: number) => padT + innerH - (v / maxTotal) * innerH;
 
-  const cum = buckets.map(() => 0)
-  const layers: { key: string; color: string; fillOpacity: number; path: string }[] = []
+  const cum = buckets.map(() => 0);
+  const layers: {
+    key: string;
+    color: string;
+    fillOpacity: number;
+    path: string;
+  }[] = [];
   for (const s of series) {
-    const top = buckets.map((d, i) => cum[i] + (d.values[s.key] ?? 0))
-    const bottom = cum.slice()
+    const top = buckets.map((d, i) => cum[i] + (d.values[s.key] ?? 0));
+    const bottom = cum.slice();
     const path =
-      top.map((v, i) => `${i === 0 ? 'M' : 'L'}${x(i)},${y(v)}`).join(' ') +
-      ' ' +
-      bottom.map((_, i) => `L${x(buckets.length - 1 - i)},${y(bottom[buckets.length - 1 - i])}`).join(' ') +
-      ' Z'
-    layers.push({ key: s.key, color: s.color, fillOpacity: s.fillOpacity ?? 0.3, path })
-    buckets.forEach((_, i) => (cum[i] = top[i]))
+      top.map((v, i) => `${i === 0 ? "M" : "L"}${x(i)},${y(v)}`).join(" ") +
+      " " +
+      bottom
+        .map(
+          (_, i) =>
+            `L${x(buckets.length - 1 - i)},${y(bottom[buckets.length - 1 - i])}`,
+        )
+        .join(" ") +
+      " Z";
+    layers.push({
+      key: s.key,
+      color: s.color,
+      fillOpacity: s.fillOpacity ?? 0.3,
+      path,
+    });
+    buckets.forEach((_, i) => (cum[i] = top[i]));
   }
 
-  const n = buckets.length
-  const mode = (buckets[0] && buckets[0].mode) || 'day'
+  const n = buckets.length;
+  const mode = (buckets[0] && buckets[0].mode) || "day";
   const ticks = (() => {
-    const want = Math.min(5, n)
-    if (n <= 1) return [0]
-    const step = (n - 1) / (want - 1)
-    const s = new Set<number>()
-    for (let i = 0; i < want; i++) s.add(Math.round(i * step))
-    return [...s].sort((a, b) => a - b)
-  })()
+    const want = Math.min(5, n);
+    if (n <= 1) return [0];
+    const step = (n - 1) / (want - 1);
+    const s = new Set<number>();
+    for (let i = 0; i < want; i++) s.add(Math.round(i * step));
+    return [...s].sort((a, b) => a - b);
+  })();
   const fmt = (dt: Date) =>
-    mode === 'hour'
-      ? dt.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true }).replace(' ', '').toLowerCase()
-      : dt.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    mode === "hour"
+      ? dt
+          .toLocaleTimeString("en-US", { hour: "numeric", hour12: true })
+          .replace(" ", "")
+          .toLowerCase()
+      : dt.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 
   return (
     <div
@@ -120,36 +162,76 @@ export function AreaChart({ buckets, series, height = 240 }: { buckets: ChartBuc
       className="relative w-full"
       onMouseLeave={() => setHover(null)}
       onMouseMove={(e) => {
-        const rect = e.currentTarget.getBoundingClientRect()
-        const rx = e.clientX - rect.left - padL
-        const i = Math.round((rx / innerW) * (buckets.length - 1))
-        setHover(Math.max(0, Math.min(buckets.length - 1, i)))
+        const rect = e.currentTarget.getBoundingClientRect();
+        const rx = e.clientX - rect.left - padL;
+        const i = Math.round((rx / innerW) * (buckets.length - 1));
+        setHover(Math.max(0, Math.min(buckets.length - 1, i)));
       }}
     >
       <svg width={W} height={height} className="block">
         {[0.25, 0.5, 0.75, 1].map((f) => (
-          <line key={f} x1={padL} x2={W - padR} y1={padT + innerH * (1 - f)} y2={padT + innerH * (1 - f)} stroke="hsl(var(--border))" strokeOpacity="0.5" strokeDasharray="2 4" />
+          <line
+            key={f}
+            x1={padL}
+            x2={W - padR}
+            y1={padT + innerH * (1 - f)}
+            y2={padT + innerH * (1 - f)}
+            stroke="hsl(var(--border))"
+            strokeOpacity="0.5"
+            strokeDasharray="2 4"
+          />
         ))}
         {layers.map((l) => (
           <path key={l.key} d={l.path} fill={l.color} opacity={l.fillOpacity} />
         ))}
         {(() => {
-          const c2 = buckets.map(() => 0)
+          const c2 = buckets.map(() => 0);
           return series.map((s) => {
-            const top = buckets.map((d, i) => c2[i] + (d.values[s.key] ?? 0))
-            const line = top.map((v, i) => `${i === 0 ? 'M' : 'L'}${x(i)},${y(v)}`).join(' ')
-            buckets.forEach((_, i) => (c2[i] = top[i]))
-            return <path key={s.key} d={line} fill="none" stroke={s.color} strokeWidth="1.5" strokeOpacity="0.9" />
-          })
+            const top = buckets.map((d, i) => c2[i] + (d.values[s.key] ?? 0));
+            const line = top
+              .map((v, i) => `${i === 0 ? "M" : "L"}${x(i)},${y(v)}`)
+              .join(" ");
+            buckets.forEach((_, i) => (c2[i] = top[i]));
+            return (
+              <path
+                key={s.key}
+                d={line}
+                fill="none"
+                stroke={s.color}
+                strokeWidth="1.5"
+                strokeOpacity="0.9"
+              />
+            );
+          });
         })()}
         {hover != null && (
           <g>
-            <line x1={x(hover)} x2={x(hover)} y1={padT} y2={padT + innerH} stroke="hsl(var(--muted-foreground))" strokeOpacity="0.5" />
-            <circle cx={x(hover)} cy={y(cum[hover])} r="3" fill="hsl(var(--primary))" />
+            <line
+              x1={x(hover)}
+              x2={x(hover)}
+              y1={padT}
+              y2={padT + innerH}
+              stroke="hsl(var(--muted-foreground))"
+              strokeOpacity="0.5"
+            />
+            <circle
+              cx={x(hover)}
+              cy={y(cum[hover])}
+              r="3"
+              fill="hsl(var(--primary))"
+            />
           </g>
         )}
         {ticks.map((t) => (
-          <text key={t} x={x(t)} y={height - 8} fontSize="10.5" fill="hsl(var(--muted-foreground))" textAnchor={t === 0 ? 'start' : t === n - 1 ? 'end' : 'middle'} fontFamily="var(--font-mono)">
+          <text
+            key={t}
+            x={x(t)}
+            y={height - 8}
+            fontSize="10.5"
+            fill="hsl(var(--muted-foreground))"
+            textAnchor={t === 0 ? "start" : t === n - 1 ? "end" : "middle"}
+            fontFamily="var(--font-mono)"
+          >
             {fmt(buckets[t].label)}
           </text>
         ))}
@@ -160,69 +242,118 @@ export function AreaChart({ buckets, series, height = 240 }: { buckets: ChartBuc
           style={{ left: Math.min(Math.max(x(hover) + 10, 8), W - 150) }}
         >
           <div className="mb-1 text-[11px] text-muted-foreground">
-            {mode === 'hour'
-              ? buckets[hover].label.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true })
-              : buckets[hover].label.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            {mode === "hour"
+              ? buckets[hover].label.toLocaleTimeString("en-US", {
+                  hour: "numeric",
+                  minute: "2-digit",
+                  hour12: true,
+                })
+              : buckets[hover].label.toLocaleDateString("en-US", {
+                  weekday: "short",
+                  month: "short",
+                  day: "numeric",
+                })}
           </div>
-          {series.slice().reverse().map((s) => (
-            <div key={s.key} className="flex items-center gap-1.5 leading-[1.7]">
-              <span className={`size-2 rounded-sm ${s.swatchClass}`} />
-              <span className="flex-1 text-muted-foreground">{s.label}</span>
-              <span className="font-mono text-foreground">{buckets[hover].values[s.key] ?? 0}</span>
-            </div>
-          ))}
+          {series
+            .slice()
+            .reverse()
+            .map((s) => (
+              <div
+                key={s.key}
+                className="flex items-center gap-1.5 leading-[1.7]"
+              >
+                <span className={`size-2 rounded-sm ${s.swatchClass}`} />
+                <span className="flex-1 text-muted-foreground">{s.label}</span>
+                <span className="font-mono text-foreground">
+                  {buckets[hover].values[s.key] ?? 0}
+                </span>
+              </div>
+            ))}
         </div>
       )}
     </div>
-  )
+  );
 }
 
 // ——— Donut with centred total + per-series legend ———
 export function Donut({
-  values, total, series, caption, size = 168, stroke = 20,
+  values,
+  total,
+  series,
+  caption,
+  size = 168,
+  stroke = 20,
 }: {
-  values: Record<string, number>
-  total: number
-  series: ChartSeries[]
-  caption: string
-  size?: number
-  stroke?: number
+  values: Record<string, number>;
+  total: number;
+  series: ChartSeries[];
+  caption: string;
+  size?: number;
+  stroke?: number;
 }) {
-  const r = (size - stroke) / 2
-  const cx = size / 2, cy = size / 2
-  const circ = 2 * Math.PI * r
-  const frac = (k: string) => (total ? (values[k] ?? 0) / total : 0)
+  const r = (size - stroke) / 2;
+  const cx = size / 2,
+    cy = size / 2;
+  const circ = 2 * Math.PI * r;
+  const frac = (k: string) => (total ? (values[k] ?? 0) / total : 0);
   // Cumulative offset via prefix sum (no render-time reassignment).
   const segs = series.map((s, i) => ({
     s,
     dash: frac(s.key) * circ,
-    offset: series.slice(0, i).reduce((sum, ss) => sum + frac(ss.key), 0) * circ,
-  }))
+    offset:
+      series.slice(0, i).reduce((sum, ss) => sum + frac(ss.key), 0) * circ,
+  }));
   return (
     <div className="flex items-center gap-[18px]">
       <svg width={size} height={size} className="shrink-0 -rotate-90">
-        <circle cx={cx} cy={cy} r={r} fill="none" stroke="hsl(var(--secondary))" strokeWidth={stroke} />
+        <circle
+          cx={cx}
+          cy={cy}
+          r={r}
+          fill="none"
+          stroke="hsl(var(--secondary))"
+          strokeWidth={stroke}
+        />
         {segs.map(({ s, dash, offset }) => (
-          <circle key={s.key} cx={cx} cy={cy} r={r} fill="none" stroke={s.color} strokeWidth={stroke}
-            strokeDasharray={`${dash} ${circ - dash}`} strokeDashoffset={-offset} strokeLinecap="butt" />
+          <circle
+            key={s.key}
+            cx={cx}
+            cy={cy}
+            r={r}
+            fill="none"
+            stroke={s.color}
+            strokeWidth={stroke}
+            strokeDasharray={`${dash} ${circ - dash}`}
+            strokeDashoffset={-offset}
+            strokeLinecap="butt"
+          />
         ))}
       </svg>
       <div className="min-w-0 flex-1">
-        <div className="text-[26px] font-semibold leading-none tracking-tight">{total.toLocaleString()}</div>
+        <div className="text-[26px] font-semibold leading-none tracking-tight">
+          {total.toLocaleString()}
+        </div>
         <div className="mb-3 text-xs text-muted-foreground">{caption}</div>
         {series.map((s) => {
-          const v = values[s.key] ?? 0
-          const pct = total ? Math.round((v / total) * 100) : 0
+          const v = values[s.key] ?? 0;
+          const pct = total ? Math.round((v / total) * 100) : 0;
           return (
-            <div key={s.key} className="flex items-center gap-2 py-[3px] text-[12.5px]">
+            <div
+              key={s.key}
+              className="flex items-center gap-2 py-[3px] text-[12.5px]"
+            >
               <span className={`size-[9px] rounded-sm ${s.swatchClass}`} />
               <span className="flex-1 text-foreground">{s.label}</span>
-              <span className="font-mono text-foreground">{v.toLocaleString()}</span>
-              <span className="w-[34px] text-right font-mono text-muted-foreground">{pct}%</span>
+              <span className="font-mono text-foreground">
+                {v.toLocaleString()}
+              </span>
+              <span className="w-[34px] text-right font-mono text-muted-foreground">
+                {pct}%
+              </span>
             </div>
-          )
+          );
         })}
       </div>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/components/ui/dialog.tsx
+++ b/platform/dashboard/src/components/ui/dialog.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import * as DialogPrimitive from '@radix-ui/react-dialog'
-import { X } from 'lucide-react'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-const Dialog = DialogPrimitive.Root
-const DialogTrigger = DialogPrimitive.Trigger
-const DialogPortal = DialogPrimitive.Portal
-const DialogClose = DialogPrimitive.Close
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -15,13 +15,13 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      "fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
   />
-))
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -32,8 +32,8 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg sm:rounded-lg',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        "fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-card p-6 shadow-lg sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}
@@ -45,21 +45,30 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-))
-DialogContent.displayName = DialogPrimitive.Content.displayName
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col gap-1.5', className)} {...props} />
-)
-DialogHeader.displayName = 'DialogHeader'
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col gap-1.5", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
 
-const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+    className={cn(
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+      className,
+    )}
     {...props}
   />
-)
-DialogFooter.displayName = 'DialogFooter'
+);
+DialogFooter.displayName = "DialogFooter";
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -67,11 +76,11 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn('text-base font-semibold', className)}
+    className={cn("text-base font-semibold", className)}
     {...props}
   />
-))
-DialogTitle.displayName = DialogPrimitive.Title.displayName
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
@@ -79,11 +88,11 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-DialogDescription.displayName = DialogPrimitive.Description.displayName
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
@@ -94,4 +103,4 @@ export {
   DialogTitle,
   DialogDescription,
   DialogClose,
-}
+};

--- a/platform/dashboard/src/components/ui/dropdown-menu.tsx
+++ b/platform/dashboard/src/components/ui/dropdown-menu.tsx
@@ -1,27 +1,27 @@
-import * as React from 'react'
-import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu'
-import { Check, ChevronRight, Circle } from 'lucide-react'
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils";
 
-const DropdownMenu = DropdownMenuPrimitive.Root
-const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger
-const DropdownMenuGroup = DropdownMenuPrimitive.Group
-const DropdownMenuPortal = DropdownMenuPrimitive.Portal
-const DropdownMenuSub = DropdownMenuPrimitive.Sub
-const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup
+const DropdownMenu = DropdownMenuPrimitive.Root;
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, children, ...props }, ref) => (
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
-      inset && 'pl-8',
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
+      inset && "pl-8",
       className,
     )}
     {...props}
@@ -29,8 +29,9 @@ const DropdownMenuSubTrigger = React.forwardRef<
     {children}
     <ChevronRight className="ml-auto h-4 w-4" />
   </DropdownMenuPrimitive.SubTrigger>
-))
-DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
 
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
@@ -39,13 +40,14 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg',
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg",
       className,
     )}
     {...props}
   />
-))
-DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;
 
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
@@ -56,33 +58,33 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
-))
-DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      inset && 'pl-8',
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
       className,
     )}
     {...props}
   />
-))
-DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
 const DropdownMenuCheckboxItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
@@ -91,7 +93,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground',
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground",
       className,
     )}
     checked={checked}
@@ -104,8 +106,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.CheckboxItem>
-))
-DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
 
 const DropdownMenuRadioItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
@@ -114,7 +117,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground',
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground",
       className,
     )}
     {...props}
@@ -126,26 +129,26 @@ const DropdownMenuRadioItem = React.forwardRef<
     </span>
     {children}
   </DropdownMenuPrimitive.RadioItem>
-))
-DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
 
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
-    inset?: boolean
+    inset?: boolean;
   }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
-      'px-2 py-1.5 text-xs font-medium text-muted-foreground',
-      inset && 'pl-8',
+      "px-2 py-1.5 text-xs font-medium text-muted-foreground",
+      inset && "pl-8",
       className,
     )}
     {...props}
   />
-))
-DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
 
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
@@ -153,22 +156,22 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-border', className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
-))
-DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
 const DropdownMenuShortcut = ({
   className,
   ...props
 }: React.HTMLAttributes<HTMLSpanElement>) => (
   <span
-    className={cn('ml-auto text-xs tracking-widest opacity-60', className)}
+    className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
     {...props}
   />
-)
-DropdownMenuShortcut.displayName = 'DropdownMenuShortcut'
+);
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,
@@ -186,4 +189,4 @@ export {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuRadioGroup,
-}
+};

--- a/platform/dashboard/src/components/ui/input.tsx
+++ b/platform/dashboard/src/components/ui/input.tsx
@@ -1,21 +1,22 @@
-import * as React from 'react'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
-const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        ref={ref}
-        className={cn(
-          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
-          className,
-        )}
-        {...props}
-      />
-    )
-  },
-)
-Input.displayName = 'Input'
+const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      ref={ref}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
 
-export { Input }
+export { Input };

--- a/platform/dashboard/src/components/ui/label.tsx
+++ b/platform/dashboard/src/components/ui/label.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react'
-import * as LabelPrimitive from '@radix-ui/react-label'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { cn } from "@/lib/utils";
 
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
@@ -9,12 +9,12 @@ const Label = React.forwardRef<
   <LabelPrimitive.Root
     ref={ref}
     className={cn(
-      'text-xs font-medium uppercase tracking-wider text-muted-foreground',
+      "text-xs font-medium uppercase tracking-wider text-muted-foreground",
       className,
     )}
     {...props}
   />
-))
-Label.displayName = LabelPrimitive.Root.displayName
+));
+Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label }
+export { Label };

--- a/platform/dashboard/src/components/ui/select.tsx
+++ b/platform/dashboard/src/components/ui/select.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react'
-import * as SelectPrimitive from '@radix-ui/react-select'
-import { Check, ChevronDown, ChevronUp } from 'lucide-react'
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils";
 
-const Select = SelectPrimitive.Root
-const SelectGroup = SelectPrimitive.Group
-const SelectValue = SelectPrimitive.Value
+const Select = SelectPrimitive.Root;
+const SelectGroup = SelectPrimitive.Group;
+const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
@@ -15,7 +15,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      "flex h-9 w-full items-center justify-between rounded-md border border-border bg-card px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className,
     )}
     {...props}
@@ -25,8 +25,8 @@ const SelectTrigger = React.forwardRef<
       <ChevronDown className="h-4 w-4 opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
-))
-SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
@@ -35,15 +35,15 @@ const SelectScrollUpButton = React.forwardRef<
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={cn(
-      'flex cursor-default items-center justify-center py-1',
+      "flex cursor-default items-center justify-center py-1",
       className,
     )}
     {...props}
   >
     <ChevronUp className="h-4 w-4" />
   </SelectPrimitive.ScrollUpButton>
-))
-SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
@@ -52,28 +52,29 @@ const SelectScrollDownButton = React.forwardRef<
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={cn(
-      'flex cursor-default items-center justify-center py-1',
+      "flex cursor-default items-center justify-center py-1",
       className,
     )}
     {...props}
   >
     <ChevronDown className="h-4 w-4" />
   </SelectPrimitive.ScrollDownButton>
-))
-SelectScrollDownButton.displayName = SelectPrimitive.ScrollDownButton.displayName
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
 
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
->(({ className, children, position = 'popper', ...props }, ref) => (
+>(({ className, children, position = "popper", ...props }, ref) => (
   <SelectPrimitive.Portal>
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md',
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,
       )}
       position={position}
@@ -82,9 +83,9 @@ const SelectContent = React.forwardRef<
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
         className={cn(
-          'p-1',
-          position === 'popper' &&
-            'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]',
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
         )}
       >
         {children}
@@ -92,8 +93,8 @@ const SelectContent = React.forwardRef<
       <SelectScrollDownButton />
     </SelectPrimitive.Content>
   </SelectPrimitive.Portal>
-))
-SelectContent.displayName = SelectPrimitive.Content.displayName
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
 
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
@@ -101,11 +102,11 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn('py-1.5 pl-8 pr-2 text-sm font-semibold', className)}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
     {...props}
   />
-))
-SelectLabel.displayName = SelectPrimitive.Label.displayName
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
@@ -114,7 +115,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}
@@ -126,8 +127,8 @@ const SelectItem = React.forwardRef<
     </span>
     <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
   </SelectPrimitive.Item>
-))
-SelectItem.displayName = SelectPrimitive.Item.displayName
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
@@ -135,11 +136,11 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-border', className)}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
     {...props}
   />
-))
-SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 
 export {
   Select,
@@ -152,4 +153,4 @@ export {
   SelectSeparator,
   SelectScrollUpButton,
   SelectScrollDownButton,
-}
+};

--- a/platform/dashboard/src/components/ui/table.tsx
+++ b/platform/dashboard/src/components/ui/table.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import { cn } from '@/lib/utils'
+import * as React from "react";
+import { cn } from "@/lib/utils";
 
 const Table = React.forwardRef<
   HTMLTableElement,
@@ -8,20 +8,20 @@ const Table = React.forwardRef<
   <div className="relative w-full overflow-auto scrollbar-thin">
     <table
       ref={ref}
-      className={cn('w-full caption-bottom text-sm', className)}
+      className={cn("w-full caption-bottom text-sm", className)}
       {...props}
     />
   </div>
-))
-Table.displayName = 'Table'
+));
+Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
-))
-TableHeader.displayName = 'TableHeader'
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
@@ -29,11 +29,11 @@ const TableBody = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tbody
     ref={ref}
-    className={cn('[&_tr:last-child]:border-0', className)}
+    className={cn("[&_tr:last-child]:border-0", className)}
     {...props}
   />
-))
-TableBody.displayName = 'TableBody'
+));
+TableBody.displayName = "TableBody";
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -42,13 +42,13 @@ const TableFooter = React.forwardRef<
   <tfoot
     ref={ref}
     className={cn(
-      'border-t bg-muted/50 font-medium [&>tr]:last:border-b-0',
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
       className,
     )}
     {...props}
   />
-))
-TableFooter.displayName = 'TableFooter'
+));
+TableFooter.displayName = "TableFooter";
 
 const TableRow = React.forwardRef<
   HTMLTableRowElement,
@@ -57,13 +57,13 @@ const TableRow = React.forwardRef<
   <tr
     ref={ref}
     className={cn(
-      'border-b border-border transition-colors hover:bg-muted/40 data-[state=selected]:bg-muted',
+      "border-b border-border transition-colors hover:bg-muted/40 data-[state=selected]:bg-muted",
       className,
     )}
     {...props}
   />
-))
-TableRow.displayName = 'TableRow'
+));
+TableRow.displayName = "TableRow";
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -72,13 +72,13 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      'h-10 px-3 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      "h-10 px-3 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
       className,
     )}
     {...props}
   />
-))
-TableHead.displayName = 'TableHead'
+));
+TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -86,14 +86,11 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn(
-      'p-3 align-middle [&:has([role=checkbox])]:pr-0',
-      className,
-    )}
+    className={cn("p-3 align-middle [&:has([role=checkbox])]:pr-0", className)}
     {...props}
   />
-))
-TableCell.displayName = 'TableCell'
+));
+TableCell.displayName = "TableCell";
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
@@ -101,11 +98,11 @@ const TableCaption = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <caption
     ref={ref}
-    className={cn('mt-4 text-sm text-muted-foreground', className)}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-TableCaption.displayName = 'TableCaption'
+));
+TableCaption.displayName = "TableCaption";
 
 export {
   Table,
@@ -116,4 +113,4 @@ export {
   TableHead,
   TableHeader,
   TableRow,
-}
+};

--- a/platform/dashboard/src/components/ui/tabs.tsx
+++ b/platform/dashboard/src/components/ui/tabs.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react'
-import * as TabsPrimitive from '@radix-ui/react-tabs'
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils";
 
-const Tabs = TabsPrimitive.Root
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -12,13 +12,13 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center gap-0.5 rounded-md border border-border bg-secondary p-[3px] text-muted-foreground',
+      "inline-flex items-center justify-center gap-0.5 rounded-md border border-border bg-secondary p-[3px] text-muted-foreground",
       className,
     )}
     {...props}
   />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
@@ -27,13 +27,13 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-sm px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground',
+      "inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-sm px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground",
       className,
     )}
     {...props}
   />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -42,12 +42,12 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+      "mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
       className,
     )}
     {...props}
   />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/platform/dashboard/src/components/ui/toggle-group.tsx
+++ b/platform/dashboard/src/components/ui/toggle-group.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react'
-import * as ToggleGroupPrimitive from '@radix-ui/react-toggle-group'
+import * as React from "react";
+import * as ToggleGroupPrimitive from "@radix-ui/react-toggle-group";
 
-import { cn } from '@/lib/utils'
+import { cn } from "@/lib/utils";
 
 const ToggleGroup = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Root>,
@@ -10,13 +10,13 @@ const ToggleGroup = React.forwardRef<
   <ToggleGroupPrimitive.Root
     ref={ref}
     className={cn(
-      'inline-flex items-stretch overflow-hidden rounded-md border border-border',
+      "inline-flex items-stretch overflow-hidden rounded-md border border-border",
       className,
     )}
     {...props}
   />
-))
-ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName
+));
+ToggleGroup.displayName = ToggleGroupPrimitive.Root.displayName;
 
 const ToggleGroupItem = React.forwardRef<
   React.ElementRef<typeof ToggleGroupPrimitive.Item>,
@@ -25,12 +25,12 @@ const ToggleGroupItem = React.forwardRef<
   <ToggleGroupPrimitive.Item
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center gap-1.5 whitespace-nowrap border-r border-border px-2.5 py-1.5 text-xs text-muted-foreground transition-colors last:border-r-0 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-background data-[state=on]:text-foreground',
+      "inline-flex items-center justify-center gap-1.5 whitespace-nowrap border-r border-border px-2.5 py-1.5 text-xs text-muted-foreground transition-colors last:border-r-0 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-background data-[state=on]:text-foreground",
       className,
     )}
     {...props}
   />
-))
-ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName
+));
+ToggleGroupItem.displayName = ToggleGroupPrimitive.Item.displayName;
 
-export { ToggleGroup, ToggleGroupItem }
+export { ToggleGroup, ToggleGroupItem };

--- a/platform/dashboard/src/index.css
+++ b/platform/dashboard/src/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import url('https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap");
 
 @source "../node_modules/streamdown/dist/*.js";
 

--- a/platform/dashboard/src/lib/active.test.tsx
+++ b/platform/dashboard/src/lib/active.test.tsx
@@ -16,81 +16,79 @@
  * be pinned.
  */
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { act, renderHook, waitFor } from '@testing-library/react'
-import type { JSX, ReactNode } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { JSX, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useActive, useProjectScoped } from './active'
+import { useActive, useProjectScoped } from "./active";
 
-describe('useActive store', () => {
+describe("useActive store", () => {
   beforeEach(() => {
     // Fresh store between tests — reset both ids to null.
     act(() => {
-      useActive.setState({ activeOrgId: null, activeProjectId: null })
-    })
-  })
+      useActive.setState({ activeOrgId: null, activeProjectId: null });
+    });
+  });
 
-  it('starts with both ids null', () => {
-    const { activeOrgId, activeProjectId } = useActive.getState()
-    expect(activeOrgId).toBeNull()
-    expect(activeProjectId).toBeNull()
-  })
+  it("starts with both ids null", () => {
+    const { activeOrgId, activeProjectId } = useActive.getState();
+    expect(activeOrgId).toBeNull();
+    expect(activeProjectId).toBeNull();
+  });
 
-  it('setActiveOrg clears activeProjectId', () => {
+  it("setActiveOrg clears activeProjectId", () => {
     // Seed both ids — simulating a user who was deep in a project
     act(() => {
       useActive.setState({
-        activeOrgId: 'old-org',
-        activeProjectId: 'old-project',
-      })
-    })
+        activeOrgId: "old-org",
+        activeProjectId: "old-project",
+      });
+    });
 
     // Switching org must clear the stale project — the old project
     // belonged to the old org and would 403 in the new one
     act(() => {
-      useActive.getState().setActiveOrg('new-org')
-    })
+      useActive.getState().setActiveOrg("new-org");
+    });
 
-    const { activeOrgId, activeProjectId } = useActive.getState()
-    expect(activeOrgId).toBe('new-org')
-    expect(activeProjectId).toBeNull()
-  })
+    const { activeOrgId, activeProjectId } = useActive.getState();
+    expect(activeOrgId).toBe("new-org");
+    expect(activeProjectId).toBeNull();
+  });
 
-  it('setActiveProject leaves activeOrgId alone', () => {
+  it("setActiveProject leaves activeOrgId alone", () => {
     act(() => {
       useActive.setState({
-        activeOrgId: 'org-1',
-        activeProjectId: 'project-a',
-      })
-    })
+        activeOrgId: "org-1",
+        activeProjectId: "project-a",
+      });
+    });
 
     act(() => {
-      useActive.getState().setActiveProject('project-b')
-    })
+      useActive.getState().setActiveProject("project-b");
+    });
 
-    const { activeOrgId, activeProjectId } = useActive.getState()
-    expect(activeOrgId).toBe('org-1')
-    expect(activeProjectId).toBe('project-b')
-  })
+    const { activeOrgId, activeProjectId } = useActive.getState();
+    expect(activeOrgId).toBe("org-1");
+    expect(activeProjectId).toBe("project-b");
+  });
 
-  it('persists to localStorage via zustand persist middleware', () => {
+  it("persists to localStorage via zustand persist middleware", () => {
     act(() => {
-      useActive.getState().setActiveOrg('persisted-org')
-    })
+      useActive.getState().setActiveOrg("persisted-org");
+    });
     // Hits the same key the store registered.
-    const raw = window.localStorage.getItem('hexgate-active')
-    expect(raw).toBeTruthy()
-    const parsed = JSON.parse(raw as string)
-    expect(parsed.state.activeOrgId).toBe('persisted-org')
-  })
-})
-
+    const raw = window.localStorage.getItem("hexgate-active");
+    expect(raw).toBeTruthy();
+    const parsed = JSON.parse(raw as string);
+    expect(parsed.state.activeOrgId).toBe("persisted-org");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // useProjectScoped
 // ---------------------------------------------------------------------------
-
 
 /** Wrap renderHook in a fresh QueryClient — useOrgs / useProjects need
  * one to mount. Same shape as test/render.tsx; duplicated here to keep
@@ -98,120 +96,120 @@ describe('useActive store', () => {
 function makeWrapper(): ({ children }: { children: ReactNode }) => JSX.Element {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: 0 } },
-  })
+  });
   return ({ children }) => (
     <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  )
+  );
 }
 
 /** Stub /v1/orgs + /v1/orgs/{id}/projects for the helper to consume. */
 function stubFetch(routes: Record<string, unknown>): void {
-  vi.spyOn(window, 'fetch').mockImplementation(
+  vi.spyOn(window, "fetch").mockImplementation(
     async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input.toString()
-      const path = url.split('?')[0]
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0];
       if (path in routes) {
         return new Response(JSON.stringify(routes[path]), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+          headers: { "Content-Type": "application/json" },
+        });
       }
-      return new Response('{}', { status: 404 })
+      return new Response("{}", { status: 404 });
     },
-  )
+  );
 }
 
-describe('useProjectScoped', () => {
+describe("useProjectScoped", () => {
   beforeEach(() => {
     act(() => {
-      useActive.setState({ activeOrgId: null, activeProjectId: null })
-    })
-  })
+      useActive.setState({ activeOrgId: null, activeProjectId: null });
+    });
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
   it("returns 'loading' while /v1/orgs is in flight", () => {
     // No stubs set up — fetch is unmocked, default jsdom behaviour is
     // a hanging promise, so the query stays in isLoading. We only
     // assert the synchronous return value once.
-    vi.spyOn(window, 'fetch').mockImplementation(
+    vi.spyOn(window, "fetch").mockImplementation(
       () => new Promise(() => undefined),
-    )
+    );
 
     const { result } = renderHook(() => useProjectScoped(), {
       wrapper: makeWrapper(),
-    })
+    });
 
-    expect(result.current.status).toBe('loading')
-    expect(result.current.projectId).toBeNull()
-  })
+    expect(result.current.status).toBe("loading");
+    expect(result.current.projectId).toBeNull();
+  });
 
   it("returns 'no-project' once orgs load but no project is active", async () => {
     stubFetch({
-      '/v1/orgs': [
+      "/v1/orgs": [
         {
-          id: 'org-1',
-          slug: 'acme',
-          name: 'Acme',
-          created_at: '2026-01-01T00:00:00Z',
-          role: 'owner',
+          id: "org-1",
+          slug: "acme",
+          name: "Acme",
+          created_at: "2026-01-01T00:00:00Z",
+          role: "owner",
         },
       ],
-      '/v1/orgs/org-1/projects': [], // org has no projects yet
-    })
+      "/v1/orgs/org-1/projects": [], // org has no projects yet
+    });
     act(() => {
       useActive.setState({
-        activeOrgId: 'org-1',
+        activeOrgId: "org-1",
         activeProjectId: null,
-      })
-    })
+      });
+    });
 
     const { result } = renderHook(() => useProjectScoped(), {
       wrapper: makeWrapper(),
-    })
+    });
 
     await waitFor(() => {
-      expect(result.current.status).toBe('no-project')
-    })
-    expect(result.current.projectId).toBeNull()
-  })
+      expect(result.current.status).toBe("no-project");
+    });
+    expect(result.current.projectId).toBeNull();
+  });
 
   it("returns 'ready' with the projectId when everything's resolved", async () => {
     stubFetch({
-      '/v1/orgs': [
+      "/v1/orgs": [
         {
-          id: 'org-1',
-          slug: 'acme',
-          name: 'Acme',
-          created_at: '2026-01-01T00:00:00Z',
-          role: 'owner',
+          id: "org-1",
+          slug: "acme",
+          name: "Acme",
+          created_at: "2026-01-01T00:00:00Z",
+          role: "owner",
         },
       ],
-      '/v1/orgs/org-1/projects': [
+      "/v1/orgs/org-1/projects": [
         {
-          id: 'proj-1',
-          org_id: 'org-1',
-          name: 'production',
-          created_at: '2026-01-01T00:00:00Z',
+          id: "proj-1",
+          org_id: "org-1",
+          name: "production",
+          created_at: "2026-01-01T00:00:00Z",
         },
       ],
-    })
+    });
     act(() => {
       useActive.setState({
-        activeOrgId: 'org-1',
-        activeProjectId: 'proj-1',
-      })
-    })
+        activeOrgId: "org-1",
+        activeProjectId: "proj-1",
+      });
+    });
 
     const { result } = renderHook(() => useProjectScoped(), {
       wrapper: makeWrapper(),
-    })
+    });
 
     await waitFor(() => {
-      expect(result.current.status).toBe('ready')
-    })
-    expect(result.current.projectId).toBe('proj-1')
-  })
-})
+      expect(result.current.status).toBe("ready");
+    });
+    expect(result.current.projectId).toBe("proj-1");
+  });
+});

--- a/platform/dashboard/src/lib/active.ts
+++ b/platform/dashboard/src/lib/active.ts
@@ -13,25 +13,25 @@
  * destination.
  */
 
-import { create } from 'zustand'
-import { createJSONStorage, persist } from 'zustand/middleware'
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
 
-import { useOrgs } from './orgs'
-import { useProjects } from './projects'
+import { useOrgs } from "./orgs";
+import { useProjects } from "./projects";
 
 interface ActiveState {
   /** Currently-active organization id (UUID), or null when the user
    * is signed out / has no orgs (impossible after Phase 4 step 1's
    * auto-default-org-on-signup, but defensive). */
-  activeOrgId: string | null
+  activeOrgId: string | null;
 
   /** Currently-active project within the active org. Null when the
    * active org has no projects yet — the dashboard's project-scoped
    * pages render an empty state until the user creates one. */
-  activeProjectId: string | null
+  activeProjectId: string | null;
 
-  setActiveOrg: (orgId: string | null) => void
-  setActiveProject: (projectId: string | null) => void
+  setActiveOrg: (orgId: string | null) => void;
+  setActiveProject: (projectId: string | null) => void;
 }
 
 export const useActive = create<ActiveState>()(
@@ -45,12 +45,12 @@ export const useActive = create<ActiveState>()(
         // a security trap if it survived the swap (the route 403s
         // anyway, but better to surface as "select a project" than
         // "you don't have access").
-        set({ activeOrgId: orgId, activeProjectId: null })
+        set({ activeOrgId: orgId, activeProjectId: null });
       },
       setActiveProject: (projectId) => set({ activeProjectId: projectId }),
     }),
     {
-      name: 'hexgate-active',
+      name: "hexgate-active",
       // ``createJSONStorage`` lazy-resolves localStorage at call time
       // rather than at module-import time. Without it, importing this
       // module from a unit test (before jsdom finishes wiring its
@@ -60,8 +60,7 @@ export const useActive = create<ActiveState>()(
       storage: createJSONStorage(() => localStorage),
     },
   ),
-)
-
+);
 
 /**
  * Resolved view of "what project is the dashboard currently scoped to?"
@@ -83,28 +82,28 @@ export const useActive = create<ActiveState>()(
  */
 export interface ProjectScope {
   /** Resolved active project id, or null when not ready. */
-  projectId: string | null
-  status: 'loading' | 'no-project' | 'ready'
+  projectId: string | null;
+  status: "loading" | "no-project" | "ready";
 }
 
 export function useProjectScoped(): ProjectScope {
-  const activeOrgId = useActive((s) => s.activeOrgId)
-  const activeProjectId = useActive((s) => s.activeProjectId)
+  const activeOrgId = useActive((s) => s.activeOrgId);
+  const activeProjectId = useActive((s) => s.activeProjectId);
   // useOrgs() is the load-bearing query — once it resolves, the
   // AppShell bootstrap kicks in and picks a default project. We touch
   // it here mostly to surface its ``isLoading`` state; the cache is
   // already populated by the time any project-scoped page mounts.
-  const orgsQuery = useOrgs()
-  const projectsQuery = useProjects(activeOrgId)
+  const orgsQuery = useOrgs();
+  const projectsQuery = useProjects(activeOrgId);
 
   if (
     orgsQuery.isLoading ||
     (activeOrgId !== null && projectsQuery.isLoading)
   ) {
-    return { projectId: null, status: 'loading' }
+    return { projectId: null, status: "loading" };
   }
   if (!activeProjectId) {
-    return { projectId: null, status: 'no-project' }
+    return { projectId: null, status: "no-project" };
   }
-  return { projectId: activeProjectId, status: 'ready' }
+  return { projectId: activeProjectId, status: "ready" };
 }

--- a/platform/dashboard/src/lib/api.ts
+++ b/platform/dashboard/src/lib/api.ts
@@ -2,21 +2,21 @@
  * away from these on a 401, otherwise we'd bounce the sign-in form itself
  * back to /sign-in in a loop when the user has bad credentials. */
 const PUBLIC_AUTH_PATHS = [
-  '/sign-in',
-  '/sign-up',
-  '/forgot-password',
-  '/reset-password',
-  '/verify-email',
-]
+  "/sign-in",
+  "/sign-up",
+  "/forgot-password",
+  "/reset-password",
+  "/verify-email",
+];
 
 /** Thrown by ``request`` when the backend returns 401, after the global
  * "redirect to /sign-in" side-effect has fired. Tests assert against the
  * error type; production code rarely catches it (the redirect already
  * happened). */
 export class UnauthenticatedError extends Error {
-  constructor(message = 'not authenticated') {
-    super(message)
-    this.name = 'UnauthenticatedError'
+  constructor(message = "not authenticated") {
+    super(message);
+    this.name = "UnauthenticatedError";
   }
 }
 
@@ -26,14 +26,14 @@ export class UnauthenticatedError extends Error {
  * constructor parameter properties) because the project's tsconfig
  * enables ``erasableSyntaxOnly``. */
 export class ApiError extends Error {
-  readonly status: number
-  readonly detail: unknown
+  readonly status: number;
+  readonly detail: unknown;
 
   constructor(status: number, detail: unknown, message: string) {
-    super(message)
-    this.name = 'ApiError'
-    this.status = status
-    this.detail = detail
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.detail = detail;
   }
 }
 
@@ -43,66 +43,66 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     // ``include`` so the hexgate_session cookie rides on cross-origin
     // dev (vite on 5173 → api on 8000) and on prod where the dashboard
     // and API may live on different subdomains.
-    credentials: 'include',
+    credentials: "include",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
       ...(init?.headers ?? {}),
     },
-  })
+  });
   if (res.status === 401) {
     // Single global redirect — every component that does a request gets
     // sent to sign-in if their session expired. Public auth routes are
     // exempt: a 401 there is just "wrong password", surface it normally.
     const onAuthPage = PUBLIC_AUTH_PATHS.some((p) =>
       window.location.pathname.startsWith(p),
-    )
+    );
     if (!onAuthPage) {
-      window.location.href = '/sign-in'
+      window.location.href = "/sign-in";
     }
-    throw new UnauthenticatedError()
+    throw new UnauthenticatedError();
   }
   if (!res.ok) {
-    let detail: unknown
-    let bodyText = ''
+    let detail: unknown;
+    let bodyText = "";
     try {
-      bodyText = await res.text()
-      detail = bodyText ? JSON.parse(bodyText) : null
+      bodyText = await res.text();
+      detail = bodyText ? JSON.parse(bodyText) : null;
     } catch {
-      detail = bodyText
+      detail = bodyText;
     }
     const message =
-      typeof detail === 'object' && detail !== null && 'detail' in detail
+      typeof detail === "object" && detail !== null && "detail" in detail
         ? String((detail as { detail: unknown }).detail)
-        : `${res.status} ${res.statusText}`
-    throw new ApiError(res.status, detail, message)
+        : `${res.status} ${res.statusText}`;
+    throw new ApiError(res.status, detail, message);
   }
-  if (res.status === 204) return undefined as T
-  return (await res.json()) as T
+  if (res.status === 204) return undefined as T;
+  return (await res.json()) as T;
 }
 
 export interface TokenListItem {
-  id: string
-  name: string
-  masked: string
-  scopes: string[]
-  created_at: string
-  last_used_at: string | null
+  id: string;
+  name: string;
+  masked: string;
+  scopes: string[];
+  created_at: string;
+  last_used_at: string | null;
 }
 
 export interface TokenMintResponse extends TokenListItem {
-  full: string
+  full: string;
 }
 
 export interface TokenMintRequest {
-  name: string
-  scopes?: string[]
-  env?: 'test' | 'live'
+  name: string;
+  scopes?: string[];
+  env?: "test" | "live";
 }
 
 export interface AgentRead {
-  id: string
-  name: string
-  agent_yaml: string
+  id: string;
+  name: string;
+  agent_yaml: string;
   /**
    * Canonical policy document. Flat single-policy YAML or — when the agent
    * declares per-role behaviour — an inline-roles YAML with a top-level
@@ -110,31 +110,31 @@ export interface AgentRead {
    * client-side helper that extracts the role list (for the Playground
    * picker, etc).
    */
-  policy_yaml: string
-  system_md: string
-  updated_at: string
+  policy_yaml: string;
+  system_md: string;
+  updated_at: string;
 }
 
 export interface AgentUpdate {
-  agent_yaml?: string
-  policy_yaml?: string
-  system_md?: string
+  agent_yaml?: string;
+  policy_yaml?: string;
+  system_md?: string;
 }
 
 /**
  * Tool input parameter, mirroring InputProperty in platform/api/schemas.py.
  */
 export interface InputProperty {
-  title: string
-  type: string
+  title: string;
+  type: string;
 }
 
 /**
  * Tool input schema, mirroring InputSchema in platform/api/schemas.py.
  */
 export interface InputSchema {
-  properties: Record<string, InputProperty>
-  required: string[]
+  properties: Record<string, InputProperty>;
+  required: string[];
 }
 
 /**
@@ -142,21 +142,21 @@ export interface InputSchema {
  * nullable on read-back to match the platform-side schema.
  */
 export interface ToolDefinition {
-  name: string
-  description: string | null
-  input_schema: InputSchema
+  name: string;
+  description: string | null;
+  input_schema: InputSchema;
 }
 
 /**
  * Registered manifest body, mirroring AgentManifest in platform/api/schemas.py.
  */
 export interface AgentManifest {
-  name: string
-  description: string | null
-  framework: string
-  model: string | null
-  system_prompt: string | null
-  tools: ToolDefinition[]
+  name: string;
+  description: string | null;
+  framework: string;
+  model: string | null;
+  system_prompt: string | null;
+  tools: ToolDefinition[];
 }
 
 /**
@@ -167,112 +167,112 @@ export interface AgentManifest {
  * always reflects the Agent row's name (the picker uses it directly).
  */
 export interface AgentManifestView {
-  name: string
-  manifest: AgentManifest | null
-  version: number | null
-  content_hash: string | null
-  updated_at: string
+  name: string;
+  manifest: AgentManifest | null;
+  version: number | null;
+  content_hash: string | null;
+  updated_at: string;
 }
 
 export interface PolicyValidationError {
   /** Role name when the failure was inside an inline-roles entry; null otherwise. */
-  role: string | null
-  line: number | null
-  message: string
+  role: string | null;
+  line: number | null;
+  message: string;
 }
 
 export interface ValidatePolicyResponse {
-  ok: boolean
-  errors: PolicyValidationError[]
+  ok: boolean;
+  errors: PolicyValidationError[];
 }
 
 // --- Audit dashboard (mirrors platform/api/schemas.py) ----------------------
 
-export type AuditWindow = '24h' | '7d' | '30d' | '90d'
-export type AuditOutcome = 'allow' | 'deny' | 'needs_approval'
+export type AuditWindow = "24h" | "7d" | "30d" | "90d";
+export type AuditOutcome = "allow" | "deny" | "needs_approval";
 
 export interface OutcomeCounts {
-  all: number
-  allow: number
-  deny: number
-  needs_approval: number
+  all: number;
+  allow: number;
+  deny: number;
+  needs_approval: number;
 }
 
 /** One agent/role/tool bucket; an empty role keeps its raw `""` key —
  * the dashboard maps it to the "(none)" display label locally. */
 export interface AuditBreakdownRow extends OutcomeCounts {
-  key: string
+  key: string;
 }
 
 export interface AuditSummary {
-  totals: OutcomeCounts
-  by_agent: AuditBreakdownRow[]
-  by_role: AuditBreakdownRow[]
-  by_tool: AuditBreakdownRow[]
+  totals: OutcomeCounts;
+  by_agent: AuditBreakdownRow[];
+  by_role: AuditBreakdownRow[];
+  by_tool: AuditBreakdownRow[];
 }
 
 /** One time bucket; `bucket` is an ISO string. */
 export interface AuditTimeseriesPoint {
-  bucket: string
-  allow: number
-  deny: number
-  needs_approval: number
+  bucket: string;
+  allow: number;
+  deny: number;
+  needs_approval: number;
 }
 
 /** One events-table row; `hint`/`arguments` are decoded JSON. */
 export interface AuditDecisionRow {
-  event_id: string
-  occurred_at: string
-  received_at: string
-  agent_name: string
-  agent_version_id: string
-  session_id: string
-  user_id: string
-  tool_name: string
-  role: string
-  outcome: AuditOutcome
-  error_type: string
-  reason: string
-  violations: string[]
-  hint: unknown
-  arguments: unknown
+  event_id: string;
+  occurred_at: string;
+  received_at: string;
+  agent_name: string;
+  agent_version_id: string;
+  session_id: string;
+  user_id: string;
+  tool_name: string;
+  role: string;
+  outcome: AuditOutcome;
+  error_type: string;
+  reason: string;
+  violations: string[];
+  hint: unknown;
+  arguments: unknown;
 }
 
 export interface AuditDecisionPage {
-  rows: AuditDecisionRow[]
-  total: number
-  limit: number
-  offset: number
+  rows: AuditDecisionRow[];
+  total: number;
+  limit: number;
+  offset: number;
 }
 
 /** Scope filters shared by summary/timeseries/list. `undefined` = no
  * filter; `role: ''` = the no-role bucket (sent as `role=`). */
 export interface AuditScope {
-  window?: AuditWindow
-  agent?: string
-  role?: string
-  tool?: string
-  start_date?: string
-  end_date?: string
+  window?: AuditWindow;
+  agent?: string;
+  role?: string;
+  tool?: string;
+  start_date?: string;
+  end_date?: string;
 }
 
 /** List filters: scope + table-only outcome/session_id + paging. */
 export interface AuditDecisionFilters extends AuditScope {
-  outcome?: AuditOutcome
-  session_id?: string
-  limit?: number
-  offset?: number
+  outcome?: AuditOutcome;
+  session_id?: string;
+  limit?: number;
+  offset?: number;
 }
 
 function qs(params: Record<string, string | number | undefined>): string {
-  const search = new URLSearchParams()
+  const search = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
     // undefined = omit. '' is kept: `role=` (empty value) is meaningful —
     // it selects the no-role bucket server-side.
-    if (value !== undefined) search.set(key, String(value))
+    if (value !== undefined) search.set(key, String(value));
   }
-  const str = search.toString()
-  return str ? `?${str}` : ''
+  const str = search.toString();
+  return str ? `?${str}` : "";
 }
 
 /**
@@ -287,40 +287,34 @@ export const api = {
 
   mintToken: (body: TokenMintRequest, projectId: string) =>
     request<TokenMintResponse>(`/v1/projects/${projectId}/tokens`, {
-      method: 'POST',
+      method: "POST",
       body: JSON.stringify(body),
     }),
 
   revokeToken: (tokenId: string, projectId: string) =>
     request<void>(`/v1/projects/${projectId}/tokens/${tokenId}`, {
-      method: 'DELETE',
+      method: "DELETE",
     }),
 
   listAgents: (projectId: string) =>
     request<AgentRead[]>(`/v1/projects/${projectId}/agents`),
 
   listAgentManifests: (projectId: string) =>
-    request<AgentManifestView[]>(
-      `/v1/projects/${projectId}/agents/manifest`,
-    ),
+    request<AgentManifestView[]>(`/v1/projects/${projectId}/agents/manifest`),
 
   getAgent: (name: string, projectId: string) =>
     request<AgentRead>(`/v1/projects/${projectId}/agents/${name}`),
 
   updateAgent: (name: string, body: AgentUpdate, projectId: string) =>
     request<AgentRead>(`/v1/projects/${projectId}/agents/${name}`, {
-      method: 'PUT',
+      method: "PUT",
       body: JSON.stringify(body),
     }),
 
-  validatePolicy: (
-    name: string,
-    policy_yaml: string,
-    projectId: string,
-  ) =>
+  validatePolicy: (name: string, policy_yaml: string, projectId: string) =>
     request<ValidatePolicyResponse>(
       `/v1/projects/${projectId}/agents/${name}/validate`,
-      { method: 'POST', body: JSON.stringify({ policy_yaml }) },
+      { method: "POST", body: JSON.stringify({ policy_yaml }) },
     ),
 
   getAuditSummary: (scope: AuditScope, projectId: string) =>
@@ -337,4 +331,4 @@ export const api = {
     request<AuditDecisionPage>(
       `/v1/projects/${projectId}/audit/decisions${qs({ ...filters })}`,
     ),
-}
+};

--- a/platform/dashboard/src/lib/audit-filters.ts
+++ b/platform/dashboard/src/lib/audit-filters.ts
@@ -11,43 +11,43 @@
  * without the page component wiring that invariant by hand.
  */
 
-import { create } from 'zustand'
+import { create } from "zustand";
 
-import type { AuditOutcome } from './api'
+import type { AuditOutcome } from "./api";
 
 // '' = "all"; outcome applies to the events table only.
 export interface AuditFilters {
-  agent: string
-  role: string
-  tool: string
-  outcome: '' | AuditOutcome
-  range: '24h' | '7d' | '30d' | '90d'
-  start_date: Date | null
-  end_date: Date | null
+  agent: string;
+  role: string;
+  tool: string;
+  outcome: "" | AuditOutcome;
+  range: "24h" | "7d" | "30d" | "90d";
+  start_date: Date | null;
+  end_date: Date | null;
 }
 
 export type SetAuditFilters = (
   updater: (prev: AuditFilters) => AuditFilters,
-) => void
+) => void;
 
 export const EMPTY_AUDIT_FILTERS: AuditFilters = {
-  agent: '',
-  role: '',
-  tool: '',
-  outcome: '',
-  range: '30d',
+  agent: "",
+  role: "",
+  tool: "",
+  outcome: "",
+  range: "30d",
   start_date: null,
   end_date: null,
-}
+};
 
-const PAGE_SIZE = 40
-const MAX_LIMIT = 200
+const PAGE_SIZE = 40;
+const MAX_LIMIT = 200;
 
 interface AuditFilterState {
-  filters: AuditFilters
-  tableLimit: number
-  setFilters: SetAuditFilters
-  loadMore: () => void
+  filters: AuditFilters;
+  tableLimit: number;
+  setFilters: SetAuditFilters;
+  loadMore: () => void;
 }
 
 export const useAuditFilters = create<AuditFilterState>()((set) => ({
@@ -57,4 +57,4 @@ export const useAuditFilters = create<AuditFilterState>()((set) => ({
     set((s) => ({ filters: updater(s.filters), tableLimit: PAGE_SIZE })),
   loadMore: () =>
     set((s) => ({ tableLimit: Math.min(s.tableLimit + PAGE_SIZE, MAX_LIMIT) })),
-}))
+}));

--- a/platform/dashboard/src/lib/auth.test.tsx
+++ b/platform/dashboard/src/lib/auth.test.tsx
@@ -13,27 +13,29 @@
  * playground.ts's contract; this file only proves the wiring.
  */
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { act, renderHook, waitFor } from '@testing-library/react'
-import type { JSX, ReactNode } from 'react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { JSX, ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock('./playground', () => ({
+vi.mock("./playground", () => ({
   resetPlayground: vi.fn(),
-}))
+}));
 
 // Imported AFTER vi.mock so the hook picks up the spy version.
-import { useLogout, USER_QUERY_KEY } from './auth'
-import { resetPlayground } from './playground'
+import { useLogout, USER_QUERY_KEY } from "./auth";
+import { resetPlayground } from "./playground";
 
-function makeWrapper(qc: QueryClient): (props: { children: ReactNode }) => JSX.Element {
+function makeWrapper(
+  qc: QueryClient,
+): (props: { children: ReactNode }) => JSX.Element {
   return ({ children }) => (
     <QueryClientProvider client={qc}>{children}</QueryClientProvider>
-  )
+  );
 }
 
-describe('useLogout', () => {
-  let qc: QueryClient
+describe("useLogout", () => {
+  let qc: QueryClient;
 
   beforeEach(() => {
     qc = new QueryClient({
@@ -41,78 +43,78 @@ describe('useLogout', () => {
         queries: { retry: false, staleTime: 0 },
         mutations: { retry: false },
       },
-    })
+    });
     // Seed the user-query cache so we can observe the invalidation
     // that should run after the logout succeeds.
-    qc.setQueryData(USER_QUERY_KEY, { id: 'u1', email: 'a@b.dev' })
-  })
+    qc.setQueryData(USER_QUERY_KEY, { id: "u1", email: "a@b.dev" });
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-    vi.mocked(resetPlayground).mockClear()
-  })
+    vi.restoreAllMocks();
+    vi.mocked(resetPlayground).mockClear();
+  });
 
-  it('calls resetPlayground on logout success', async () => {
-    vi.spyOn(window, 'fetch').mockResolvedValue(
-      new Response('{}', { status: 200 }),
-    )
+  it("calls resetPlayground on logout success", async () => {
+    vi.spyOn(window, "fetch").mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
 
     const { result } = renderHook(() => useLogout(), {
       wrapper: makeWrapper(qc),
-    })
+    });
 
     await act(async () => {
-      await result.current.mutateAsync()
-    })
+      await result.current.mutateAsync();
+    });
 
-    expect(resetPlayground).toHaveBeenCalledOnce()
-  })
+    expect(resetPlayground).toHaveBeenCalledOnce();
+  });
 
-  it('does NOT call resetPlayground when the logout request fails', async () => {
+  it("does NOT call resetPlayground when the logout request fails", async () => {
     // Logout-failure path: server-side cookie didn't get cleared, so
     // the user is technically still authenticated — leaking their own
     // state to themselves isn't a leak. Skipping the reset also avoids
     // confusingly clearing playground state on a transient network
     // hiccup that the user can just retry.
-    vi.spyOn(window, 'fetch').mockResolvedValue(
+    vi.spyOn(window, "fetch").mockResolvedValue(
       new Response('{"detail":"nope"}', { status: 500 }),
-    )
+    );
 
     const { result } = renderHook(() => useLogout(), {
       wrapper: makeWrapper(qc),
-    })
+    });
 
     await act(async () => {
-      await result.current.mutateAsync().catch(() => undefined)
-    })
+      await result.current.mutateAsync().catch(() => undefined);
+    });
 
-    await waitFor(() => expect(result.current.isError).toBe(true))
-    expect(resetPlayground).not.toHaveBeenCalled()
-  })
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(resetPlayground).not.toHaveBeenCalled();
+  });
 
-  it('invalidates the user query after resetting playground', async () => {
+  it("invalidates the user query after resetting playground", async () => {
     // Order matters: playground reset must happen before React's
     // commit phase re-renders subscribers off the invalidated user
     // query (some subscriber might read playground state on the
     // sign-in screen). React Query's invalidate is synchronous from
     // the mutation's onSuccess perspective — by the time it returns,
     // the playground reset already ran.
-    vi.spyOn(window, 'fetch').mockResolvedValue(
-      new Response('{}', { status: 200 }),
-    )
+    vi.spyOn(window, "fetch").mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
 
     const { result } = renderHook(() => useLogout(), {
       wrapper: makeWrapper(qc),
-    })
+    });
 
     await act(async () => {
-      await result.current.mutateAsync()
-    })
+      await result.current.mutateAsync();
+    });
 
     // Cache entry was marked stale (invalidate doesn't immediately
     // clear data — it flags isStale + triggers refetch).
-    expect(qc.getQueryState(USER_QUERY_KEY)?.isInvalidated).toBe(true)
+    expect(qc.getQueryState(USER_QUERY_KEY)?.isInvalidated).toBe(true);
     // And the reset ran in the same onSuccess pass.
-    expect(resetPlayground).toHaveBeenCalledOnce()
-  })
-})
+    expect(resetPlayground).toHaveBeenCalledOnce();
+  });
+});

--- a/platform/dashboard/src/lib/auth.ts
+++ b/platform/dashboard/src/lib/auth.ts
@@ -14,24 +14,24 @@
  * 'include'`` in lib/api.ts handles it.
  */
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { ApiError, UnauthenticatedError } from './api'
-import { resetPlayground } from './playground'
+import { ApiError, UnauthenticatedError } from "./api";
+import { resetPlayground } from "./playground";
 
 /** Public shape of a User. Mirrors UserRead on the backend
  * (fastapi_users.schemas.BaseUser[str] — id, email, is_active,
  * is_superuser, is_verified). hashed_password never crosses the wire. */
 export interface UserRead {
-  id: string
-  email: string
-  is_active: boolean
-  is_superuser: boolean
-  is_verified: boolean
+  id: string;
+  email: string;
+  is_active: boolean;
+  is_superuser: boolean;
+  is_verified: boolean;
 }
 
 /** Reusable cache key so mutations can invalidate without typos. */
-export const USER_QUERY_KEY = ['user', 'me'] as const
+export const USER_QUERY_KEY = ["user", "me"] as const;
 
 // ---------------------------------------------------------------------------
 // Reads
@@ -39,15 +39,15 @@ export const USER_QUERY_KEY = ['user', 'me'] as const
 
 async function fetchMe(): Promise<UserRead | null> {
   try {
-    const res = await fetch('/v1/users/me', { credentials: 'include' })
-    if (res.status === 401) return null
-    if (!res.ok) throw new Error(`/users/me ${res.status}`)
-    return (await res.json()) as UserRead
+    const res = await fetch("/v1/users/me", { credentials: "include" });
+    if (res.status === 401) return null;
+    if (!res.ok) throw new Error(`/users/me ${res.status}`);
+    return (await res.json()) as UserRead;
   } catch (err) {
     // Network-level errors surface as null so the UI can render the
     // "loading … then signed-out" path without a noisy console.
-    if (err instanceof TypeError) return null
-    throw err
+    if (err instanceof TypeError) return null;
+    throw err;
   }
 }
 
@@ -66,12 +66,12 @@ export function useUser() {
     // staleness is the longest a stale "logged in" view should linger
     // after a logout from another tab.
     staleTime: 30_000,
-  })
+  });
   return {
     user: query.data ?? null,
     loading: query.isLoading,
     error: query.error,
-  }
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -83,46 +83,46 @@ export function useUser() {
  * (OAuth2 password-flow shape) with ``username`` = email.
  */
 async function loginRequest(creds: {
-  email: string
-  password: string
+  email: string;
+  password: string;
 }): Promise<void> {
   const body = new URLSearchParams({
     username: creds.email,
     password: creds.password,
-  })
-  const res = await fetch('/v1/auth/cookie/login', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  });
+  const res = await fetch("/v1/auth/cookie/login", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
     body,
-  })
+  });
   if (!res.ok) {
-    const detail = await res.text().catch(() => '')
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    const detail = await res.text().catch(() => "");
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
 }
 
 export function useLogin() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: loginRequest,
     onSuccess: () => qc.invalidateQueries({ queryKey: USER_QUERY_KEY }),
-  })
+  });
 }
 
 async function logoutRequest(): Promise<void> {
-  const res = await fetch('/v1/auth/cookie/logout', {
-    method: 'POST',
-    credentials: 'include',
-  })
+  const res = await fetch("/v1/auth/cookie/logout", {
+    method: "POST",
+    credentials: "include",
+  });
   // 401 here means "you weren't logged in anyway" — same end state.
   if (!res.ok && res.status !== 401) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
 }
 
 export function useLogout() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: logoutRequest,
     onSuccess: () => {
@@ -131,98 +131,98 @@ export function useLogout() {
       // user's chat history. There's no full page reload on logout
       // (just a cookie invalidation), so without this the module
       // globals survive.
-      resetPlayground()
-      qc.invalidateQueries({ queryKey: USER_QUERY_KEY })
+      resetPlayground();
+      qc.invalidateQueries({ queryKey: USER_QUERY_KEY });
     },
-  })
+  });
 }
 
 async function registerRequest(payload: {
-  email: string
-  password: string
+  email: string;
+  password: string;
 }): Promise<UserRead> {
-  const res = await fetch('/v1/auth/register', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+  const res = await fetch("/v1/auth/register", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as UserRead
+  return (await res.json()) as UserRead;
 }
 
 export function useRegister() {
-  return useMutation({ mutationFn: registerRequest })
+  return useMutation({ mutationFn: registerRequest });
 }
 
 async function forgotPasswordRequest(email: string): Promise<void> {
-  const res = await fetch('/v1/auth/forgot-password', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+  const res = await fetch("/v1/auth/forgot-password", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email }),
-  })
+  });
   // 202 Accepted is the success status — same response whether the
   // email exists or not (no enumeration leak).
   if (!res.ok) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
 }
 
 export function useForgotPassword() {
-  return useMutation({ mutationFn: forgotPasswordRequest })
+  return useMutation({ mutationFn: forgotPasswordRequest });
 }
 
 async function resetPasswordRequest(payload: {
-  token: string
-  password: string
+  token: string;
+  password: string;
 }): Promise<void> {
-  const res = await fetch('/v1/auth/reset-password', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+  const res = await fetch("/v1/auth/reset-password", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
 }
 
 export function useResetPassword() {
-  return useMutation({ mutationFn: resetPasswordRequest })
+  return useMutation({ mutationFn: resetPasswordRequest });
 }
 
 async function verifyEmailRequest(token: string): Promise<UserRead> {
-  const res = await fetch('/v1/auth/verify', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+  const res = await fetch("/v1/auth/verify", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ token }),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as UserRead
+  return (await res.json()) as UserRead;
 }
 
 /**
@@ -246,15 +246,15 @@ async function verifyEmailRequest(token: string): Promise<UserRead> {
  * other open tab sees ``is_verified: true`` on its next read.
  */
 export function useVerifyEmail(token: string | undefined) {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useQuery({
-    queryKey: ['verify-email', token],
+    queryKey: ["verify-email", token],
     queryFn: async () => {
-      const user = await verifyEmailRequest(token as string)
+      const user = await verifyEmailRequest(token as string);
       // Same cache-bust the old useMutation onSuccess did — runs once
       // when the query resolves, never on cache reads.
-      qc.invalidateQueries({ queryKey: USER_QUERY_KEY })
-      return user
+      qc.invalidateQueries({ queryKey: USER_QUERY_KEY });
+      return user;
     },
     enabled: !!token,
     retry: false,
@@ -262,23 +262,23 @@ export function useVerifyEmail(token: string | undefined) {
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
-  })
+  });
 }
 
 async function requestVerifyRequest(email: string): Promise<void> {
-  const res = await fetch('/v1/auth/request-verify-token', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+  const res = await fetch("/v1/auth/request-verify-token", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email }),
-  })
+  });
   if (!res.ok && res.status !== 202) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
 }
 
 export function useRequestVerify() {
-  return useMutation({ mutationFn: requestVerifyRequest })
+  return useMutation({ mutationFn: requestVerifyRequest });
 }
 
 // ---------------------------------------------------------------------------
@@ -295,31 +295,40 @@ export function useRequestVerify() {
  * callers hide the Google button when this returns null on mount.
  */
 export async function startGoogleSignIn(): Promise<void> {
-  const res = await fetch('/v1/auth/google/authorize?scopes=openid&scopes=email', {
-    credentials: 'include',
-  })
+  const res = await fetch(
+    "/v1/auth/google/authorize?scopes=openid&scopes=email",
+    {
+      credentials: "include",
+    },
+  );
   if (res.status === 404) {
-    throw new ApiError(404, null, 'Google sign-in is not enabled on this server')
+    throw new ApiError(
+      404,
+      null,
+      "Google sign-in is not enabled on this server",
+    );
   }
   if (!res.ok) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
-  const { authorization_url } = (await res.json()) as { authorization_url: string }
-  window.location.href = authorization_url
+  const { authorization_url } = (await res.json()) as {
+    authorization_url: string;
+  };
+  window.location.href = authorization_url;
 }
 
 /** Returns true if /v1/auth/google/authorize exists on this server. */
 export async function googleOAuthAvailable(): Promise<boolean> {
   try {
     const res = await fetch(
-      '/v1/auth/google/authorize?scopes=openid&scopes=email',
-      { credentials: 'include', method: 'HEAD' },
-    )
-    return res.status !== 404
+      "/v1/auth/google/authorize?scopes=openid&scopes=email",
+      { credentials: "include", method: "HEAD" },
+    );
+    return res.status !== 404;
   } catch {
-    return false
+    return false;
   }
 }
 
 // Re-export so callers don't need a second import.
-export { UnauthenticatedError }
+export { UnauthenticatedError };

--- a/platform/dashboard/src/lib/graph.ts
+++ b/platform/dashboard/src/lib/graph.ts
@@ -1,155 +1,169 @@
-import type { Edge, Node } from '@xyflow/react'
-import type { AgentRead } from './api'
-import { buildAgentView, effectiveMode, MODE_COLOR, type AgentView, type Mode } from './policy'
+import type { Edge, Node } from "@xyflow/react";
+import type { AgentRead } from "./api";
+import {
+  buildAgentView,
+  effectiveMode,
+  MODE_COLOR,
+  type AgentView,
+  type Mode,
+} from "./policy";
 
 /** Column-based layout constants. */
 const COL = {
   role: 40,
   agent: 360,
   tool: 720,
-} as const
+} as const;
 
-const ROW_H = 72
+const ROW_H = 72;
 
 export interface OverviewGraph {
-  nodes: Node[]
-  edges: Edge[]
-  agentViews: AgentView[]
+  nodes: Node[];
+  edges: Edge[];
+  agentViews: AgentView[];
 }
 
 /** Build the full project overview: everyone → all agents → all tools. */
 export function buildOverviewGraph(agents: AgentRead[]): OverviewGraph {
   const agentViews = agents
     .map(buildAgentView)
-    .filter((a): a is AgentView => a !== null)
+    .filter((a): a is AgentView => a !== null);
 
-  const uniqueTools = new Set<string>()
+  const uniqueTools = new Set<string>();
   for (const view of agentViews) {
-    for (const tool of view.tools) uniqueTools.add(tool)
+    for (const tool of view.tools) uniqueTools.add(tool);
   }
-  const toolList = Array.from(uniqueTools).sort()
+  const toolList = Array.from(uniqueTools).sort();
 
-  const nodes: Node[] = []
-  const edges: Edge[] = []
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
 
   // Everyone role at centre y of agents
-  const agentCenterY = ((agentViews.length - 1) * ROW_H) / 2
+  const agentCenterY = ((agentViews.length - 1) * ROW_H) / 2;
   nodes.push({
-    id: 'role:everyone',
-    type: 'role',
+    id: "role:everyone",
+    type: "role",
     position: { x: COL.role, y: agentCenterY },
-    data: { label: 'everyone', muted: true },
+    data: { label: "everyone", muted: true },
     draggable: false,
-  })
+  });
 
   agentViews.forEach((view, i) => {
-    const agentId = `agent:${view.name}`
+    const agentId = `agent:${view.name}`;
     nodes.push({
       id: agentId,
-      type: 'agent',
+      type: "agent",
       position: { x: COL.agent, y: i * ROW_H },
-      data: { name: view.name, model: view.model, toolCount: view.tools.length },
+      data: {
+        name: view.name,
+        model: view.model,
+        toolCount: view.tools.length,
+      },
       draggable: false,
-    })
+    });
 
     // everyone → agent
     edges.push({
       id: `e:everyone->${agentId}`,
-      source: 'role:everyone',
+      source: "role:everyone",
       target: agentId,
-      style: { stroke: 'hsl(var(--muted-foreground))', strokeWidth: 1, opacity: 0.5 },
-    })
+      style: {
+        stroke: "hsl(var(--muted-foreground))",
+        strokeWidth: 1,
+        opacity: 0.5,
+      },
+    });
 
     // agent → tools
     for (const toolName of view.tools) {
-      const mode = effectiveMode(view, toolName)
+      const mode = effectiveMode(view, toolName);
       edges.push({
         id: `e:${agentId}->tool:${toolName}`,
         source: agentId,
         target: `tool:${toolName}`,
         style: edgeStyle(mode),
-        animated: mode === 'approval_required',
-      })
+        animated: mode === "approval_required",
+      });
     }
-  })
+  });
 
-  const toolCenterY = ((toolList.length - 1) * ROW_H) / 2
-  const shift = agentCenterY - toolCenterY
+  const toolCenterY = ((toolList.length - 1) * ROW_H) / 2;
+  const shift = agentCenterY - toolCenterY;
   toolList.forEach((toolName, i) => {
     // Determine the "worst" mode for the left strip on the tool node
     const modesForTool: Mode[] = agentViews
       .filter((v) => v.tools.includes(toolName))
-      .map((v) => effectiveMode(v, toolName))
-    const mode = pickStripMode(modesForTool)
+      .map((v) => effectiveMode(v, toolName));
+    const mode = pickStripMode(modesForTool);
     nodes.push({
       id: `tool:${toolName}`,
-      type: 'tool',
+      type: "tool",
       position: { x: COL.tool, y: i * ROW_H + shift },
       data: { name: toolName, mode },
       draggable: false,
-    })
-  })
+    });
+  });
 
-  return { nodes, edges, agentViews }
+  return { nodes, edges, agentViews };
 }
 
 /** Build a per-agent local graph: the agent + its tools only. */
 export function buildAgentGraph(agent: AgentRead): {
-  nodes: Node[]
-  edges: Edge[]
-  view: AgentView | null
+  nodes: Node[];
+  edges: Edge[];
+  view: AgentView | null;
 } {
-  const view = buildAgentView(agent)
-  if (!view) return { nodes: [], edges: [], view: null }
+  const view = buildAgentView(agent);
+  if (!view) return { nodes: [], edges: [], view: null };
 
-  const nodes: Node[] = []
-  const edges: Edge[] = []
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
 
-  const centerY = ((view.tools.length - 1) * ROW_H) / 2
+  const centerY = ((view.tools.length - 1) * ROW_H) / 2;
 
   nodes.push({
-    id: 'agent:self',
-    type: 'agent',
+    id: "agent:self",
+    type: "agent",
     position: { x: 40, y: centerY },
     data: { name: view.name, model: view.model, toolCount: view.tools.length },
     draggable: false,
-  })
+  });
 
   view.tools.forEach((toolName, i) => {
-    const mode = effectiveMode(view, toolName)
+    const mode = effectiveMode(view, toolName);
     nodes.push({
       id: `tool:${toolName}`,
-      type: 'tool',
+      type: "tool",
       position: { x: 380, y: i * ROW_H },
       data: { name: toolName, mode },
       draggable: false,
-    })
+    });
     edges.push({
       id: `e:agent->${toolName}`,
-      source: 'agent:self',
+      source: "agent:self",
       target: `tool:${toolName}`,
       style: edgeStyle(mode),
-      animated: mode === 'approval_required',
-    })
-  })
+      animated: mode === "approval_required",
+    });
+  });
 
-  return { nodes, edges, view }
+  return { nodes, edges, view };
 }
 
 function edgeStyle(mode: Mode): React.CSSProperties {
-  const base = { stroke: MODE_COLOR[mode], strokeWidth: 1.75 }
-  if (mode === 'approval_required') {
-    return { ...base, strokeDasharray: '6 4' }
+  const base = { stroke: MODE_COLOR[mode], strokeWidth: 1.75 };
+  if (mode === "approval_required") {
+    return { ...base, strokeDasharray: "6 4" };
   }
-  if (mode === 'deny') {
-    return { ...base, strokeWidth: 1.5, opacity: 0.85 }
+  if (mode === "deny") {
+    return { ...base, strokeWidth: 1.5, opacity: 0.85 };
   }
-  return base
+  return base;
 }
 
-function pickStripMode(modes: Mode[]): Mode | 'default' {
-  if (modes.includes('deny')) return 'deny'
-  if (modes.includes('approval_required')) return 'approval_required'
-  if (modes.includes('allow')) return 'allow'
-  return 'default'
+function pickStripMode(modes: Mode[]): Mode | "default" {
+  if (modes.includes("deny")) return "deny";
+  if (modes.includes("approval_required")) return "approval_required";
+  if (modes.includes("allow")) return "allow";
+  return "default";
 }

--- a/platform/dashboard/src/lib/invites.ts
+++ b/platform/dashboard/src/lib/invites.ts
@@ -12,38 +12,38 @@
  * definitions (Role, InvitationRead/Preview) in one place.
  */
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { ApiError } from './api'
-import { USER_QUERY_KEY } from './auth'
-import type { MemberRead } from './members'
-import type { Role } from './orgs'
+import { ApiError } from "./api";
+import { USER_QUERY_KEY } from "./auth";
+import type { MemberRead } from "./members";
+import type { Role } from "./orgs";
 
 /** Mirror of platform/api/schemas.py:InvitationRead. ``id`` is exposed
  * so the dashboard's Cancel button has a row to address — the strict
  * email-match guard on accept is what stops the id from being an
  * impersonation vector. */
 export interface InvitationRead {
-  id: string
-  email: string
-  role: Role
-  invited_by_email: string
-  expires_at: string
-  created_at: string
+  id: string;
+  email: string;
+  role: Role;
+  invited_by_email: string;
+  expires_at: string;
+  created_at: string;
 }
 
 function invitesKey(orgId: string | null) {
-  return ['org-invitations', orgId] as const
+  return ["org-invitations", orgId] as const;
 }
 
 async function fetchInvitations(orgId: string): Promise<InvitationRead[]> {
   const res = await fetch(`/v1/orgs/${orgId}/invites`, {
-    credentials: 'include',
-  })
+    credentials: "include",
+  });
   if (!res.ok) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as InvitationRead[]
+  return (await res.json()) as InvitationRead[];
 }
 
 /** Pending invitations for an org — admin/owner only on the backend.
@@ -57,86 +57,84 @@ export function useInvitations(orgId: string | null) {
     // Slightly fresher than members — admin churn happens on a faster
     // cadence than membership changes during demos.
     staleTime: 15_000,
-  })
+  });
 }
 
 interface CreateInvitationInput {
-  orgId: string
-  email: string
-  role: Role
+  orgId: string;
+  email: string;
+  role: Role;
 }
 
 async function createInvitationRequest(
   input: CreateInvitationInput,
 ): Promise<InvitationRead> {
   const res = await fetch(`/v1/orgs/${input.orgId}/invites`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: input.email, role: input.role }),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as InvitationRead
+  return (await res.json()) as InvitationRead;
 }
 
 export function useCreateInvitation() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: createInvitationRequest,
     onSuccess: (_invite, vars) => {
       // Refresh the pending list for the org we just invited into.
-      qc.invalidateQueries({ queryKey: invitesKey(vars.orgId) })
+      qc.invalidateQueries({ queryKey: invitesKey(vars.orgId) });
     },
-  })
+  });
 }
 
 interface RevokeInvitationInput {
-  invitationId: string
+  invitationId: string;
   /** The org id is only used to invalidate the right cache entry — the
    * backend's DELETE /v1/invites/{id} doesn't need it in the URL. */
-  orgId: string
+  orgId: string;
 }
 
 async function revokeInvitationRequest(
   input: RevokeInvitationInput,
 ): Promise<void> {
   const res = await fetch(`/v1/invites/${input.invitationId}`, {
-    method: 'DELETE',
-    credentials: 'include',
-  })
-  if (res.status === 204) return
-  let detail: unknown
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (res.status === 204) return;
+  let detail: unknown;
   try {
-    detail = await res.json()
+    detail = await res.json();
   } catch {
-    detail = null
+    detail = null;
   }
-  throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+  throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
 }
 
 export function useRevokeInvitation() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: revokeInvitationRequest,
     onSuccess: (_, vars) => {
-      qc.invalidateQueries({ queryKey: invitesKey(vars.orgId) })
+      qc.invalidateQueries({ queryKey: invitesKey(vars.orgId) });
     },
-  })
+  });
 }
-
 
 // ---------------------------------------------------------------------------
 // Invitee-facing: preview + accept
 // ---------------------------------------------------------------------------
-
 
 /** Mirror of platform/api/schemas.py:InvitationPreview. Returned by the
  * PUBLIC ``GET /v1/invites/{id}`` route so the accept landing page can
@@ -145,13 +143,13 @@ export function useRevokeInvitation() {
  * the accept POST is what keeps a leaked id from being an
  * impersonation vector. */
 export interface InvitationPreview {
-  email: string
-  role: Role
-  invited_by_email: string
-  org_id: string
-  org_name: string
-  org_slug: string
-  expires_at: string
+  email: string;
+  role: Role;
+  invited_by_email: string;
+  org_id: string;
+  org_name: string;
+  org_slug: string;
+  expires_at: string;
 }
 
 async function fetchInvitationPreview(
@@ -162,18 +160,18 @@ async function fetchInvitationPreview(
   // any browser "third-party cookie" path differently across this page
   // vs. the rest of the dashboard.
   const res = await fetch(`/v1/invites/${invitationId}`, {
-    credentials: 'include',
-  })
+    credentials: "include",
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as InvitationPreview
+  return (await res.json()) as InvitationPreview;
 }
 
 /** Fetch the public preview for an invitation id. Doesn't retry —
@@ -182,7 +180,7 @@ async function fetchInvitationPreview(
  * cards off ``query.error`` (an ApiError with the status code). */
 export function useInvitationPreview(invitationId: string) {
   return useQuery<InvitationPreview, ApiError>({
-    queryKey: ['invitation-preview', invitationId],
+    queryKey: ["invitation-preview", invitationId],
     queryFn: () => fetchInvitationPreview(invitationId),
     retry: false,
     // The preview is effectively immutable for the duration of an
@@ -190,26 +188,26 @@ export function useInvitationPreview(invitationId: string) {
     refetchOnWindowFocus: false,
     staleTime: 60_000,
     enabled: !!invitationId,
-  })
+  });
 }
 
 async function acceptInvitationRequest(
   invitationId: string,
 ): Promise<MemberRead> {
   const res = await fetch(`/v1/invites/${invitationId}/accept`, {
-    method: 'POST',
-    credentials: 'include',
-  })
+    method: "POST",
+    credentials: "include",
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as MemberRead
+  return (await res.json()) as MemberRead;
 }
 
 /** Consume an invitation. Cookie-authed; the backend will 403 if the
@@ -218,15 +216,15 @@ async function acceptInvitationRequest(
  * landing page can navigate straight to the joined org without
  * waiting on a ``/v1/orgs`` round-trip. */
 export function useAcceptInvitation() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation<MemberRead, ApiError, string>({
     mutationFn: acceptInvitationRequest,
     onSuccess: () => {
       // The user is now a member of a new org — the switcher's list
       // needs to refresh, and re-reading /users/me is cheap insurance
       // in case any verified-email side-effects fired.
-      qc.invalidateQueries({ queryKey: ['orgs'] })
-      qc.invalidateQueries({ queryKey: USER_QUERY_KEY })
+      qc.invalidateQueries({ queryKey: ["orgs"] });
+      qc.invalidateQueries({ queryKey: USER_QUERY_KEY });
     },
-  })
+  });
 }

--- a/platform/dashboard/src/lib/members.ts
+++ b/platform/dashboard/src/lib/members.ts
@@ -9,43 +9,40 @@
  * UI translates to a sonner toast.
  */
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { ApiError } from './api'
-import type { Role } from './orgs'
+import { ApiError } from "./api";
+import type { Role } from "./orgs";
 
 interface LeaveOrgInput {
   /** Org the caller is leaving. Resolved server-side to a 204; if the
    * caller is the only owner, backend returns 409 LastOwnerError and
    * the mutation surfaces it via :class:`ApiError`. */
-  orgId: string
+  orgId: string;
 
   /** The caller's own user id. The DELETE route accepts admin/owner
    * removing anyone OR plain members removing themselves; passing
    * ``user.id`` here uses the self-removal path. */
-  userId: string
+  userId: string;
 }
 
 async function leaveOrgRequest(input: LeaveOrgInput): Promise<void> {
-  const res = await fetch(
-    `/v1/orgs/${input.orgId}/members/${input.userId}`,
-    {
-      method: 'DELETE',
-      credentials: 'include',
-    },
-  )
-  if (res.status === 204) return
-  let detail: unknown
+  const res = await fetch(`/v1/orgs/${input.orgId}/members/${input.userId}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (res.status === 204) return;
+  let detail: unknown;
   try {
-    detail = await res.json()
+    detail = await res.json();
   } catch {
-    detail = null
+    detail = null;
   }
-  throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+  throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
 }
 
 export function useLeaveOrg() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: leaveOrgRequest,
     onSuccess: () => {
@@ -53,39 +50,37 @@ export function useLeaveOrg() {
       // OrgProjectSwitcher refreshes correctly. The active-org
       // bootstrap effect in AppShell handles "stale activeOrgId after
       // leaving" by picking the next remaining org.
-      qc.invalidateQueries({ queryKey: ['orgs'] })
+      qc.invalidateQueries({ queryKey: ["orgs"] });
     },
-  })
+  });
 }
-
 
 // ---------------------------------------------------------------------------
 // Full members API — used by the /orgs/:id/members page (Step 3)
 // ---------------------------------------------------------------------------
 
-
 /** Mirror of platform/api/schemas.py:MemberRead. ``joined_at`` is the
  * OrganizationMember row's created_at on the backend, surfaced under
  * a friendlier name in the wire schema. */
 export interface MemberRead {
-  user_id: string
-  email: string
-  role: Role
-  joined_at: string
+  user_id: string;
+  email: string;
+  role: Role;
+  joined_at: string;
 }
 
 function membersKey(orgId: string | null) {
-  return ['org-members', orgId] as const
+  return ["org-members", orgId] as const;
 }
 
 async function fetchMembers(orgId: string): Promise<MemberRead[]> {
   const res = await fetch(`/v1/orgs/${orgId}/members`, {
-    credentials: 'include',
-  })
+    credentials: "include",
+  });
   if (!res.ok) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as MemberRead[]
+  return (await res.json()) as MemberRead[];
 }
 
 /** Lists every member of an org (with their role). Disabled while
@@ -97,83 +92,79 @@ export function useMembers(orgId: string | null) {
     queryFn: () => fetchMembers(orgId as string),
     enabled: !!orgId,
     staleTime: 30_000,
-  })
+  });
 }
 
 interface UpdateMemberRoleInput {
-  orgId: string
-  userId: string
-  role: Role
+  orgId: string;
+  userId: string;
+  role: Role;
 }
 
 async function updateMemberRoleRequest(
   input: UpdateMemberRoleInput,
 ): Promise<MemberRead> {
-  const res = await fetch(
-    `/v1/orgs/${input.orgId}/members/${input.userId}`,
-    {
-      method: 'PATCH',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ role: input.role }),
-    },
-  )
+  const res = await fetch(`/v1/orgs/${input.orgId}/members/${input.userId}`, {
+    method: "PATCH",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ role: input.role }),
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as MemberRead
+  return (await res.json()) as MemberRead;
 }
 
 export function useUpdateMemberRole() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: updateMemberRoleRequest,
     onSuccess: (member) => {
       // Refresh both the members list and the user's orgs list — the
       // latter carries role badges in the OrgProjectSwitcher.
-      qc.invalidateQueries({ queryKey: membersKey(member.user_id ? null : null) })
-      qc.invalidateQueries({ queryKey: ['org-members'] })
-      qc.invalidateQueries({ queryKey: ['orgs'] })
+      qc.invalidateQueries({
+        queryKey: membersKey(member.user_id ? null : null),
+      });
+      qc.invalidateQueries({ queryKey: ["org-members"] });
+      qc.invalidateQueries({ queryKey: ["orgs"] });
     },
-  })
+  });
 }
 
 interface RemoveMemberInput {
-  orgId: string
-  userId: string
+  orgId: string;
+  userId: string;
 }
 
 async function removeMemberRequest(input: RemoveMemberInput): Promise<void> {
-  const res = await fetch(
-    `/v1/orgs/${input.orgId}/members/${input.userId}`,
-    {
-      method: 'DELETE',
-      credentials: 'include',
-    },
-  )
-  if (res.status === 204) return
-  let detail: unknown
+  const res = await fetch(`/v1/orgs/${input.orgId}/members/${input.userId}`, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (res.status === 204) return;
+  let detail: unknown;
   try {
-    detail = await res.json()
+    detail = await res.json();
   } catch {
-    detail = null
+    detail = null;
   }
-  throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+  throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
 }
 
 export function useRemoveMember() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: removeMemberRequest,
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['org-members'] })
-      qc.invalidateQueries({ queryKey: ['orgs'] })
+      qc.invalidateQueries({ queryKey: ["org-members"] });
+      qc.invalidateQueries({ queryKey: ["orgs"] });
     },
-  })
+  });
 }

--- a/platform/dashboard/src/lib/orgs.ts
+++ b/platform/dashboard/src/lib/orgs.ts
@@ -3,35 +3,35 @@
  * /v1/orgs/* surface.
  */
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { ApiError } from './api'
+import { ApiError } from "./api";
 
-export const ROLES = ['owner', 'admin', 'member'] as const
-export type Role = (typeof ROLES)[number]
+export const ROLES = ["owner", "admin", "member"] as const;
+export type Role = (typeof ROLES)[number];
 
 /** Mirror of platform/api/schemas.py:OrgRead. ``created_at`` arrives as
  * an ISO-8601 string (JSON has no native datetime). */
 export interface OrgRead {
-  id: string
-  slug: string
-  name: string
-  created_at: string
+  id: string;
+  slug: string;
+  name: string;
+  created_at: string;
 }
 
 /** Mirror of OrgWithRole — what /v1/orgs returns per row. */
 export interface OrgWithRole extends OrgRead {
-  role: Role
+  role: Role;
 }
 
-const ORGS_KEY = ['orgs'] as const
+const ORGS_KEY = ["orgs"] as const;
 
 async function fetchOrgs(): Promise<OrgWithRole[]> {
-  const res = await fetch('/v1/orgs', { credentials: 'include' })
+  const res = await fetch("/v1/orgs", { credentials: "include" });
   if (!res.ok) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as OrgWithRole[]
+  return (await res.json()) as OrgWithRole[];
 }
 
 /** All orgs the caller is a member of (with their role on each). The
@@ -42,75 +42,75 @@ export function useOrgs() {
     queryKey: ORGS_KEY,
     queryFn: fetchOrgs,
     staleTime: 60_000,
-  })
+  });
 }
 
 interface CreateOrgInput {
-  name: string
+  name: string;
   /** Optional — when omitted the server derives a slug from the name. */
-  slug?: string
+  slug?: string;
 }
 
 async function createOrgRequest(input: CreateOrgInput): Promise<OrgRead> {
-  const res = await fetch('/v1/orgs', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+  const res = await fetch("/v1/orgs", {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as OrgRead
+  return (await res.json()) as OrgRead;
 }
 
 export function useCreateOrg() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: createOrgRequest,
     onSuccess: () => {
       // The new org won't show up in useOrgs() output without a refetch.
-      qc.invalidateQueries({ queryKey: ORGS_KEY })
+      qc.invalidateQueries({ queryKey: ORGS_KEY });
     },
-  })
+  });
 }
 
 interface UpdateOrgInput {
-  orgId: string
-  name?: string
-  slug?: string
+  orgId: string;
+  name?: string;
+  slug?: string;
 }
 
 async function updateOrgRequest(input: UpdateOrgInput): Promise<OrgRead> {
-  const { orgId, ...patch } = input
+  const { orgId, ...patch } = input;
   const res = await fetch(`/v1/orgs/${orgId}`, {
-    method: 'PATCH',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    method: "PATCH",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(patch),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as OrgRead
+  return (await res.json()) as OrgRead;
 }
 
 export function useUpdateOrg() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: updateOrgRequest,
     onSuccess: () => qc.invalidateQueries({ queryKey: ORGS_KEY }),
-  })
+  });
 }

--- a/platform/dashboard/src/lib/playground.ts
+++ b/platform/dashboard/src/lib/playground.ts
@@ -1,56 +1,56 @@
-import { useEffect, useSyncExternalStore } from 'react'
+import { useEffect, useSyncExternalStore } from "react";
 
-export type ToolCallState = 'started' | 'completed' | 'failed'
-export type BlockType = 'text' | 'reasoning' | 'tool_call'
+export type ToolCallState = "started" | "completed" | "failed";
+export type BlockType = "text" | "reasoning" | "tool_call";
 
 export interface RunStartEvent {
-  event_type: 'run_start'
-  query: string
-  run_id: string
+  event_type: "run_start";
+  query: string;
+  run_id: string;
 }
 
 export interface BlockStartEvent {
-  event_type: 'block_start'
-  block_id: string
-  block_type: BlockType
+  event_type: "block_start";
+  block_id: string;
+  block_type: BlockType;
 }
 
 export interface BlockDeltaEvent {
-  event_type: 'block_delta'
-  block_id: string
-  block_type: BlockType
-  text: string
+  event_type: "block_delta";
+  block_id: string;
+  block_type: BlockType;
+  text: string;
 }
 
 export interface BlockEndEvent {
-  event_type: 'block_end'
-  block_id: string
-  block_type: BlockType
+  event_type: "block_end";
+  block_id: string;
+  block_type: BlockType;
 }
 
 export interface ToolStartEvent {
-  event_type: 'tool_start'
-  tool_id: string
-  tool_name: string
-  arguments: Record<string, unknown>
+  event_type: "tool_start";
+  tool_id: string;
+  tool_name: string;
+  arguments: Record<string, unknown>;
 }
 
 export interface ToolEndEvent {
-  event_type: 'tool_end'
-  tool_id: string
-  tool_name: string
-  state: ToolCallState
-  output_summary?: string | null
+  event_type: "tool_end";
+  tool_id: string;
+  tool_name: string;
+  state: ToolCallState;
+  output_summary?: string | null;
 }
 
 export interface RunEndEvent {
-  event_type: 'run_end'
-  result: { message: string }
+  event_type: "run_end";
+  result: { message: string };
 }
 
 export interface ErrorEvent {
-  event_type: 'error'
-  message: string
+  event_type: "error";
+  message: string;
 }
 
 export type StreamEvent =
@@ -61,58 +61,58 @@ export type StreamEvent =
   | ToolStartEvent
   | ToolEndEvent
   | RunEndEvent
-  | ErrorEvent
+  | ErrorEvent;
 
 export interface AgentOnlineEvent {
-  type: 'agent_online'
-  online: boolean
-  agent?: string | null
+  type: "agent_online";
+  online: boolean;
+  agent?: string | null;
 }
 export interface SessionResetEvent {
-  type: 'session_reset'
+  type: "session_reset";
 }
-export type ControlEvent = AgentOnlineEvent | SessionResetEvent
+export type ControlEvent = AgentOnlineEvent | SessionResetEvent;
 
 // ——— UI model ———
 
 export interface ToolCall {
-  id: string
-  name: string
-  args: Record<string, unknown>
-  state: ToolCallState
-  outputSummary?: string | null
-  startedAt: number
-  endedAt?: number
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+  state: ToolCallState;
+  outputSummary?: string | null;
+  startedAt: number;
+  endedAt?: number;
 }
 
 export interface AssistantTurn {
-  id: string
-  streaming: boolean
-  text: string
-  reasoning: string
-  tools: ToolCall[]
-  error?: string
+  id: string;
+  streaming: boolean;
+  text: string;
+  reasoning: string;
+  tools: ToolCall[];
+  error?: string;
 }
 
 export interface ChatMessage {
-  id: string
-  role: 'user' | 'assistant'
-  content: string
-  turn?: AssistantTurn
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  turn?: AssistantTurn;
 }
 
 export interface PlaygroundState {
-  connected: boolean
-  agentOnline: boolean
-  agentName: string | null
-  messages: ChatMessage[]
-  decisions: ToolCall[]
+  connected: boolean;
+  agentOnline: boolean;
+  agentName: string | null;
+  messages: ChatMessage[];
+  decisions: ToolCall[];
   /** id of the assistant turn currently being streamed into. */
-  currentTurnId: string | null
+  currentTurnId: string | null;
 }
 
 interface Options {
-  projectId: string
+  projectId: string;
 }
 
 // ---------------------------------------------------------------------
@@ -141,78 +141,78 @@ const INITIAL_STATE: PlaygroundState = {
   messages: [],
   decisions: [],
   currentTurnId: null,
-}
+};
 
-let cachedState: PlaygroundState = INITIAL_STATE
-const listeners = new Set<() => void>()
+let cachedState: PlaygroundState = INITIAL_STATE;
+const listeners = new Set<() => void>();
 
-let activeSocket: WebSocket | null = null
-let activeProjectId: string | null = null
-let reconnectTimer: ReturnType<typeof setTimeout> | null = null
-let reconnectAttempts = 0
+let activeSocket: WebSocket | null = null;
+let activeProjectId: string | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let reconnectAttempts = 0;
 
 function setStore(updater: (s: PlaygroundState) => PlaygroundState): void {
-  cachedState = updater(cachedState)
-  listeners.forEach((l) => l())
+  cachedState = updater(cachedState);
+  listeners.forEach((l) => l());
 }
 
 function subscribe(listener: () => void): () => void {
-  listeners.add(listener)
+  listeners.add(listener);
   return () => {
-    listeners.delete(listener)
-  }
+    listeners.delete(listener);
+  };
 }
 
 function getSnapshot(): PlaygroundState {
-  return cachedState
+  return cachedState;
 }
 
 function handleFrame(frame: unknown): void {
-  if (!frame || typeof frame !== 'object') return
-  const f = frame as { type?: string; event_type?: string }
-  if (f.type === 'agent_online') {
-    const ev = f as AgentOnlineEvent
+  if (!frame || typeof frame !== "object") return;
+  const f = frame as { type?: string; event_type?: string };
+  if (f.type === "agent_online") {
+    const ev = f as AgentOnlineEvent;
     setStore((s) => ({
       ...s,
       agentOnline: Boolean(ev.online),
       agentName: ev.agent ?? (ev.online ? s.agentName : null),
-    }))
-    return
+    }));
+    return;
   }
-  if (f.type === 'session_reset') return
-  if (f.event_type) setStore((s) => applyEvent(s, f as StreamEvent))
+  if (f.type === "session_reset") return;
+  if (f.event_type) setStore((s) => applyEvent(s, f as StreamEvent));
 }
 
 function connectSocket(projectId: string): void {
   // Project changed under us while a reconnect was pending — abandon.
-  if (activeProjectId !== projectId) return
-  const url = `${location.protocol === 'https:' ? 'wss' : 'ws'}://${location.host}/v1/projects/${projectId}/chat`
-  const ws = new WebSocket(url)
-  activeSocket = ws
+  if (activeProjectId !== projectId) return;
+  const url = `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/v1/projects/${projectId}/chat`;
+  const ws = new WebSocket(url);
+  activeSocket = ws;
 
-  ws.addEventListener('open', () => {
-    reconnectAttempts = 0
-    setStore((s) => ({ ...s, connected: true }))
-  })
+  ws.addEventListener("open", () => {
+    reconnectAttempts = 0;
+    setStore((s) => ({ ...s, connected: true }));
+  });
 
-  ws.addEventListener('close', () => {
-    setStore((s) => ({ ...s, connected: false, agentOnline: false }))
+  ws.addEventListener("close", () => {
+    setStore((s) => ({ ...s, connected: false, agentOnline: false }));
     if (activeProjectId === projectId) {
-      const delay = Math.min(1000 * 2 ** reconnectAttempts, 15000)
-      reconnectAttempts += 1
-      reconnectTimer = setTimeout(() => connectSocket(projectId), delay)
+      const delay = Math.min(1000 * 2 ** reconnectAttempts, 15000);
+      reconnectAttempts += 1;
+      reconnectTimer = setTimeout(() => connectSocket(projectId), delay);
     }
-  })
+  });
 
-  ws.addEventListener('message', (evt) => {
-    let payload: unknown
+  ws.addEventListener("message", (evt) => {
+    let payload: unknown;
     try {
-      payload = JSON.parse(evt.data)
+      payload = JSON.parse(evt.data);
     } catch {
-      return
+      return;
     }
-    handleFrame(payload)
-  })
+    handleFrame(payload);
+  });
 }
 
 /**
@@ -226,38 +226,38 @@ function connectSocket(projectId: string): void {
  */
 export function resetPlayground(): void {
   if (activeSocket) {
-    activeSocket.close()
-    activeSocket = null
+    activeSocket.close();
+    activeSocket = null;
   }
   if (reconnectTimer) {
-    clearTimeout(reconnectTimer)
-    reconnectTimer = null
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
   }
-  activeProjectId = null
-  reconnectAttempts = 0
-  cachedState = INITIAL_STATE
-  listeners.forEach((l) => l())
+  activeProjectId = null;
+  reconnectAttempts = 0;
+  cachedState = INITIAL_STATE;
+  listeners.forEach((l) => l());
 }
 
 function ensureSocketFor(projectId: string): void {
   // Same project + live socket → nothing to do. This is the common
   // remount path (route navigated away and back).
-  if (activeProjectId === projectId && activeSocket) return
+  if (activeProjectId === projectId && activeSocket) return;
 
   // Project switched — the prior session belongs to a different project,
   // wipe it and open a fresh connection.
   if (activeProjectId !== null && activeProjectId !== projectId) {
-    activeSocket?.close()
-    cachedState = INITIAL_STATE
-    listeners.forEach((l) => l())
+    activeSocket?.close();
+    cachedState = INITIAL_STATE;
+    listeners.forEach((l) => l());
   }
   if (reconnectTimer) {
-    clearTimeout(reconnectTimer)
-    reconnectTimer = null
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
   }
-  activeProjectId = projectId
-  reconnectAttempts = 0
-  connectSocket(projectId)
+  activeProjectId = projectId;
+  reconnectAttempts = 0;
+  connectSocket(projectId);
 }
 
 // ---------------------------------------------------------------------
@@ -265,14 +265,14 @@ function ensureSocketFor(projectId: string): void {
 // ---------------------------------------------------------------------
 
 export function usePlayground({ projectId }: Options) {
-  const state = useSyncExternalStore(subscribe, getSnapshot)
+  const state = useSyncExternalStore(subscribe, getSnapshot);
 
   useEffect(() => {
-    ensureSocketFor(projectId)
+    ensureSocketFor(projectId);
     // No cleanup — the socket is intentionally module-scoped so
     // chat history survives route changes. Project-switch teardown
     // happens inside ensureSocketFor on the next mount.
-  }, [projectId])
+  }, [projectId]);
 
   /**
    * Send a chat message, optionally scoped to a role.
@@ -283,50 +283,55 @@ export function usePlayground({ projectId }: Options) {
    * turn. The role's policy bundle then drives tool authorization.
    */
   function sendChat(message: string, opts?: { role?: string | null }) {
-    const ws = activeSocket
-    if (!ws || ws.readyState !== WebSocket.OPEN) return
-    const turnId = randomId()
+    const ws = activeSocket;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    const turnId = randomId();
     const userMsg: ChatMessage = {
       id: randomId(),
-      role: 'user',
+      role: "user",
       content: message,
-    }
+    };
     const turn: AssistantTurn = {
       id: turnId,
       streaming: true,
-      text: '',
-      reasoning: '',
+      text: "",
+      reasoning: "",
       tools: [],
-    }
+    };
     setStore((s) => ({
       ...s,
       currentTurnId: turnId,
       messages: [
         ...s.messages,
         userMsg,
-        { id: turn.id, role: 'assistant', content: '', turn },
+        { id: turn.id, role: "assistant", content: "", turn },
       ],
-    }))
-    const frame: Record<string, unknown> = { type: 'chat', message }
+    }));
+    const frame: Record<string, unknown> = { type: "chat", message };
     if (opts?.role) {
       frame.user_attenuation = {
-        user: 'playground',
+        user: "playground",
         role: opts.role,
         ttl_seconds: 300,
-      }
+      };
     }
-    ws.send(JSON.stringify(frame))
+    ws.send(JSON.stringify(frame));
   }
 
   function reset() {
-    const ws = activeSocket
+    const ws = activeSocket;
     if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: 'reset' }))
+      ws.send(JSON.stringify({ type: "reset" }));
     }
-    setStore((s) => ({ ...s, currentTurnId: null, messages: [], decisions: [] }))
+    setStore((s) => ({
+      ...s,
+      currentTurnId: null,
+      messages: [],
+      decisions: [],
+    }));
   }
 
-  return { state, sendChat, reset }
+  return { state, sendChat, reset };
 }
 
 /**
@@ -336,82 +341,85 @@ export function usePlayground({ projectId }: Options) {
  * double-invokes state updaters to verify they're deterministic. Called
  * N times with the same input, always returns the same output.
  */
-function applyEvent(state: PlaygroundState, event: StreamEvent): PlaygroundState {
-  const turnId = state.currentTurnId
-  if (!turnId) return state
+function applyEvent(
+  state: PlaygroundState,
+  event: StreamEvent,
+): PlaygroundState {
+  const turnId = state.currentTurnId;
+  if (!turnId) return state;
 
-  const msgIdx = state.messages.findIndex((m) => m.turn?.id === turnId)
-  if (msgIdx < 0) return state
+  const msgIdx = state.messages.findIndex((m) => m.turn?.id === turnId);
+  if (msgIdx < 0) return state;
 
-  const msg = state.messages[msgIdx]
-  const turn = msg.turn
-  if (!turn) return state
+  const msg = state.messages[msgIdx];
+  const turn = msg.turn;
+  if (!turn) return state;
 
   const withTurn = (nextTurn: AssistantTurn): PlaygroundState => {
-    const nextMessages = state.messages.slice()
-    nextMessages[msgIdx] = { ...msg, content: nextTurn.text, turn: nextTurn }
-    return { ...state, messages: nextMessages }
-  }
+    const nextMessages = state.messages.slice();
+    nextMessages[msgIdx] = { ...msg, content: nextTurn.text, turn: nextTurn };
+    return { ...state, messages: nextMessages };
+  };
 
   switch (event.event_type) {
-    case 'run_start':
-      return withTurn({ ...turn, streaming: true })
+    case "run_start":
+      return withTurn({ ...turn, streaming: true });
 
-    case 'block_delta': {
-      if (event.block_type === 'text') {
-        return withTurn({ ...turn, text: turn.text + event.text })
+    case "block_delta": {
+      if (event.block_type === "text") {
+        return withTurn({ ...turn, text: turn.text + event.text });
       }
-      if (event.block_type === 'reasoning') {
-        return withTurn({ ...turn, reasoning: turn.reasoning + event.text })
+      if (event.block_type === "reasoning") {
+        return withTurn({ ...turn, reasoning: turn.reasoning + event.text });
       }
-      return state
+      return state;
     }
 
-    case 'tool_start': {
+    case "tool_start": {
       if (turn.tools.some((t) => t.id === event.tool_id)) {
-        return state
+        return state;
       }
       const call: ToolCall = {
         id: event.tool_id,
         name: event.tool_name,
         args: event.arguments,
-        state: 'started',
+        state: "started",
         startedAt: Date.now(),
-      }
-      const nextTurn: AssistantTurn = { ...turn, tools: [...turn.tools, call] }
+      };
+      const nextTurn: AssistantTurn = { ...turn, tools: [...turn.tools, call] };
       const decisions = state.decisions.some((d) => d.id === call.id)
         ? state.decisions
-        : [...state.decisions, call]
-      return { ...withTurn(nextTurn), decisions }
+        : [...state.decisions, call];
+      return { ...withTurn(nextTurn), decisions };
     }
 
-    case 'tool_end': {
-      const idx = turn.tools.findIndex((t) => t.id === event.tool_id)
-      if (idx < 0) return state
-      const existing = turn.tools[idx]
+    case "tool_end": {
+      const idx = turn.tools.findIndex((t) => t.id === event.tool_id);
+      if (idx < 0) return state;
+      const existing = turn.tools[idx];
       // No-op if already in the terminal state from a prior pass.
       if (
         existing.state === event.state &&
         existing.outputSummary === (event.output_summary ?? undefined)
       ) {
-        return state
+        return state;
       }
       const updated: ToolCall = {
         ...existing,
         state: event.state,
         outputSummary: event.output_summary ?? undefined,
         endedAt: existing.endedAt ?? Date.now(),
-      }
-      const tools = turn.tools.slice()
-      tools[idx] = updated
-      const nextTurn: AssistantTurn = { ...turn, tools }
+      };
+      const tools = turn.tools.slice();
+      tools[idx] = updated;
+      const nextTurn: AssistantTurn = { ...turn, tools };
       const decisions = state.decisions.map((d) =>
         d.id === event.tool_id ? updated : d,
-      )
-      return { ...withTurn(nextTurn), decisions }
+      );
+      return { ...withTurn(nextTurn), decisions };
     }
 
-    case 'run_end':
+    case "run_end":
       return {
         ...withTurn({
           ...turn,
@@ -419,19 +427,19 @@ function applyEvent(state: PlaygroundState, event: StreamEvent): PlaygroundState
           text: event.result.message || turn.text,
         }),
         currentTurnId: null,
-      }
+      };
 
-    case 'error':
+    case "error":
       return {
         ...withTurn({ ...turn, streaming: false, error: event.message }),
         currentTurnId: null,
-      }
+      };
 
     default:
-      return state
+      return state;
   }
 }
 
 function randomId(): string {
-  return Math.random().toString(36).slice(2, 10)
+  return Math.random().toString(36).slice(2, 10);
 }

--- a/platform/dashboard/src/lib/policy.ts
+++ b/platform/dashboard/src/lib/policy.ts
@@ -1,53 +1,56 @@
-import yaml from 'js-yaml'
-import type { AgentRead } from './api'
+import yaml from "js-yaml";
+import type { AgentRead } from "./api";
 
-export type Mode = 'allow' | 'deny' | 'approval_required'
+export type Mode = "allow" | "deny" | "approval_required";
 
 export interface ToolPolicy {
-  mode: Mode
+  mode: Mode;
   file_scope?: {
-    allowed_paths?: string[]
-  }
+    allowed_paths?: string[];
+  };
 }
 
 export interface ParsedPolicy {
-  version: number
-  default_policy: { mode: Mode }
-  tools: Record<string, ToolPolicy>
+  version: number;
+  default_policy: { mode: Mode };
+  tools: Record<string, ToolPolicy>;
 }
 
 export interface ParsedAgent {
-  name: string
-  model: string
-  tools: string[]
+  name: string;
+  model: string;
+  tools: string[];
 }
 
 export interface AgentView {
-  name: string
-  model: string
-  tools: string[]
-  policy: ParsedPolicy
+  name: string;
+  model: string;
+  tools: string[];
+  policy: ParsedPolicy;
   /** Tools that appear in agent.yaml but have no entry in policy.yaml → default_policy applies */
-  missingInPolicy: string[]
+  missingInPolicy: string[];
 }
 
 function isMode(x: unknown): x is Mode {
-  return x === 'allow' || x === 'deny' || x === 'approval_required'
+  return x === "allow" || x === "deny" || x === "approval_required";
 }
 
-export function parseAgent(agentYaml: string, policyYaml: string): ParsedAgent | null {
+export function parseAgent(
+  agentYaml: string,
+  policyYaml: string,
+): ParsedAgent | null {
   try {
-    const agent = yaml.load(agentYaml) as Partial<ParsedAgent> | null
-    if (!agent || typeof agent !== 'object') return null
+    const agent = yaml.load(agentYaml) as Partial<ParsedAgent> | null;
+    if (!agent || typeof agent !== "object") return null;
     return {
-      name: String(agent.name ?? ''),
-      model: String(agent.model ?? ''),
+      name: String(agent.name ?? ""),
+      model: String(agent.model ?? ""),
       tools: Array.isArray(agent.tools) ? agent.tools.map(String) : [],
-    }
+    };
   } catch {
-    return null
+    return null;
   }
-  void policyYaml
+  void policyYaml;
 }
 
 export function parsePolicy(policyYaml: string): ParsedPolicy | null {
@@ -55,53 +58,60 @@ export function parsePolicy(policyYaml: string): ParsedPolicy | null {
     // `yaml.load` returns `unknown`; the shape checks below narrow it
     // before we dereference. Using `unknown` over `any` so a missed
     // check is a compile error rather than a silent dereference.
-    const raw = yaml.load(policyYaml) as Record<string, unknown> | null | undefined
-    if (!raw || typeof raw !== 'object') return null
-    const defaultPolicy = raw.default_policy as { mode?: unknown } | undefined
-    const defaultMode = isMode(defaultPolicy?.mode) ? defaultPolicy.mode : 'deny'
-    const rawTools = (raw.tools ?? {}) as Record<string, unknown>
-    const tools: Record<string, ToolPolicy> = {}
+    const raw = yaml.load(policyYaml) as
+      | Record<string, unknown>
+      | null
+      | undefined;
+    if (!raw || typeof raw !== "object") return null;
+    const defaultPolicy = raw.default_policy as { mode?: unknown } | undefined;
+    const defaultMode = isMode(defaultPolicy?.mode)
+      ? defaultPolicy.mode
+      : "deny";
+    const rawTools = (raw.tools ?? {}) as Record<string, unknown>;
+    const tools: Record<string, ToolPolicy> = {};
     for (const [toolName, entry] of Object.entries(rawTools)) {
-      const e = entry as { mode?: unknown; file_scope?: unknown }
-      if (!isMode(e?.mode)) continue
+      const e = entry as { mode?: unknown; file_scope?: unknown };
+      if (!isMode(e?.mode)) continue;
       tools[toolName] = {
         mode: e.mode,
-        file_scope: e.file_scope as ToolPolicy['file_scope'],
-      }
+        file_scope: e.file_scope as ToolPolicy["file_scope"],
+      };
     }
     return {
       version: Number(raw.version ?? 1),
       default_policy: { mode: defaultMode },
       tools,
-    }
+    };
   } catch {
-    return null
+    return null;
   }
 }
 
 export function buildAgentView(agent: AgentRead): AgentView | null {
-  const parsedAgent = parseAgent(agent.agent_yaml, agent.policy_yaml)
-  const parsedPolicy = parsePolicy(agent.policy_yaml)
-  if (!parsedAgent || !parsedPolicy) return null
-  const missingInPolicy = parsedAgent.tools.filter((t) => !(t in parsedPolicy.tools))
+  const parsedAgent = parseAgent(agent.agent_yaml, agent.policy_yaml);
+  const parsedPolicy = parsePolicy(agent.policy_yaml);
+  if (!parsedAgent || !parsedPolicy) return null;
+  const missingInPolicy = parsedAgent.tools.filter(
+    (t) => !(t in parsedPolicy.tools),
+  );
   return {
     name: parsedAgent.name || agent.name,
     model: parsedAgent.model,
     tools: parsedAgent.tools,
     policy: parsedPolicy,
     missingInPolicy,
-  }
+  };
 }
 
 export function effectiveMode(view: AgentView, toolName: string): Mode {
-  return view.policy.tools[toolName]?.mode ?? view.policy.default_policy.mode
+  return view.policy.tools[toolName]?.mode ?? view.policy.default_policy.mode;
 }
 
 export const MODE_COLOR: Record<Mode, string> = {
-  allow: 'hsl(var(--semantic-allow))',
-  deny: 'hsl(var(--semantic-deny))',
-  approval_required: 'hsl(var(--semantic-approval))',
-}
+  allow: "hsl(var(--semantic-allow))",
+  deny: "hsl(var(--semantic-deny))",
+  approval_required: "hsl(var(--semantic-approval))",
+};
 
 /**
  * Extract the selectable role names from an inline-roles ``policy.yaml``.
@@ -117,26 +127,30 @@ export const MODE_COLOR: Record<Mode, string> = {
  * server's /validate endpoint.
  */
 export function parseRolesFromPolicy(policyYaml: string): string[] {
-  let parsed: unknown
+  let parsed: unknown;
   try {
-    parsed = yaml.load(policyYaml)
+    parsed = yaml.load(policyYaml);
   } catch {
-    return []
+    return [];
   }
-  if (!parsed || typeof parsed !== 'object') return []
-  const roles = (parsed as { roles?: unknown }).roles
-  if (!roles || typeof roles !== 'object' || Array.isArray(roles)) return []
+  if (!parsed || typeof parsed !== "object") return [];
+  const roles = (parsed as { roles?: unknown }).roles;
+  if (!roles || typeof roles !== "object" || Array.isArray(roles)) return [];
 
-  const concrete: string[] = []
+  const concrete: string[] = [];
   for (const [name, spec] of Object.entries(roles as Record<string, unknown>)) {
-    if (spec && typeof spec === 'object' && (spec as { is_mixin?: unknown }).is_mixin === true) {
-      continue
+    if (
+      spec &&
+      typeof spec === "object" &&
+      (spec as { is_mixin?: unknown }).is_mixin === true
+    ) {
+      continue;
     }
-    concrete.push(name)
+    concrete.push(name);
   }
-  concrete.sort()
-  if (concrete.includes('default')) {
-    return ['default', ...concrete.filter((r) => r !== 'default')]
+  concrete.sort();
+  if (concrete.includes("default")) {
+    return ["default", ...concrete.filter((r) => r !== "default")];
   }
-  return concrete
+  return concrete;
 }

--- a/platform/dashboard/src/lib/policy_graph.ts
+++ b/platform/dashboard/src/lib/policy_graph.ts
@@ -29,39 +29,39 @@
  * Graph tab in /policies passes the output to <ReactFlow> verbatim.
  */
 
-import yaml from 'js-yaml'
-import type { Edge, Node } from '@xyflow/react'
+import yaml from "js-yaml";
+import type { Edge, Node } from "@xyflow/react";
 
-export type Mode = 'allow' | 'deny' | 'approval_required'
+export type Mode = "allow" | "deny" | "approval_required";
 
 interface ToolPolicySpec {
-  mode?: Mode
-  constraints?: string[]
+  mode?: Mode;
+  constraints?: string[];
 }
 
 interface RoleSpec {
-  is_mixin?: boolean
-  inherits?: string[]
-  tools?: Record<string, ToolPolicySpec>
-  default_policy?: { mode?: Mode }
+  is_mixin?: boolean;
+  inherits?: string[];
+  tools?: Record<string, ToolPolicySpec>;
+  default_policy?: { mode?: Mode };
 }
 
 interface InlinePolicy {
-  version?: number
-  roles?: Record<string, RoleSpec>
+  version?: number;
+  roles?: Record<string, RoleSpec>;
 }
 
 const MODE_COLOR: Record<Mode, string> = {
-  allow: 'hsl(var(--semantic-allow))',
-  approval_required: 'hsl(var(--semantic-approval))',
-  deny: 'hsl(var(--semantic-deny))',
-}
+  allow: "hsl(var(--semantic-allow))",
+  approval_required: "hsl(var(--semantic-approval))",
+  deny: "hsl(var(--semantic-deny))",
+};
 
 export interface PolicyGraph {
-  nodes: Node[]
-  edges: Edge[]
+  nodes: Node[];
+  edges: Edge[];
   /** True if the YAML parsed and has at least one role; false → tab should render an empty/invalid placeholder. */
-  ok: boolean
+  ok: boolean;
 }
 
 /**
@@ -70,58 +70,60 @@ export interface PolicyGraph {
  * "fix the YAML to see the graph" message.
  */
 export function buildPolicyGraph(policyYaml: string): PolicyGraph {
-  let parsed: unknown
+  let parsed: unknown;
   try {
-    parsed = yaml.load(policyYaml)
+    parsed = yaml.load(policyYaml);
   } catch {
-    return { nodes: [], edges: [], ok: false }
+    return { nodes: [], edges: [], ok: false };
   }
-  if (!parsed || typeof parsed !== 'object') {
-    return { nodes: [], edges: [], ok: false }
+  if (!parsed || typeof parsed !== "object") {
+    return { nodes: [], edges: [], ok: false };
   }
-  const doc = parsed as InlinePolicy
-  const rolesMap = doc.roles
-  if (!rolesMap || typeof rolesMap !== 'object') {
-    return { nodes: [], edges: [], ok: false }
+  const doc = parsed as InlinePolicy;
+  const rolesMap = doc.roles;
+  if (!rolesMap || typeof rolesMap !== "object") {
+    return { nodes: [], edges: [], ok: false };
   }
 
-  const roleNames = Object.keys(rolesMap)
+  const roleNames = Object.keys(rolesMap);
   // Tools = union across all roles, source order (first occurrence wins).
-  const toolSet = new Set<string>()
+  const toolSet = new Set<string>();
   for (const role of roleNames) {
-    const tools = rolesMap[role]?.tools ?? {}
-    for (const t of Object.keys(tools)) toolSet.add(t)
+    const tools = rolesMap[role]?.tools ?? {};
+    for (const t of Object.keys(tools)) toolSet.add(t);
   }
-  const toolNames = Array.from(toolSet)
+  const toolNames = Array.from(toolSet);
 
   // Layout constants: two columns, role boxes vertically stacked on the left,
   // tool nodes on the right. Vertical spacing tuned so the columns visually
   // balance for typical policies (≤8 roles, ≤8 tools).
-  const COL_ROLES_X = 0
-  const COL_TOOLS_X = 480
-  const ROLE_GAP_Y = 110
-  const TOOL_GAP_Y = 80
-  const ROLE_Y_START = 0
-  const TOOL_Y_START =
-    Math.max(0, (roleNames.length * ROLE_GAP_Y - toolNames.length * TOOL_GAP_Y) / 2)
+  const COL_ROLES_X = 0;
+  const COL_TOOLS_X = 480;
+  const ROLE_GAP_Y = 110;
+  const TOOL_GAP_Y = 80;
+  const ROLE_Y_START = 0;
+  const TOOL_Y_START = Math.max(
+    0,
+    (roleNames.length * ROLE_GAP_Y - toolNames.length * TOOL_GAP_Y) / 2,
+  );
 
-  const nodes: Node[] = []
-  const edges: Edge[] = []
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
 
   // Role nodes — mixin entries rendered with the muted flag so they read
   // as inheritance helpers rather than active personas.
   roleNames.forEach((role, idx) => {
-    const spec = rolesMap[role]
+    const spec = rolesMap[role];
     nodes.push({
       id: `role:${role}`,
-      type: 'role',
+      type: "role",
       position: { x: COL_ROLES_X, y: ROLE_Y_START + idx * ROLE_GAP_Y },
       data: {
         label: role,
         muted: spec?.is_mixin === true,
       },
-    })
-  })
+    });
+  });
 
   // Tool nodes — mode defaults to 'default' (renders as the muted strip);
   // the tool's mode varies per role, so this represents "the tool exists"
@@ -129,36 +131,36 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
   toolNames.forEach((tool, idx) => {
     nodes.push({
       id: `tool:${tool}`,
-      type: 'tool',
+      type: "tool",
       position: { x: COL_TOOLS_X, y: TOOL_Y_START + idx * TOOL_GAP_Y },
-      data: { name: tool, mode: 'default' },
-    })
-  })
+      data: { name: tool, mode: "default" },
+    });
+  });
 
   // Inheritance edges — role → parent role, dashed, secondary color.
   for (const role of roleNames) {
-    const parents = rolesMap[role]?.inherits ?? []
+    const parents = rolesMap[role]?.inherits ?? [];
     for (const parent of parents) {
-      if (!rolesMap[parent]) continue
+      if (!rolesMap[parent]) continue;
       edges.push({
         id: `inh:${role}->${parent}`,
         source: `role:${role}`,
         target: `role:${parent}`,
-        type: 'smoothstep',
+        type: "smoothstep",
         animated: false,
         style: {
-          stroke: 'hsl(var(--muted-foreground))',
-          strokeDasharray: '4 4',
+          stroke: "hsl(var(--muted-foreground))",
+          strokeDasharray: "4 4",
           strokeWidth: 1.5,
         },
-        label: 'inherits',
+        label: "inherits",
         labelStyle: {
           fontSize: 10,
-          fill: 'hsl(var(--muted-foreground))',
+          fill: "hsl(var(--muted-foreground))",
         },
-        labelBgStyle: { fill: 'hsl(var(--background))' },
+        labelBgStyle: { fill: "hsl(var(--background))" },
         labelBgPadding: [4, 2],
-      })
+      });
     }
   }
 
@@ -166,35 +168,35 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
   // count surfaces in the label so the user knows the rule has gates
   // without opening the YAML.
   for (const role of roleNames) {
-    const spec = rolesMap[role]
-    if (spec?.is_mixin) continue // mixins don't terminate; their tools surface via children
-    const tools = spec?.tools ?? {}
+    const spec = rolesMap[role];
+    if (spec?.is_mixin) continue; // mixins don't terminate; their tools surface via children
+    const tools = spec?.tools ?? {};
     for (const [tool, toolSpec] of Object.entries(tools)) {
-      const mode = (toolSpec?.mode ?? 'deny') as Mode
-      const constraintCount = toolSpec?.constraints?.length ?? 0
+      const mode = (toolSpec?.mode ?? "deny") as Mode;
+      const constraintCount = toolSpec?.constraints?.length ?? 0;
       edges.push({
         id: `mode:${role}->${tool}`,
         source: `role:${role}`,
         target: `tool:${tool}`,
-        type: 'smoothstep',
-        animated: mode === 'allow',
+        type: "smoothstep",
+        animated: mode === "allow",
         style: {
           stroke: MODE_COLOR[mode],
           strokeWidth: 2,
         },
         label:
           constraintCount > 0
-            ? `${mode} · ${constraintCount} check${constraintCount === 1 ? '' : 's'}`
+            ? `${mode} · ${constraintCount} check${constraintCount === 1 ? "" : "s"}`
             : mode,
         labelStyle: {
           fontSize: 10,
-          fill: 'hsl(var(--foreground))',
+          fill: "hsl(var(--foreground))",
         },
-        labelBgStyle: { fill: 'hsl(var(--background))' },
+        labelBgStyle: { fill: "hsl(var(--background))" },
         labelBgPadding: [4, 2],
-      })
+      });
     }
   }
 
-  return { nodes, edges, ok: true }
+  return { nodes, edges, ok: true };
 }

--- a/platform/dashboard/src/lib/projects.ts
+++ b/platform/dashboard/src/lib/projects.ts
@@ -3,30 +3,30 @@
  * /v1/orgs/{org_id}/projects and /v1/projects/{id} surface.
  */
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { ApiError } from './api'
+import { ApiError } from "./api";
 
 /** Mirror of platform/api/schemas.py:ProjectRead. */
 export interface ProjectRead {
-  id: string
-  org_id: string
-  name: string
-  created_at: string
+  id: string;
+  org_id: string;
+  name: string;
+  created_at: string;
 }
 
 function projectsKey(orgId: string | null) {
-  return ['projects', orgId] as const
+  return ["projects", orgId] as const;
 }
 
 async function fetchProjects(orgId: string): Promise<ProjectRead[]> {
   const res = await fetch(`/v1/orgs/${orgId}/projects`, {
-    credentials: 'include',
-  })
+    credentials: "include",
+  });
   if (!res.ok) {
-    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, null, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as ProjectRead[]
+  return (await res.json()) as ProjectRead[];
 }
 
 /** Projects inside an org. ``enabled: !!orgId`` means callers can
@@ -38,80 +38,80 @@ export function useProjects(orgId: string | null) {
     queryFn: () => fetchProjects(orgId as string),
     enabled: !!orgId,
     staleTime: 60_000,
-  })
+  });
 }
 
 interface CreateProjectInput {
-  orgId: string
-  name: string
+  orgId: string;
+  name: string;
 }
 
 async function createProjectRequest(
   input: CreateProjectInput,
 ): Promise<ProjectRead> {
   const res = await fetch(`/v1/orgs/${input.orgId}/projects`, {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name: input.name }),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as ProjectRead
+  return (await res.json()) as ProjectRead;
 }
 
 export function useCreateProject() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: createProjectRequest,
     onSuccess: (project) => {
       // Bust the listing for the org this project landed in. Use the
       // returned project's org_id rather than the input so a future
       // server-side org-redirect (we don't do this today) still works.
-      qc.invalidateQueries({ queryKey: projectsKey(project.org_id) })
+      qc.invalidateQueries({ queryKey: projectsKey(project.org_id) });
     },
-  })
+  });
 }
 
 interface RenameProjectInput {
-  projectId: string
-  name: string
+  projectId: string;
+  name: string;
 }
 
 async function renameProjectRequest(
   input: RenameProjectInput,
 ): Promise<ProjectRead> {
   const res = await fetch(`/v1/projects/${input.projectId}`, {
-    method: 'PATCH',
-    credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    method: "PATCH",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ name: input.name }),
-  })
+  });
   if (!res.ok) {
-    let detail: unknown
+    let detail: unknown;
     try {
-      detail = await res.json()
+      detail = await res.json();
     } catch {
-      detail = null
+      detail = null;
     }
-    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`)
+    throw new ApiError(res.status, detail, `${res.status} ${res.statusText}`);
   }
-  return (await res.json()) as ProjectRead
+  return (await res.json()) as ProjectRead;
 }
 
 export function useRenameProject() {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: renameProjectRequest,
     onSuccess: (project) => {
-      qc.invalidateQueries({ queryKey: projectsKey(project.org_id) })
+      qc.invalidateQueries({ queryKey: projectsKey(project.org_id) });
     },
-  })
+  });
 }

--- a/platform/dashboard/src/lib/utils.ts
+++ b/platform/dashboard/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/platform/dashboard/src/main.tsx
+++ b/platform/dashboard/src/main.tsx
@@ -1,12 +1,12 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { Toaster } from 'sonner'
-import '@xyflow/react/dist/style.css'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Toaster } from "sonner";
+import "@xyflow/react/dist/style.css";
+import "./index.css";
+import App from "./App.tsx";
 
-document.documentElement.classList.add('dark')
+document.documentElement.classList.add("dark");
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -15,9 +15,9 @@ const queryClient = new QueryClient({
       refetchOnWindowFocus: false,
     },
   },
-})
+});
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <App />
@@ -27,4 +27,4 @@ createRoot(document.getElementById('root')!).render(
       <Toaster theme="dark" richColors position="bottom-right" />
     </QueryClientProvider>
   </StrictMode>,
-)
+);

--- a/platform/dashboard/src/routes/AcceptInvitation.test.tsx
+++ b/platform/dashboard/src/routes/AcceptInvitation.test.tsx
@@ -17,44 +17,43 @@
  * cleanly.
  */
 
-import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
-import { Route, Routes } from 'react-router-dom'
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router-dom";
 
-import { AcceptInvitationPage } from '@/routes/AcceptInvitation'
-import { renderWithProviders } from '@/test/render'
+import { AcceptInvitationPage } from "@/routes/AcceptInvitation";
+import { renderWithProviders } from "@/test/render";
 
 type RouteSpec =
   | { status?: number; json: unknown }
-  | { status: number; body?: string }
+  | { status: number; body?: string };
 
 /** Tiny router for the fetch spy — keyed by ``METHOD path``. Unknown
  * routes 404 with a JSON error envelope so React Query surfaces them
  * as ApiError(404), the same shape as production. */
 function stubFetch(routes: Record<string, RouteSpec>): void {
-  vi.spyOn(window, 'fetch').mockImplementation(
+  vi.spyOn(window, "fetch").mockImplementation(
     async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === 'string' ? input : input.toString()
-      const path = url.split('?')[0]
-      const method = (init?.method ?? 'GET').toUpperCase()
-      const key = `${method} ${path}`
-      const spec = routes[key]
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0];
+      const method = (init?.method ?? "GET").toUpperCase();
+      const key = `${method} ${path}`;
+      const spec = routes[key];
       if (!spec) {
-        return new Response(
-          JSON.stringify({ detail: `no stub for ${key}` }),
-          { status: 404 },
-        )
+        return new Response(JSON.stringify({ detail: `no stub for ${key}` }), {
+          status: 404,
+        });
       }
-      if ('json' in spec) {
+      if ("json" in spec) {
         return new Response(JSON.stringify(spec.json), {
           status: spec.status ?? 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+          headers: { "Content-Type": "application/json" },
+        });
       }
-      return new Response(spec.body ?? '', { status: spec.status })
+      return new Response(spec.body ?? "", { status: spec.status });
     },
-  )
+  );
 }
 
 function renderPage(inviteId: string) {
@@ -73,146 +72,142 @@ function renderPage(inviteId: string) {
       <Route path="/sign-in" element={<div data-testid="signin-page" />} />
     </Routes>,
     { initialRoute: `/invites/${inviteId}/accept` },
-  )
+  );
 }
 
 const PREVIEW = {
-  email: 'alice@example.com',
-  role: 'admin',
-  invited_by_email: 'me@example.com',
-  org_id: 'org-1',
-  org_name: 'Acme Inc',
-  org_slug: 'acme',
-  expires_at: '2030-01-01T00:00:00Z',
-}
+  email: "alice@example.com",
+  role: "admin",
+  invited_by_email: "me@example.com",
+  org_id: "org-1",
+  org_name: "Acme Inc",
+  org_slug: "acme",
+  expires_at: "2030-01-01T00:00:00Z",
+};
 
 const USER_ALICE = {
-  id: 'alice-uid',
-  email: 'alice@example.com',
+  id: "alice-uid",
+  email: "alice@example.com",
   is_active: true,
   is_superuser: false,
   is_verified: true,
-}
+};
 
 const USER_BOB = {
-  id: 'bob-uid',
-  email: 'bob@example.com',
+  id: "bob-uid",
+  email: "bob@example.com",
   is_active: true,
   is_superuser: false,
   is_verified: true,
-}
+};
 
-describe('AcceptInvitationPage', () => {
+describe("AcceptInvitationPage", () => {
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('signed-in matching email → Accept → POST → lands on members page', async () => {
+  it("signed-in matching email → Accept → POST → lands on members page", async () => {
     stubFetch({
-      'GET /v1/invites/inv-1': { json: PREVIEW },
-      'GET /v1/users/me': { json: USER_ALICE },
-      'POST /v1/invites/inv-1/accept': {
+      "GET /v1/invites/inv-1": { json: PREVIEW },
+      "GET /v1/users/me": { json: USER_ALICE },
+      "POST /v1/invites/inv-1/accept": {
         json: {
-          user_id: 'alice-uid',
-          email: 'alice@example.com',
-          role: 'admin',
-          joined_at: '2026-06-03T00:00:00Z',
+          user_id: "alice-uid",
+          email: "alice@example.com",
+          role: "admin",
+          joined_at: "2026-06-03T00:00:00Z",
         },
       },
-    })
+    });
 
-    const user = userEvent.setup()
-    renderPage('inv-1')
+    const user = userEvent.setup();
+    renderPage("inv-1");
 
     // Wait for the preview to land and the Accept card to render.
     await waitFor(() => {
-      expect(screen.getByText(/Join Acme Inc/i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/Join Acme Inc/i)).toBeInTheDocument();
+    });
 
-    await user.click(screen.getByText('Accept invitation'))
+    await user.click(screen.getByText("Accept invitation"));
 
     // Navigation target is the joined org's members page.
     await waitFor(() => {
-      expect(screen.getByTestId('members-page')).toBeInTheDocument()
-    })
-  })
+      expect(screen.getByTestId("members-page")).toBeInTheDocument();
+    });
+  });
 
   it('preview 404 renders the "not found" card with no Accept button', async () => {
     stubFetch({
-      'GET /v1/invites/missing-1': {
+      "GET /v1/invites/missing-1": {
         status: 404,
-        json: { detail: 'invitation not found' },
+        json: { detail: "invitation not found" },
       },
-      'GET /v1/users/me': { json: USER_ALICE },
-    })
+      "GET /v1/users/me": { json: USER_ALICE },
+    });
 
-    renderPage('missing-1')
+    renderPage("missing-1");
 
     await waitFor(() => {
-      expect(screen.getByText(/Invitation not found/i)).toBeInTheDocument()
-    })
-    expect(screen.queryByText('Accept invitation')).not.toBeInTheDocument()
-  })
+      expect(screen.getByText(/Invitation not found/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Accept invitation")).not.toBeInTheDocument();
+  });
 
   it('preview 410 renders the "expired" card', async () => {
     stubFetch({
-      'GET /v1/invites/old-1': {
+      "GET /v1/invites/old-1": {
         status: 410,
-        json: { detail: 'invitation expired or already used' },
+        json: { detail: "invitation expired or already used" },
       },
-      'GET /v1/users/me': { json: USER_ALICE },
-    })
+      "GET /v1/users/me": { json: USER_ALICE },
+    });
 
-    renderPage('old-1')
+    renderPage("old-1");
 
     await waitFor(() => {
-      expect(screen.getByText(/Invitation expired/i)).toBeInTheDocument()
-    })
-    expect(screen.queryByText('Accept invitation')).not.toBeInTheDocument()
-  })
+      expect(screen.getByText(/Invitation expired/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Accept invitation")).not.toBeInTheDocument();
+  });
 
   it('signed-in wrong email → "not for this account" card, no Accept', async () => {
     stubFetch({
-      'GET /v1/invites/inv-1': { json: PREVIEW },
-      'GET /v1/users/me': { json: USER_BOB },
-    })
+      "GET /v1/invites/inv-1": { json: PREVIEW },
+      "GET /v1/users/me": { json: USER_BOB },
+    });
 
-    renderPage('inv-1')
+    renderPage("inv-1");
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/isn't for this account/i),
-      ).toBeInTheDocument()
-    })
+      expect(screen.getByText(/isn't for this account/i)).toBeInTheDocument();
+    });
     // The mismatch card names both addresses so the user knows which
     // account to switch to. The invited address shows twice (in the
     // description sentence + in the alert callout); we just want to
     // assert both names appear somewhere.
-    expect(screen.getAllByText('alice@example.com').length).toBeGreaterThan(0)
-    expect(screen.getByText('bob@example.com')).toBeInTheDocument()
-    expect(screen.queryByText('Accept invitation')).not.toBeInTheDocument()
-    expect(
-      screen.getByText(/Sign out & switch account/i),
-    ).toBeInTheDocument()
-  })
+    expect(screen.getAllByText("alice@example.com").length).toBeGreaterThan(0);
+    expect(screen.getByText("bob@example.com")).toBeInTheDocument();
+    expect(screen.queryByText("Accept invitation")).not.toBeInTheDocument();
+    expect(screen.getByText(/Sign out & switch account/i)).toBeInTheDocument();
+  });
 
   it('signed-out → "Sign in to accept" CTA, no Accept', async () => {
     // /v1/users/me returns 401 → useUser resolves to user=null. No
     // ``credentials: include`` complications — we just return the
     // status the backend would emit for an anonymous request.
     stubFetch({
-      'GET /v1/invites/inv-1': { json: PREVIEW },
-      'GET /v1/users/me': { status: 401, body: '' },
-    })
+      "GET /v1/invites/inv-1": { json: PREVIEW },
+      "GET /v1/users/me": { status: 401, body: "" },
+    });
 
-    renderPage('inv-1')
+    renderPage("inv-1");
 
     await waitFor(() => {
       expect(
         screen.getByText(/You're invited to Acme Inc/i),
-      ).toBeInTheDocument()
-    })
-    expect(screen.getByText('Sign in to accept')).toBeInTheDocument()
-    expect(screen.queryByText('Accept invitation')).not.toBeInTheDocument()
-  })
-})
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText("Sign in to accept")).toBeInTheDocument();
+    expect(screen.queryByText("Accept invitation")).not.toBeInTheDocument();
+  });
+});

--- a/platform/dashboard/src/routes/AcceptInvitation.tsx
+++ b/platform/dashboard/src/routes/AcceptInvitation.tsx
@@ -1,10 +1,10 @@
-import { useLocation, useNavigate, useParams } from 'react-router-dom'
-import { toast } from 'sonner'
-import { Loader2, ShieldCheck, XCircle } from 'lucide-react'
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { Loader2, ShieldCheck, XCircle } from "lucide-react";
 
-import { AuthCardLayout } from '@/routes/SignIn'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { AuthCardLayout } from "@/routes/SignIn";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -12,15 +12,15 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
-import { ApiError } from '@/lib/api'
-import { useActive } from '@/lib/active'
-import { useLogout, useUser } from '@/lib/auth'
+} from "@/components/ui/card";
+import { ApiError } from "@/lib/api";
+import { useActive } from "@/lib/active";
+import { useLogout, useUser } from "@/lib/auth";
 import {
   type InvitationPreview,
   useAcceptInvitation,
   useInvitationPreview,
-} from '@/lib/invites'
+} from "@/lib/invites";
 
 /**
  * Public landing page for emailed invitation links.
@@ -36,9 +36,9 @@ import {
  * never show two cards or a half-rendered Accept button.
  */
 export function AcceptInvitationPage() {
-  const { inviteId } = useParams<{ inviteId: string }>()
-  const preview = useInvitationPreview(inviteId ?? '')
-  const { user, loading: userLoading } = useUser()
+  const { inviteId } = useParams<{ inviteId: string }>();
+  const preview = useInvitationPreview(inviteId ?? "");
+  const { user, loading: userLoading } = useUser();
 
   // Loading both queries before deciding which card to show — otherwise
   // we'd flash "sign in to accept" for a moment while /users/me is
@@ -48,7 +48,7 @@ export function AcceptInvitationPage() {
       <AuthCardLayout>
         <LoadingCard />
       </AuthCardLayout>
-    )
+    );
   }
 
   if (preview.error) {
@@ -56,49 +56,46 @@ export function AcceptInvitationPage() {
       <AuthCardLayout>
         <PreviewErrorCard error={preview.error} />
       </AuthCardLayout>
-    )
+    );
   }
 
   // ``preview.data`` is defined here — error and loading are both ruled
   // out above, and react-query's discriminated union narrows once both
   // are false.
-  const inv = preview.data!
+  const inv = preview.data!;
 
   if (!user) {
     return (
       <AuthCardLayout>
         <SignedOutCard invitation={inv} inviteId={inviteId} />
       </AuthCardLayout>
-    )
+    );
   }
 
   // Case-insensitive — the backend matches lowercased emails on
   // accept, so the frontend's "mismatch" card must use the same rule
   // or we'd flash a scary warning at users whose email casing the
   // mailer normalised (e.g. Alice@... vs alice@...).
-  const emailMatches =
-    user.email.toLowerCase() === inv.email.toLowerCase()
+  const emailMatches = user.email.toLowerCase() === inv.email.toLowerCase();
 
   if (!emailMatches) {
     return (
       <AuthCardLayout>
         <EmailMismatchCard invitation={inv} signedInAs={user.email} />
       </AuthCardLayout>
-    )
+    );
   }
 
   return (
     <AuthCardLayout>
       <AcceptCard invitation={inv} inviteId={inviteId} />
     </AuthCardLayout>
-  )
+  );
 }
-
 
 // ---------------------------------------------------------------------------
 // Card variants — one per state-machine branch
 // ---------------------------------------------------------------------------
-
 
 function LoadingCard() {
   return (
@@ -108,9 +105,8 @@ function LoadingCard() {
         Loading invitation…
       </CardContent>
     </Card>
-  )
+  );
 }
-
 
 function PreviewErrorCard({ error }: { error: ApiError }) {
   // 404 → "this link is broken or the invite was withdrawn"
@@ -118,16 +114,17 @@ function PreviewErrorCard({ error }: { error: ApiError }) {
   // Other → generic "couldn't load" — covers transient network blips
   // and the unlikely 5xx case. Backend doesn't return 401/403 here
   // because preview is public.
-  let title = 'Invitation unavailable'
-  let body = 'We couldn\'t load this invitation. Please try the link again later.'
+  let title = "Invitation unavailable";
+  let body =
+    "We couldn't load this invitation. Please try the link again later.";
   if (error.status === 404) {
-    title = 'Invitation not found'
+    title = "Invitation not found";
     body =
-      'This link is broken, or the invitation was cancelled. Ask the person who invited you to send a fresh one.'
+      "This link is broken, or the invitation was cancelled. Ask the person who invited you to send a fresh one.";
   } else if (error.status === 410) {
-    title = 'Invitation expired'
+    title = "Invitation expired";
     body =
-      'This invitation has expired or has already been used. Ask an admin for a new one if you still need access.'
+      "This invitation has expired or has already been used. Ask an admin for a new one if you still need access.";
   }
 
   return (
@@ -145,31 +142,30 @@ function PreviewErrorCard({ error }: { error: ApiError }) {
         </Button>
       </CardFooter>
     </Card>
-  )
+  );
 }
-
 
 function SignedOutCard({
   invitation,
   inviteId,
 }: {
-  invitation: InvitationPreview
-  inviteId: string
+  invitation: InvitationPreview;
+  inviteId: string;
 }) {
-  const navigate = useNavigate()
-  const location = useLocation()
+  const navigate = useNavigate();
+  const location = useLocation();
 
   // Preserve the invite URL as ``state.from`` so SignIn bounces the
   // user straight back here after a successful login. Mirrors the
   // ProtectedRoute pattern used by every other authed page.
   function goSignIn() {
-    const from = location.pathname + location.search
-    navigate('/sign-in', { state: { from } })
+    const from = location.pathname + location.search;
+    navigate("/sign-in", { state: { from } });
   }
 
   function goSignUp() {
-    const from = location.pathname + location.search
-    navigate('/sign-up', { state: { from } })
+    const from = location.pathname + location.search;
+    navigate("/sign-up", { state: { from } });
   }
 
   return (
@@ -184,17 +180,19 @@ function SignedOutCard({
         <CardDescription className="text-center">
           <span className="font-medium text-foreground">
             {invitation.invited_by_email}
-          </span>{' '}
-          invited <span className="font-medium text-foreground">{invitation.email}</span>{' '}
+          </span>{" "}
+          invited{" "}
+          <span className="font-medium text-foreground">
+            {invitation.email}
+          </span>{" "}
           to join as <span className="capitalize">{invitation.role}</span>.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <Alert>
           <AlertDescription>
-            Sign in as{' '}
-            <span className="font-medium">{invitation.email}</span> to
-            accept this invitation.
+            Sign in as <span className="font-medium">{invitation.email}</span>{" "}
+            to accept this invitation.
           </AlertDescription>
         </Alert>
       </CardContent>
@@ -210,30 +208,29 @@ function SignedOutCard({
         <span className="sr-only">Invitation {inviteId}</span>
       </CardFooter>
     </Card>
-  )
+  );
 }
-
 
 function EmailMismatchCard({
   invitation,
   signedInAs,
 }: {
-  invitation: InvitationPreview
-  signedInAs: string
+  invitation: InvitationPreview;
+  signedInAs: string;
 }) {
-  const navigate = useNavigate()
-  const location = useLocation()
-  const logout = useLogout()
+  const navigate = useNavigate();
+  const location = useLocation();
+  const logout = useLogout();
 
   async function switchAccount() {
     try {
-      await logout.mutateAsync()
+      await logout.mutateAsync();
     } catch {
       // Logging out while already-logged-out is fine — we'll send them
       // to sign-in regardless. ``useLogout`` already swallows 401.
     }
-    const from = location.pathname + location.search
-    navigate('/sign-in', { state: { from }, replace: true })
+    const from = location.pathname + location.search;
+    navigate("/sign-in", { state: { from }, replace: true });
   }
 
   return (
@@ -242,23 +239,24 @@ function EmailMismatchCard({
         <div className="mb-2 flex justify-center">
           <XCircle className="h-8 w-8 text-destructive" />
         </div>
-        <CardTitle className="text-center">This invite isn't for this account</CardTitle>
+        <CardTitle className="text-center">
+          This invite isn't for this account
+        </CardTitle>
         <CardDescription className="text-center">
-          The invitation is for{' '}
+          The invitation is for{" "}
           <span className="font-medium text-foreground">
             {invitation.email}
           </span>
-          , but you're signed in as{' '}
+          , but you're signed in as{" "}
           <span className="font-medium text-foreground">{signedInAs}</span>.
         </CardDescription>
       </CardHeader>
       <CardContent>
         <Alert variant="destructive">
           <AlertDescription>
-            Sign out and sign back in with{' '}
-            <span className="font-medium">{invitation.email}</span> to
-            accept, or ask the inviter to re-send to your current
-            address.
+            Sign out and sign back in with{" "}
+            <span className="font-medium">{invitation.email}</span> to accept,
+            or ask the inviter to re-send to your current address.
           </AlertDescription>
         </Alert>
       </CardContent>
@@ -268,24 +266,23 @@ function EmailMismatchCard({
           onClick={switchAccount}
           disabled={logout.isPending}
         >
-          {logout.isPending ? 'Signing out…' : 'Sign out & switch account'}
+          {logout.isPending ? "Signing out…" : "Sign out & switch account"}
         </Button>
       </CardFooter>
     </Card>
-  )
+  );
 }
-
 
 function AcceptCard({
   invitation,
   inviteId,
 }: {
-  invitation: InvitationPreview
-  inviteId: string
+  invitation: InvitationPreview;
+  inviteId: string;
 }) {
-  const navigate = useNavigate()
-  const accept = useAcceptInvitation()
-  const setActiveOrg = useActive((s) => s.setActiveOrg)
+  const navigate = useNavigate();
+  const accept = useAcceptInvitation();
+  const setActiveOrg = useActive((s) => s.setActiveOrg);
 
   // Translate the backend's tagged error responses into friendly
   // copy. The race-case 410/409 happens if the invite expired or got
@@ -294,31 +291,30 @@ function AcceptCard({
   // surfaced defensively in case the user's email changed under us.
   function translateError(err: unknown): string {
     if (err instanceof ApiError) {
-      if (err.status === 410) return 'This invitation has expired.'
-      if (err.status === 409) return 'This invitation has already been used.'
-      if (err.status === 403)
-        return "This invitation isn't for this account."
+      if (err.status === 410) return "This invitation has expired.";
+      if (err.status === 409) return "This invitation has already been used.";
+      if (err.status === 403) return "This invitation isn't for this account.";
     }
-    return "Couldn't accept the invitation. Please try again."
+    return "Couldn't accept the invitation. Please try again.";
   }
 
   async function onAccept() {
     try {
-      await accept.mutateAsync(inviteId)
-      toast.success(`Joined ${invitation.org_name}`)
+      await accept.mutateAsync(inviteId);
+      toast.success(`Joined ${invitation.org_name}`);
       // Drop the user into the new org. ``setActiveOrg`` clears the
       // active project as a side-effect — the project picker will
       // populate from the org's project list on the next page.
-      setActiveOrg(invitation.org_id)
+      setActiveOrg(invitation.org_id);
       // Members page is the most useful landing — the user can
       // immediately see who else is in the org they just joined.
-      navigate(`/orgs/${invitation.org_id}/members`, { replace: true })
+      navigate(`/orgs/${invitation.org_id}/members`, { replace: true });
     } catch (err) {
-      toast.error(translateError(err))
+      toast.error(translateError(err));
     }
   }
 
-  const errorText = accept.error ? translateError(accept.error) : null
+  const errorText = accept.error ? translateError(accept.error) : null;
 
   return (
     <Card className="w-full max-w-md">
@@ -332,10 +328,9 @@ function AcceptCard({
         <CardDescription className="text-center">
           <span className="font-medium text-foreground">
             {invitation.invited_by_email}
-          </span>{' '}
-          invited you to join as{' '}
-          <span className="capitalize text-foreground">{invitation.role}</span>
-          .
+          </span>{" "}
+          invited you to join as{" "}
+          <span className="capitalize text-foreground">{invitation.role}</span>.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
@@ -347,7 +342,7 @@ function AcceptCard({
         <dl className="grid grid-cols-3 gap-2 text-sm">
           <dt className="text-muted-foreground">Organization</dt>
           <dd className="col-span-2 font-medium">
-            {invitation.org_name}{' '}
+            {invitation.org_name}{" "}
             <span className="font-mono text-xs text-muted-foreground">
               ({invitation.org_slug})
             </span>
@@ -364,17 +359,17 @@ function AcceptCard({
           onClick={onAccept}
           disabled={accept.isPending}
         >
-          {accept.isPending ? 'Joining…' : 'Accept invitation'}
+          {accept.isPending ? "Joining…" : "Accept invitation"}
         </Button>
         <Button
           variant="ghost"
           className="w-full"
-          onClick={() => navigate('/', { replace: true })}
+          onClick={() => navigate("/", { replace: true })}
           disabled={accept.isPending}
         >
           Not now
         </Button>
       </CardFooter>
     </Card>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/Agents.tsx
+++ b/platform/dashboard/src/routes/Agents.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { Bot, FileText, ShieldCheck, Wrench } from 'lucide-react'
-import { Link } from 'react-router-dom'
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Bot, FileText, ShieldCheck, Wrench } from "lucide-react";
+import { Link } from "react-router-dom";
 import {
   api,
   type AgentManifestView,
   type InputSchema,
   type ToolDefinition,
-} from '@/lib/api'
-import { useProjectScoped } from '@/lib/active'
-import { Badge } from '@/components/ui/badge'
-import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
+} from "@/lib/api";
+import { useProjectScoped } from "@/lib/active";
+import { Badge } from "@/components/ui/badge";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
 
 /**
  * /agents — read-only manifest view.
@@ -25,30 +25,30 @@ import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
  * manifest registration goes through the SDK's ``hexgate register``.
  */
 export function AgentsPage() {
-  const scope = useProjectScoped()
+  const scope = useProjectScoped();
   const manifests = useQuery({
-    queryKey: ['agent-manifests', scope.projectId],
+    queryKey: ["agent-manifests", scope.projectId],
     queryFn: () => api.listAgentManifests(scope.projectId as string),
     enabled: !!scope.projectId,
-  })
-  const [selectedName, setSelectedName] = useState<string | null>(null)
+  });
+  const [selectedName, setSelectedName] = useState<string | null>(null);
 
   // Switching projects clears the selected agent — the previous
   // project's agent names mean nothing in the new project.
   useEffect(() => {
-    setSelectedName(null)
-  }, [scope.projectId])
+    setSelectedName(null);
+  }, [scope.projectId]);
 
   useEffect(() => {
     if (!selectedName && manifests.data && manifests.data.length > 0) {
-      setSelectedName(manifests.data[0].name)
+      setSelectedName(manifests.data[0].name);
     }
-  }, [manifests.data, selectedName])
+  }, [manifests.data, selectedName]);
 
-  const active = manifests.data?.find((m) => m.name === selectedName)
+  const active = manifests.data?.find((m) => m.name === selectedName);
 
-  if (scope.status === 'no-project') {
-    return <NoProjectEmptyState resource="agents" />
+  if (scope.status === "no-project") {
+    return <NoProjectEmptyState resource="agents" />;
   }
 
   return (
@@ -79,12 +79,12 @@ export function AgentsPage() {
           <ManifestView agent={active} />
         ) : (
           <div className="h-full grid place-items-center text-sm text-muted-foreground">
-            {manifests.isLoading ? 'Loading agents…' : 'No agents to inspect.'}
+            {manifests.isLoading ? "Loading agents…" : "No agents to inspect."}
           </div>
         )}
       </div>
     </div>
-  )
+  );
 }
 
 function AgentPicker({
@@ -93,15 +93,16 @@ function AgentPicker({
   onChange,
   loading,
 }: {
-  agents: { name: string }[]
-  value: string | null
-  onChange: (name: string) => void
-  loading: boolean
+  agents: { name: string }[];
+  value: string | null;
+  onChange: (name: string) => void;
+  loading: boolean;
 }) {
-  if (loading) return <span className="text-xs text-muted-foreground">loading…</span>
+  if (loading)
+    return <span className="text-xs text-muted-foreground">loading…</span>;
   return (
     <select
-      value={value ?? ''}
+      value={value ?? ""}
       onChange={(e) => onChange(e.target.value)}
       className="h-8 rounded-md border border-border bg-background px-3 text-sm font-mono focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
     >
@@ -111,7 +112,7 @@ function AgentPicker({
         </option>
       ))}
     </select>
-  )
+  );
 }
 
 function ManifestView({ agent }: { agent: AgentManifestView }) {
@@ -127,12 +128,12 @@ function ManifestView({ agent }: { agent: AgentManifestView }) {
         unregistered={agent.manifest === null}
       />
     </div>
-  )
+  );
 }
 
 function ManifestSummary({ agent }: { agent: AgentManifestView }) {
   const versionLabel =
-    agent.version !== null ? `v${agent.version}` : 'not registered'
+    agent.version !== null ? `v${agent.version}` : "not registered";
   return (
     <section className="rounded-lg border border-border bg-card">
       <div className="px-5 py-4 border-b border-border flex items-center gap-2">
@@ -146,30 +147,33 @@ function ManifestSummary({ agent }: { agent: AgentManifestView }) {
         <ManifestRow label="Name" value={agent.name} mono />
         <ManifestRow
           label="Model"
-          value={agent.manifest?.model?.trim() || '—'}
+          value={agent.manifest?.model?.trim() || "—"}
           mono
         />
         <ManifestRow
           label="Description"
-          value={agent.manifest?.description?.trim() || '—'}
+          value={agent.manifest?.description?.trim() || "—"}
         />
         <ManifestRow
           label="Framework"
-          value={agent.manifest?.framework?.trim() || '—'}
+          value={agent.manifest?.framework?.trim() || "—"}
           mono
         />
-        <ManifestRow label="Last updated" value={formatDate(agent.updated_at)} />
+        <ManifestRow
+          label="Last updated"
+          value={formatDate(agent.updated_at)}
+        />
       </dl>
     </section>
-  )
+  );
 }
 
 function ToolsSection({
   tools,
   unregistered,
 }: {
-  tools: ToolDefinition[]
-  unregistered: boolean
+  tools: ToolDefinition[];
+  unregistered: boolean;
 }) {
   return (
     <section className="rounded-lg border border-border bg-card">
@@ -183,8 +187,8 @@ function ToolsSection({
       {tools.length === 0 ? (
         <p className="px-5 py-4 text-xs text-muted-foreground">
           {unregistered
-            ? 'Agent not registered yet — run `hexgate register` to populate.'
-            : 'No tools declared.'}
+            ? "Agent not registered yet — run `hexgate register` to populate."
+            : "No tools declared."}
         </p>
       ) : (
         <ul className="divide-y divide-border">
@@ -194,15 +198,15 @@ function ToolsSection({
         </ul>
       )}
     </section>
-  )
+  );
 }
 
 function SystemPromptSection({
   prompt,
   unregistered,
 }: {
-  prompt: string | null
-  unregistered: boolean
+  prompt: string | null;
+  unregistered: boolean;
 }) {
   return (
     <section className="rounded-lg border border-border bg-card">
@@ -227,12 +231,12 @@ function SystemPromptSection({
       ) : (
         <p className="px-5 py-4 text-xs text-muted-foreground">
           {unregistered
-            ? 'Agent not registered yet — run `hexgate register` to populate.'
-            : 'No system prompt declared.'}
+            ? "Agent not registered yet — run `hexgate register` to populate."
+            : "No system prompt declared."}
         </p>
       )}
     </section>
-  )
+  );
 }
 
 function ToolRow({ tool }: { tool: ToolDefinition }) {
@@ -246,12 +250,12 @@ function ToolRow({ tool }: { tool: ToolDefinition }) {
       ) : null}
       <InputSchemaDetails schema={tool.input_schema} />
     </li>
-  )
+  );
 }
 
 function InputSchemaDetails({ schema }: { schema: InputSchema }) {
-  const entries = Object.entries(schema.properties)
-  const required = new Set(schema.required)
+  const entries = Object.entries(schema.properties);
+  const required = new Set(schema.required);
   return (
     <details className="rounded-md border border-border bg-background/40 group">
       <summary className="px-3 py-2 cursor-pointer flex items-center gap-2 text-[11px] text-muted-foreground select-none">
@@ -280,7 +284,7 @@ function InputSchemaDetails({ schema }: { schema: InputSchema }) {
         </ul>
       )}
     </details>
-  )
+  );
 }
 
 function ManifestRow({
@@ -288,24 +292,24 @@ function ManifestRow({
   value,
   mono,
 }: {
-  label: string
-  value: string
-  mono?: boolean
+  label: string;
+  value: string;
+  mono?: boolean;
 }) {
   return (
     <div className="grid grid-cols-[120px_1fr] gap-4 px-5 py-2.5">
       <dt className="text-xs text-muted-foreground">{label}</dt>
-      <dd className={mono ? 'font-mono text-foreground' : 'text-foreground'}>
+      <dd className={mono ? "font-mono text-foreground" : "text-foreground"}>
         {value}
       </dd>
     </div>
-  )
+  );
 }
 
 function formatDate(iso: string): string {
   try {
-    return new Date(iso).toLocaleString()
+    return new Date(iso).toLocaleString();
   } catch {
-    return iso
+    return iso;
   }
 }

--- a/platform/dashboard/src/routes/Audit.test.tsx
+++ b/platform/dashboard/src/routes/Audit.test.tsx
@@ -12,64 +12,67 @@
  *      and the "Same session" list cross-links to the sibling event.
  */
 
-import { act, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { AuditDecisionRow } from '@/lib/api'
-import { useActive } from '@/lib/active'
-import { EMPTY_AUDIT_FILTERS, useAuditFilters } from '@/lib/audit-filters'
-import { AuditPage } from '@/routes/Audit'
-import { renderWithProviders } from '@/test/render'
+import type { AuditDecisionRow } from "@/lib/api";
+import { useActive } from "@/lib/active";
+import { EMPTY_AUDIT_FILTERS, useAuditFilters } from "@/lib/audit-filters";
+import { AuditPage } from "@/routes/Audit";
+import { renderWithProviders } from "@/test/render";
 
-const PROJECT = 'p1'
+const PROJECT = "p1";
 
 const counts = (all: number, allow: number, deny: number, appr = 0) => ({
-  all, allow, deny, needs_approval: appr,
-})
+  all,
+  allow,
+  deny,
+  needs_approval: appr,
+});
 
 const SUMMARY = {
   totals: counts(10, 6, 4),
   by_agent: [
-    { key: 'researcher', ...counts(9, 6, 3) },
-    { key: 'scraper', ...counts(1, 0, 1) },
+    { key: "researcher", ...counts(9, 6, 3) },
+    { key: "scraper", ...counts(1, 0, 1) },
   ],
   by_role: [
-    { key: 'analyst', ...counts(6, 6, 0) },
+    { key: "analyst", ...counts(6, 6, 0) },
     // The no-role bucket arrives as a raw "" key over the wire.
-    { key: '', ...counts(4, 0, 4) },
+    { key: "", ...counts(4, 0, 4) },
   ],
-  by_tool: [{ key: 'read_file', ...counts(4, 0, 4) }],
-}
+  by_tool: [{ key: "read_file", ...counts(4, 0, 4) }],
+};
 
 const ROW: AuditDecisionRow = {
-  event_id: 'evt-1',
-  occurred_at: '2026-06-01T10:00:00Z',
-  received_at: '2026-06-01T10:00:01Z',
-  agent_name: 'researcher',
-  agent_version_id: 'v1',
-  session_id: 'sess-1',
-  user_id: 'u1',
-  tool_name: 'read_file',
-  role: '',
-  outcome: 'deny',
-  error_type: 'policy_denied',
-  reason: 'blocked by policy',
-  violations: ['no-secrets'],
+  event_id: "evt-1",
+  occurred_at: "2026-06-01T10:00:00Z",
+  received_at: "2026-06-01T10:00:01Z",
+  agent_name: "researcher",
+  agent_version_id: "v1",
+  session_id: "sess-1",
+  user_id: "u1",
+  tool_name: "read_file",
+  role: "",
+  outcome: "deny",
+  error_type: "policy_denied",
+  reason: "blocked by policy",
+  violations: ["no-secrets"],
   hint: null,
-  arguments: { path: '/etc/passwd' },
-}
+  arguments: { path: "/etc/passwd" },
+};
 
 /** Sibling event in the same session — only reachable via the drawer's
  * "Same session" list (the main table stub returns ROW alone). */
 const SIBLING: AuditDecisionRow = {
   ...ROW,
-  event_id: 'evt-2',
-  tool_name: 'send_email',
-  outcome: 'allow',
-  reason: '',
+  event_id: "evt-2",
+  tool_name: "send_email",
+  outcome: "allow",
+  reason: "",
   violations: [],
-}
+};
 
 /**
  * Same fetch-stub helper pattern as Orgs.test.tsx, extended to record
@@ -77,199 +80,213 @@ const SIBLING: AuditDecisionRow = {
  * state actually reached the API.
  */
 function stubFetch(): string[] {
-  const calls: string[] = []
+  const calls: string[] = [];
   const json = (body: unknown) =>
     new Response(JSON.stringify(body), {
       status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
+      headers: { "Content-Type": "application/json" },
+    });
 
-  vi.spyOn(window, 'fetch').mockImplementation(
+  vi.spyOn(window, "fetch").mockImplementation(
     async (input: RequestInfo | URL) => {
-      const raw = typeof input === 'string' ? input : input.toString()
-      const url = new URL(raw, 'http://localhost')
-      calls.push(url.pathname + url.search)
+      const raw = typeof input === "string" ? input : input.toString();
+      const url = new URL(raw, "http://localhost");
+      calls.push(url.pathname + url.search);
 
       switch (url.pathname) {
-        case '/v1/orgs':
+        case "/v1/orgs":
           return json([
             {
-              id: 'org-1',
-              slug: 'acme',
-              name: 'Acme Inc',
-              created_at: '2026-01-01T00:00:00Z',
-              role: 'owner',
+              id: "org-1",
+              slug: "acme",
+              name: "Acme Inc",
+              created_at: "2026-01-01T00:00:00Z",
+              role: "owner",
             },
-          ])
-        case '/v1/orgs/org-1/projects':
+          ]);
+        case "/v1/orgs/org-1/projects":
           return json([
             {
               id: PROJECT,
-              org_id: 'org-1',
-              name: 'demo-project',
-              created_at: '2026-01-01T00:00:00Z',
+              org_id: "org-1",
+              name: "demo-project",
+              created_at: "2026-01-01T00:00:00Z",
             },
-          ])
+          ]);
         case `/v1/projects/${PROJECT}/audit/summary`:
-          return json(SUMMARY)
+          return json(SUMMARY);
         case `/v1/projects/${PROJECT}/audit/timeseries`:
-          return json([])
+          return json([]);
         case `/v1/projects/${PROJECT}/audit/decisions`: {
           // The drawer's session drill-down vs the main table.
-          if (url.searchParams.get('session_id') === 'sess-1') {
-            return json({ rows: [ROW, SIBLING], total: 2, limit: 12, offset: 0 })
+          if (url.searchParams.get("session_id") === "sess-1") {
+            return json({
+              rows: [ROW, SIBLING],
+              total: 2,
+              limit: 12,
+              offset: 0,
+            });
           }
-          return json({ rows: [ROW], total: 1, limit: 40, offset: 0 })
+          return json({ rows: [ROW], total: 1, limit: 40, offset: 0 });
         }
         default:
-          return new Response('not found', { status: 404 })
+          return new Response("not found", { status: 404 });
       }
     },
-  )
-  return calls
+  );
+  return calls;
 }
 
 /** Open the detail drawer by clicking ROW's line in the events table. */
 async function openDrawer(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(await screen.findByText('blocked by policy'))
+  await user.click(await screen.findByText("blocked by policy"));
   // The drawer header renders the event id — unique to the drawer.
-  await screen.findByText('evt-1')
+  await screen.findByText("evt-1");
 }
 
-describe('AuditPage', () => {
+describe("AuditPage", () => {
   beforeEach(() => {
     act(() => {
-      useActive.setState({ activeOrgId: 'org-1', activeProjectId: PROJECT })
+      useActive.setState({ activeOrgId: "org-1", activeProjectId: PROJECT });
       // The filter store is module-global — reset so a filter dialled in
       // by test A doesn't narrow test B's queries.
-      useAuditFilters.setState({ filters: EMPTY_AUDIT_FILTERS, tableLimit: 40 })
-    })
-  })
+      useAuditFilters.setState({
+        filters: EMPTY_AUDIT_FILTERS,
+        tableLimit: 40,
+      });
+    });
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('agent filter selection lands in the next query URL', async () => {
-    const calls = stubFetch()
-    const user = userEvent.setup()
-    renderWithProviders(<AuditPage />)
+  it("agent filter selection lands in the next query URL", async () => {
+    const calls = stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
 
     // Wait for data to land, then open the agent select (Radix trigger)
     // and pick an option from the popup.
-    await screen.findByText('blocked by policy')
+    await screen.findByText("blocked by policy");
     // The subtitle names the ACTIVE project — not a hardcoded constant.
-    expect(await screen.findByText('demo-project')).toBeInTheDocument()
+    expect(await screen.findByText("demo-project")).toBeInTheDocument();
 
     // With no filters set, optionsQ and summaryQ hash to the same query key
     // and dedupe into ONE fetch of the unscoped summary.
     expect(
-      calls.filter((u) => u === `/v1/projects/${PROJECT}/audit/summary?window=30d`),
-    ).toHaveLength(1)
+      calls.filter(
+        (u) => u === `/v1/projects/${PROJECT}/audit/summary?window=30d`,
+      ),
+    ).toHaveLength(1);
     // Radix puts pointer-events:none on the value span — click the trigger.
-    await user.click(screen.getByText('All agents').closest('button')!)
-    await user.click(await screen.findByRole('option', { name: 'researcher' }))
+    await user.click(screen.getByText("All agents").closest("button")!);
+    await user.click(await screen.findByRole("option", { name: "researcher" }));
 
     await waitFor(() => {
       expect(
         calls.some(
-          (u) => u.includes('/audit/decisions') && u.includes('agent=researcher'),
+          (u) =>
+            u.includes("/audit/decisions") && u.includes("agent=researcher"),
         ),
-      ).toBe(true)
-    })
+      ).toBe(true);
+    });
     // The scoped summary (KPIs/breakdown) narrows too.
     expect(
       calls.some(
-        (u) => u.includes('/audit/summary') && u.includes('agent=researcher'),
+        (u) => u.includes("/audit/summary") && u.includes("agent=researcher"),
       ),
-    ).toBe(true)
-  })
+    ).toBe(true);
+  });
 
   it('maps the empty-role bucket to "(none)" locally and queries role=', async () => {
-    const calls = stubFetch()
-    const user = userEvent.setup()
-    renderWithProviders(<AuditPage />)
+    const calls = stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
 
     // The "" key from the wire displays as "(none)" in the dropdown…
-    await screen.findByText('blocked by policy')
-    await user.click(screen.getByText('All roles').closest('button')!)
-    await user.click(await screen.findByRole('option', { name: '(none)' }))
+    await screen.findByText("blocked by policy");
+    await user.click(screen.getByText("All roles").closest("button")!);
+    await user.click(await screen.findByRole("option", { name: "(none)" }));
 
     // …and selecting it sends `role=` (empty value) — no "(none)" sentinel
     // ever leaves the dashboard.
     await waitFor(() => {
       expect(
         calls.some(
-          (u) => u.includes('/audit/decisions') && /[?&]role=(&|$)/.test(u),
+          (u) => u.includes("/audit/decisions") && /[?&]role=(&|$)/.test(u),
         ),
-      ).toBe(true)
-    })
-    expect(calls.some((u) => u.includes('(none)') || u.includes('%28none%29'))).toBe(false)
-  })
+      ).toBe(true);
+    });
+    expect(
+      calls.some((u) => u.includes("(none)") || u.includes("%28none%29")),
+    ).toBe(false);
+  });
 
-  it('outcome KPI card toggles the outcome filter', async () => {
-    const calls = stubFetch()
-    const user = userEvent.setup()
-    renderWithProviders(<AuditPage />)
+  it("outcome KPI card toggles the outcome filter", async () => {
+    const calls = stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
 
-    await user.click(await screen.findByText('Denied'))
+    await user.click(await screen.findByText("Denied"));
 
     // On: the decisions query narrows and the active chip appears.
     await waitFor(() => {
       expect(
         calls.some(
-          (u) => u.includes('/audit/decisions') && u.includes('outcome=deny'),
+          (u) => u.includes("/audit/decisions") && u.includes("outcome=deny"),
         ),
-      ).toBe(true)
-    })
+      ).toBe(true);
+    });
     // ActiveChips only renders when a filter is set — "Clear all" is its
     // unique anchor ("deny" alone also matches the FilterBar segment).
-    expect(screen.getByText('Clear all')).toBeInTheDocument()
+    expect(screen.getByText("Clear all")).toBeInTheDocument();
 
     // Off: clicking the same card clears the filter again.
-    await user.click(screen.getByText('Denied'))
+    await user.click(screen.getByText("Denied"));
     await waitFor(() => {
-      expect(screen.queryByText('Clear all')).not.toBeInTheDocument()
-    })
-  })
+      expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+    });
+  });
 
-  it('row click opens the detail drawer; Esc closes it', async () => {
-    stubFetch()
-    const user = userEvent.setup()
-    renderWithProviders(<AuditPage />)
+  it("row click opens the detail drawer; Esc closes it", async () => {
+    stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
 
-    await openDrawer(user)
+    await openDrawer(user);
     // Drawer body renders the violation tag and the envelope section.
-    expect(screen.getByText('no-secrets')).toBeInTheDocument()
-    expect(screen.getByText('Envelope')).toBeInTheDocument()
+    expect(screen.getByText("no-secrets")).toBeInTheDocument();
+    expect(screen.getByText("Envelope")).toBeInTheDocument();
 
-    await user.keyboard('{Escape}')
+    await user.keyboard("{Escape}");
     await waitFor(() => {
-      expect(screen.queryByText('evt-1')).not.toBeInTheDocument()
-    })
-  })
+      expect(screen.queryByText("evt-1")).not.toBeInTheDocument();
+    });
+  });
 
-  it('same-session list drills into the sibling event', async () => {
-    const calls = stubFetch()
-    const user = userEvent.setup()
-    renderWithProviders(<AuditPage />)
+  it("same-session list drills into the sibling event", async () => {
+    const calls = stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
 
-    await openDrawer(user)
+    await openDrawer(user);
 
     // Selecting the row fires the session drill-down query…
     await waitFor(() => {
       expect(
         calls.some(
-          (u) => u.includes('/audit/decisions') && u.includes('session_id=sess-1'),
+          (u) =>
+            u.includes("/audit/decisions") && u.includes("session_id=sess-1"),
         ),
-      ).toBe(true)
-    })
+      ).toBe(true);
+    });
     // …whose result lists the sibling (selected event excluded).
-    const sibling = await screen.findByText('send_email')
-    await user.click(sibling)
+    const sibling = await screen.findByText("send_email");
+    await user.click(sibling);
 
     // The drawer now shows the sibling event.
-    await screen.findByText('evt-2')
-    expect(screen.queryByText('evt-1')).not.toBeInTheDocument()
-  })
-})
+    await screen.findByText("evt-2");
+    expect(screen.queryByText("evt-1")).not.toBeInTheDocument();
+  });
+});

--- a/platform/dashboard/src/routes/Audit.tsx
+++ b/platform/dashboard/src/routes/Audit.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from 'react'
-import { keepPreviousData, useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from "react";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import {
   Activity,
   Check,
@@ -7,108 +7,191 @@ import {
   Filter,
   Lightbulb,
   X,
-} from 'lucide-react'
-import { api, type AuditDecisionRow, type AuditOutcome } from '@/lib/api'
-import { useActive, useProjectScoped } from '@/lib/active'
-import { useProjects } from '@/lib/projects'
-import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
-import { Button } from '@/components/ui/button'
-import { Card } from '@/components/ui/card'
-import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
-import { AreaChart, type ChartBucket, Donut } from '@/components/ui/charts'
-import { type Counts, DecisionBadge } from '@/components/audit/charts'
-import { NO_VALUE_LABEL, OUT_LABEL, OUTCOME_SERIES } from '@/components/audit/chart-tokens'
+} from "lucide-react";
+import { api, type AuditDecisionRow, type AuditOutcome } from "@/lib/api";
+import { useActive, useProjectScoped } from "@/lib/active";
+import { useProjects } from "@/lib/projects";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { AreaChart, type ChartBucket, Donut } from "@/components/ui/charts";
+import { type Counts, DecisionBadge } from "@/components/audit/charts";
+import {
+  NO_VALUE_LABEL,
+  OUT_LABEL,
+  OUTCOME_SERIES,
+} from "@/components/audit/chart-tokens";
 import {
   type AuditFilters as Filters,
   useAuditFilters,
-} from '@/lib/audit-filters'
+} from "@/lib/audit-filters";
 import {
   ActiveChips,
   BreakdownCard,
   EventsTable,
   FilterBar,
   KpiCard,
-} from '@/components/audit/pieces'
+} from "@/components/audit/pieces";
 
-const ZERO_COUNTS: Counts = { allow: 0, deny: 0, needs_approval: 0, total: 0 }
+const ZERO_COUNTS: Counts = { allow: 0, deny: 0, needs_approval: 0, total: 0 };
 
 const fmtTs = (d: Date) =>
-  d.toLocaleString('en-US', {
-    month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
-  }) + '.' + String(d.getMilliseconds()).padStart(3, '0')
-const fmtFull = (d: Date) => d.toISOString().replace('T', ' ').replace('Z', ' UTC')
+  d.toLocaleString("en-US", {
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }) +
+  "." +
+  String(d.getMilliseconds()).padStart(3, "0");
+const fmtFull = (d: Date) =>
+  d.toISOString().replace("T", " ").replace("Z", " UTC");
 
 // ————————————————————————————————————————————— Detail drawer
-function KV({ k, children, mono, muted }: { k: string; children: React.ReactNode; mono?: boolean; muted?: boolean }) {
+function KV({
+  k,
+  children,
+  mono,
+  muted,
+}: {
+  k: string;
+  children: React.ReactNode;
+  mono?: boolean;
+  muted?: boolean;
+}) {
   return (
     <div className="grid grid-cols-[116px_1fr] items-baseline gap-2.5 py-[5px] text-[12.5px]">
       <div className="text-muted-foreground">{k}</div>
-      <div className={`break-words ${mono ? 'font-mono text-xs' : ''} ${muted ? 'text-muted-foreground' : 'text-foreground'}`}>{children}</div>
+      <div
+        className={`break-words ${mono ? "font-mono text-xs" : ""} ${muted ? "text-muted-foreground" : "text-foreground"}`}
+      >
+        {children}
+      </div>
     </div>
-  )
+  );
 }
-function DrawerSection({ label, children, accent }: { label: string; children: React.ReactNode; accent?: string }) {
+function DrawerSection({
+  label,
+  children,
+  accent,
+}: {
+  label: string;
+  children: React.ReactNode;
+  accent?: string;
+}) {
   return (
     <div className="mt-[22px]">
-      <div className={`mb-2 text-[11px] font-medium uppercase tracking-wider ${accent || 'text-muted-foreground'}`}>{label}</div>
+      <div
+        className={`mb-2 text-[11px] font-medium uppercase tracking-wider ${accent || "text-muted-foreground"}`}
+      >
+        {label}
+      </div>
       {children}
     </div>
-  )
+  );
 }
 
 // Per-outcome drawer accents (reason box + error text).
 const TONE: Record<AuditOutcome, { text: string; box: string }> = {
-  allow: { text: 'text-allow', box: 'border-allow/25 bg-allow/10' },
-  deny: { text: 'text-deny', box: 'border-deny/25 bg-deny/10' },
-  needs_approval: { text: 'text-approval', box: 'border-approval/25 bg-approval/10' },
-}
+  allow: { text: "text-allow", box: "border-allow/25 bg-allow/10" },
+  deny: { text: "text-deny", box: "border-deny/25 bg-deny/10" },
+  needs_approval: {
+    text: "text-approval",
+    box: "border-approval/25 bg-approval/10",
+  },
+};
 
 function DetailDrawer({
-  event, related, onClose, onSelect, setF,
+  event,
+  related,
+  onClose,
+  onSelect,
+  setF,
 }: {
-  event: AuditDecisionRow | null
-  related: AuditDecisionRow[]
-  onClose: () => void
-  onSelect: (e: AuditDecisionRow) => void
-  setF: (u: (p: Filters) => Filters) => void
+  event: AuditDecisionRow | null;
+  related: AuditDecisionRow[];
+  onClose: () => void;
+  onSelect: (e: AuditDecisionRow) => void;
+  setF: (u: (p: Filters) => Filters) => void;
 }) {
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose()
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [onClose])
-  if (!event) return null
-  const e = event
-  const argStr = e.arguments == null ? '—' : JSON.stringify(e.arguments, null, 2)
-  const hintStr = typeof e.hint === 'string' ? e.hint : e.hint == null ? '' : JSON.stringify(e.hint)
-  const tone = TONE[e.outcome]
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+  if (!event) return null;
+  const e = event;
+  const argStr =
+    e.arguments == null ? "—" : JSON.stringify(e.arguments, null, 2);
+  const hintStr =
+    typeof e.hint === "string"
+      ? e.hint
+      : e.hint == null
+        ? ""
+        : JSON.stringify(e.hint);
+  const tone = TONE[e.outcome];
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
-      <div onClick={onClose} className="absolute inset-0 bg-black/55 backdrop-blur-[1px]" />
+      <div
+        onClick={onClose}
+        className="absolute inset-0 bg-black/55 backdrop-blur-[1px]"
+      />
       <aside className="relative flex h-full w-[472px] max-w-[92vw] flex-col border-l border-border bg-card shadow-2xl">
         <div className="flex items-center gap-2.5 border-b border-border px-5 py-4">
           <DecisionBadge d={e.outcome} />
-          <span className="flex-1 truncate font-mono text-xs text-muted-foreground">{e.event_id}</span>
-          <Button variant="ghost" size="icon" onClick={onClose} title="Close (Esc)"><X className="size-4" /></Button>
+          <span className="flex-1 truncate font-mono text-xs text-muted-foreground">
+            {e.event_id}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            title="Close (Esc)"
+          >
+            <X className="size-4" />
+          </Button>
         </div>
 
         <div className="flex-1 overflow-auto px-5 pb-6 pt-1 scrollbar-thin">
           <div className="mt-[18px] flex flex-wrap items-baseline gap-2">
-            <span className="font-mono text-[17px] font-semibold text-foreground">{e.tool_name}</span>
+            <span className="font-mono text-[17px] font-semibold text-foreground">
+              {e.tool_name}
+            </span>
             <span className="text-[13px] text-muted-foreground">by</span>
-            <span className="font-mono text-sm text-foreground">{e.agent_name}</span>
+            <span className="font-mono text-sm text-foreground">
+              {e.agent_name}
+            </span>
           </div>
-          <div className={`mt-2 rounded-lg border px-3 py-2.5 text-[13px] leading-relaxed text-foreground ${tone.box}`}>
-            {e.reason || (e.outcome === 'allow' ? 'Allowed — no rule violated.' : 'No reason recorded.')}
-            {e.error_type && <span className={`mt-1.5 block font-mono text-[11.5px] ${tone.text}`}>error_type: {e.error_type}</span>}
+          <div
+            className={`mt-2 rounded-lg border px-3 py-2.5 text-[13px] leading-relaxed text-foreground ${tone.box}`}
+          >
+            {e.reason ||
+              (e.outcome === "allow"
+                ? "Allowed — no rule violated."
+                : "No reason recorded.")}
+            {e.error_type && (
+              <span
+                className={`mt-1.5 block font-mono text-[11.5px] ${tone.text}`}
+              >
+                error_type: {e.error_type}
+              </span>
+            )}
           </div>
 
           {e.violations.length > 0 && (
             <DrawerSection label="Violations" accent="text-deny">
               <div className="flex flex-wrap gap-1.5">
                 {e.violations.map((v) => (
-                  <span key={v} className="rounded-md bg-deny/15 px-2 py-[3px] font-mono text-[11.5px] text-deny">{v}</span>
+                  <span
+                    key={v}
+                    className="rounded-md bg-deny/15 px-2 py-[3px] font-mono text-[11.5px] text-deny"
+                  >
+                    {v}
+                  </span>
                 ))}
               </div>
             </DrawerSection>
@@ -125,66 +208,117 @@ function DetailDrawer({
 
           <DrawerSection label="Decision">
             <KV k="outcome">{OUT_LABEL[e.outcome]}</KV>
-            <KV k="tool_name" mono>{e.tool_name}</KV>
-            <KV k="role">{e.role || <span className="text-muted-foreground">∅ none</span>}</KV>
-            {e.error_type && <KV k="error_type" mono>{e.error_type}</KV>}
+            <KV k="tool_name" mono>
+              {e.tool_name}
+            </KV>
+            <KV k="role">
+              {e.role || <span className="text-muted-foreground">∅ none</span>}
+            </KV>
+            {e.error_type && (
+              <KV k="error_type" mono>
+                {e.error_type}
+              </KV>
+            )}
           </DrawerSection>
 
           <DrawerSection label="Arguments">
-            <pre className="m-0 whitespace-pre-wrap rounded-lg border border-border bg-muted p-3 font-mono text-[11.5px] leading-relaxed text-foreground">{argStr}</pre>
+            <pre className="m-0 whitespace-pre-wrap rounded-lg border border-border bg-muted p-3 font-mono text-[11.5px] leading-relaxed text-foreground">
+              {argStr}
+            </pre>
           </DrawerSection>
 
           <DrawerSection label="Envelope">
-            <KV k="occurred_at" mono>{fmtFull(new Date(e.occurred_at))}</KV>
-            <KV k="received_at" mono muted>{fmtFull(new Date(e.received_at))}</KV>
-            <KV k="agent_name" mono>{e.agent_name}</KV>
-            <KV k="session_id" mono muted>{e.session_id || '∅'}</KV>
-            <KV k="user_id" mono muted>{e.user_id || '∅'}</KV>
+            <KV k="occurred_at" mono>
+              {fmtFull(new Date(e.occurred_at))}
+            </KV>
+            <KV k="received_at" mono muted>
+              {fmtFull(new Date(e.received_at))}
+            </KV>
+            <KV k="agent_name" mono>
+              {e.agent_name}
+            </KV>
+            <KV k="session_id" mono muted>
+              {e.session_id || "∅"}
+            </KV>
+            <KV k="user_id" mono muted>
+              {e.user_id || "∅"}
+            </KV>
           </DrawerSection>
 
           <DrawerSection label={`Same session · ${related.length}`}>
             {related.length ? (
               <div className="overflow-hidden rounded-lg border border-border">
                 {related.map((r, i) => (
-                  <div key={r.event_id} onClick={() => onSelect(r)}
-                    className={`flex cursor-pointer items-center gap-2 px-2.5 py-2 text-xs hover:bg-accent ${i < related.length - 1 ? 'border-b border-border' : ''}`}>
+                  <div
+                    key={r.event_id}
+                    onClick={() => onSelect(r)}
+                    className={`flex cursor-pointer items-center gap-2 px-2.5 py-2 text-xs hover:bg-accent ${i < related.length - 1 ? "border-b border-border" : ""}`}
+                  >
                     <DecisionBadge d={r.outcome} />
-                    <span className="flex-1 truncate font-mono">{r.tool_name}</span>
-                    <span className="font-mono text-[11px] text-muted-foreground">{fmtTs(new Date(r.occurred_at))}</span>
+                    <span className="flex-1 truncate font-mono">
+                      {r.tool_name}
+                    </span>
+                    <span className="font-mono text-[11px] text-muted-foreground">
+                      {fmtTs(new Date(r.occurred_at))}
+                    </span>
                   </div>
                 ))}
               </div>
-            ) : <div className="text-xs text-muted-foreground">No other events in this session.</div>}
+            ) : (
+              <div className="text-xs text-muted-foreground">
+                No other events in this session.
+              </div>
+            )}
           </DrawerSection>
         </div>
 
         <div className="flex gap-2 border-t border-border px-5 py-3">
-          <Button variant="secondary" size="sm" onClick={() => { setF((p) => ({ ...p, agent: e.agent_name })); onClose() }}><Filter className="size-3" />Filter to agent</Button>
-          <Button variant="secondary" size="sm" onClick={() => { setF((p) => ({ ...p, tool: e.tool_name })); onClose() }}><Filter className="size-3" />Filter to tool</Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              setF((p) => ({ ...p, agent: e.agent_name }));
+              onClose();
+            }}
+          >
+            <Filter className="size-3" />
+            Filter to agent
+          </Button>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              setF((p) => ({ ...p, tool: e.tool_name }));
+              onClose();
+            }}
+          >
+            <Filter className="size-3" />
+            Filter to tool
+          </Button>
         </div>
       </aside>
     </div>
-  )
+  );
 }
 
 // ————————————————————————————————————————————— Root
 export function AuditPage() {
-  const projectScope = useProjectScoped()
-  const projectId = projectScope.projectId
-  const activeOrgId = useActive((s) => s.activeOrgId)
+  const projectScope = useProjectScoped();
+  const projectId = projectScope.projectId;
+  const activeOrgId = useActive((s) => s.activeOrgId);
   // Resolve the active project's display name for the page subtitle
   // (already cached by the AppShell bootstrap; falls back to the id).
-  const projectsQ = useProjects(activeOrgId)
+  const projectsQ = useProjects(activeOrgId);
   const projectName =
-    projectsQ.data?.find((p) => p.id === projectId)?.name ?? projectId
+    projectsQ.data?.find((p) => p.id === projectId)?.name ?? projectId;
   // Filter + paging state lives in a zustand store (see lib/audit-filters)
   // so the dialled-in slice survives route switches; drawer selection is
   // ephemeral and stays local.
-  const f = useAuditFilters((s) => s.filters)
-  const setF = useAuditFilters((s) => s.setFilters)
-  const tableLimit = useAuditFilters((s) => s.tableLimit)
-  const loadMore = useAuditFilters((s) => s.loadMore)
-  const [sel, setSel] = useState<AuditDecisionRow | null>(null)
+  const f = useAuditFilters((s) => s.filters);
+  const setF = useAuditFilters((s) => s.setFilters);
+  const tableLimit = useAuditFilters((s) => s.tableLimit);
+  const loadMore = useAuditFilters((s) => s.loadMore);
+  const [sel, setSel] = useState<AuditDecisionRow | null>(null);
 
   // UI state → wire: '' = "all" locally, so unset filters are omitted
   // (undefined). The "(none)" label maps to `role: ''` — the wire's
@@ -192,11 +326,11 @@ export function AuditPage() {
   const scope = {
     window: f.range,
     agent: f.agent || undefined,
-    role: f.role === NO_VALUE_LABEL ? '' : f.role || undefined,
+    role: f.role === NO_VALUE_LABEL ? "" : f.role || undefined,
     tool: f.tool || undefined,
     start_date: f.start_date ? f.start_date.toISOString() : undefined,
     end_date: f.end_date ? f.end_date.toISOString() : undefined,
-  }
+  };
 
   // Range-only (unscoped) summary: filter dropdown options + the "X of Y"
   // total. Shares the summaryQ key shape on purpose: React Query's key hash
@@ -204,96 +338,128 @@ export function AuditPage() {
   // to summaryQ's and both dedupe into ONE fetch + cache entry; with a
   // filter active the keys diverge and the second request is real.
   const optionsQ = useQuery({
-    queryKey: ['audit', 'summary', projectId, { window: f.range }],
+    queryKey: ["audit", "summary", projectId, { window: f.range }],
     enabled: !!projectId,
-    queryFn: () => api.getAuditSummary({ window: f.range }, projectId as string),
-  })
+    queryFn: () =>
+      api.getAuditSummary({ window: f.range }, projectId as string),
+  });
   // Scoped summary/timeseries: KPIs, donut, area, breakdown.
   const summaryQ = useQuery({
-    queryKey: ['audit', 'summary', projectId, scope],
+    queryKey: ["audit", "summary", projectId, scope],
     enabled: !!projectId,
     queryFn: () => api.getAuditSummary(scope, projectId as string),
     placeholderData: keepPreviousData,
     refetchInterval: 30_000,
-  })
+  });
   const tsQ = useQuery({
-    queryKey: ['audit', 'ts', projectId, scope],
+    queryKey: ["audit", "ts", projectId, scope],
     enabled: !!projectId,
     queryFn: () => api.getAuditTimeseries(scope, projectId as string),
     placeholderData: keepPreviousData,
     refetchInterval: 30_000,
-  })
-  const listFilters = { ...scope, outcome: f.outcome || undefined, limit: tableLimit }
+  });
+  const listFilters = {
+    ...scope,
+    outcome: f.outcome || undefined,
+    limit: tableLimit,
+  };
   const listQ = useQuery({
-    queryKey: ['audit', 'list', projectId, listFilters],
+    queryKey: ["audit", "list", projectId, listFilters],
     enabled: !!projectId,
     queryFn: () => api.listAuditDecisions(listFilters, projectId as string),
     placeholderData: keepPreviousData,
     refetchInterval: 30_000,
-  })
+  });
   const relatedQ = useQuery({
-    queryKey: ['audit', 'session', projectId, f.range, sel?.session_id],
+    queryKey: ["audit", "session", projectId, f.range, sel?.session_id],
     enabled: !!sel?.session_id && !!projectId,
     queryFn: () =>
       api.listAuditDecisions(
         { window: f.range, session_id: sel!.session_id, limit: 12 },
         projectId as string,
       ),
-  })
+  });
 
-  const summary = summaryQ.data
+  const summary = summaryQ.data;
   const counts: Counts = summary
-    ? { allow: summary.totals.allow, deny: summary.totals.deny, needs_approval: summary.totals.needs_approval, total: summary.totals.all }
-    : ZERO_COUNTS
+    ? {
+        allow: summary.totals.allow,
+        deny: summary.totals.deny,
+        needs_approval: summary.totals.needs_approval,
+        total: summary.totals.all,
+      }
+    : ZERO_COUNTS;
 
   const days: ChartBucket[] = useMemo(
-    () => (tsQ.data ?? []).map((p) => ({
-      label: new Date(p.bucket),
-      mode: f.range === '24h' ? 'hour' : 'day',
-      values: { allow: p.allow, deny: p.deny, needs_approval: p.needs_approval },
-      total: p.allow + p.deny + p.needs_approval,
-    })),
+    () =>
+      (tsQ.data ?? []).map((p) => ({
+        label: new Date(p.bucket),
+        mode: f.range === "24h" ? "hour" : "day",
+        values: {
+          allow: p.allow,
+          deny: p.deny,
+          needs_approval: p.needs_approval,
+        },
+        total: p.allow + p.deny + p.needs_approval,
+      })),
     [tsQ.data, f.range],
-  )
-  const spark = useMemo(() => ({
-    total: days.map((d) => d.total),
-    allow: days.map((d) => d.values.allow),
-    deny: days.map((d) => d.values.deny),
-    needs_approval: days.map((d) => d.values.needs_approval),
-  }), [days])
+  );
+  const spark = useMemo(
+    () => ({
+      total: days.map((d) => d.total),
+      allow: days.map((d) => d.values.allow),
+      deny: days.map((d) => d.values.deny),
+      needs_approval: days.map((d) => d.values.needs_approval),
+    }),
+    [days],
+  );
 
-  const denyRate = counts.total ? ((counts.deny / counts.total) * 100).toFixed(1) : '0.0'
-  const allowPct = counts.total ? Math.round((counts.allow / counts.total) * 100) : 0
-  const apprPct = counts.total ? Math.round((counts.needs_approval / counts.total) * 100) : 0
-  const nDays = f.range === '7d' ? 7 : f.range === '90d' ? 90 : 30
-  const avgLabel = f.range === '24h' ? `${(counts.total / 24).toFixed(1)}/hr avg` : `${(counts.total / nDays).toFixed(0)}/day avg`
-  const setOutcome = (o: AuditOutcome) => setF((p) => ({ ...p, outcome: p.outcome === o ? '' : o }))
+  const denyRate = counts.total
+    ? ((counts.deny / counts.total) * 100).toFixed(1)
+    : "0.0";
+  const allowPct = counts.total
+    ? Math.round((counts.allow / counts.total) * 100)
+    : 0;
+  const apprPct = counts.total
+    ? Math.round((counts.needs_approval / counts.total) * 100)
+    : 0;
+  const nDays = f.range === "7d" ? 7 : f.range === "90d" ? 90 : 30;
+  const avgLabel =
+    f.range === "24h"
+      ? `${(counts.total / 24).toFixed(1)}/hr avg`
+      : `${(counts.total / nDays).toFixed(0)}/day avg`;
+  const setOutcome = (o: AuditOutcome) =>
+    setF((p) => ({ ...p, outcome: p.outcome === o ? "" : o }));
 
-  const options = optionsQ.data
-  const rangeTotal = options?.totals.all ?? 0
+  const options = optionsQ.data;
+  const rangeTotal = options?.totals.all ?? 0;
   // Wire → display: the empty-role bucket arrives as a raw "" key; label
   // it locally. Filter state then holds the label, mapped back in `scope`.
   const displayRole = <T extends { key: string }>(r: T): T =>
-    r.key === '' ? { ...r, key: NO_VALUE_LABEL } : r
-  const related = (relatedQ.data?.rows ?? []).filter((r) => r.event_id !== sel?.event_id).slice(0, 6)
+    r.key === "" ? { ...r, key: NO_VALUE_LABEL } : r;
+  const related = (relatedQ.data?.rows ?? [])
+    .filter((r) => r.event_id !== sel?.event_id)
+    .slice(0, 6);
 
   // Exports the LOADED page only (up to tableLimit ≤ 200 rows), not every
   // row matching the filters — "export everything" would need a streaming
   // server-side endpoint, not a client-side blob.
   const exportJsonl = () => {
-    const rows = listQ.data?.rows ?? []
-    if (!rows.length) return
-    const blob = new Blob([rows.map((r) => JSON.stringify(r)).join('\n')], { type: 'application/x-ndjson' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'decisions.jsonl'
-    a.click()
-    URL.revokeObjectURL(url)
-  }
+    const rows = listQ.data?.rows ?? [];
+    if (!rows.length) return;
+    const blob = new Blob([rows.map((r) => JSON.stringify(r)).join("\n")], {
+      type: "application/x-ndjson",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "decisions.jsonl";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
 
-  if (projectScope.status === 'no-project') {
-    return <NoProjectEmptyState resource="audit events" />
+  if (projectScope.status === "no-project") {
+    return <NoProjectEmptyState resource="audit events" />;
   }
 
   return (
@@ -302,15 +468,22 @@ export function AuditPage() {
         <header className="mb-6 flex items-end justify-between gap-4">
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Audit</h1>
-            <p className="mt-1 text-sm text-muted-foreground">Every policy decision for project <span className="font-mono text-foreground">{projectName}</span></p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Every policy decision for project{" "}
+              <span className="font-mono text-foreground">{projectName}</span>
+            </p>
           </div>
           <ToggleGroup
             type="single"
             value={f.range}
-            onValueChange={(v) => v && setF((p) => ({ ...p, range: v as Filters['range'] }))}
+            onValueChange={(v) =>
+              v && setF((p) => ({ ...p, range: v as Filters["range"] }))
+            }
           >
-            {(['24h', '7d', '30d', '90d'] as const).map((r) => (
-              <ToggleGroupItem key={r} value={r}>{r}</ToggleGroupItem>
+            {(["24h", "7d", "30d", "90d"] as const).map((r) => (
+              <ToggleGroupItem key={r} value={r}>
+                {r}
+              </ToggleGroupItem>
             ))}
           </ToggleGroup>
         </header>
@@ -327,32 +500,97 @@ export function AuditPage() {
         <ActiveChips f={f} setF={setF} />
 
         <div className="mb-4 grid grid-cols-4 gap-4">
-          <KpiCard label="Decisions" icon={Activity} value={counts.total.toLocaleString()} sub={avgLabel} spark={spark.total} sparkColor="hsl(var(--primary))" showSpark />
-          <KpiCard label="Allowed" icon={Check} value={counts.allow.toLocaleString()} color="allow" sub={`${allowPct}% of decisions`} spark={spark.allow} sparkColor="hsl(var(--semantic-allow))" showSpark onClick={() => setOutcome('allow')} active={f.outcome === 'allow'} />
-          <KpiCard label="Denied" icon={X} value={counts.deny.toLocaleString()} color="deny" sub={`${denyRate}% deny rate`} spark={spark.deny} sparkColor="hsl(var(--semantic-deny))" showSpark onClick={() => setOutcome('deny')} active={f.outcome === 'deny'} />
-          <KpiCard label="Needs approval" icon={CircleDashed} value={counts.needs_approval.toLocaleString()} color="approval" sub={`${apprPct}% of decisions`} spark={spark.needs_approval} sparkColor="hsl(var(--semantic-approval))" showSpark onClick={() => setOutcome('needs_approval')} active={f.outcome === 'needs_approval'} />
+          <KpiCard
+            label="Decisions"
+            icon={Activity}
+            value={counts.total.toLocaleString()}
+            sub={avgLabel}
+            spark={spark.total}
+            sparkColor="hsl(var(--primary))"
+            showSpark
+          />
+          <KpiCard
+            label="Allowed"
+            icon={Check}
+            value={counts.allow.toLocaleString()}
+            color="allow"
+            sub={`${allowPct}% of decisions`}
+            spark={spark.allow}
+            sparkColor="hsl(var(--semantic-allow))"
+            showSpark
+            onClick={() => setOutcome("allow")}
+            active={f.outcome === "allow"}
+          />
+          <KpiCard
+            label="Denied"
+            icon={X}
+            value={counts.deny.toLocaleString()}
+            color="deny"
+            sub={`${denyRate}% deny rate`}
+            spark={spark.deny}
+            sparkColor="hsl(var(--semantic-deny))"
+            showSpark
+            onClick={() => setOutcome("deny")}
+            active={f.outcome === "deny"}
+          />
+          <KpiCard
+            label="Needs approval"
+            icon={CircleDashed}
+            value={counts.needs_approval.toLocaleString()}
+            color="approval"
+            sub={`${apprPct}% of decisions`}
+            spark={spark.needs_approval}
+            sparkColor="hsl(var(--semantic-approval))"
+            showSpark
+            onClick={() => setOutcome("needs_approval")}
+            active={f.outcome === "needs_approval"}
+          />
         </div>
 
         <div className="mb-4 grid grid-cols-[1.55fr_1fr] gap-4">
           <Card className="p-6">
             <div className="mb-3.5 flex items-center justify-between">
-              <div className="text-[13px] font-medium text-muted-foreground">Decisions over time</div>
+              <div className="text-[13px] font-medium text-muted-foreground">
+                Decisions over time
+              </div>
               <div className="flex gap-3.5 text-[11px] text-muted-foreground">
                 {OUTCOME_SERIES.map((s) => (
-                  <span key={s.key} className="flex items-center gap-1.5"><span className={`size-2 rounded-sm ${s.swatchClass}`} />{s.label}</span>
+                  <span key={s.key} className="flex items-center gap-1.5">
+                    <span className={`size-2 rounded-sm ${s.swatchClass}`} />
+                    {s.label}
+                  </span>
                 ))}
               </div>
             </div>
-            {days.length ? <AreaChart buckets={days} series={OUTCOME_SERIES} /> : <div className="flex h-60 items-center justify-center text-[13px] text-muted-foreground">No decisions in this range.</div>}
+            {days.length ? (
+              <AreaChart buckets={days} series={OUTCOME_SERIES} />
+            ) : (
+              <div className="flex h-60 items-center justify-center text-[13px] text-muted-foreground">
+                No decisions in this range.
+              </div>
+            )}
           </Card>
           <Card className="p-6">
-            <div className="mb-4 text-[13px] font-medium text-muted-foreground">Outcome breakdown</div>
-            <Donut values={{ ...counts }} total={counts.total} series={OUTCOME_SERIES} caption="decisions" />
+            <div className="mb-4 text-[13px] font-medium text-muted-foreground">
+              Outcome breakdown
+            </div>
+            <Donut
+              values={{ ...counts }}
+              total={counts.total}
+              series={OUTCOME_SERIES}
+              caption="decisions"
+            />
           </Card>
         </div>
 
         <div className="mb-4">
-          <BreakdownCard byTool={summary?.by_tool ?? []} byAgent={summary?.by_agent ?? []} byRole={summary?.by_role.map(displayRole) ?? []} f={f} setF={setF} />
+          <BreakdownCard
+            byTool={summary?.by_tool ?? []}
+            byAgent={summary?.by_agent ?? []}
+            byRole={summary?.by_role.map(displayRole) ?? []}
+            f={f}
+            setF={setF}
+          />
         </div>
 
         <EventsTable
@@ -366,7 +604,13 @@ export function AuditPage() {
         />
       </div>
 
-      <DetailDrawer event={sel} related={related} onClose={() => setSel(null)} onSelect={setSel} setF={setF} />
+      <DetailDrawer
+        event={sel}
+        related={related}
+        onClose={() => setSel(null)}
+        onSelect={setSel}
+        setF={setF}
+      />
     </>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/ForgotPassword.tsx
+++ b/platform/dashboard/src/routes/ForgotPassword.tsx
@@ -1,10 +1,10 @@
-import { Link } from 'react-router-dom'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
-import { MailCheck } from 'lucide-react'
+import { Link } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { MailCheck } from "lucide-react";
 
-import { Button } from '@/components/ui/button'
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -12,27 +12,27 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { useForgotPassword } from '@/lib/auth'
-import { AuthCardLayout } from './SignIn'
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useForgotPassword } from "@/lib/auth";
+import { AuthCardLayout } from "./SignIn";
 
-const Schema = z.object({ email: z.string().email('Enter a valid email') })
-type Values = z.infer<typeof Schema>
+const Schema = z.object({ email: z.string().email("Enter a valid email") });
+type Values = z.infer<typeof Schema>;
 
 export function ForgotPasswordPage() {
-  const forgot = useForgotPassword()
+  const forgot = useForgotPassword();
   const form = useForm<Values>({
     resolver: zodResolver(Schema),
-    defaultValues: { email: '' },
-  })
+    defaultValues: { email: "" },
+  });
 
   async function onSubmit(values: Values) {
     // The backend always returns 202 — same status whether the email
     // exists or not, so we don't leak which addresses are registered.
     // The UI mirrors that opacity: success message regardless.
-    await forgot.mutateAsync(values.email).catch(() => undefined)
+    await forgot.mutateAsync(values.email).catch(() => undefined);
   }
 
   if (forgot.isSuccess) {
@@ -45,9 +45,8 @@ export function ForgotPasswordPage() {
             </div>
             <CardTitle className="text-center">Check your email</CardTitle>
             <CardDescription className="text-center">
-              If an account exists for {form.getValues('email')}, we just sent
-              a reset link to it. Open it and follow the prompt within an
-              hour.
+              If an account exists for {form.getValues("email")}, we just sent a
+              reset link to it. Open it and follow the prompt within an hour.
             </CardDescription>
           </CardHeader>
           <CardFooter>
@@ -57,7 +56,7 @@ export function ForgotPasswordPage() {
           </CardFooter>
         </Card>
       </AuthCardLayout>
-    )
+    );
   }
 
   return (
@@ -78,7 +77,7 @@ export function ForgotPasswordPage() {
                 type="email"
                 autoComplete="email"
                 placeholder="you@example.com"
-                {...form.register('email')}
+                {...form.register("email")}
               />
               {form.formState.errors.email && (
                 <p className="text-xs text-destructive">
@@ -88,8 +87,12 @@ export function ForgotPasswordPage() {
             </div>
           </CardContent>
           <CardFooter className="flex-col gap-3">
-            <Button type="submit" className="w-full" disabled={forgot.isPending}>
-              {forgot.isPending ? 'Sending…' : 'Send reset link'}
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={forgot.isPending}
+            >
+              {forgot.isPending ? "Sending…" : "Send reset link"}
             </Button>
             <p className="text-center text-sm text-muted-foreground">
               <Link
@@ -103,5 +106,5 @@ export function ForgotPasswordPage() {
         </form>
       </Card>
     </AuthCardLayout>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/Graph.tsx
+++ b/platform/dashboard/src/routes/Graph.tsx
@@ -1,37 +1,45 @@
-import { useMemo } from 'react'
-import { useQuery } from '@tanstack/react-query'
-import { ReactFlow, Background, Controls, MiniMap, BackgroundVariant } from '@xyflow/react'
-import { api } from '@/lib/api'
-import { useProjectScoped } from '@/lib/active'
-import { buildOverviewGraph } from '@/lib/graph'
-import { nodeTypes } from '@/components/graph/nodes'
-import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
-import { Badge } from '@/components/ui/badge'
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  BackgroundVariant,
+} from "@xyflow/react";
+import { api } from "@/lib/api";
+import { useProjectScoped } from "@/lib/active";
+import { buildOverviewGraph } from "@/lib/graph";
+import { nodeTypes } from "@/components/graph/nodes";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { Badge } from "@/components/ui/badge";
 
 export function GraphPage() {
-  const scope = useProjectScoped()
+  const scope = useProjectScoped();
   const agents = useQuery({
-    queryKey: ['agents', scope.projectId],
+    queryKey: ["agents", scope.projectId],
     queryFn: () => api.listAgents(scope.projectId as string),
     enabled: !!scope.projectId,
-  })
+  });
 
   const { nodes, edges, agentViews } = useMemo(() => {
-    if (!agents.data) return { nodes: [], edges: [], agentViews: [] }
-    return buildOverviewGraph(agents.data)
-  }, [agents.data])
+    if (!agents.data) return { nodes: [], edges: [], agentViews: [] };
+    return buildOverviewGraph(agents.data);
+  }, [agents.data]);
 
-  if (scope.status === 'no-project') {
-    return <NoProjectEmptyState resource="graph" />
+  if (scope.status === "no-project") {
+    return <NoProjectEmptyState resource="graph" />;
   }
 
   return (
     <div className="-mx-8 -my-6 h-[calc(100vh-56px)] flex flex-col">
       <div className="flex items-start justify-between px-8 py-5 border-b border-border">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Graph overview</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Graph overview
+          </h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Roles, agents, and tools for this project. Read-only — edit in{' '}
+            Roles, agents, and tools for this project. Read-only — edit in{" "}
             <span className="font-mono text-foreground">/agents</span>.
           </p>
         </div>
@@ -75,5 +83,5 @@ export function GraphPage() {
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/OrgMembers.test.tsx
+++ b/platform/dashboard/src/routes/OrgMembers.test.tsx
@@ -14,28 +14,28 @@
  * end-to-end; here we focus on the visual permission gating.
  */
 
-import { screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Route, Routes } from 'react-router-dom'
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router-dom";
 
-import { OrgMembersPage } from '@/routes/OrgMembers'
-import { renderWithProviders } from '@/test/render'
+import { OrgMembersPage } from "@/routes/OrgMembers";
+import { renderWithProviders } from "@/test/render";
 
 function stubFetch(routes: Record<string, unknown>): void {
-  vi.spyOn(window, 'fetch').mockImplementation(
+  vi.spyOn(window, "fetch").mockImplementation(
     async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input.toString()
-      const path = url.split('?')[0]
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0];
       if (path in routes) {
         return new Response(JSON.stringify(routes[path]), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+          headers: { "Content-Type": "application/json" },
+        });
       }
-      return new Response('not found', { status: 404 })
+      return new Response("not found", { status: 404 });
     },
-  )
+  );
 }
 
 function renderPage(orgId: string) {
@@ -44,137 +44,131 @@ function renderPage(orgId: string) {
       <Route path="/orgs/:orgId/members" element={<OrgMembersPage />} />
     </Routes>,
     { initialRoute: `/orgs/${orgId}/members` },
-  )
+  );
 }
 
 const OWNER_USER = {
-  id: 'me-owner',
-  email: 'me@example.com',
+  id: "me-owner",
+  email: "me@example.com",
   is_active: true,
   is_superuser: false,
   is_verified: true,
-}
+};
 
 const ORG_OWNER = {
-  id: 'org-1',
-  slug: 'acme',
-  name: 'Acme Inc',
-  created_at: '2026-01-01T00:00:00Z',
-  role: 'owner' as const,
-}
+  id: "org-1",
+  slug: "acme",
+  name: "Acme Inc",
+  created_at: "2026-01-01T00:00:00Z",
+  role: "owner" as const,
+};
 
-const ORG_AS_MEMBER = { ...ORG_OWNER, role: 'member' as const }
+const ORG_AS_MEMBER = { ...ORG_OWNER, role: "member" as const };
 
 const MEMBERS = [
   {
-    user_id: 'me-owner',
-    email: 'me@example.com',
-    role: 'owner',
-    joined_at: '2026-01-01T00:00:00Z',
+    user_id: "me-owner",
+    email: "me@example.com",
+    role: "owner",
+    joined_at: "2026-01-01T00:00:00Z",
   },
   {
-    user_id: 'alice-uid',
-    email: 'alice@example.com',
-    role: 'admin',
-    joined_at: '2026-01-02T00:00:00Z',
+    user_id: "alice-uid",
+    email: "alice@example.com",
+    role: "admin",
+    joined_at: "2026-01-02T00:00:00Z",
   },
-]
+];
 
 const INVITATIONS = [
   {
-    id: 'inv-1',
-    email: 'carol@example.com',
-    role: 'admin',
-    invited_by_email: 'me@example.com',
-    expires_at: '2030-01-01T00:00:00Z',
-    created_at: '2026-06-01T00:00:00Z',
+    id: "inv-1",
+    email: "carol@example.com",
+    role: "admin",
+    invited_by_email: "me@example.com",
+    expires_at: "2030-01-01T00:00:00Z",
+    created_at: "2026-06-01T00:00:00Z",
   },
-]
+];
 
-describe('OrgMembersPage', () => {
+describe("OrgMembersPage", () => {
   beforeEach(() => {
     // Default stubs — each test overrides via stubFetch
-  })
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('shows Invite button + inline RoleSelect + Remove for owners', async () => {
+  it("shows Invite button + inline RoleSelect + Remove for owners", async () => {
     stubFetch({
-      '/v1/orgs': [ORG_OWNER],
-      '/v1/users/me': OWNER_USER,
-      '/v1/orgs/org-1/members': MEMBERS,
-      '/v1/orgs/org-1/invites': INVITATIONS,
-    })
+      "/v1/orgs": [ORG_OWNER],
+      "/v1/users/me": OWNER_USER,
+      "/v1/orgs/org-1/members": MEMBERS,
+      "/v1/orgs/org-1/invites": INVITATIONS,
+    });
 
-    renderPage('org-1')
+    renderPage("org-1");
 
     await waitFor(() => {
-      expect(screen.getByText(/Members of Acme Inc/i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/Members of Acme Inc/i)).toBeInTheDocument();
+    });
     // Invite button — owner-only.
-    expect(screen.getByText('Invite member')).toBeInTheDocument()
+    expect(screen.getByText("Invite member")).toBeInTheDocument();
     // Member email appears (use alice — me@example.com also shows in the
     // invitations row's invited_by column, so it matches twice).
-    expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
     // "Remove" buttons exist for non-self rows.
-    expect(screen.getAllByText('Remove').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText("Remove").length).toBeGreaterThanOrEqual(1);
     // Pending invitations section is visible.
-    expect(
-      screen.getByText(/Pending invitations/i),
-    ).toBeInTheDocument()
-    expect(screen.getByText('carol@example.com')).toBeInTheDocument()
-  })
+    expect(screen.getByText(/Pending invitations/i)).toBeInTheDocument();
+    expect(screen.getByText("carol@example.com")).toBeInTheDocument();
+  });
 
-  it('hides Invite + Remove + pending invitations for plain members', async () => {
+  it("hides Invite + Remove + pending invitations for plain members", async () => {
     stubFetch({
-      '/v1/orgs': [ORG_AS_MEMBER],
-      '/v1/users/me': OWNER_USER,
-      '/v1/orgs/org-1/members': MEMBERS,
+      "/v1/orgs": [ORG_AS_MEMBER],
+      "/v1/users/me": OWNER_USER,
+      "/v1/orgs/org-1/members": MEMBERS,
       // Backend would 403 invites for a plain member; the page never
       // calls it because the section is hidden — stub returns empty.
-      '/v1/orgs/org-1/invites': [],
-    })
+      "/v1/orgs/org-1/invites": [],
+    });
 
-    renderPage('org-1')
+    renderPage("org-1");
 
     await waitFor(() => {
-      expect(screen.getByText(/Members of Acme Inc/i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/Members of Acme Inc/i)).toBeInTheDocument();
+    });
 
     // Plain members don't see the Invite button.
-    expect(screen.queryByText('Invite member')).not.toBeInTheDocument()
+    expect(screen.queryByText("Invite member")).not.toBeInTheDocument();
     // No Remove buttons.
-    expect(screen.queryByText('Remove')).not.toBeInTheDocument()
+    expect(screen.queryByText("Remove")).not.toBeInTheDocument();
     // Pending invitations section hidden entirely (admin/owner-only info).
-    expect(
-      screen.queryByText(/Pending invitations/i),
-    ).not.toBeInTheDocument()
+    expect(screen.queryByText(/Pending invitations/i)).not.toBeInTheDocument();
     // Members table still renders so the user can see who's around.
-    expect(screen.getByText('alice@example.com')).toBeInTheDocument()
-  })
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+  });
 
   it('"Invite member" opens the invite dialog with email + role fields', async () => {
     stubFetch({
-      '/v1/orgs': [ORG_OWNER],
-      '/v1/users/me': OWNER_USER,
-      '/v1/orgs/org-1/members': MEMBERS,
-      '/v1/orgs/org-1/invites': [],
-    })
+      "/v1/orgs": [ORG_OWNER],
+      "/v1/users/me": OWNER_USER,
+      "/v1/orgs/org-1/members": MEMBERS,
+      "/v1/orgs/org-1/invites": [],
+    });
 
-    const user = userEvent.setup()
-    renderPage('org-1')
+    const user = userEvent.setup();
+    renderPage("org-1");
 
     await waitFor(() => {
-      expect(screen.getByText('Invite member')).toBeInTheDocument()
-    })
-    await user.click(screen.getByText('Invite member'))
+      expect(screen.getByText("Invite member")).toBeInTheDocument();
+    });
+    await user.click(screen.getByText("Invite member"));
 
     // Dialog content shows the title — unique to the dialog body.
-    expect(
-      await screen.findByText('Invite a teammate'),
-    ).toBeInTheDocument()
-    expect(screen.getByLabelText('Email')).toBeInTheDocument()
-  })
-})
+    expect(await screen.findByText("Invite a teammate")).toBeInTheDocument();
+    expect(screen.getByLabelText("Email")).toBeInTheDocument();
+  });
+});

--- a/platform/dashboard/src/routes/OrgMembers.tsx
+++ b/platform/dashboard/src/routes/OrgMembers.tsx
@@ -1,14 +1,14 @@
-import { useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
-import { toast } from 'sonner'
-import { ArrowLeft, Mail, Plus, X } from 'lucide-react'
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { toast } from "sonner";
+import { ArrowLeft, Mail, Plus, X } from "lucide-react";
 
-import { ConfirmDialog } from '@/components/ConfirmDialog'
-import { InviteMemberDialog } from '@/components/InviteMemberDialog'
-import { RoleSelect } from '@/components/RoleSelect'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { InviteMemberDialog } from "@/components/InviteMemberDialog";
+import { RoleSelect } from "@/components/RoleSelect";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -16,21 +16,21 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { ApiError } from '@/lib/api'
-import { useUser } from '@/lib/auth'
+} from "@/components/ui/table";
+import { ApiError } from "@/lib/api";
+import { useUser } from "@/lib/auth";
 import {
   useInvitations,
   useRevokeInvitation,
   type InvitationRead,
-} from '@/lib/invites'
+} from "@/lib/invites";
 import {
   useMembers,
   useRemoveMember,
   useUpdateMemberRole,
   type MemberRead,
-} from '@/lib/members'
-import { useOrgs, type Role } from '@/lib/orgs'
+} from "@/lib/members";
+import { useOrgs, type Role } from "@/lib/orgs";
 
 /**
  * `/orgs/:orgId/members` — two adjacent tables in one page.
@@ -46,37 +46,37 @@ import { useOrgs, type Role } from '@/lib/orgs'
  * trip on every render.
  */
 export function OrgMembersPage() {
-  const { orgId } = useParams<{ orgId: string }>()
-  const navigate = useNavigate()
-  const { user: me } = useUser()
-  const orgsQuery = useOrgs()
-  const membersQuery = useMembers(orgId ?? null)
-  const invitationsQuery = useInvitations(orgId ?? null)
-  const updateRole = useUpdateMemberRole()
-  const removeMember = useRemoveMember()
-  const revokeInvite = useRevokeInvitation()
+  const { orgId } = useParams<{ orgId: string }>();
+  const navigate = useNavigate();
+  const { user: me } = useUser();
+  const orgsQuery = useOrgs();
+  const membersQuery = useMembers(orgId ?? null);
+  const invitationsQuery = useInvitations(orgId ?? null);
+  const updateRole = useUpdateMemberRole();
+  const removeMember = useRemoveMember();
+  const revokeInvite = useRevokeInvitation();
 
-  const [inviteOpen, setInviteOpen] = useState(false)
-  const [confirmRemove, setConfirmRemove] = useState<MemberRead | null>(null)
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState<MemberRead | null>(null);
   const [confirmRevoke, setConfirmRevoke] = useState<InvitationRead | null>(
     null,
-  )
+  );
 
-  const org = orgsQuery.data?.find((o) => o.id === orgId) ?? null
-  const canManage = org?.role === 'owner' || org?.role === 'admin'
+  const org = orgsQuery.data?.find((o) => o.id === orgId) ?? null;
+  const canManage = org?.role === "owner" || org?.role === "admin";
 
   if (orgsQuery.isLoading) {
     return (
       <div className="mx-auto max-w-4xl p-6 text-sm text-muted-foreground">
         Loading…
       </div>
-    )
+    );
   }
 
   if (!org) {
     return (
       <div className="mx-auto max-w-4xl space-y-4 p-6">
-        <Button variant="ghost" size="sm" onClick={() => navigate('/orgs')}>
+        <Button variant="ghost" size="sm" onClick={() => navigate("/orgs")}>
           <ArrowLeft className="h-3.5 w-3.5" />
           Back to organizations
         </Button>
@@ -86,62 +86,62 @@ export function OrgMembersPage() {
           </AlertDescription>
         </Alert>
       </div>
-    )
+    );
   }
 
   async function onRoleChange(member: MemberRead, role: Role): Promise<void> {
-    if (member.role === role || !org) return
+    if (member.role === role || !org) return;
     try {
       await updateRole.mutateAsync({
         orgId: org.id,
         userId: member.user_id,
         role,
-      })
-      toast.success(`${member.email} is now ${role}`)
+      });
+      toast.success(`${member.email} is now ${role}`);
     } catch (err) {
-      const detail = err instanceof ApiError ? String(err.message) : ''
-      const lastOwner = detail.toLowerCase().includes('last owner')
+      const detail = err instanceof ApiError ? String(err.message) : "";
+      const lastOwner = detail.toLowerCase().includes("last owner");
       toast.error(
         lastOwner
           ? "Can't demote the only owner — promote someone else first."
           : `Could not update ${member.email}'s role.`,
-      )
+      );
     }
   }
 
   async function onRemove(member: MemberRead): Promise<void> {
-    if (!org) return
+    if (!org) return;
     try {
       await removeMember.mutateAsync({
         orgId: org.id,
         userId: member.user_id,
-      })
-      toast.success(`Removed ${member.email}`)
+      });
+      toast.success(`Removed ${member.email}`);
     } catch (err) {
-      const detail = err instanceof ApiError ? String(err.message) : ''
-      const lastOwner = detail.toLowerCase().includes('last owner')
+      const detail = err instanceof ApiError ? String(err.message) : "";
+      const lastOwner = detail.toLowerCase().includes("last owner");
       toast.error(
         lastOwner
           ? "Can't remove the only owner — promote someone else first."
           : `Could not remove ${member.email}.`,
-      )
+      );
     } finally {
-      setConfirmRemove(null)
+      setConfirmRemove(null);
     }
   }
 
   async function onRevokeInvite(invitation: InvitationRead): Promise<void> {
-    if (!org) return
+    if (!org) return;
     try {
       await revokeInvite.mutateAsync({
         invitationId: invitation.id,
         orgId: org.id,
-      })
-      toast.success(`Cancelled invite to ${invitation.email}`)
+      });
+      toast.success(`Cancelled invite to ${invitation.email}`);
     } catch {
-      toast.error(`Could not cancel invite to ${invitation.email}.`)
+      toast.error(`Could not cancel invite to ${invitation.email}.`);
     } finally {
-      setConfirmRevoke(null)
+      setConfirmRevoke(null);
     }
   }
 
@@ -191,21 +191,17 @@ export function OrgMembersPage() {
                 <TableHead>Email</TableHead>
                 <TableHead className="w-[140px]">Role</TableHead>
                 {canManage && (
-                  <TableHead className="w-[80px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-[80px] text-right">Actions</TableHead>
                 )}
               </TableRow>
             </TableHeader>
             <TableBody>
               {membersQuery.data.map((member) => {
-                const isSelf = member.user_id === me?.id
+                const isSelf = member.user_id === me?.id;
                 return (
                   <TableRow key={member.user_id}>
                     <TableCell>
-                      <span className="font-mono text-xs">
-                        {member.email}
-                      </span>
+                      <span className="font-mono text-xs">{member.email}</span>
                       {isSelf && (
                         <span className="ml-2 text-[10px] uppercase tracking-wider text-muted-foreground">
                           you
@@ -222,7 +218,7 @@ export function OrgMembersPage() {
                       ) : (
                         <Badge
                           variant={
-                            member.role === 'owner' ? 'primary' : 'outline'
+                            member.role === "owner" ? "primary" : "outline"
                           }
                           className="font-normal capitalize"
                         >
@@ -246,7 +242,7 @@ export function OrgMembersPage() {
                       </TableCell>
                     )}
                   </TableRow>
-                )
+                );
               })}
             </TableBody>
           </Table>
@@ -279,9 +275,7 @@ export function OrgMembersPage() {
                   <TableHead>Email</TableHead>
                   <TableHead className="w-[120px]">Role</TableHead>
                   <TableHead className="w-[160px]">Invited by</TableHead>
-                  <TableHead className="w-[80px] text-right">
-                    Actions
-                  </TableHead>
+                  <TableHead className="w-[80px] text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -333,17 +327,19 @@ export function OrgMembersPage() {
       <ConfirmDialog
         open={confirmRemove !== null}
         onOpenChange={(open) => !open && setConfirmRemove(null)}
-        title={confirmRemove ? `Remove ${confirmRemove.email}?` : ''}
+        title={confirmRemove ? `Remove ${confirmRemove.email}?` : ""}
         description="They'll lose access to this organization's projects, tokens, and audit logs. An admin can re-invite them later."
         confirmLabel="Remove member"
         pending={removeMember.isPending}
-        onConfirm={() => (confirmRemove ? onRemove(confirmRemove) : Promise.resolve())}
+        onConfirm={() =>
+          confirmRemove ? onRemove(confirmRemove) : Promise.resolve()
+        }
       />
 
       <ConfirmDialog
         open={confirmRevoke !== null}
         onOpenChange={(open) => !open && setConfirmRevoke(null)}
-        title={confirmRevoke ? `Cancel invite to ${confirmRevoke.email}?` : ''}
+        title={confirmRevoke ? `Cancel invite to ${confirmRevoke.email}?` : ""}
         description="The magic link in their email will stop working. You can always send a fresh invite later."
         confirmLabel="Cancel invitation"
         pending={revokeInvite.isPending}
@@ -352,5 +348,5 @@ export function OrgMembersPage() {
         }
       />
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/OrgSettings.test.tsx
+++ b/platform/dashboard/src/routes/OrgSettings.test.tsx
@@ -11,27 +11,27 @@
  * walkthrough + Phase 4's backend tests, not duplicated here.
  */
 
-import { screen, waitFor } from '@testing-library/react'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Route, Routes } from 'react-router-dom'
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Routes } from "react-router-dom";
 
-import { OrgSettingsPage } from '@/routes/OrgSettings'
-import { renderWithProviders } from '@/test/render'
+import { OrgSettingsPage } from "@/routes/OrgSettings";
+import { renderWithProviders } from "@/test/render";
 
 function stubFetch(routes: Record<string, unknown>): void {
-  vi.spyOn(window, 'fetch').mockImplementation(
+  vi.spyOn(window, "fetch").mockImplementation(
     async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input.toString()
-      const path = url.split('?')[0]
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0];
       if (path in routes) {
         return new Response(JSON.stringify(routes[path]), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+          headers: { "Content-Type": "application/json" },
+        });
       }
-      return new Response('not found', { status: 404 })
+      return new Response("not found", { status: 404 });
     },
-  )
+  );
 }
 
 /** Routed test render — OrgSettings reads :orgId from the URL via
@@ -42,101 +42,99 @@ function renderSettings(orgId: string) {
       <Route path="/orgs/:orgId/settings" element={<OrgSettingsPage />} />
     </Routes>,
     { initialRoute: `/orgs/${orgId}/settings` },
-  )
+  );
 }
 
-describe('OrgSettingsPage', () => {
+describe("OrgSettingsPage", () => {
   beforeEach(() => {
     // No localStorage state needed — the page reads from useOrgs(),
     // not the active store, to find the org details.
-  })
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('renders view-only mode for plain members (no save button)', async () => {
+  it("renders view-only mode for plain members (no save button)", async () => {
     stubFetch({
-      '/v1/orgs': [
+      "/v1/orgs": [
         {
-          id: 'org-1',
-          slug: 'acme',
-          name: 'Acme Inc',
-          created_at: '2026-01-01T00:00:00Z',
-          role: 'member',
+          id: "org-1",
+          slug: "acme",
+          name: "Acme Inc",
+          created_at: "2026-01-01T00:00:00Z",
+          role: "member",
         },
       ],
-      '/v1/users/me': {
-        id: 'me',
-        email: 'plain@example.com',
+      "/v1/users/me": {
+        id: "me",
+        email: "plain@example.com",
         is_active: true,
         is_superuser: false,
         is_verified: true,
       },
-    })
+    });
 
-    renderSettings('org-1')
+    renderSettings("org-1");
 
     await waitFor(() => {
-      expect(screen.getByText(/View-only/i)).toBeInTheDocument()
-    })
+      expect(screen.getByText(/View-only/i)).toBeInTheDocument();
+    });
     // Save button isn't rendered for plain members.
-    expect(screen.queryByText('Save changes')).not.toBeInTheDocument()
+    expect(screen.queryByText("Save changes")).not.toBeInTheDocument();
     // "Leave organization" is always available — members can leave.
-    expect(screen.getByText('Leave organization')).toBeInTheDocument()
-  })
+    expect(screen.getByText("Leave organization")).toBeInTheDocument();
+  });
 
-  it('renders editable form + Save button for owners', async () => {
+  it("renders editable form + Save button for owners", async () => {
     stubFetch({
-      '/v1/orgs': [
+      "/v1/orgs": [
         {
-          id: 'org-1',
-          slug: 'acme',
-          name: 'Acme Inc',
-          created_at: '2026-01-01T00:00:00Z',
-          role: 'owner',
+          id: "org-1",
+          slug: "acme",
+          name: "Acme Inc",
+          created_at: "2026-01-01T00:00:00Z",
+          role: "owner",
         },
       ],
-      '/v1/users/me': {
-        id: 'me',
-        email: 'owner@example.com',
+      "/v1/users/me": {
+        id: "me",
+        email: "owner@example.com",
         is_active: true,
         is_superuser: false,
         is_verified: true,
       },
-    })
+    });
 
-    renderSettings('org-1')
+    renderSettings("org-1");
 
     await waitFor(() => {
-      expect(screen.getByLabelText('Name')).toBeInTheDocument()
-    })
-    expect(screen.getByLabelText('Name')).not.toBeDisabled()
-    expect(screen.getByLabelText('Slug')).not.toBeDisabled()
-    expect(screen.getByText('Save changes')).toBeInTheDocument()
+      expect(screen.getByLabelText("Name")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Name")).not.toBeDisabled();
+    expect(screen.getByLabelText("Slug")).not.toBeDisabled();
+    expect(screen.getByText("Save changes")).toBeInTheDocument();
     // The view-only banner shouldn't show.
-    expect(screen.queryByText(/View-only/i)).not.toBeInTheDocument()
-  })
+    expect(screen.queryByText(/View-only/i)).not.toBeInTheDocument();
+  });
 
-  it('shows "not found" when the org isn\'t in the user\'s list', async () => {
+  it("shows \"not found\" when the org isn't in the user's list", async () => {
     // Empty list — orgsQuery resolves, but no org matches the URL id.
     stubFetch({
-      '/v1/orgs': [],
-      '/v1/users/me': {
-        id: 'me',
-        email: 'wanderer@example.com',
+      "/v1/orgs": [],
+      "/v1/users/me": {
+        id: "me",
+        email: "wanderer@example.com",
         is_active: true,
         is_superuser: false,
         is_verified: true,
       },
-    })
+    });
 
-    renderSettings('nonexistent-org')
+    renderSettings("nonexistent-org");
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/Organization not found/i),
-      ).toBeInTheDocument()
-    })
-  })
-})
+      expect(screen.getByText(/Organization not found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/platform/dashboard/src/routes/OrgSettings.tsx
+++ b/platform/dashboard/src/routes/OrgSettings.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
-import { toast } from 'sonner'
-import { AlertTriangle, ArrowLeft } from 'lucide-react'
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { AlertTriangle, ArrowLeft } from "lucide-react";
 
-import { Users } from 'lucide-react'
+import { Users } from "lucide-react";
 
-import { ConfirmDialog } from '@/components/ConfirmDialog'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { ConfirmDialog } from "@/components/ConfirmDialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -18,31 +18,31 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { ApiError } from '@/lib/api'
-import { useActive } from '@/lib/active'
-import { useUser } from '@/lib/auth'
-import { useLeaveOrg } from '@/lib/members'
-import { useOrgs, useUpdateOrg } from '@/lib/orgs'
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ApiError } from "@/lib/api";
+import { useActive } from "@/lib/active";
+import { useUser } from "@/lib/auth";
+import { useLeaveOrg } from "@/lib/members";
+import { useOrgs, useUpdateOrg } from "@/lib/orgs";
 
 /** Mirror of CreateOrgDialog's slug regex (DNS-label shape). */
-const SLUG_REGEX = /^([a-z]|[a-z][a-z0-9-]*[a-z0-9])$/
+const SLUG_REGEX = /^([a-z]|[a-z][a-z0-9-]*[a-z0-9])$/;
 
 const SettingsSchema = z.object({
-  name: z.string().min(1, 'Required').max(64, 'Max 64 characters'),
+  name: z.string().min(1, "Required").max(64, "Max 64 characters"),
   slug: z
     .string()
-    .min(1, 'Required')
-    .max(32, 'Max 32 characters')
+    .min(1, "Required")
+    .max(32, "Max 32 characters")
     .regex(
       SLUG_REGEX,
-      'Lowercase letters, digits, hyphens. Must start with a letter.',
+      "Lowercase letters, digits, hyphens. Must start with a letter.",
     ),
-})
+});
 
-type SettingsValues = z.infer<typeof SettingsSchema>
+type SettingsValues = z.infer<typeof SettingsSchema>;
 
 /**
  * `/orgs/:orgId/settings` — name + slug editing + the "Leave organization"
@@ -56,40 +56,40 @@ type SettingsValues = z.infer<typeof SettingsSchema>
  *     toast ("you're the only owner; promote someone first")
  */
 export function OrgSettingsPage() {
-  const { orgId } = useParams<{ orgId: string }>()
-  const navigate = useNavigate()
-  const { user } = useUser()
-  const orgsQuery = useOrgs()
-  const updateOrg = useUpdateOrg()
-  const leaveOrg = useLeaveOrg()
-  const setActiveOrg = useActive((s) => s.setActiveOrg)
-  const [confirmLeaveOpen, setConfirmLeaveOpen] = useState(false)
+  const { orgId } = useParams<{ orgId: string }>();
+  const navigate = useNavigate();
+  const { user } = useUser();
+  const orgsQuery = useOrgs();
+  const updateOrg = useUpdateOrg();
+  const leaveOrg = useLeaveOrg();
+  const setActiveOrg = useActive((s) => s.setActiveOrg);
+  const [confirmLeaveOpen, setConfirmLeaveOpen] = useState(false);
 
-  const org = orgsQuery.data?.find((o) => o.id === orgId) ?? null
-  const canEdit = org?.role === 'owner' || org?.role === 'admin'
+  const org = orgsQuery.data?.find((o) => o.id === orgId) ?? null;
+  const canEdit = org?.role === "owner" || org?.role === "admin";
 
   const form = useForm<SettingsValues>({
     resolver: zodResolver(SettingsSchema),
-    defaultValues: { name: '', slug: '' },
-  })
+    defaultValues: { name: "", slug: "" },
+  });
 
   // Reset the form whenever the active org row changes — switching orgs
   // via the switcher while sitting on this page should re-populate the
   // fields with the new org's values.
   useEffect(() => {
     if (org) {
-      form.reset({ name: org.name, slug: org.slug })
-      updateOrg.reset()
+      form.reset({ name: org.name, slug: org.slug });
+      updateOrg.reset();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [org?.id, org?.name, org?.slug])
+  }, [org?.id, org?.name, org?.slug]);
 
   if (orgsQuery.isLoading) {
     return (
       <div className="mx-auto max-w-3xl p-6 text-sm text-muted-foreground">
         Loading…
       </div>
-    )
+    );
   }
 
   if (!org) {
@@ -99,7 +99,13 @@ export function OrgSettingsPage() {
     return (
       <div className="mx-auto max-w-3xl space-y-4 p-6">
         <Button asChild variant="ghost" size="sm">
-          <a href="/orgs" onClick={(e) => { e.preventDefault(); navigate('/orgs') }}>
+          <a
+            href="/orgs"
+            onClick={(e) => {
+              e.preventDefault();
+              navigate("/orgs");
+            }}
+          >
             <ArrowLeft className="h-3.5 w-3.5" />
             Back to organizations
           </a>
@@ -110,47 +116,47 @@ export function OrgSettingsPage() {
           </AlertDescription>
         </Alert>
       </div>
-    )
+    );
   }
 
   async function onSubmit(values: SettingsValues): Promise<void> {
-    if (!org) return  // narrows the type below
+    if (!org) return; // narrows the type below
     try {
       await updateOrg.mutateAsync({
         orgId: org.id,
         name: values.name !== org.name ? values.name : undefined,
         slug: values.slug !== org.slug ? values.slug : undefined,
-      })
-      toast.success('Organization saved')
+      });
+      toast.success("Organization saved");
     } catch (err) {
-      const detail = err instanceof ApiError ? String(err.message) : ''
-      const slugTaken = detail.toLowerCase().includes('taken')
+      const detail = err instanceof ApiError ? String(err.message) : "";
+      const slugTaken = detail.toLowerCase().includes("taken");
       toast.error(
         slugTaken
-          ? 'That slug is already in use. Try a different one.'
-          : 'Could not save changes.',
-      )
+          ? "That slug is already in use. Try a different one."
+          : "Could not save changes.",
+      );
     }
   }
 
   async function onLeave(): Promise<void> {
-    if (!user || !org) return
+    if (!user || !org) return;
     try {
-      await leaveOrg.mutateAsync({ orgId: org.id, userId: user.id })
-      toast.success(`Left "${org.name}"`)
+      await leaveOrg.mutateAsync({ orgId: org.id, userId: user.id });
+      toast.success(`Left "${org.name}"`);
       // Drop active-org so the bootstrap in AppShell picks a fresh one.
-      setActiveOrg(null)
-      navigate('/orgs', { replace: true })
+      setActiveOrg(null);
+      navigate("/orgs", { replace: true });
     } catch (err) {
-      const detail = err instanceof ApiError ? String(err.message) : ''
-      const lastOwner = detail.toLowerCase().includes('last owner')
+      const detail = err instanceof ApiError ? String(err.message) : "";
+      const lastOwner = detail.toLowerCase().includes("last owner");
       toast.error(
         lastOwner
           ? "You're the only owner — promote someone to owner before leaving."
-          : 'Could not leave the organization.',
-      )
+          : "Could not leave the organization.",
+      );
     } finally {
-      setConfirmLeaveOpen(false)
+      setConfirmLeaveOpen(false);
     }
   }
 
@@ -159,7 +165,7 @@ export function OrgSettingsPage() {
       <Button
         variant="ghost"
         size="sm"
-        onClick={() => navigate('/orgs')}
+        onClick={() => navigate("/orgs")}
         className="-ml-2"
       >
         <ArrowLeft className="h-3.5 w-3.5" />
@@ -195,7 +201,7 @@ export function OrgSettingsPage() {
                 id="org-name"
                 disabled={!canEdit}
                 autoComplete="off"
-                {...form.register('name')}
+                {...form.register("name")}
               />
               {form.formState.errors.name && (
                 <p className="text-xs text-destructive">
@@ -210,7 +216,7 @@ export function OrgSettingsPage() {
                 id="org-slug"
                 disabled={!canEdit}
                 autoComplete="off"
-                {...form.register('slug')}
+                {...form.register("slug")}
               />
               <p className="text-xs text-muted-foreground">
                 Used in URLs. Changing this breaks existing bookmarks.
@@ -229,7 +235,7 @@ export function OrgSettingsPage() {
                 type="submit"
                 disabled={updateOrg.isPending || !form.formState.isDirty}
               >
-                {updateOrg.isPending ? 'Saving…' : 'Save changes'}
+                {updateOrg.isPending ? "Saving…" : "Save changes"}
               </Button>
             </CardFooter>
           )}
@@ -262,8 +268,8 @@ export function OrgSettingsPage() {
             Danger zone
           </CardTitle>
           <CardDescription>
-            Leaving removes your access to this organization's projects.
-            You can't undo this — re-joining requires an invite.
+            Leaving removes your access to this organization's projects. You
+            can't undo this — re-joining requires an invite.
           </CardDescription>
         </CardHeader>
         <CardFooter className="justify-end">
@@ -288,5 +294,5 @@ export function OrgSettingsPage() {
         onConfirm={onLeave}
       />
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/Orgs.test.tsx
+++ b/platform/dashboard/src/routes/Orgs.test.tsx
@@ -9,104 +9,104 @@
  *      orgs has a working path to create one).
  */
 
-import { act, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { OrgsPage } from '@/routes/Orgs'
-import { useActive } from '@/lib/active'
-import { renderWithProviders } from '@/test/render'
+import { OrgsPage } from "@/routes/Orgs";
+import { useActive } from "@/lib/active";
+import { renderWithProviders } from "@/test/render";
 
 /** Same fetch-stub helper pattern as the switcher tests. */
 function stubFetch(routes: Record<string, unknown>): void {
-  vi.spyOn(window, 'fetch').mockImplementation(
+  vi.spyOn(window, "fetch").mockImplementation(
     async (input: RequestInfo | URL) => {
-      const url = typeof input === 'string' ? input : input.toString()
-      const path = url.split('?')[0]
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0];
       if (path in routes) {
         return new Response(JSON.stringify(routes[path]), {
           status: 200,
-          headers: { 'Content-Type': 'application/json' },
-        })
+          headers: { "Content-Type": "application/json" },
+        });
       }
-      return new Response('not found', { status: 404 })
+      return new Response("not found", { status: 404 });
     },
-  )
+  );
 }
 
-describe('OrgsPage', () => {
+describe("OrgsPage", () => {
   beforeEach(() => {
     act(() => {
-      useActive.setState({ activeOrgId: null, activeProjectId: null })
-    })
-  })
+      useActive.setState({ activeOrgId: null, activeProjectId: null });
+    });
+  });
 
   afterEach(() => {
-    vi.restoreAllMocks()
-  })
+    vi.restoreAllMocks();
+  });
 
-  it('renders one row per org with role text visible', async () => {
+  it("renders one row per org with role text visible", async () => {
     stubFetch({
-      '/v1/orgs': [
+      "/v1/orgs": [
         {
-          id: 'org-1',
-          slug: 'acme',
-          name: 'Acme Inc',
-          created_at: '2026-01-01T00:00:00Z',
-          role: 'owner',
+          id: "org-1",
+          slug: "acme",
+          name: "Acme Inc",
+          created_at: "2026-01-01T00:00:00Z",
+          role: "owner",
         },
         {
-          id: 'org-2',
-          slug: 'marketing',
-          name: 'Marketing Co',
-          created_at: '2026-02-01T00:00:00Z',
-          role: 'member',
+          id: "org-2",
+          slug: "marketing",
+          name: "Marketing Co",
+          created_at: "2026-02-01T00:00:00Z",
+          role: "member",
         },
       ],
-    })
+    });
 
-    renderWithProviders(<OrgsPage />)
+    renderWithProviders(<OrgsPage />);
 
     await waitFor(() => {
-      expect(screen.getByText('Acme Inc')).toBeInTheDocument()
-    })
-    expect(screen.getByText('Marketing Co')).toBeInTheDocument()
+      expect(screen.getByText("Acme Inc")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Marketing Co")).toBeInTheDocument();
     // Role text — case-insensitive because the Badge capitalises via CSS,
     // not by replacing the underlying text. The string in DOM stays "owner".
-    expect(screen.getByText('owner')).toBeInTheDocument()
-    expect(screen.getByText('member')).toBeInTheDocument()
-  })
+    expect(screen.getByText("owner")).toBeInTheDocument();
+    expect(screen.getByText("member")).toBeInTheDocument();
+  });
 
-  it('header button opens the create dialog', async () => {
-    stubFetch({ '/v1/orgs': [] })  // empty list — the header button is still rendered
+  it("header button opens the create dialog", async () => {
+    stubFetch({ "/v1/orgs": [] }); // empty list — the header button is still rendered
 
-    const user = userEvent.setup()
-    renderWithProviders(<OrgsPage />)
+    const user = userEvent.setup();
+    renderWithProviders(<OrgsPage />);
 
     // Header button. The empty-state CTA is a separate render path
     // tested below — they're different DOM nodes.
-    const headerButtons = await screen.findAllByText('Create organization')
+    const headerButtons = await screen.findAllByText("Create organization");
     // headerButtons[0] is the header button. The empty-state's button
     // also matches but is hidden when there are >0 orgs. Stubbing the
     // empty list means the empty-state IS rendered too — so we click
     // the first (header) button explicitly.
-    await user.click(headerButtons[0]!)
+    await user.click(headerButtons[0]!);
 
     // CreateOrgDialog renders its description, which is unique to the dialog.
     expect(
       await screen.findByText(/Teams in Hexgate live inside/i),
-    ).toBeInTheDocument()
-  })
+    ).toBeInTheDocument();
+  });
 
-  it('shows the empty-state CTA when the user has no orgs', async () => {
-    stubFetch({ '/v1/orgs': [] })
-    renderWithProviders(<OrgsPage />)
+  it("shows the empty-state CTA when the user has no orgs", async () => {
+    stubFetch({ "/v1/orgs": [] });
+    renderWithProviders(<OrgsPage />);
 
     expect(
       await screen.findByText(/No organizations yet/i),
-    ).toBeInTheDocument()
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Create one to start a workspace/i),
-    ).toBeInTheDocument()
-  })
-})
+    ).toBeInTheDocument();
+  });
+});

--- a/platform/dashboard/src/routes/Orgs.tsx
+++ b/platform/dashboard/src/routes/Orgs.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
-import { Building2, Plus, ArrowRight } from 'lucide-react'
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Building2, Plus, ArrowRight } from "lucide-react";
 
-import { CreateOrgDialog } from '@/components/CreateOrgDialog'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
+import { CreateOrgDialog } from "@/components/CreateOrgDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Table,
   TableBody,
@@ -12,9 +12,9 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { useActive } from '@/lib/active'
-import { useOrgs, type OrgWithRole, type Role } from '@/lib/orgs'
+} from "@/components/ui/table";
+import { useActive } from "@/lib/active";
+import { useOrgs, type OrgWithRole, type Role } from "@/lib/orgs";
 
 /**
  * `/orgs` — list every organization the caller belongs to with their
@@ -26,17 +26,17 @@ import { useOrgs, type OrgWithRole, type Role } from '@/lib/orgs'
  * footer action does — single source of truth for the create form.
  */
 export function OrgsPage() {
-  const [createOpen, setCreateOpen] = useState(false)
-  const orgsQuery = useOrgs()
-  const setActiveOrg = useActive((s) => s.setActiveOrg)
-  const navigate = useNavigate()
+  const [createOpen, setCreateOpen] = useState(false);
+  const orgsQuery = useOrgs();
+  const setActiveOrg = useActive((s) => s.setActiveOrg);
+  const navigate = useNavigate();
 
   function openOrg(org: OrgWithRole): void {
     // Setting active + navigating is one mental action; do both so
     // the user lands on the settings page WITH the active-org chrome
     // (switcher, sidebar) already in the right state.
-    setActiveOrg(org.id)
-    navigate(`/orgs/${org.id}/settings`)
+    setActiveOrg(org.id);
+    navigate(`/orgs/${org.id}/settings`);
   }
 
   return (
@@ -106,8 +106,8 @@ export function OrgsPage() {
                         to={`/orgs/${org.id}/settings`}
                         onClick={(e) => {
                           // Stop the row's onClick from also firing.
-                          e.stopPropagation()
-                          setActiveOrg(org.id)
+                          e.stopPropagation();
+                          setActiveOrg(org.id);
                         }}
                       >
                         Open
@@ -127,11 +127,11 @@ export function OrgsPage() {
         onOpenChange={setCreateOpen}
         onCreated={(orgId) => {
           // The dialog already sets activeOrg; we just navigate.
-          navigate(`/orgs/${orgId}/settings`)
+          navigate(`/orgs/${orgId}/settings`);
         }}
       />
     </div>
-  )
+  );
 }
 
 function EmptyState({ onCreate }: { onCreate: () => void }) {
@@ -144,29 +144,29 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
       <Building2 className="h-10 w-10 text-muted-foreground" />
       <h2 className="text-lg font-medium">No organizations yet</h2>
       <p className="max-w-md text-sm text-muted-foreground">
-        Create one to start a workspace. You'll be the owner — you can
-        invite teammates afterwards.
+        Create one to start a workspace. You'll be the owner — you can invite
+        teammates afterwards.
       </p>
       <Button onClick={onCreate} className="mt-2">
         <Plus className="h-4 w-4" />
         Create organization
       </Button>
     </div>
-  )
+  );
 }
 
 function RoleBadge({ role }: { role: Role }) {
   // Reuse the existing dashboard Badge palette. Owners get the
   // primary tint (load-bearing role); admins the neutral default
   // (the secondary in shadcn parlance), members the outline-only.
-  const variant: Record<Role, 'primary' | 'default' | 'outline'> = {
-    owner: 'primary',
-    admin: 'default',
-    member: 'outline',
-  }
+  const variant: Record<Role, "primary" | "default" | "outline"> = {
+    owner: "primary",
+    admin: "default",
+    member: "outline",
+  };
   return (
     <Badge variant={variant[role]} className="font-normal capitalize">
       {role}
     </Badge>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/Playground.tsx
+++ b/platform/dashboard/src/routes/Playground.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
-import { Streamdown } from 'streamdown'
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { Streamdown } from "streamdown";
 import {
   Bot,
   MessageSquareCode,
@@ -15,22 +15,26 @@ import {
   CircleDashed,
   ShieldAlert,
   UserCog,
-} from 'lucide-react'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { usePlayground, type ChatMessage, type ToolCall } from '@/lib/playground'
-import { api, type AgentRead } from '@/lib/api'
-import { useProjectScoped } from '@/lib/active'
-import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
-import { parseRolesFromPolicy } from '@/lib/policy'
-import { cn } from '@/lib/utils'
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  usePlayground,
+  type ChatMessage,
+  type ToolCall,
+} from "@/lib/playground";
+import { api, type AgentRead } from "@/lib/api";
+import { useProjectScoped } from "@/lib/active";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { parseRolesFromPolicy } from "@/lib/policy";
+import { cn } from "@/lib/utils";
 
 export function PlaygroundPage() {
-  const scope = useProjectScoped()
-  if (scope.status === 'no-project') {
-    return <NoProjectEmptyState resource="playground" />
+  const scope = useProjectScoped();
+  if (scope.status === "no-project") {
+    return <NoProjectEmptyState resource="playground" />;
   }
-  if (scope.status === 'loading' || !scope.projectId) {
+  if (scope.status === "loading" || !scope.projectId) {
     // Brief while the bootstrap effect picks a default project. The
     // live UI opens a WS keyed on projectId — don't mount it until we
     // have a real one, otherwise the reconnect loop would spam ``ws://
@@ -39,69 +43,69 @@ export function PlaygroundPage() {
       <div className="grid place-items-center h-full text-sm text-muted-foreground">
         Loading…
       </div>
-    )
+    );
   }
-  return <PlaygroundLive projectId={scope.projectId} />
+  return <PlaygroundLive projectId={scope.projectId} />;
 }
 
 function PlaygroundLive({ projectId }: { projectId: string }) {
-  const { state, sendChat, reset } = usePlayground({ projectId })
-  const [composer, setComposer] = useState('')
-  const [agent, setAgent] = useState<AgentRead | null>(null)
-  const [activeRole, setActiveRole] = useState<string | null>(null)
-  const transcriptRef = useRef<HTMLDivElement>(null)
+  const { state, sendChat, reset } = usePlayground({ projectId });
+  const [composer, setComposer] = useState("");
+  const [agent, setAgent] = useState<AgentRead | null>(null);
+  const [activeRole, setActiveRole] = useState<string | null>(null);
+  const transcriptRef = useRef<HTMLDivElement>(null);
 
   // Fetch the serving agent so we know which roles are available. Roles
   // are a per-agent concept today (M1); when the dashboard later owns
   // a global role registry this useEffect moves into a shared hook.
   useEffect(() => {
     if (!state.agentName) {
-      setAgent(null)
-      return
+      setAgent(null);
+      return;
     }
-    let cancelled = false
+    let cancelled = false;
     api
       .getAgent(state.agentName, projectId)
       .then((a) => {
-        if (!cancelled) setAgent(a)
+        if (!cancelled) setAgent(a);
       })
       .catch(() => {
-        if (!cancelled) setAgent(null)
-      })
+        if (!cancelled) setAgent(null);
+      });
     return () => {
-      cancelled = true
-    }
-  }, [state.agentName, projectId])
+      cancelled = true;
+    };
+  }, [state.agentName, projectId]);
 
   const roleOptions = useMemo(
     () => (agent ? parseRolesFromPolicy(agent.policy_yaml) : []),
     [agent],
-  )
+  );
 
   // Auto-select a sensible default when the role list changes:
   // prefer 'default', else first option, else null (single-policy agents).
   useEffect(() => {
     if (roleOptions.length === 0) {
-      setActiveRole(null)
-      return
+      setActiveRole(null);
+      return;
     }
     setActiveRole((prev) =>
       prev && roleOptions.includes(prev) ? prev : roleOptions[0],
-    )
-  }, [roleOptions])
+    );
+  }, [roleOptions]);
 
   useEffect(() => {
     transcriptRef.current?.scrollTo({
       top: transcriptRef.current.scrollHeight,
-      behavior: 'smooth',
-    })
-  }, [state.messages])
+      behavior: "smooth",
+    });
+  }, [state.messages]);
 
   function submit() {
-    const text = composer.trim()
-    if (!text) return
-    sendChat(text, activeRole ? { role: activeRole } : undefined)
-    setComposer('')
+    const text = composer.trim();
+    if (!text) return;
+    sendChat(text, activeRole ? { role: activeRole } : undefined);
+    setComposer("");
   }
 
   return (
@@ -155,8 +159,9 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
               No agent serving
             </div>
             <div className="mt-2 text-muted-foreground">
-              Run <span className="font-mono text-foreground">hexgate serve</span> with
-              your HEXGATE_KEY to expose an agent session here.
+              Run{" "}
+              <span className="font-mono text-foreground">hexgate serve</span>{" "}
+              with your HEXGATE_KEY to expose an agent session here.
             </div>
           </div>
         )}
@@ -168,7 +173,7 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
               Acting as
             </div>
             <select
-              value={activeRole ?? ''}
+              value={activeRole ?? ""}
               onChange={(e) => setActiveRole(e.target.value || null)}
               className="h-9 rounded-md border border-border bg-background px-2.5 text-sm font-mono focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             >
@@ -179,9 +184,9 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
               ))}
             </select>
             <p className="text-[11px] text-muted-foreground leading-snug">
-              Each chat turn attenuates the agent's token with{' '}
-              <span className="font-mono">role(&quot;{activeRole}&quot;)</span>. The
-              role's policy bundle decides which tools fire and with what
+              Each chat turn attenuates the agent's token with{" "}
+              <span className="font-mono">role(&quot;{activeRole}&quot;)</span>.
+              The role's policy bundle decides which tools fire and with what
               constraints.
             </p>
           </div>
@@ -208,8 +213,13 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
             Relay status
           </div>
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <Radio className={cn('size-3.5', state.connected ? 'text-allow' : 'text-muted-foreground')} />
-            {state.connected ? 'relay connected' : 'reconnecting…'}
+            <Radio
+              className={cn(
+                "size-3.5",
+                state.connected ? "text-allow" : "text-muted-foreground",
+              )}
+            />
+            {state.connected ? "relay connected" : "reconnecting…"}
           </div>
         </div>
       </aside>
@@ -220,7 +230,9 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
           <div className="flex items-center gap-2 text-sm">
             <MessageSquareCode className="size-4 text-muted-foreground" />
             <span className="font-medium">Session</span>
-            <span className="text-muted-foreground text-xs">live relay via control plane</span>
+            <span className="text-muted-foreground text-xs">
+              live relay via control plane
+            </span>
           </div>
           {activeRole && (
             <Badge
@@ -244,7 +256,9 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
                 {!state.agentOnline && (
                   <>
                     <br />
-                    <span className="text-xs">(No agent connected — responses will wait.)</span>
+                    <span className="text-xs">
+                      (No agent connected — responses will wait.)
+                    </span>
                   </>
                 )}
               </div>
@@ -260,15 +274,19 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
               value={composer}
               onChange={(e) => setComposer(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey) {
-                  e.preventDefault()
-                  submit()
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  submit();
                 }
               }}
               placeholder="Ask the agent to do something…"
               className="flex-1 h-10 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             />
-            <Button onClick={submit} disabled={!composer.trim()} className="gap-2 h-10">
+            <Button
+              onClick={submit}
+              disabled={!composer.trim()}
+              className="gap-2 h-10"
+            >
               <Send className="size-4" />
               Send
             </Button>
@@ -284,7 +302,9 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
             <span className="font-medium">Decisions</span>
           </div>
           {state.decisions.length > 0 && (
-            <span className="text-xs text-muted-foreground">{state.decisions.length}</span>
+            <span className="text-xs text-muted-foreground">
+              {state.decisions.length}
+            </span>
           )}
         </header>
         <div className="flex-1 overflow-y-auto px-3 py-2 scrollbar-thin">
@@ -302,11 +322,11 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
         </div>
       </aside>
     </div>
-  )
+  );
 }
 
 function MessageView({ message }: { message: ChatMessage }) {
-  if (message.role === 'user') {
+  if (message.role === "user") {
     return (
       <div className="flex items-start gap-3">
         <span className="size-7 rounded-full bg-primary/20 text-primary grid place-items-center text-[11px] font-medium">
@@ -317,10 +337,10 @@ function MessageView({ message }: { message: ChatMessage }) {
           <div className="text-sm whitespace-pre-wrap">{message.content}</div>
         </div>
       </div>
-    )
+    );
   }
 
-  const turn = message.turn
+  const turn = message.turn;
   return (
     <div className="flex items-start gap-3">
       <span className="size-7 rounded-full bg-secondary grid place-items-center">
@@ -333,7 +353,9 @@ function MessageView({ message }: { message: ChatMessage }) {
             {turn.reasoning}
           </div>
         )}
-        {turn?.tools.map((t) => <ToolCallBlock key={t.id} call={t} />)}
+        {turn?.tools.map((t) => (
+          <ToolCallBlock key={t.id} call={t} />
+        ))}
         {message.content && (
           <div className="text-sm prose prose-sm prose-invert max-w-none">
             <Streamdown parseIncompleteMarkdown>{message.content}</Streamdown>
@@ -350,14 +372,22 @@ function MessageView({ message }: { message: ChatMessage }) {
         )}
       </div>
     </div>
-  )
+  );
 }
 
 function ToolCallBlock({ call }: { call: ToolCall }) {
   const StateIcon =
-    call.state === 'completed' ? Check : call.state === 'failed' ? X : CircleDashed
-  const stateVariant: 'allow' | 'deny' | 'approval' =
-    call.state === 'completed' ? 'allow' : call.state === 'failed' ? 'deny' : 'approval'
+    call.state === "completed"
+      ? Check
+      : call.state === "failed"
+        ? X
+        : CircleDashed;
+  const stateVariant: "allow" | "deny" | "approval" =
+    call.state === "completed"
+      ? "allow"
+      : call.state === "failed"
+        ? "deny"
+        : "approval";
   return (
     <div className="rounded-md border border-border bg-card/50">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
@@ -379,27 +409,31 @@ function ToolCallBlock({ call }: { call: ToolCall }) {
         </div>
       )}
     </div>
-  )
+  );
 }
 
 function DecisionRow({ call }: { call: ToolCall }) {
   const StateIcon =
-    call.state === 'completed' ? Check : call.state === 'failed' ? X : CircleDashed
+    call.state === "completed"
+      ? Check
+      : call.state === "failed"
+        ? X
+        : CircleDashed;
   const stateColor =
-    call.state === 'completed'
-      ? 'text-allow'
-      : call.state === 'failed'
-        ? 'text-deny'
-        : 'text-approval'
+    call.state === "completed"
+      ? "text-allow"
+      : call.state === "failed"
+        ? "text-deny"
+        : "text-approval";
   return (
     <div className="rounded-md px-2.5 py-1.5 hover:bg-accent/50 text-xs">
       <div className="flex items-center gap-2">
-        <StateIcon className={cn('size-3.5', stateColor)} />
+        <StateIcon className={cn("size-3.5", stateColor)} />
         <span className="font-mono flex-1 truncate">{call.name}</span>
         <span className="text-muted-foreground text-[10px]">
-          {call.endedAt ? `${call.endedAt - call.startedAt}ms` : '…'}
+          {call.endedAt ? `${call.endedAt - call.startedAt}ms` : "…"}
         </span>
       </div>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/Policies.tsx
+++ b/platform/dashboard/src/routes/Policies.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
   Bot,
@@ -7,55 +7,60 @@ import {
   Network,
   Save,
   ShieldCheck,
-} from 'lucide-react'
-import { ReactFlow, Background, BackgroundVariant, Controls } from '@xyflow/react'
-import { api, type PolicyValidationError } from '@/lib/api'
-import { useProjectScoped } from '@/lib/active'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
-import { PolicyEditor } from '@/components/PolicyEditor'
-import { nodeTypes } from '@/components/graph/nodes'
-import { buildPolicyGraph } from '@/lib/policy_graph'
-import { cn } from '@/lib/utils'
+} from "lucide-react";
+import {
+  ReactFlow,
+  Background,
+  BackgroundVariant,
+  Controls,
+} from "@xyflow/react";
+import { api, type PolicyValidationError } from "@/lib/api";
+import { useProjectScoped } from "@/lib/active";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { PolicyEditor } from "@/components/PolicyEditor";
+import { nodeTypes } from "@/components/graph/nodes";
+import { buildPolicyGraph } from "@/lib/policy_graph";
+import { cn } from "@/lib/utils";
 
-type Tab = 'yaml' | 'graph'
+type Tab = "yaml" | "graph";
 
 const TAB_LABEL: Record<Tab, string> = {
-  yaml: 'YAML',
-  graph: 'Graph',
-}
+  yaml: "YAML",
+  graph: "Graph",
+};
 
 const TAB_ICON: Record<Tab, typeof FileCode> = {
   yaml: FileCode,
   graph: Network,
-}
+};
 
 export function PoliciesPage() {
-  const scope = useProjectScoped()
+  const scope = useProjectScoped();
   const agents = useQuery({
-    queryKey: ['agents', scope.projectId],
+    queryKey: ["agents", scope.projectId],
     queryFn: () => api.listAgents(scope.projectId as string),
     enabled: !!scope.projectId,
-  })
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null)
-  const [tab, setTab] = useState<Tab>('yaml')
+  });
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("yaml");
 
   // Wipe the selection on project switch — the previous project's
   // agents don't exist over here.
   useEffect(() => {
-    setSelectedAgent(null)
-  }, [scope.projectId])
+    setSelectedAgent(null);
+  }, [scope.projectId]);
 
   // Auto-select the first agent once the list loads.
   useEffect(() => {
     if (!selectedAgent && agents.data && agents.data.length > 0) {
-      setSelectedAgent(agents.data[0].name)
+      setSelectedAgent(agents.data[0].name);
     }
-  }, [agents.data, selectedAgent])
+  }, [agents.data, selectedAgent]);
 
-  if (scope.status === 'no-project') {
-    return <NoProjectEmptyState resource="policies" />
+  if (scope.status === "no-project") {
+    return <NoProjectEmptyState resource="policies" />;
   }
 
   return (
@@ -78,11 +83,8 @@ export function PoliciesPage() {
       {/* Content */}
       <div className="flex-1 overflow-hidden">
         {selectedAgent && scope.projectId ? (
-          tab === 'yaml' ? (
-            <YamlEditor
-              agentName={selectedAgent}
-              projectId={scope.projectId}
-            />
+          tab === "yaml" ? (
+            <YamlEditor agentName={selectedAgent} projectId={scope.projectId} />
           ) : (
             <PolicyGraphTab
               agentName={selectedAgent}
@@ -91,48 +93,42 @@ export function PoliciesPage() {
           )
         ) : (
           <div className="h-full grid place-items-center text-sm text-muted-foreground">
-            {agents.isLoading ? 'Loading agents…' : 'No agents to select.'}
+            {agents.isLoading ? "Loading agents…" : "No agents to select."}
           </div>
         )}
       </div>
     </div>
-  )
+  );
 }
 
 /**
  * Lightweight tab strip used in /policies. Two tabs today (YAML, Graph);
  * the M2 Rego adapter will land a third here without restructuring.
  */
-function Tabs({
-  value,
-  onChange,
-}: {
-  value: Tab
-  onChange: (t: Tab) => void
-}) {
+function Tabs({ value, onChange }: { value: Tab; onChange: (t: Tab) => void }) {
   return (
     <div className="flex items-center gap-1 rounded-md border border-border bg-background p-0.5">
-      {(['yaml', 'graph'] as const).map((t) => {
-        const Icon = TAB_ICON[t]
-        const active = value === t
+      {(["yaml", "graph"] as const).map((t) => {
+        const Icon = TAB_ICON[t];
+        const active = value === t;
         return (
           <button
             key={t}
             onClick={() => onChange(t)}
             className={cn(
-              'flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors',
+              "flex items-center gap-1.5 rounded px-3 py-1 text-xs font-medium transition-colors",
               active
-                ? 'bg-primary text-primary-foreground'
-                : 'text-muted-foreground hover:text-foreground',
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
             )}
           >
             <Icon className="size-3" />
             {TAB_LABEL[t]}
           </button>
-        )
+        );
       })}
     </div>
-  )
+  );
 }
 
 /**
@@ -146,13 +142,13 @@ function AgentPicker({
   onChange,
   loading,
 }: {
-  agents: { name: string }[]
-  value: string | null
-  onChange: (name: string) => void
-  loading: boolean
+  agents: { name: string }[];
+  value: string | null;
+  onChange: (name: string) => void;
+  loading: boolean;
 }) {
   if (loading) {
-    return <span className="text-xs text-muted-foreground">loading…</span>
+    return <span className="text-xs text-muted-foreground">loading…</span>;
   }
   return (
     <div className="flex items-center gap-2 text-sm">
@@ -160,7 +156,7 @@ function AgentPicker({
       <div className="relative">
         <Bot className="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground pointer-events-none" />
         <select
-          value={value ?? ''}
+          value={value ?? ""}
           onChange={(e) => onChange(e.target.value)}
           className="h-8 rounded-md border border-border bg-background pl-7 pr-3 text-sm font-mono focus:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
@@ -172,7 +168,7 @@ function AgentPicker({
         </select>
       </div>
     </div>
-  )
+  );
 }
 
 /**
@@ -185,55 +181,55 @@ function YamlEditor({
   agentName,
   projectId,
 }: {
-  agentName: string
-  projectId: string
+  agentName: string;
+  projectId: string;
 }) {
-  const qc = useQueryClient()
+  const qc = useQueryClient();
   const agent = useQuery({
-    queryKey: ['agent', projectId, agentName],
+    queryKey: ["agent", projectId, agentName],
     queryFn: () => api.getAgent(agentName, projectId),
-  })
+  });
 
-  const [draft, setDraft] = useState<string>('')
-  const [dirty, setDirty] = useState(false)
-  const [errors, setErrors] = useState<PolicyValidationError[] | null>(null)
+  const [draft, setDraft] = useState<string>("");
+  const [dirty, setDirty] = useState(false);
+  const [errors, setErrors] = useState<PolicyValidationError[] | null>(null);
 
   // Re-sync the draft when we switch agents or the server copy refreshes.
   useEffect(() => {
-    if (!agent.data) return
-    setDraft(agent.data.policy_yaml)
-    setDirty(false)
-    setErrors(null)
-  }, [agent.data])
+    if (!agent.data) return;
+    setDraft(agent.data.policy_yaml);
+    setDirty(false);
+    setErrors(null);
+  }, [agent.data]);
 
   const saveMutation = useMutation({
     mutationFn: () =>
       api.updateAgent(agentName, { policy_yaml: draft }, projectId),
     onSuccess: () => {
-      setDirty(false)
-      qc.invalidateQueries({ queryKey: ['agent', projectId, agentName] })
-      qc.invalidateQueries({ queryKey: ['agents', projectId] })
+      setDirty(false);
+      qc.invalidateQueries({ queryKey: ["agent", projectId, agentName] });
+      qc.invalidateQueries({ queryKey: ["agents", projectId] });
     },
-  })
+  });
 
   const validateMutation = useMutation({
     mutationFn: () => api.validatePolicy(agentName, draft, projectId),
     onSuccess: (resp) => setErrors(resp.errors),
-  })
+  });
 
-  const originalSource = agent.data?.policy_yaml ?? ''
+  const originalSource = agent.data?.policy_yaml ?? "";
 
   // Stable identity so PolicyEditor doesn't trigger a CodeMirror
   // reconfigure on every keystroke — @uiw/react-codemirror puts
   // `onChange` in its reconfigure effect's dep array.
   const handleEditorChange = useCallback(
     (next: string) => {
-      setDraft(next)
-      setDirty(next !== originalSource)
-      setErrors((prev) => (prev ? null : prev))
+      setDraft(next);
+      setDirty(next !== originalSource);
+      setErrors((prev) => (prev ? null : prev));
     },
     [originalSource],
-  )
+  );
 
   return (
     <div className="h-full flex flex-col">
@@ -252,7 +248,7 @@ function YamlEditor({
             className="gap-1.5 h-8"
           >
             <ShieldCheck className="size-3.5" />
-            {validateMutation.isPending ? 'Checking…' : 'Validate'}
+            {validateMutation.isPending ? "Checking…" : "Validate"}
           </Button>
           <Button
             size="sm"
@@ -261,17 +257,17 @@ function YamlEditor({
             className="gap-2 h-8"
           >
             <Save className="size-3.5" />
-            {saveMutation.isPending ? 'Saving…' : 'Save'}
+            {saveMutation.isPending ? "Saving…" : "Save"}
           </Button>
         </div>
       </header>
       {errors && (
         <div
           className={cn(
-            'px-6 py-2 text-xs border-b',
+            "px-6 py-2 text-xs border-b",
             errors.length === 0
-              ? 'bg-allow/5 border-allow/30 text-allow'
-              : 'bg-deny/5 border-deny/30 text-deny',
+              ? "bg-allow/5 border-allow/30 text-allow"
+              : "bg-deny/5 border-deny/30 text-deny",
           )}
         >
           {errors.length === 0 ? (
@@ -280,10 +276,12 @@ function YamlEditor({
             <ul className="space-y-0.5 font-mono">
               {errors.map((err, i) => (
                 <li key={i}>
-                  {err.role && <span className="text-foreground">{err.role}</span>}
-                  {err.role && err.line ? ':' : ''}
-                  {err.line ? err.line : ''}
-                  {err.role || err.line ? ' — ' : ''}
+                  {err.role && (
+                    <span className="text-foreground">{err.role}</span>
+                  )}
+                  {err.role && err.line ? ":" : ""}
+                  {err.line ? err.line : ""}
+                  {err.role || err.line ? " — " : ""}
                   {err.message}
                 </li>
               ))}
@@ -298,7 +296,7 @@ function YamlEditor({
         className="flex-1 overflow-hidden"
       />
     </div>
-  )
+  );
 }
 
 /**
@@ -318,25 +316,25 @@ function PolicyGraphTab({
   agentName,
   projectId,
 }: {
-  agentName: string
-  projectId: string
+  agentName: string;
+  projectId: string;
 }) {
   const agent = useQuery({
-    queryKey: ['agent', projectId, agentName],
+    queryKey: ["agent", projectId, agentName],
     queryFn: () => api.getAgent(agentName, projectId),
-  })
+  });
 
   const graph = useMemo(() => {
-    if (!agent.data) return null
-    return buildPolicyGraph(agent.data.policy_yaml)
-  }, [agent.data])
+    if (!agent.data) return null;
+    return buildPolicyGraph(agent.data.policy_yaml);
+  }, [agent.data]);
 
   if (!graph) {
     return (
       <div className="h-full grid place-items-center text-sm text-muted-foreground">
         Loading policy…
       </div>
-    )
+    );
   }
 
   if (!graph.ok) {
@@ -344,11 +342,11 @@ function PolicyGraphTab({
       <div className="h-full grid place-items-center gap-2 text-center px-8">
         <AlertTriangle className="size-6 text-approval mx-auto" />
         <p className="text-sm text-muted-foreground max-w-md">
-          Fix the YAML to render the graph. The document must parse cleanly
-          and declare a top-level <span className="font-mono">roles:</span> map.
+          Fix the YAML to render the graph. The document must parse cleanly and
+          declare a top-level <span className="font-mono">roles:</span> map.
         </p>
       </div>
-    )
+    );
   }
 
   return (
@@ -377,5 +375,5 @@ function PolicyGraphTab({
         />
       </ReactFlow>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/ResetPassword.tsx
+++ b/platform/dashboard/src/routes/ResetPassword.tsx
@@ -1,10 +1,10 @@
-import { Link, useNavigate, useParams } from 'react-router-dom'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -12,43 +12,43 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
-import { useResetPassword } from '@/lib/auth'
-import { AuthCardLayout } from './SignIn'
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useResetPassword } from "@/lib/auth";
+import { AuthCardLayout } from "./SignIn";
 
 const Schema = z
   .object({
-    password: z.string().min(8, 'At least 8 characters'),
+    password: z.string().min(8, "At least 8 characters"),
     confirm: z.string(),
   })
   .refine((v) => v.password === v.confirm, {
     message: "Passwords don't match",
-    path: ['confirm'],
-  })
+    path: ["confirm"],
+  });
 
-type Values = z.infer<typeof Schema>
+type Values = z.infer<typeof Schema>;
 
 export function ResetPasswordPage() {
-  const { token } = useParams<{ token: string }>()
-  const navigate = useNavigate()
-  const reset = useResetPassword()
+  const { token } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const reset = useResetPassword();
   const form = useForm<Values>({
     resolver: zodResolver(Schema),
-    defaultValues: { password: '', confirm: '' },
-  })
+    defaultValues: { password: "", confirm: "" },
+  });
 
   // Token comes from the URL — emailed links land here directly. The
   // backend validates the JWT signature + expiry on /reset-password,
   // so we don't pre-check here; a tampered or expired token surfaces
   // as the .isError branch below.
   async function onSubmit(values: Values) {
-    if (!token) return
+    if (!token) return;
     try {
-      await reset.mutateAsync({ token, password: values.password })
+      await reset.mutateAsync({ token, password: values.password });
       // After 2 seconds on the success card, bounce to sign-in.
-      setTimeout(() => navigate('/sign-in', { replace: true }), 2000)
+      setTimeout(() => navigate("/sign-in", { replace: true }), 2000);
     } catch {
       // surfaces via reset.isError
     }
@@ -72,7 +72,7 @@ export function ResetPasswordPage() {
           </CardFooter>
         </Card>
       </AuthCardLayout>
-    )
+    );
   }
 
   if (reset.isSuccess) {
@@ -87,7 +87,7 @@ export function ResetPasswordPage() {
           </CardHeader>
         </Card>
       </AuthCardLayout>
-    )
+    );
   }
 
   return (
@@ -104,8 +104,8 @@ export function ResetPasswordPage() {
             {reset.isError && (
               <Alert variant="destructive">
                 <AlertDescription>
-                  This reset link has expired or is invalid. Request a fresh
-                  one from the{' '}
+                  This reset link has expired or is invalid. Request a fresh one
+                  from the{" "}
                   <Link
                     to="/forgot-password"
                     className="underline underline-offset-2"
@@ -123,7 +123,7 @@ export function ResetPasswordPage() {
                 id="password"
                 type="password"
                 autoComplete="new-password"
-                {...form.register('password')}
+                {...form.register("password")}
               />
               {form.formState.errors.password && (
                 <p className="text-xs text-destructive">
@@ -138,7 +138,7 @@ export function ResetPasswordPage() {
                 id="confirm"
                 type="password"
                 autoComplete="new-password"
-                {...form.register('confirm')}
+                {...form.register("confirm")}
               />
               {form.formState.errors.confirm && (
                 <p className="text-xs text-destructive">
@@ -149,11 +149,11 @@ export function ResetPasswordPage() {
           </CardContent>
           <CardFooter>
             <Button type="submit" className="w-full" disabled={reset.isPending}>
-              {reset.isPending ? 'Updating…' : 'Update password'}
+              {reset.isPending ? "Updating…" : "Update password"}
             </Button>
           </CardFooter>
         </form>
       </Card>
     </AuthCardLayout>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/Settings.tsx
+++ b/platform/dashboard/src/routes/Settings.tsx
@@ -2,7 +2,9 @@ export function SettingsPage() {
   return (
     <div className="max-w-[1400px] mx-auto">
       <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-      <p className="mt-1 text-sm text-muted-foreground">Project configuration.</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Project configuration.
+      </p>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/SignIn.tsx
+++ b/platform/dashboard/src/routes/SignIn.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from 'react'
-import { Link, Navigate, useLocation, useNavigate } from 'react-router-dom'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
-import { ShieldCheck } from 'lucide-react'
+import { useEffect, useState } from "react";
+import { Link, Navigate, useLocation, useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ShieldCheck } from "lucide-react";
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -14,53 +14,53 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   googleOAuthAvailable,
   startGoogleSignIn,
   useLogin,
   useUser,
-} from '@/lib/auth'
+} from "@/lib/auth";
 
 const SignInSchema = z.object({
-  email: z.string().email('Enter a valid email'),
-  password: z.string().min(1, 'Required'),
-})
+  email: z.string().email("Enter a valid email"),
+  password: z.string().min(1, "Required"),
+});
 
-type SignInValues = z.infer<typeof SignInSchema>
+type SignInValues = z.infer<typeof SignInSchema>;
 
 export function SignInPage() {
-  const { user, loading } = useUser()
-  const navigate = useNavigate()
-  const location = useLocation()
-  const login = useLogin()
-  const [googleAvailable, setGoogleAvailable] = useState(false)
+  const { user, loading } = useUser();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const login = useLogin();
+  const [googleAvailable, setGoogleAvailable] = useState(false);
 
   // Probe once on mount — the button stays hidden when Google sign-in
   // isn't enabled on the backend (HEXGATE_GOOGLE_CLIENT_ID unset).
   useEffect(() => {
-    googleOAuthAvailable().then(setGoogleAvailable)
-  }, [])
+    googleOAuthAvailable().then(setGoogleAvailable);
+  }, []);
 
   const form = useForm<SignInValues>({
     resolver: zodResolver(SignInSchema),
-    defaultValues: { email: '', password: '' },
-  })
+    defaultValues: { email: "", password: "" },
+  });
 
   // If a session already exists, bounce to wherever the user was trying
   // to reach (preserved by ProtectedRoute) — or the dashboard root.
   if (!loading && user) {
-    const target = (location.state as { from?: string } | null)?.from ?? '/'
-    return <Navigate to={target} replace />
+    const target = (location.state as { from?: string } | null)?.from ?? "/";
+    return <Navigate to={target} replace />;
   }
 
   async function onSubmit(values: SignInValues) {
     try {
-      await login.mutateAsync(values)
-      const target = (location.state as { from?: string } | null)?.from ?? '/'
-      navigate(target, { replace: true })
+      await login.mutateAsync(values);
+      const target = (location.state as { from?: string } | null)?.from ?? "/";
+      navigate(target, { replace: true });
     } catch {
       // Error surfaces via login.error below — no toast needed.
     }
@@ -84,7 +84,7 @@ export function SignInPage() {
             {login.isError && (
               <Alert variant="destructive">
                 <AlertDescription>
-                  Incorrect email or password. Try again, or{' '}
+                  Incorrect email or password. Try again, or{" "}
                   <Link
                     to="/forgot-password"
                     className="underline underline-offset-2"
@@ -103,7 +103,7 @@ export function SignInPage() {
                 type="email"
                 autoComplete="email"
                 placeholder="you@example.com"
-                {...form.register('email')}
+                {...form.register("email")}
               />
               {form.formState.errors.email && (
                 <p className="text-xs text-destructive">
@@ -126,7 +126,7 @@ export function SignInPage() {
                 id="password"
                 type="password"
                 autoComplete="current-password"
-                {...form.register('password')}
+                {...form.register("password")}
               />
               {form.formState.errors.password && (
                 <p className="text-xs text-destructive">
@@ -142,7 +142,7 @@ export function SignInPage() {
               className="w-full"
               disabled={login.isPending || !form.formState.isValid}
             >
-              {login.isPending ? 'Signing in…' : 'Sign in'}
+              {login.isPending ? "Signing in…" : "Sign in"}
             </Button>
 
             {googleAvailable && (
@@ -170,7 +170,7 @@ export function SignInPage() {
             )}
 
             <p className="text-center text-sm text-muted-foreground">
-              No account?{' '}
+              No account?{" "}
               <Link
                 to="/sign-up"
                 className="text-primary underline-offset-2 hover:underline"
@@ -182,7 +182,7 @@ export function SignInPage() {
         </form>
       </Card>
     </AuthCardLayout>
-  )
+  );
 }
 
 /** Shared centred-card layout the auth pages all share. Extracted here
@@ -193,5 +193,5 @@ export function AuthCardLayout({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen items-center justify-center bg-background px-4 py-12">
       {children}
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/SignUp.tsx
+++ b/platform/dashboard/src/routes/SignUp.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from 'react'
-import { Link, Navigate, useNavigate } from 'react-router-dom'
-import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
-import { ShieldCheck } from 'lucide-react'
+import { useEffect, useState } from "react";
+import { Link, Navigate, useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ShieldCheck } from "lucide-react";
 
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
@@ -14,9 +14,9 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   googleOAuthAvailable,
   startGoogleSignIn,
@@ -24,62 +24,68 @@ import {
   useRegister,
   useRequestVerify,
   useUser,
-} from '@/lib/auth'
-import { AuthCardLayout } from './SignIn'
+} from "@/lib/auth";
+import { AuthCardLayout } from "./SignIn";
 
 const SignUpSchema = z
   .object({
-    email: z.string().email('Enter a valid email'),
+    email: z.string().email("Enter a valid email"),
     // FastAPI Users' default password rule is min length 8 — match here
     // so the client-side preview matches the server check exactly. When
     // we tighten server rules in Phase 3d-tail, update both in lock-step.
-    password: z.string().min(8, 'At least 8 characters'),
+    password: z.string().min(8, "At least 8 characters"),
     confirm: z.string(),
   })
   .refine((v) => v.password === v.confirm, {
     message: "Passwords don't match",
-    path: ['confirm'],
-  })
+    path: ["confirm"],
+  });
 
-type SignUpValues = z.infer<typeof SignUpSchema>
+type SignUpValues = z.infer<typeof SignUpSchema>;
 
 export function SignUpPage() {
-  const { user, loading } = useUser()
-  const navigate = useNavigate()
-  const register = useRegister()
-  const login = useLogin()
-  const requestVerify = useRequestVerify()
-  const [googleAvailable, setGoogleAvailable] = useState(false)
+  const { user, loading } = useUser();
+  const navigate = useNavigate();
+  const register = useRegister();
+  const login = useLogin();
+  const requestVerify = useRequestVerify();
+  const [googleAvailable, setGoogleAvailable] = useState(false);
 
   useEffect(() => {
-    googleOAuthAvailable().then(setGoogleAvailable)
-  }, [])
+    googleOAuthAvailable().then(setGoogleAvailable);
+  }, []);
 
   const form = useForm<SignUpValues>({
     resolver: zodResolver(SignUpSchema),
-    defaultValues: { email: '', password: '', confirm: '' },
-  })
+    defaultValues: { email: "", password: "", confirm: "" },
+  });
 
-  if (!loading && user) return <Navigate to="/" replace />
+  if (!loading && user) return <Navigate to="/" replace />;
 
   async function onSubmit(values: SignUpValues) {
     try {
       // Three-step: create → log in → request the verification email
       // so the new user lands on the dashboard already signed in with
       // a verification token in their inbox.
-      await register.mutateAsync({ email: values.email, password: values.password })
-      await login.mutateAsync({ email: values.email, password: values.password })
+      await register.mutateAsync({
+        email: values.email,
+        password: values.password,
+      });
+      await login.mutateAsync({
+        email: values.email,
+        password: values.password,
+      });
       // Kick off verification — non-blocking; user already signed in.
-      requestVerify.mutate(values.email)
-      navigate('/', { replace: true })
+      requestVerify.mutate(values.email);
+      navigate("/", { replace: true });
     } catch {
       // Error path renders via register.error / login.error below.
     }
   }
 
-  const registerError = register.error
+  const registerError = register.error;
   const duplicateEmail =
-    registerError && extractDetail(registerError).includes('exists')
+    registerError && extractDetail(registerError).includes("exists");
 
   return (
     <AuthCardLayout>
@@ -100,8 +106,8 @@ export function SignUpPage() {
               <Alert variant="destructive">
                 <AlertDescription>
                   {duplicateEmail
-                    ? 'An account with that email already exists. Try signing in instead.'
-                    : 'Could not create the account. Please try again.'}
+                    ? "An account with that email already exists. Try signing in instead."
+                    : "Could not create the account. Please try again."}
                 </AlertDescription>
               </Alert>
             )}
@@ -113,7 +119,7 @@ export function SignUpPage() {
                 type="email"
                 autoComplete="email"
                 placeholder="you@example.com"
-                {...form.register('email')}
+                {...form.register("email")}
               />
               {form.formState.errors.email && (
                 <p className="text-xs text-destructive">
@@ -128,7 +134,7 @@ export function SignUpPage() {
                 id="password"
                 type="password"
                 autoComplete="new-password"
-                {...form.register('password')}
+                {...form.register("password")}
               />
               {form.formState.errors.password && (
                 <p className="text-xs text-destructive">
@@ -143,7 +149,7 @@ export function SignUpPage() {
                 id="confirm"
                 type="password"
                 autoComplete="new-password"
-                {...form.register('confirm')}
+                {...form.register("confirm")}
               />
               {form.formState.errors.confirm && (
                 <p className="text-xs text-destructive">
@@ -159,7 +165,9 @@ export function SignUpPage() {
               className="w-full"
               disabled={register.isPending || login.isPending}
             >
-              {register.isPending || login.isPending ? 'Creating…' : 'Create account'}
+              {register.isPending || login.isPending
+                ? "Creating…"
+                : "Create account"}
             </Button>
 
             {googleAvailable && (
@@ -187,7 +195,7 @@ export function SignUpPage() {
             )}
 
             <p className="text-center text-sm text-muted-foreground">
-              Already have an account?{' '}
+              Already have an account?{" "}
               <Link
                 to="/sign-in"
                 className="text-primary underline-offset-2 hover:underline"
@@ -199,17 +207,17 @@ export function SignUpPage() {
         </form>
       </Card>
     </AuthCardLayout>
-  )
+  );
 }
 
 function extractDetail(err: unknown): string {
-  if (err && typeof err === 'object' && 'detail' in err) {
-    const d = (err as { detail: unknown }).detail
-    if (typeof d === 'string') return d
-    if (typeof d === 'object' && d !== null && 'detail' in d) {
-      const inner = (d as { detail: unknown }).detail
-      if (typeof inner === 'string') return inner
+  if (err && typeof err === "object" && "detail" in err) {
+    const d = (err as { detail: unknown }).detail;
+    if (typeof d === "string") return d;
+    if (typeof d === "object" && d !== null && "detail" in d) {
+      const inner = (d as { detail: unknown }).detail;
+      if (typeof inner === "string") return inner;
     }
   }
-  return ''
+  return "";
 }

--- a/platform/dashboard/src/routes/Tokens.tsx
+++ b/platform/dashboard/src/routes/Tokens.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   BookOpen,
   Check,
@@ -12,11 +12,11 @@ import {
   Trash2,
   Clock,
   AlertTriangle,
-} from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -25,61 +25,67 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog'
-import { NoProjectEmptyState } from '@/components/NoProjectEmptyState'
-import { api, type TokenMintResponse } from '@/lib/api'
-import { useProjectScoped } from '@/lib/active'
-import { cn } from '@/lib/utils'
+} from "@/components/ui/dialog";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { api, type TokenMintResponse } from "@/lib/api";
+import { useProjectScoped } from "@/lib/active";
+import { cn } from "@/lib/utils";
 
 function formatRelative(iso: string | null): string {
-  if (!iso) return 'Never'
-  const then = new Date(iso).getTime()
-  const diff = Date.now() - then
-  if (diff < 60_000) return 'just now'
-  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
-  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
-  return `${Math.floor(diff / 86_400_000)}d ago`
+  if (!iso) return "Never";
+  const then = new Date(iso).getTime();
+  const diff = Date.now() - then;
+  if (diff < 60_000) return "just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return `${Math.floor(diff / 86_400_000)}d ago`;
 }
 
 function formatCreated(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: '2-digit',
-  })
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+  });
 }
 
-function CopyButton({ value, size = 'sm' }: { value: string; size?: 'sm' | 'default' }) {
-  const [copied, setCopied] = useState(false)
+function CopyButton({
+  value,
+  size = "sm",
+}: {
+  value: string;
+  size?: "sm" | "default";
+}) {
+  const [copied, setCopied] = useState(false);
   return (
     <Button
       variant="ghost"
-      size={size === 'sm' ? 'icon' : 'default'}
+      size={size === "sm" ? "icon" : "default"}
       onClick={async () => {
-        await navigator.clipboard.writeText(value)
-        setCopied(true)
-        setTimeout(() => setCopied(false), 1200)
+        await navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
       }}
-      className={size === 'sm' ? 'size-7' : undefined}
+      className={size === "sm" ? "size-7" : undefined}
     >
       {copied ? <Check className="text-allow" /> : <Copy />}
     </Button>
-  )
+  );
 }
 
 function JustMintedBanner({
   token,
   onDismiss,
 }: {
-  token: TokenMintResponse
-  onDismiss: () => void
+  token: TokenMintResponse;
+  onDismiss: () => void;
 }) {
   // Brief "Copied!" feedback on successful copy — same pattern as the
   // inline `CopyButton` above, just with a label since this is the
   // prominent action on the dialog. 1200ms is long enough to register,
   // short enough that the operator who clicks twice doesn't see a stale
   // checkmark.
-  const [copied, setCopied] = useState(false)
+  const [copied, setCopied] = useState(false);
   // Copy-only \u2014 no reveal UI. Matches the show-once + copy-only pattern
   // GitHub / AWS / Stripe / Vercel / Discord use for API tokens. The
   // mask still shows the env-tagged prefix and the last 4 chars so the
@@ -89,11 +95,11 @@ function JustMintedBanner({
   // Tokens are `fty_(test|live)_<uuid>_<biscuit>` \u2014 keep the 9-char
   // env-tagged prefix and the last 4 of the biscuit; everything between
   // (the project UUID + opaque biscuit bytes) is masked.
-  const prefixEnd = token.full.indexOf('_', 4) + 1
+  const prefixEnd = token.full.indexOf("_", 4) + 1;
   const masked =
     token.full.slice(0, prefixEnd > 0 ? prefixEnd : 9) +
-    '\u2022'.repeat(20) +
-    token.full.slice(-4)
+    "\u2022".repeat(20) +
+    token.full.slice(-4);
   return (
     <div className="rounded-lg border border-primary/40 bg-primary/5 p-5">
       <div className="flex items-start justify-between">
@@ -119,9 +125,9 @@ function JustMintedBanner({
           variant="default"
           size="sm"
           onClick={async () => {
-            await navigator.clipboard.writeText(token.full)
-            setCopied(true)
-            setTimeout(() => setCopied(false), 1200)
+            await navigator.clipboard.writeText(token.full);
+            setCopied(true);
+            setTimeout(() => setCopied(false), 1200);
           }}
           className="gap-1.5"
         >
@@ -130,7 +136,7 @@ function JustMintedBanner({
           ) : (
             <Copy className="size-3.5" />
           )}
-          {copied ? 'Copied!' : 'Copy'}
+          {copied ? "Copied!" : "Copy"}
         </Button>
       </div>
 
@@ -141,7 +147,7 @@ function JustMintedBanner({
         </span>
         <span className="flex items-center gap-1.5">
           <KeyRound className="size-3.5" />
-          {token.scopes.length} scope{token.scopes.length === 1 ? '' : 's'}
+          {token.scopes.length} scope{token.scopes.length === 1 ? "" : "s"}
         </span>
         <button
           onClick={onDismiss}
@@ -151,38 +157,38 @@ function JustMintedBanner({
         </button>
       </div>
     </div>
-  )
+  );
 }
 
 function MintDialog({
   projectId,
   onSuccess,
 }: {
-  projectId: string
-  onSuccess: (token: TokenMintResponse) => void
+  projectId: string;
+  onSuccess: (token: TokenMintResponse) => void;
 }) {
-  const [open, setOpen] = useState(false)
-  const [name, setName] = useState('')
-  const [env, setEnv] = useState<'test' | 'live'>('live')
-  const qc = useQueryClient()
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [env, setEnv] = useState<"test" | "live">("live");
+  const qc = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: (body: Parameters<typeof api.mintToken>[0]) =>
       api.mintToken(body, projectId),
     onSuccess: (token) => {
-      qc.invalidateQueries({ queryKey: ['tokens', projectId] })
-      onSuccess(token)
-      setOpen(false)
-      setName('')
+      qc.invalidateQueries({ queryKey: ["tokens", projectId] });
+      onSuccess(token);
+      setOpen(false);
+      setName("");
     },
-  })
+  });
 
   return (
     <Dialog
       open={open}
       onOpenChange={(o) => {
-        setOpen(o)
-        if (!o) mutation.reset()
+        setOpen(o);
+        if (!o) mutation.reset();
       }}
     >
       <DialogTrigger asChild>
@@ -195,8 +201,8 @@ function MintDialog({
         <DialogHeader>
           <DialogTitle>Mint dev token</DialogTitle>
           <DialogDescription>
-            Tokens authenticate backend services to Hexgate. Use a clear name so you know
-            where it's deployed.
+            Tokens authenticate backend services to Hexgate. Use a clear name so
+            you know where it's deployed.
           </DialogDescription>
         </DialogHeader>
 
@@ -215,16 +221,16 @@ function MintDialog({
           <div className="space-y-1.5">
             <Label>Environment</Label>
             <div className="flex gap-2">
-              {(['test', 'live'] as const).map((value) => (
+              {(["test", "live"] as const).map((value) => (
                 <button
                   key={value}
                   type="button"
                   onClick={() => setEnv(value)}
                   className={cn(
-                    'flex-1 h-9 rounded-md border text-sm capitalize transition-colors',
+                    "flex-1 h-9 rounded-md border text-sm capitalize transition-colors",
                     env === value
-                      ? 'border-primary bg-primary/10 text-primary'
-                      : 'border-border text-muted-foreground hover:text-foreground',
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border-border text-muted-foreground hover:text-foreground",
                   )}
                 >
                   {value}
@@ -232,9 +238,10 @@ function MintDialog({
               ))}
             </div>
             <p className="text-[11px] text-muted-foreground">
-              <span className="font-mono">fty_test_</span> keys read from a local policy file.
-              <span className="font-mono">fty_live_</span> keys fetch signed bundles from the
-              control plane.
+              <span className="font-mono">fty_test_</span> keys read from a
+              local policy file.
+              <span className="font-mono">fty_live_</span> keys fetch signed
+              bundles from the control plane.
             </p>
           </div>
 
@@ -253,40 +260,40 @@ function MintDialog({
             onClick={() => mutation.mutate({ name, env })}
             disabled={name.trim().length === 0 || mutation.isPending}
           >
-            {mutation.isPending ? 'Minting…' : 'Mint token'}
+            {mutation.isPending ? "Minting…" : "Mint token"}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
-  )
+  );
 }
 
 export function TokensPage() {
-  const [justMinted, setJustMinted] = useState<TokenMintResponse | null>(null)
-  const scope = useProjectScoped()
+  const [justMinted, setJustMinted] = useState<TokenMintResponse | null>(null);
+  const scope = useProjectScoped();
   // ``enabled: !!scope.projectId`` keeps React Query quiet while we
   // wait for the active-project bootstrap; the cache key includes the
   // id so switching projects doesn't show stale rows.
   const tokens = useQuery({
-    queryKey: ['tokens', scope.projectId],
+    queryKey: ["tokens", scope.projectId],
     queryFn: () => api.listTokens(scope.projectId as string),
     enabled: !!scope.projectId,
-  })
-  const qc = useQueryClient()
+  });
+  const qc = useQueryClient();
   const revoke = useMutation({
     mutationFn: (tokenId: string) =>
       api.revokeToken(tokenId, scope.projectId as string),
     onSuccess: () =>
-      qc.invalidateQueries({ queryKey: ['tokens', scope.projectId] }),
-  })
+      qc.invalidateQueries({ queryKey: ["tokens", scope.projectId] }),
+  });
 
-  if (scope.status === 'no-project') {
+  if (scope.status === "no-project") {
     return (
       <div className="max-w-[1400px] mx-auto">
         <h1 className="text-2xl font-semibold tracking-tight">Tokens</h1>
         <NoProjectEmptyState resource="tokens" />
       </div>
-    )
+    );
   }
 
   return (
@@ -295,7 +302,8 @@ export function TokensPage() {
         <div>
           <h1 className="text-2xl font-semibold tracking-tight">Tokens</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Long-lived dev tokens for backend services. Never commit to source control.
+            Long-lived dev tokens for backend services. Never commit to source
+            control.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -311,14 +319,20 @@ export function TokensPage() {
 
       {justMinted && (
         <div className="mt-6">
-          <JustMintedBanner token={justMinted} onDismiss={() => setJustMinted(null)} />
+          <JustMintedBanner
+            token={justMinted}
+            onDismiss={() => setJustMinted(null)}
+          />
         </div>
       )}
 
       <div className="mt-6 rounded-lg border border-border bg-card">
         <div className="flex items-center justify-between border-b border-border px-5 py-3">
           <div className="text-sm">
-            Dev tokens <span className="text-muted-foreground">· {tokens.data?.length ?? 0}</span>
+            Dev tokens{" "}
+            <span className="text-muted-foreground">
+              · {tokens.data?.length ?? 0}
+            </span>
           </div>
           <div className="flex items-center gap-1 text-xs text-muted-foreground">
             <Button variant="ghost" size="sm" className="gap-1.5 text-xs">
@@ -333,13 +347,16 @@ export function TokensPage() {
         </div>
 
         {tokens.isLoading ? (
-          <div className="p-12 text-center text-sm text-muted-foreground">Loading…</div>
+          <div className="p-12 text-center text-sm text-muted-foreground">
+            Loading…
+          </div>
         ) : !tokens.data || tokens.data.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
             <KeyRound className="size-12 text-muted-foreground/50" />
             <div className="text-sm font-medium">No tokens yet</div>
             <div className="max-w-xs text-xs text-muted-foreground">
-              Mint your first dev token to let a backend service authenticate to Hexgate.
+              Mint your first dev token to let a backend service authenticate to
+              Hexgate.
             </div>
           </div>
         ) : (
@@ -356,7 +373,7 @@ export function TokensPage() {
             </thead>
             <tbody>
               {tokens.data.map((t) => {
-                const isTest = t.masked.startsWith('fty_test_')
+                const isTest = t.masked.startsWith("fty_test_");
                 return (
                   <tr
                     key={t.id}
@@ -373,7 +390,9 @@ export function TokensPage() {
                       </span>
                     </td>
                     <td className="px-5 py-3">
-                      <span className="font-mono text-xs text-muted-foreground">{t.masked}</span>
+                      <span className="font-mono text-xs text-muted-foreground">
+                        {t.masked}
+                      </span>
                     </td>
                     <td className="px-5 py-3">
                       <span className="inline-flex flex-wrap gap-1">
@@ -383,7 +402,9 @@ export function TokensPage() {
                           </Badge>
                         ))}
                         {t.scopes.length > 2 && (
-                          <Badge variant="outline">+{t.scopes.length - 2}</Badge>
+                          <Badge variant="outline">
+                            +{t.scopes.length - 2}
+                          </Badge>
                         )}
                       </span>
                     </td>
@@ -392,8 +413,10 @@ export function TokensPage() {
                     </td>
                     <td
                       className={cn(
-                        'px-5 py-3',
-                        t.last_used_at ? 'text-muted-foreground' : 'text-approval',
+                        "px-5 py-3",
+                        t.last_used_at
+                          ? "text-muted-foreground"
+                          : "text-approval",
                       )}
                     >
                       {formatRelative(t.last_used_at)}
@@ -422,12 +445,12 @@ export function TokensPage() {
                       </div>
                     </td>
                   </tr>
-                )
+                );
               })}
             </tbody>
           </table>
         )}
       </div>
     </div>
-  )
+  );
 }

--- a/platform/dashboard/src/routes/VerifyEmail.tsx
+++ b/platform/dashboard/src/routes/VerifyEmail.tsx
@@ -1,16 +1,16 @@
-import { Link, useParams } from 'react-router-dom'
-import { CheckCircle2, MailX } from 'lucide-react'
+import { Link, useParams } from "react-router-dom";
+import { CheckCircle2, MailX } from "lucide-react";
 
-import { Button } from '@/components/ui/button'
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
-} from '@/components/ui/card'
-import { useUser, useVerifyEmail } from '@/lib/auth'
-import { AuthCardLayout } from './SignIn'
+} from "@/components/ui/card";
+import { useUser, useVerifyEmail } from "@/lib/auth";
+import { AuthCardLayout } from "./SignIn";
 
 /**
  * Landing page for the verify-email link. Auto-consumes the token on
@@ -31,16 +31,18 @@ import { AuthCardLayout } from './SignIn'
  * never reconnected to the in-flight request.
  */
 export function VerifyEmailPage() {
-  const { token } = useParams<{ token: string }>()
-  const verify = useVerifyEmail(token)
-  const { user } = useUser()
+  const { token } = useParams<{ token: string }>();
+  const verify = useVerifyEmail(token);
+  const { user } = useUser();
 
   if (!token) {
     return (
       <AuthCardLayout>
         <Card className="w-full max-w-md">
           <CardHeader>
-            <CardTitle className="text-center">Invalid verification link</CardTitle>
+            <CardTitle className="text-center">
+              Invalid verification link
+            </CardTitle>
             <CardDescription className="text-center">
               This link is missing its token. Sign in and request a fresh
               verification email from your account.
@@ -53,7 +55,7 @@ export function VerifyEmailPage() {
           </CardFooter>
         </Card>
       </AuthCardLayout>
-    )
+    );
   }
 
   // Query is in flight on first mount + while the request runs.
@@ -70,7 +72,7 @@ export function VerifyEmailPage() {
           </CardHeader>
         </Card>
       </AuthCardLayout>
-    )
+    );
   }
 
   if (verify.isSuccess) {
@@ -88,14 +90,14 @@ export function VerifyEmailPage() {
           </CardHeader>
           <CardFooter>
             <Button asChild className="w-full">
-              <Link to={user ? '/' : '/sign-in'}>
-                {user ? 'Continue to dashboard' : 'Sign in'}
+              <Link to={user ? "/" : "/sign-in"}>
+                {user ? "Continue to dashboard" : "Sign in"}
               </Link>
             </Button>
           </CardFooter>
         </Card>
       </AuthCardLayout>
-    )
+    );
   }
 
   return (
@@ -107,8 +109,8 @@ export function VerifyEmailPage() {
           </div>
           <CardTitle className="text-center">Verification failed</CardTitle>
           <CardDescription className="text-center">
-            This verification link is expired or invalid. Sign in and request
-            a fresh one from the banner at the top of the dashboard.
+            This verification link is expired or invalid. Sign in and request a
+            fresh one from the banner at the top of the dashboard.
           </CardDescription>
         </CardHeader>
         <CardFooter>
@@ -118,5 +120,5 @@ export function VerifyEmailPage() {
         </CardFooter>
       </Card>
     </AuthCardLayout>
-  )
+  );
 }

--- a/platform/dashboard/src/test/render.tsx
+++ b/platform/dashboard/src/test/render.tsx
@@ -5,11 +5,11 @@
  * boilerplate context setup.
  */
 
-import type { ReactNode } from 'react'
+import type { ReactNode } from "react";
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { render, type RenderOptions } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, type RenderOptions } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 
 /** Build a fresh QueryClient per test so cached requests don't leak
  * between cases (React Query caches by reference, not by request URL). */
@@ -24,24 +24,24 @@ function makeQueryClient(): QueryClient {
       },
       mutations: { retry: false },
     },
-  })
+  });
 }
 
-interface Options extends Omit<RenderOptions, 'wrapper'> {
-  initialRoute?: string
+interface Options extends Omit<RenderOptions, "wrapper"> {
+  initialRoute?: string;
 }
 
 /** Drop-in for ``render`` from @testing-library/react with the
  * project's standard providers wrapped around the tree. */
 export function renderWithProviders(
   ui: ReactNode,
-  { initialRoute = '/', ...rest }: Options = {},
+  { initialRoute = "/", ...rest }: Options = {},
 ) {
-  const qc = makeQueryClient()
+  const qc = makeQueryClient();
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter initialEntries={[initialRoute]}>{ui}</MemoryRouter>
     </QueryClientProvider>,
     rest,
-  )
+  );
 }

--- a/platform/dashboard/src/test/setup.ts
+++ b/platform/dashboard/src/test/setup.ts
@@ -6,9 +6,9 @@
  * zustand active-org store) initialise.
  */
 
-import { afterEach, beforeEach } from 'vitest'
-import { cleanup } from '@testing-library/react'
-import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
 
 // ---------------------------------------------------------------------------
 // 1. localStorage shim
@@ -22,42 +22,42 @@ import '@testing-library/jest-dom/vitest'
 // ---------------------------------------------------------------------------
 
 function makeMemoryStorage(): Storage {
-  const store = new Map<string, string>()
+  const store = new Map<string, string>();
   return {
     get length() {
-      return store.size
+      return store.size;
     },
     clear() {
-      store.clear()
+      store.clear();
     },
     getItem(key) {
-      return store.get(key) ?? null
+      return store.get(key) ?? null;
     },
     setItem(key, value) {
-      store.set(key, String(value))
+      store.set(key, String(value));
     },
     removeItem(key) {
-      store.delete(key)
+      store.delete(key);
     },
     key(index) {
-      return Array.from(store.keys())[index] ?? null
+      return Array.from(store.keys())[index] ?? null;
     },
-  }
+  };
 }
 
-Object.defineProperty(window, 'localStorage', {
+Object.defineProperty(window, "localStorage", {
   configurable: true,
   writable: true,
   value: makeMemoryStorage(),
-})
+});
 
 // ---------------------------------------------------------------------------
 // 2. jsdom doesn't implement matchMedia — Radix UI's hooks call it.
 //    Stub the shape Radix expects so dropdown/dialog mounts don't crash.
 // ---------------------------------------------------------------------------
 
-if (typeof window.matchMedia === 'undefined') {
-  Object.defineProperty(window, 'matchMedia', {
+if (typeof window.matchMedia === "undefined") {
+  Object.defineProperty(window, "matchMedia", {
     writable: true,
     value: (query: string) => ({
       matches: false,
@@ -69,7 +69,7 @@ if (typeof window.matchMedia === 'undefined') {
       removeEventListener: () => undefined,
       dispatchEvent: () => false,
     }),
-  })
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -78,10 +78,10 @@ if (typeof window.matchMedia === 'undefined') {
 //    that open dropdowns (e.g. the Audit filter bar) from crashing.
 // ---------------------------------------------------------------------------
 
-Element.prototype.scrollIntoView ??= () => undefined
-Element.prototype.hasPointerCapture ??= () => false
-Element.prototype.setPointerCapture ??= () => undefined
-Element.prototype.releasePointerCapture ??= () => undefined
+Element.prototype.scrollIntoView ??= () => undefined;
+Element.prototype.hasPointerCapture ??= () => false;
+Element.prototype.setPointerCapture ??= () => undefined;
+Element.prototype.releasePointerCapture ??= () => undefined;
 
 // ---------------------------------------------------------------------------
 // 4. Per-test housekeeping
@@ -91,11 +91,11 @@ beforeEach(() => {
   // Reset the storage backing between tests so persisted state from
   // test A (e.g., an activeOrgId set during an assertion) doesn't
   // leak into test B's fresh component tree.
-  window.localStorage.clear()
-})
+  window.localStorage.clear();
+});
 
 afterEach(() => {
   // @testing-library/react needs explicit cleanup with vitest — Jest
   // auto-cleans, vitest doesn't.
-  cleanup()
-})
+  cleanup();
+});


### PR DESCRIPTION
## What is changing

Adds prettier as a dev dependency with `format` and `format:check` pnpm scripts. Extends make fmt and make fmt-check to cover platform/api (ruff) in addition to the SDK. Adds standalone dashboard-fmt, dashboard-fmt-check, dashboard-lint, and dashboard-typecheck make targets.


Runs prettier across all dashboard src files for the first time.

Also add make commands to test / format the entire codebase all at once.


## Tests
- `make check-all`