### PR TITLE
feat(platform/api): optional Postgres backend (DATABASE_URL, SQLite fallback)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,47 @@ jobs:
       - name: Tests
         run: make platform-api-test
 
+  platform-api-postgres:
+    # Isolated from the platform-api job on purpose: that job runs the whole
+    # suite on SQLite (its fixtures build their own engines), so it never
+    # exercises asyncpg. This job sets DATABASE_URL and runs ONLY the opt-in
+    # smoke test, which points the real engine at Postgres and round-trips a
+    # row — the only coverage that the schema actually builds on PG. No OPA
+    # needed (the smoke test doesn't compile bundles).
+    name: Platform API (Postgres smoke)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: hexgate
+          POSTGRES_USER: hexgate
+          POSTGRES_PASSWORD: ci
+        ports:
+          - "5432:5432"
+        options: >-
+          --health-cmd "pg_isready -U hexgate -d hexgate"
+          --health-interval 5s --health-timeout 3s --health-retries 10
+    env:
+      DATABASE_URL: postgresql+asyncpg://hexgate:ci@localhost:5432/hexgate
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: "platform/api/uv.lock"
+
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+
+      - name: Sync platform-api deps
+        run: cd platform/api && uv sync --group dev
+
+      - name: Postgres smoke test
+        run: cd platform/api && uv run pytest tests/test_postgres_smoke.py -v
+
   dashboard:
     name: Dashboard
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,12 +89,9 @@ jobs:
         run: make platform-api-test
 
   platform-api-postgres:
-    # Isolated from the platform-api job on purpose: that job runs the whole
-    # suite on SQLite (its fixtures build their own engines), so it never
-    # exercises asyncpg. This job sets DATABASE_URL and runs ONLY the opt-in
-    # smoke test, which points the real engine at Postgres and round-trips a
-    # row — the only coverage that the schema actually builds on PG. No OPA
-    # needed (the smoke test doesn't compile bundles).
+    # The platform-api job runs the whole suite on SQLite, never exercising
+    # asyncpg. This job sets DATABASE_URL and runs only the opt-in smoke test
+    # — the sole coverage that the schema builds on Postgres.
     name: Platform API (Postgres smoke)
     runs-on: ubuntu-latest
     services:

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,35 @@ clickhouse-reset: ## Wipe the data volume and re-run init scripts
 	$(COMPOSE) down -v
 	$(COMPOSE) up -d clickhouse
 
+# -------- Platform infra (Postgres control-plane DB) --------
+#
+# The control-plane DB. Unset DATABASE_URL → the API uses a local SQLite
+# file; point it at this service to run on Postgres (`make platform-api-pg`).
+# Service lives in platform/docker-compose.yml. NOTE: `clickhouse-down` /
+# `clickhouse-reset` run `down` on the whole compose, so they also stop
+# Postgres — use the granular `postgres-*` targets below to avoid that.
+
+# DSN matching the postgres service (host port 5433, committed dev creds).
+POSTGRES_DSN ?= postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate
+
+.PHONY: postgres-up
+postgres-up: ## Start local Postgres and wait until healthy
+	$(COMPOSE) up -d --wait postgres
+
+.PHONY: postgres-stop
+postgres-stop: ## Stop Postgres (keeps the data volume)
+	$(COMPOSE) stop postgres
+
+.PHONY: postgres-psql
+postgres-psql: ## Open a psql shell against local Postgres
+	docker exec -it hexgate-postgres psql -U hexgate -d hexgate
+
+.PHONY: postgres-reset
+postgres-reset: ## Wipe ONLY the Postgres data volume and restart
+	$(COMPOSE) rm -sf postgres
+	-docker volume rm platform_postgres-data
+	$(COMPOSE) up -d --wait postgres
+
 # -------- Platform API (FastAPI control plane) --------
 #
 # The platform API is a separate uv project under platform/api/ with its
@@ -135,8 +164,12 @@ platform-api-install: ## Install platform API deps (first time)
 	cd platform/api && uv sync --group dev
 
 .PHONY: platform-api
-platform-api: ## Run the platform API dev server (FastAPI on :8000)
+platform-api: ## Run the platform API dev server (FastAPI on :8000, SQLite)
 	cd platform/api && uv run uvicorn main:app --reload --port 8000
+
+.PHONY: platform-api-pg
+platform-api-pg: postgres-up ## Run the platform API against local Postgres (starts PG first)
+	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run uvicorn main:app --reload --port 8000
 
 .PHONY: platform-api-test
 platform-api-test: ## Run the platform API test suite

--- a/Makefile
+++ b/Makefile
@@ -126,11 +126,9 @@ clickhouse-reset: ## Wipe the data volume and re-run init scripts
 
 # -------- Platform infra (Postgres control-plane DB) --------
 #
-# The control-plane DB. Unset DATABASE_URL → the API uses a local SQLite
-# file; point it at this service to run on Postgres (`make platform-api-pg`).
-# Service lives in platform/docker-compose.yml. NOTE: `clickhouse-down` /
-# `clickhouse-reset` run `down` on the whole compose, so they also stop
-# Postgres — use the granular `postgres-*` targets below to avoid that.
+# Control-plane DB (service in platform/docker-compose.yml). NOTE:
+# `clickhouse-down`/`clickhouse-reset` run `down` on the whole compose and so
+# also stop Postgres — use the `postgres-*` targets below to avoid that.
 
 # DSN matching the postgres service (host port 5433, committed dev creds).
 POSTGRES_DSN ?= postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate

--- a/README.md
+++ b/README.md
@@ -184,6 +184,31 @@ make dashboard-install      # pnpm install inside platform/dashboard/
 
 Then open http://localhost:5173/playground — type a message, watch the live stream of tool calls and policy decisions from your local agent.
 
+### Control-plane database (SQLite / Postgres)
+
+`make platform-api` uses a local **SQLite** file — zero setup, fine for
+dev and the test suite. Set `DATABASE_URL` to run on **Postgres** instead
+(what deployments use); bare `postgres://` URLs are normalized to the
+`asyncpg` driver. A local Postgres is in the dev compose:
+
+```bash
+make platform-api-pg      # starts Postgres (Docker) + runs the API against it
+# equivalent to:
+make postgres-up          # start Postgres, wait until healthy
+DATABASE_URL=postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate make platform-api
+make postgres-reset       # wipe ONLY the Postgres data volume
+```
+
+No migration system: the schema is created with `create_all`, so a model
+change means resetting the volume (`make postgres-reset`), not migrating —
+data is treated as disposable. A managed Postgres (e.g. Scaleway) needs SSL
+in the DSN, e.g. `…/hexgate?ssl=require`.
+
+`DATABASE_URL` is read from the real environment or `platform/api/.env`
+(see `.env.sample`). The opt-in `tests/test_postgres_smoke.py` is the only
+test that exercises the Postgres path (the rest run on SQLite); it runs
+when `DATABASE_URL` points at Postgres.
+
 ### Audit log (ClickHouse)
 
 Policy decisions are written to a local ClickHouse instance for the audit dashboard. Requires Docker.

--- a/platform/api/.env.sample
+++ b/platform/api/.env.sample
@@ -1,11 +1,10 @@
 # Platform API config. Copy to `.env` for local runs; set on the container
 # in production. Most vars use the HEXGATE_ prefix (DATABASE_URL is the
-# conventional exception).
+# exception).
 
 # --- Database ----------------------------------------------------------
-# Async DB URL. Unset = local SQLite file (dev/test). Postgres in
-# deployment; bare postgres:// is normalized to the asyncpg driver. Local PG
-# via `make postgres-up`:
+# Async DB URL. Unset = local SQLite (dev/test); bare postgres:// is
+# normalized to asyncpg. Local PG via `make postgres-up`:
 #   DATABASE_URL=postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate
 DATABASE_URL=
 

--- a/platform/api/.env.sample
+++ b/platform/api/.env.sample
@@ -1,5 +1,13 @@
 # Platform API config. Copy to `.env` for local runs; set on the container
-# in production. All vars use the HEXGATE_ prefix.
+# in production. Most vars use the HEXGATE_ prefix (DATABASE_URL is the
+# conventional exception).
+
+# --- Database ----------------------------------------------------------
+# Async DB URL. Unset = local SQLite file (dev/test). Postgres in
+# deployment; bare postgres:// is normalized to the asyncpg driver. Local PG
+# via `make postgres-up`:
+#   DATABASE_URL=postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate
+DATABASE_URL=
 
 # --- Web / auth --------------------------------------------------------
 # Comma-separated dashboard origins, no wildcard. Unset = http://localhost:5173.

--- a/platform/api/db.py
+++ b/platform/api/db.py
@@ -1,9 +1,7 @@
 """Async SQLAlchemy engine + session factory.
 
-The platform runs on async I/O end-to-end — every route handler is
-``async def`` and every session call is awaited. ``DATABASE_URL`` selects
-Postgres (asyncpg) in deployment; unset falls back to a local SQLite file
-so dev and tests stay zero-setup.
+``DATABASE_URL`` selects Postgres (asyncpg) in deployment; unset falls back
+to a local SQLite file so dev and tests stay zero-setup.
 """
 
 import os
@@ -14,9 +12,8 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-# Load .env here, not just in main: the engine is built at import time (below),
-# which runs before main's own load_dotenv(), so DATABASE_URL must be in the
-# environment now. Idempotent and non-overriding, so real env vars still win.
+# The engine is built at import, before main's load_dotenv(), so load .env
+# here too. Non-overriding, so real env vars still win.
 load_dotenv()
 
 DB_PATH = Path(__file__).parent / "hexgate.db"
@@ -24,12 +21,10 @@ _DEFAULT_URL = f"sqlite+aiosqlite:///{DB_PATH}"
 
 
 def _database_url() -> str:
-    """Resolve the async DB URL.
+    """Resolve the async DB URL: ``DATABASE_URL`` or the SQLite fallback.
 
-    ``DATABASE_URL`` (read as a real env var, not via ``.env``) drives it in
-    deployment; unset falls back to the local SQLite file. Bare
-    ``postgres(ql)://`` URLs that managed providers hand out are rewritten to
-    the ``asyncpg`` driver the async engine requires.
+    Bare ``postgres(ql)://`` URLs are rewritten to the ``asyncpg`` driver
+    the async engine requires.
     """
     url = os.environ.get("DATABASE_URL", "").strip() or _DEFAULT_URL
     for prefix in ("postgresql://", "postgres://"):
@@ -39,8 +34,7 @@ def _database_url() -> str:
 
 
 # pool_pre_ping tolerates connections dropped by a managed Postgres; harmless
-# on SQLite. The async engine gives each task its own pooled connection, so
-# SQLite's check_same_thread isn't a concern.
+# on SQLite.
 engine = create_async_engine(_database_url(), echo=False, pool_pre_ping=True)
 
 # Session factory — used by ``get_session()`` and one-off scripts (seeds,

--- a/platform/api/db.py
+++ b/platform/api/db.py
@@ -33,9 +33,13 @@ def _database_url() -> str:
     return url
 
 
-# pool_pre_ping tolerates connections dropped by a managed Postgres; harmless
-# on SQLite.
-engine = create_async_engine(_database_url(), echo=False, pool_pre_ping=True)
+_url = _database_url()
+_engine_kwargs: dict = {"echo": False}
+# pre_ping catches connections dropped by a managed Postgres; on SQLite
+# (in-process, no server-side reaping) it's pure overhead, so PG-only.
+if "postgresql" in _url:
+    _engine_kwargs["pool_pre_ping"] = True
+engine = create_async_engine(_url, **_engine_kwargs)
 
 # Session factory — used by ``get_session()`` and one-off scripts (seeds,
 # tests). ``expire_on_commit=False`` keeps ORM objects usable after a

--- a/platform/api/db.py
+++ b/platform/api/db.py
@@ -9,9 +9,15 @@ so dev and tests stay zero-setup.
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
+
+# Load .env here, not just in main: the engine is built at import time (below),
+# which runs before main's own load_dotenv(), so DATABASE_URL must be in the
+# environment now. Idempotent and non-overriding, so real env vars still win.
+load_dotenv()
 
 DB_PATH = Path(__file__).parent / "hexgate.db"
 _DEFAULT_URL = f"sqlite+aiosqlite:///{DB_PATH}"

--- a/platform/api/db.py
+++ b/platform/api/db.py
@@ -1,15 +1,12 @@
 """Async SQLAlchemy engine + session factory.
 
-The platform runs on async I/O end-to-end (M3 Phase 3 prerequisite) —
-every route handler is ``async def``, every dependency yields an
-``AsyncSession``, every ``session.exec`` / ``session.get`` /
-``session.commit`` / ``session.refresh`` is awaited.
-
-SQLite is single-writer regardless of driver; ``aiosqlite`` just stops
-disk I/O from blocking the event loop. Postgres will swap this for
-``asyncpg`` later via env-switched ``DATABASE_URL``.
+The platform runs on async I/O end-to-end — every route handler is
+``async def`` and every session call is awaited. ``DATABASE_URL`` selects
+Postgres (asyncpg) in deployment; unset falls back to a local SQLite file
+so dev and tests stay zero-setup.
 """
 
+import os
 from pathlib import Path
 
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -17,14 +14,28 @@ from sqlmodel import SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 DB_PATH = Path(__file__).parent / "hexgate.db"
+_DEFAULT_URL = f"sqlite+aiosqlite:///{DB_PATH}"
 
-# Async engine. ``aiosqlite`` requires the ``sqlite+aiosqlite://`` URL prefix
-# — the plain ``sqlite://`` driver is sync-only. ``check_same_thread`` is
-# unnecessary on async: each task gets its own connection from the pool.
-engine = create_async_engine(
-    f"sqlite+aiosqlite:///{DB_PATH}",
-    echo=False,
-)
+
+def _database_url() -> str:
+    """Resolve the async DB URL.
+
+    ``DATABASE_URL`` (read as a real env var, not via ``.env``) drives it in
+    deployment; unset falls back to the local SQLite file. Bare
+    ``postgres(ql)://`` URLs that managed providers hand out are rewritten to
+    the ``asyncpg`` driver the async engine requires.
+    """
+    url = os.environ.get("DATABASE_URL", "").strip() or _DEFAULT_URL
+    for prefix in ("postgresql://", "postgres://"):
+        if url.startswith(prefix):
+            return "postgresql+asyncpg://" + url[len(prefix) :]
+    return url
+
+
+# pool_pre_ping tolerates connections dropped by a managed Postgres; harmless
+# on SQLite. The async engine gives each task its own pooled connection, so
+# SQLite's check_same_thread isn't a concern.
+engine = create_async_engine(_database_url(), echo=False, pool_pre_ping=True)
 
 # Session factory — used by ``get_session()`` and one-off scripts (seeds,
 # tests). ``expire_on_commit=False`` keeps ORM objects usable after a

--- a/platform/api/models.py
+++ b/platform/api/models.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import JSON, Column, LargeBinary
+from sqlalchemy import JSON, Column, DateTime, LargeBinary
 from sqlmodel import Field, Relationship, SQLModel, UniqueConstraint
 
 
@@ -54,7 +54,9 @@ class Organization(SQLModel, table=True):
     # call), but the immutable ``id`` is what every FK points at.
     slug: str = Field(index=True, unique=True)
     name: str
-    created_at: datetime = Field(default_factory=utcnow)
+    created_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
 
 
 class User(SQLModel, table=True):
@@ -83,7 +85,9 @@ class User(SQLModel, table=True):
     # Email verified via the magic-link flow (Phase 3b). Created users start
     # unverified; production gates destructive actions until verified.
     is_verified: bool = Field(default=False)
-    created_at: datetime = Field(default_factory=utcnow)
+    created_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
 
     # Link to the provider rows (Google, GitHub, …) FastAPI Users uses to
     # find a returning OAuth user. ``lazy="selectin"`` so every User
@@ -149,7 +153,9 @@ class OrganizationMember(SQLModel, table=True):
     user_id: str = Field(foreign_key="user.id", index=True)
     org_id: str = Field(foreign_key="organization.id", index=True)
     role: str  # "owner" | "admin" | "member"
-    created_at: datetime = Field(default_factory=utcnow)
+    created_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
 
 
 class Invitation(SQLModel, table=True):
@@ -178,10 +184,16 @@ class Invitation(SQLModel, table=True):
     # their own role.
     role: str
     invited_by_user_id: str = Field(foreign_key="user.id")
-    expires_at: datetime
-    accepted_at: Optional[datetime] = None
-    revoked_at: Optional[datetime] = None
-    created_at: datetime = Field(default_factory=utcnow)
+    expires_at: datetime = Field(sa_type=DateTime(timezone=True))
+    accepted_at: Optional[datetime] = Field(
+        default=None, sa_type=DateTime(timezone=True)
+    )
+    revoked_at: Optional[datetime] = Field(
+        default=None, sa_type=DateTime(timezone=True)
+    )
+    created_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +218,9 @@ class Project(SQLModel, table=True):
     # before any access to project-scoped data.
     org_id: str = Field(foreign_key="organization.id", index=True)
     name: str
-    created_at: datetime = Field(default_factory=utcnow)
+    created_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
 
 
 class DevToken(SQLModel, table=True):
@@ -216,8 +230,12 @@ class DevToken(SQLModel, table=True):
     prefix: str  # "fty_test" or "fty_live"
     secret: str  # full token value; opaque random string for Phase A
     scopes_csv: str = ""  # comma-separated for now
-    created_at: datetime = Field(default_factory=utcnow)
-    last_used_at: Optional[datetime] = None
+    created_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
+    last_used_at: Optional[datetime] = Field(
+        default=None, sa_type=DateTime(timezone=True)
+    )
 
 
 class Agent(SQLModel, table=True):
@@ -235,7 +253,9 @@ class Agent(SQLModel, table=True):
     # which shape is present.
     policy_yaml: str
     system_md: str = ""
-    updated_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
 
     # Compiled + signed WASM bundle, produced from policy_yaml at save time
     # (see services.compile_bundle). Null when opa is unavailable or the
@@ -265,7 +285,9 @@ class AgentVersion(SQLModel, table=True):
     description: Optional[str] = None
     content_hash: str
     manifest: Optional[dict] = Field(default=None, sa_column=Column(JSON))
-    created_at: datetime = Field(default_factory=utcnow)
+    created_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
 
 
 class Tool(SQLModel, table=True):

--- a/platform/api/pyproject.toml
+++ b/platform/api/pyproject.toml
@@ -17,10 +17,11 @@ dependencies = [
     # main.py imports load_dotenv directly; transitive via pydantic-settings
     # but pinned since we use it.
     "python-dotenv>=1.1.1",
-    # Async SQLite driver — required by SQLAlchemy's async engine. SQLite
-    # itself is single-writer; aiosqlite just stops the event loop from
-    # blocking on disk I/O. Future Postgres switch swaps this for asyncpg.
+    # Async DB drivers for SQLAlchemy's async engine. aiosqlite backs the
+    # local SQLite fallback; asyncpg backs Postgres when DATABASE_URL is set
+    # (see db._database_url). Both are pinned so either path works out of box.
     "aiosqlite>=0.20",
+    "asyncpg>=0.29",
     # SQLAlchemy's async engine bridges sync ORM internals to async DB
     # drivers via greenlet — it's a transitive dep but not auto-installed
     # on every distribution, so pin it explicitly.

--- a/platform/api/pyproject.toml
+++ b/platform/api/pyproject.toml
@@ -17,9 +17,8 @@ dependencies = [
     # main.py imports load_dotenv directly; transitive via pydantic-settings
     # but pinned since we use it.
     "python-dotenv>=1.1.1",
-    # Async DB drivers for SQLAlchemy's async engine. aiosqlite backs the
-    # local SQLite fallback; asyncpg backs Postgres when DATABASE_URL is set
-    # (see db._database_url). Both are pinned so either path works out of box.
+    # Async DB drivers. aiosqlite backs the local SQLite fallback; asyncpg
+    # backs Postgres when DATABASE_URL is set (see db._database_url).
     "aiosqlite>=0.20",
     "asyncpg>=0.29",
     # SQLAlchemy's async engine bridges sync ORM internals to async DB

--- a/platform/api/tests/test_postgres_smoke.py
+++ b/platform/api/tests/test_postgres_smoke.py
@@ -1,16 +1,9 @@
 """Opt-in Postgres smoke test — the only coverage of the asyncpg path.
 
-The rest of the suite builds its own in-memory SQLite engines and overrides
-``get_session``, so it never exercises Postgres. This test points the real
-engine at a live PG (via ``DATABASE_URL``), runs ``init_db`` against it, and
-round-trips a row — proving the schema (FastAPI-Users tables, JSON +
-LargeBinary columns, string-UUID PKs) builds and works on Postgres.
-
-Skipped unless ``DATABASE_URL`` names a Postgres DSN — set by the
-``platform-api-postgres`` CI job, or locally via ``make postgres-up``:
-
-    DATABASE_URL=postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate \\
-        uv run pytest tests/test_postgres_smoke.py -v
+The rest of the suite runs on SQLite, so this is the only test that points
+the real engine at a live PG and round-trips a row. Skipped unless
+``DATABASE_URL`` names a Postgres DSN (set by the ``platform-api-postgres``
+CI job, or locally via ``make postgres-up``).
 """
 
 from __future__ import annotations
@@ -27,36 +20,54 @@ pytestmark = pytest.mark.skipif(
 
 
 async def test_schema_builds_and_round_trips_on_postgres() -> None:
-    # Imported lazily so the module collects (and skips) even if importing the
-    # app eagerly built a Postgres engine that couldn't connect.
+    # Lazy import so the module still collects (and skips) if a bad
+    # DATABASE_URL made the app's engine fail to build.
     import models
     from db import async_session_factory, engine, init_db
 
-    # The engine must actually be talking asyncpg, not the SQLite fallback —
-    # guards against a misconfigured DATABASE_URL silently passing the test.
+    # Guard against a misconfigured DATABASE_URL silently using SQLite.
     assert engine.url.drivername == "postgresql+asyncpg"
 
-    await init_db()  # create_all against Postgres — the real schema port
+    await init_db()  # create_all against Postgres
 
     async with async_session_factory() as session:
+        # Self-heal a row leaked by a prior run that failed before cleanup.
+        await _delete_smoke_org(session)
+
         org = models.Organization(slug="pg-smoke", name="PG Smoke")
         session.add(org)
         await session.commit()
 
-        fetched = await session.get(models.Organization, org.id)
-        assert fetched is not None and fetched.slug == "pg-smoke"
+        try:
+            fetched = await session.get(models.Organization, org.id)
+            assert fetched is not None and fetched.slug == "pg-smoke"
 
-        # exec() path too — the dialect-sensitive query layer, not just get().
-        by_slug = (
-            await session.exec(
-                select(models.Organization).where(
-                    models.Organization.slug == "pg-smoke"
+            # exec() path too — the dialect-sensitive query layer.
+            by_slug = (
+                await session.exec(
+                    select(models.Organization).where(
+                        models.Organization.slug == "pg-smoke"
+                    )
                 )
-            )
-        ).first()
-        assert by_slug is not None and by_slug.id == org.id
+            ).first()
+            assert by_slug is not None and by_slug.id == org.id
+        finally:
+            # Clean up even on assertion failure, so reruns against a
+            # persistent volume don't collide on the unique slug.
+            await _delete_smoke_org(session)
 
-        # Clean up so reruns against a persistent volume don't collide on the
-        # unique slug.
-        await session.delete(fetched)
+
+async def _delete_smoke_org(session) -> None:
+    """Delete the pg-smoke org if present."""
+    import models
+
+    existing = (
+        await session.exec(
+            select(models.Organization).where(
+                models.Organization.slug == "pg-smoke"
+            )
+        )
+    ).first()
+    if existing is not None:
+        await session.delete(existing)
         await session.commit()

--- a/platform/api/tests/test_postgres_smoke.py
+++ b/platform/api/tests/test_postgres_smoke.py
@@ -63,9 +63,7 @@ async def _delete_smoke_org(session) -> None:
 
     existing = (
         await session.exec(
-            select(models.Organization).where(
-                models.Organization.slug == "pg-smoke"
-            )
+            select(models.Organization).where(models.Organization.slug == "pg-smoke")
         )
     ).first()
     if existing is not None:

--- a/platform/api/tests/test_postgres_smoke.py
+++ b/platform/api/tests/test_postgres_smoke.py
@@ -1,0 +1,62 @@
+"""Opt-in Postgres smoke test — the only coverage of the asyncpg path.
+
+The rest of the suite builds its own in-memory SQLite engines and overrides
+``get_session``, so it never exercises Postgres. This test points the real
+engine at a live PG (via ``DATABASE_URL``), runs ``init_db`` against it, and
+round-trips a row — proving the schema (FastAPI-Users tables, JSON +
+LargeBinary columns, string-UUID PKs) builds and works on Postgres.
+
+Skipped unless ``DATABASE_URL`` names a Postgres DSN — set by the
+``platform-api-postgres`` CI job, or locally via ``make postgres-up``:
+
+    DATABASE_URL=postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate \\
+        uv run pytest tests/test_postgres_smoke.py -v
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlmodel import select
+
+pytestmark = pytest.mark.skipif(
+    "postgres" not in os.environ.get("DATABASE_URL", ""),
+    reason="set DATABASE_URL to a Postgres DSN to run (see `make postgres-up`)",
+)
+
+
+async def test_schema_builds_and_round_trips_on_postgres() -> None:
+    # Imported lazily so the module collects (and skips) even if importing the
+    # app eagerly built a Postgres engine that couldn't connect.
+    import models
+    from db import async_session_factory, engine, init_db
+
+    # The engine must actually be talking asyncpg, not the SQLite fallback —
+    # guards against a misconfigured DATABASE_URL silently passing the test.
+    assert engine.url.drivername == "postgresql+asyncpg"
+
+    await init_db()  # create_all against Postgres — the real schema port
+
+    async with async_session_factory() as session:
+        org = models.Organization(slug="pg-smoke", name="PG Smoke")
+        session.add(org)
+        await session.commit()
+
+        fetched = await session.get(models.Organization, org.id)
+        assert fetched is not None and fetched.slug == "pg-smoke"
+
+        # exec() path too — the dialect-sensitive query layer, not just get().
+        by_slug = (
+            await session.exec(
+                select(models.Organization).where(
+                    models.Organization.slug == "pg-smoke"
+                )
+            )
+        ).first()
+        assert by_slug is not None and by_slug.id == org.id
+
+        # Clean up so reruns against a persistent volume don't collide on the
+        # unique slug.
+        await session.delete(fetched)
+        await session.commit()

--- a/platform/api/uv.lock
+++ b/platform/api/uv.lock
@@ -178,6 +178,38 @@ wheels = [
 ]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -975,6 +1007,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "asyncpg" },
     { name = "biscuit-python" },
     { name = "clickhouse-connect" },
     { name = "cryptography" },
@@ -1001,6 +1034,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20" },
+    { name = "asyncpg", specifier = ">=0.29" },
     { name = "biscuit-python", specifier = ">=0.4" },
     { name = "clickhouse-connect", specifier = ">=0.8" },
     { name = "cryptography", specifier = ">=42" },

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     image: postgres:16
     container_name: hexgate-postgres
     ports:
-      # Offset from 5432 to coexist with a local Postgres; loopback-only
-      # since the dev credentials are committed.
+      # Loopback-only, offset from 5432 (committed creds; coexists with a
+      # local Postgres).
       - "127.0.0.1:5433:5432"
     environment:
       # LOCAL DEV ONLY — never reuse these credentials anywhere deployed.

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -1,6 +1,27 @@
-# Local dev infrastructure for the platform. Driven via `make clickhouse-*` targets.
+# Local dev infrastructure for the platform. Driven via `make clickhouse-*`
+# and `make postgres-*` targets.
 
 services:
+  postgres:
+    image: postgres:16
+    container_name: hexgate-postgres
+    ports:
+      # Offset from 5432 to coexist with a local Postgres; loopback-only
+      # since the dev credentials are committed.
+      - "127.0.0.1:5433:5432"
+    environment:
+      # LOCAL DEV ONLY — never reuse these credentials anywhere deployed.
+      POSTGRES_DB: hexgate
+      POSTGRES_USER: hexgate
+      POSTGRES_PASSWORD: ${HEXGATE_POSTGRES_PASSWORD:-hexgate-dev-password}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hexgate -d hexgate"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   clickhouse:
     image: clickhouse/clickhouse-server:24.10
     container_name: hexgate-clickhouse
@@ -31,3 +52,4 @@ services:
 
 volumes:
   clickhouse-data:
+  postgres-data:


### PR DESCRIPTION
## Summary

Make the control-plane API run on **Postgres**, driven by `DATABASE_URL`, while keeping **SQLite as the zero-setup fallback** so dev and the test suite are unchanged. Schema is still created with `create_all` — **no Alembic / no migration system** (beta decision: data is disposable across schema changes, wipe rather than migrate).

"Use Postgres" and "build migrations" are deliberately separated — this PR does the first and skips the second. Doing the engine swap now, while data is disposable, is the cheapest time to do it.

## Changes

- **`db.py`** — engine URL comes from `DATABASE_URL`; unset falls back to the local SQLite file. Bare `postgres://` / `postgresql://` URLs are normalized to the `asyncpg` driver the async engine needs. `pool_pre_ping=True` for managed-PG dropped connections. `load_dotenv()` runs here too, since the engine is built at import (before `main`'s own `load_dotenv`), so `DATABASE_URL` works from `platform/api/.env`. Public interface (`init_db`/`get_session`/`async_session_factory`) unchanged.
- **`pyproject.toml` + `uv.lock`** — add `asyncpg`.
- **`models.py`** — every `datetime` column now uses `sa_type=DateTime(timezone=True)`. **This fixes a real PG blocker:** `utcnow()` is tz-aware but the columns mapped to `TIMESTAMP WITHOUT TIME ZONE`; SQLite tolerated it, asyncpg rejected the insert (so the lifespan seed would have failed at startup on PG). `timestamptz` on Postgres. On SQLite, read-backs are now tz-aware to match writes (previously naive). Project code uses `utcnow()` (tz-aware) everywhere and already normalizes DB-loaded datetimes before comparison (`_ensure_utc_aware` in `services.py`, `_ensure_utc` in `audit.py`), so there's no observable change in behavior.
- **`docker-compose.yml`** — local `postgres:16` service (loopback `5433:5432`, dev creds, healthcheck) + `postgres-data` volume.
- **`Makefile`** — `postgres-up` (waits healthy) / `postgres-stop` / `postgres-psql` / `postgres-reset`, and `platform-api-pg` (starts PG, runs the API against it). `make platform-api` stays SQLite.
- **`.env.sample`** — `DATABASE_URL` section with the local-PG DSN.
- **`tests/test_postgres_smoke.py`** — opt-in (skipif on `DATABASE_URL`) smoke test: `init_db` + round-trip against a live PG. The rest of the suite builds its own SQLite engines, so this is the only coverage of the asyncpg path.
- **`.github/workflows/tests.yml`** — isolated `platform-api-postgres` job (PG service container, `DATABASE_URL` set) running only the smoke test, kept separate so it can't destabilize the SQLite suite.
- **`README.md`** — "Control-plane database (SQLite / Postgres)" section.

## Validation

- SQLite suite: **318 passed, 2 skipped** (unchanged; the PG smoke test skips without `DATABASE_URL`).
- Against a live local Postgres: smoke test passes, and the full lifespan seed lands cleanly (orgs=1, users=1, projects=1, agents=3 — exercises JSON + LargeBinary columns), tz-aware timestamps preserved.
- `ruff` clean; workflow YAML validated.

## Reviewer note

The **`models.py` timestamptz change** is the substantive part — it touches every table's datetime columns and was surfaced by the smoke test (not in the original plan). Worth a closer look.

## Out of scope

Alembic, the production compose (Caddy/ClickHouse/TLS), and parametrizing the existing test fixtures to run on PG (they stay SQLite — the smoke test is the PG coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
