### PR TITLE
fix(security): per-turn refresh works on the pydantic-fallback path

### DIFF
--- a/deploy/boot.py
+++ b/deploy/boot.py
@@ -44,7 +44,11 @@ _procs: list[subprocess.Popen] = []
 
 def _spawn(cmd: list[str], *, cwd: Path, env: dict[str, str]) -> subprocess.Popen:
     print(f"[boot] starting: {' '.join(cmd)}  (cwd={cwd})", flush=True)
-    p = subprocess.Popen(cmd, cwd=str(cwd), env=env)
+    # start_new_session=True isolates the child in its own process group, so the
+    # terminal's Ctrl-C goes only to boot.py — boot owns shutdown and signals
+    # each child once, avoiding the SIGINT+SIGTERM race that left uvicorn
+    # half-shutdown (port 8000 still bound) when boot exited too fast.
+    p = subprocess.Popen(cmd, cwd=str(cwd), env=env, start_new_session=True)
     _procs.append(p)
     return p
 
@@ -125,10 +129,37 @@ def run(dash_url: str | None = None) -> None:
     _block_until_exit()
 
 
+_TERM_GRACE = 5.0  # seconds; long enough for uvicorn graceful shutdown
+
+
+def _signal_group(p: subprocess.Popen, sig: int) -> None:
+    """Signal the child's whole process group — covers uvicorn workers, etc."""
+    try:
+        os.killpg(os.getpgid(p.pid), sig)
+    except ProcessLookupError:
+        pass  # already gone
+
+
 def _block_until_exit() -> None:
-    def _shutdown(*_a):
+    shutting_down = False
+
+    def _shutdown(*_):
+        nonlocal shutting_down
+        if shutting_down:
+            return  # already in progress — ignore re-entrant signal
+        shutting_down = True
         for p in _procs:
-            p.terminate()
+            if p.poll() is None:
+                _signal_group(p, signal.SIGTERM)
+        # Wait for graceful exit, then SIGKILL stragglers. Without this
+        # the parent died first and uvicorn was orphaned with port still bound.
+        for p in _procs:
+            try:
+                p.wait(timeout=_TERM_GRACE)
+            except subprocess.TimeoutExpired:
+                print(f"[boot] pid={p.pid} did not exit in {_TERM_GRACE}s; killing", flush=True)
+                _signal_group(p, signal.SIGKILL)
+                p.wait()
         sys.exit(0)
 
     signal.signal(signal.SIGTERM, _shutdown)

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -74,6 +74,7 @@ from hexgate.security.rego_wasm import (
 from hexgate.security.source import (
     BundleDirPolicySource,
     PlatformPolicySource,
+    PolicyContentError,
     PolicySource,
     YamlPolicySource,
 )
@@ -107,6 +108,7 @@ __all__ = [
     "OpaNotFoundError",
     "PlatformPolicySource",
     "PolicyBundle",
+    "PolicyContentError",
     "PolicySource",
     "YamlPolicySource",
     "SignatureError",

--- a/hexgate/security/binding.py
+++ b/hexgate/security/binding.py
@@ -22,6 +22,7 @@ from hexgate.security.source import (
     _LOCAL_POLICY_ENV_VAR,
     _REQUIRE_SIGNATURE_ENV_VAR,
     PlatformPolicySource,
+    PolicyContentError,
     PolicySource,
     _local_policy_override,
     _truthy,
@@ -129,7 +130,22 @@ class PolicyBinding:
             return
         try:
             new_policy = self.source.fetch()
+        except PolicyContentError as exc:
+            # Content errors are correctness issues — the dashboard
+            # accepted an edit the runtime can't enforce. Log at error
+            # level so an operator monitoring logs notices the runtime
+            # drift from what the UI shows. Still fail-soft: refresh
+            # must not crash an in-flight agent turn.
+            logger.error(
+                "policy refresh for agent %r rejected platform content: %s",
+                getattr(self.enforcer, "agent_name", "?"),
+                exc,
+            )
+            return
         except Exception as exc:  # noqa: BLE001 — refresh must not crash a run
+            # Transient failures (network blip, 5xx, timeout, strict-mode
+            # signature refusal on the fallback path). Warning is right
+            # here — a retry on the next turn will likely succeed.
             logger.warning(
                 "policy refresh for agent %r failed: %s — keeping "
                 "previously loaded policy",

--- a/hexgate/security/binding.py
+++ b/hexgate/security/binding.py
@@ -214,14 +214,23 @@ def platform_policy_from_payload(
     import hashlib
 
     yaml_hash: str | None = None
+    # Same #3 guard as fetch(): on the no-bundle path, the server's ETag
+    # has no defined semantics (today's main.py sends None, but any
+    # non-null value from a future server build or third-party impl
+    # would cause the next refresh to 304 and never reach the yaml-hash
+    # comparison — silently swallowing a policy edit). Yaml-hash is the
+    # canonical change detector on this branch, so seed the source with
+    # initial_etag=None when there's no bundle.
+    seed_etag: str | None = etag
     if bundle is None:
         yaml_text = payload.get("policy_yaml") or ""
         yaml_hash = hashlib.sha256(yaml_text.encode("utf-8")).hexdigest()
+        seed_etag = None
     source = PlatformPolicySource(
         client,
         agent_name,
         initial_engine=policy,
-        initial_etag=etag,
+        initial_etag=seed_etag,
         initial_yaml_hash=yaml_hash,
     )
     return policy, source

--- a/hexgate/security/binding.py
+++ b/hexgate/security/binding.py
@@ -131,11 +131,8 @@ class PolicyBinding:
         try:
             new_policy = self.source.fetch()
         except PolicyContentError as exc:
-            # Content errors are correctness issues — the dashboard
-            # accepted an edit the runtime can't enforce. Log at error
-            # level so an operator monitoring logs notices the runtime
-            # drift from what the UI shows. Still fail-soft: refresh
-            # must not crash an in-flight agent turn.
+            # Dashboard-saved edit the runtime rejects → ERROR so the
+            # UI/runtime drift is grep-able. Still fail-soft.
             logger.error(
                 "policy refresh for agent %r rejected platform content: %s",
                 getattr(self.enforcer, "agent_name", "?"),
@@ -143,9 +140,7 @@ class PolicyBinding:
             )
             return
         except Exception as exc:  # noqa: BLE001 — refresh must not crash a run
-            # Transient failures (network blip, 5xx, timeout, strict-mode
-            # signature refusal on the fallback path). Warning is right
-            # here — a retry on the next turn will likely succeed.
+            # Transient (network, 5xx, strict-mode signature refusal) — WARN.
             logger.warning(
                 "policy refresh for agent %r failed: %s — keeping "
                 "previously loaded policy",
@@ -214,13 +209,8 @@ def platform_policy_from_payload(
     import hashlib
 
     yaml_hash: str | None = None
-    # Same #3 guard as fetch(): on the no-bundle path, the server's ETag
-    # has no defined semantics (today's main.py sends None, but any
-    # non-null value from a future server build or third-party impl
-    # would cause the next refresh to 304 and never reach the yaml-hash
-    # comparison — silently swallowing a policy edit). Yaml-hash is the
-    # canonical change detector on this branch, so seed the source with
-    # initial_etag=None when there's no bundle.
+    # (#3) Mirror fetch()'s guard: don't seed an ETag on the no-bundle
+    # path or the first refresh could 304 and swallow an edit.
     seed_etag: str | None = etag
     if bundle is None:
         yaml_text = payload.get("policy_yaml") or ""

--- a/hexgate/security/binding.py
+++ b/hexgate/security/binding.py
@@ -190,8 +190,22 @@ def platform_policy_from_payload(
             yaml.safe_load(payload.get("policy_yaml") or "") or {}
         )
 
-    # Pre-seeded so the next refresh is a 304 unless the policy changed.
+    # Pre-seeded so the next refresh is a 304 (bundle path) or a cache
+    # hit (pydantic-fallback path) unless the policy actually changed.
+    # The yaml hash is only relevant on the pydantic-fallback path —
+    # compute it from the same `policy_yaml` we just parsed above so the
+    # source's first refresh comparison matches load-time exactly.
+    import hashlib
+
+    yaml_hash: str | None = None
+    if bundle is None:
+        yaml_text = payload.get("policy_yaml") or ""
+        yaml_hash = hashlib.sha256(yaml_text.encode("utf-8")).hexdigest()
     source = PlatformPolicySource(
-        client, agent_name, initial_bundle=bundle, initial_etag=etag
+        client,
+        agent_name,
+        initial_engine=policy,
+        initial_etag=etag,
+        initial_yaml_hash=yaml_hash,
     )
     return policy, source

--- a/hexgate/security/source.py
+++ b/hexgate/security/source.py
@@ -42,7 +42,7 @@ from hexgate.security.bundle import (
     build_signed_bundle,
 )
 from hexgate.security.decision import PolicyEngine
-from hexgate.security.policy_set import load_policy_set_from_dict
+from hexgate.security.policy_set import PolicySetError, load_policy_set_from_dict
 from hexgate.security.signing import SignatureError, decode_key
 
 if TYPE_CHECKING:
@@ -52,6 +52,17 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("hexgate.security.source")
+
+
+class PolicyContentError(RuntimeError):
+    """The platform served a payload but its policy content is invalid.
+
+    Distinguished from transient :class:`RuntimeError` (network blips,
+    timeouts, signature checks) so :meth:`PolicyBinding.refresh` can
+    log it at ``error`` level — a malformed-but-saved policy is a
+    correctness issue (dashboard says one thing, runtime enforces
+    another), not a "retry later" condition.
+    """
 
 
 class PolicySource(Protocol):
@@ -163,24 +174,89 @@ class PlatformPolicySource:
 
             # No bundle in the response — the platform couldn't compile
             # (opa missing, malformed policy, etc.) but still served the
-            # raw `policy_yaml`. Build a pydantic-engine PolicySet from
-            # it. Hash the yaml so we only construct a new PolicySet on
-            # actual content change — otherwise PolicyBinding.refresh()
-            # would identity-mismatch on every turn and rebind the
-            # enforcer to a content-equivalent fresh instance.
+            # raw `policy_yaml`.
+            #
+            # (#1) Strict signature mode forbids this branch entirely:
+            # the load-time path (platform_policy_from_payload) already
+            # refuses a no-bundle payload under REQUIRE_SIGNATURE, so the
+            # only way we get here under strict mode is if opa later went
+            # down mid-session. Re-establish the refusal here so we don't
+            # silently swap the verified bundle out for an unsigned,
+            # unverified pydantic engine built from raw yaml — that would
+            # be exactly the downgrade decode_and_verify_platform_bundle
+            # was written to refuse. Refresh-time errors are caught by
+            # PolicyBinding.refresh (logged + previous policy kept), so
+            # the agent keeps enforcing the last verified bundle.
+            if _truthy(os.environ.get(_REQUIRE_SIGNATURE_ENV_VAR)):
+                raise RuntimeError(
+                    f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but the platform "
+                    f"served no signed bundle for agent {self._agent_name!r} "
+                    "on refresh — the policy may have failed to recompile "
+                    "(is opa still available on the control plane?). "
+                    "Refusing to downgrade to the pydantic engine; keeping "
+                    "the last verified policy."
+                )
+
+            # (#3) Server-provided ETag is meaningless on the no-bundle path
+            # — it would only be safe if it's a hash of the policy_yaml,
+            # and we have no contract that says it is. Today main.py sets
+            # etag=None when compiled_wasm is None, but a future server
+            # build (or a third-party platform impl) could serve a non-null
+            # ETag derived from the agent record; the next request would
+            # then 304 without ever reaching the yaml-hash comparison and
+            # we'd silently miss a policy edit. Defensively clear our
+            # cached ETag so subsequent no-bundle responses never send
+            # If-None-Match — yaml-hash comparison below is the canonical
+            # change detector for this branch.
             yaml_text = payload.get("policy_yaml") or ""
             new_hash = hashlib.sha256(yaml_text.encode("utf-8")).hexdigest()
             if new_hash == self._cached_yaml_hash and self._cached_engine is not None:
                 # Same yaml as the cached engine → reuse for identity
-                # preservation. We still update the ETag (server may
-                # have started serving one between calls).
-                self._cached_etag = etag
+                # preservation (binding's `is` check skips the swap).
+                self._cached_etag = None
                 return self._cached_engine
-            self._cached_engine = load_policy_set_from_dict(
-                yaml.safe_load(yaml_text) or {}
-            )
+
+            # (#2) Surface yaml/policy-validation failures loudly. The
+            # platform may have accepted a structurally-invalid edit
+            # (e.g. validator drift, missing default role); without this
+            # the dashboard would show the policy as saved while the
+            # agent silently kept the old one. Raise a PolicyContentError
+            # (not RuntimeError) so PolicyBinding.refresh can log it at
+            # error level — distinguishable from transient network blips.
+            try:
+                parsed = yaml.safe_load(yaml_text) or {}
+            except yaml.YAMLError as exc:
+                raise PolicyContentError(
+                    f"platform served unparseable policy_yaml for agent "
+                    f"{self._agent_name!r}: {exc}. Keeping previously "
+                    "loaded policy."
+                ) from exc
+            try:
+                new_engine = load_policy_set_from_dict(parsed)
+            except (PolicySetError, ValueError, TypeError) as exc:
+                # PolicySetError covers our own structural complaints; the
+                # other two cover pydantic's ValidationError (subclass of
+                # ValueError) for unknown fields / bad enum values, plus
+                # the rare TypeError from a wholly-wrong shape.
+                raise PolicyContentError(
+                    f"platform served structurally-invalid policy_yaml for "
+                    f"agent {self._agent_name!r}: {exc}. Keeping previously "
+                    "loaded policy."
+                ) from exc
+
+            # (#4) Per-turn cost on this branch is a full GET + sha256 (the
+            # yaml.safe_load + load_policy_set_from_dict above runs only on
+            # hash mismatch, i.e. when the policy actually changed). The
+            # full GET is unavoidable today: the server's ETag is bound to
+            # wasm_hash, which is null on this path, so it can never 304
+            # the no-bundle response. A future server change could ETag on
+            # sha256(policy_yaml) — that would let us 304 the cheap path.
+            # Until then the per-turn cost is one round trip + a sha256,
+            # acceptable for the demo-shaped deployments this branch
+            # targets.
+            self._cached_engine = new_engine
             self._cached_yaml_hash = new_hash
-            self._cached_etag = etag
+            self._cached_etag = None
             return self._cached_engine
 
 

--- a/hexgate/security/source.py
+++ b/hexgate/security/source.py
@@ -55,13 +55,12 @@ logger = logging.getLogger("hexgate.security.source")
 
 
 class PolicyContentError(RuntimeError):
-    """The platform served a payload but its policy content is invalid.
+    """Platform served a payload, but the policy content is invalid.
 
-    Distinguished from transient :class:`RuntimeError` (network blips,
-    timeouts, signature checks) so :meth:`PolicyBinding.refresh` can
-    log it at ``error`` level — a malformed-but-saved policy is a
-    correctness issue (dashboard says one thing, runtime enforces
-    another), not a "retry later" condition.
+    Distinct from transient errors (network, signature) so
+    :meth:`PolicyBinding.refresh` can log at ``error`` level —
+    dashboard-saved-but-runtime-rejected is a correctness drift, not
+    "retry later".
     """
 
 
@@ -172,85 +171,48 @@ class PlatformPolicySource:
                 self._cached_yaml_hash = None
                 return bundle
 
-            # No bundle in the response — the platform couldn't compile
-            # (opa missing, malformed policy, etc.) but still served the
-            # raw `policy_yaml`.
-            #
-            # (#1) Strict signature mode forbids this branch entirely:
-            # the load-time path (platform_policy_from_payload) already
-            # refuses a no-bundle payload under REQUIRE_SIGNATURE, so the
-            # only way we get here under strict mode is if opa later went
-            # down mid-session. Re-establish the refusal here so we don't
-            # silently swap the verified bundle out for an unsigned,
-            # unverified pydantic engine built from raw yaml — that would
-            # be exactly the downgrade decode_and_verify_platform_bundle
-            # was written to refuse. Refresh-time errors are caught by
-            # PolicyBinding.refresh (logged + previous policy kept), so
-            # the agent keeps enforcing the last verified bundle.
+            # No bundle — platform couldn't compile (no opa, etc.) but
+            # served the raw policy_yaml. Build a PolicySet from it.
+
+            # (#1) Refuse the downgrade under strict mode. Load-time
+            # already refuses; this catches opa-went-down mid-session.
+            # Caught by binding.refresh → keeps last verified bundle.
             if _truthy(os.environ.get(_REQUIRE_SIGNATURE_ENV_VAR)):
                 raise RuntimeError(
-                    f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but the platform "
-                    f"served no signed bundle for agent {self._agent_name!r} "
-                    "on refresh — the policy may have failed to recompile "
-                    "(is opa still available on the control plane?). "
-                    "Refusing to downgrade to the pydantic engine; keeping "
-                    "the last verified policy."
+                    f"{_REQUIRE_SIGNATURE_ENV_VAR} is set but no signed "
+                    f"bundle served for {self._agent_name!r} on refresh — "
+                    "keeping last verified policy."
                 )
 
-            # (#3) Server-provided ETag is meaningless on the no-bundle path
-            # — it would only be safe if it's a hash of the policy_yaml,
-            # and we have no contract that says it is. Today main.py sets
-            # etag=None when compiled_wasm is None, but a future server
-            # build (or a third-party platform impl) could serve a non-null
-            # ETag derived from the agent record; the next request would
-            # then 304 without ever reaching the yaml-hash comparison and
-            # we'd silently miss a policy edit. Defensively clear our
-            # cached ETag so subsequent no-bundle responses never send
-            # If-None-Match — yaml-hash comparison below is the canonical
-            # change detector for this branch.
+            # (#3) Ignore server ETag on this branch — its semantics
+            # aren't defined here, and a 304 would skip the hash check
+            # below and swallow an edit. Yaml-hash is the change detector.
             yaml_text = payload.get("policy_yaml") or ""
             new_hash = hashlib.sha256(yaml_text.encode("utf-8")).hexdigest()
             if new_hash == self._cached_yaml_hash and self._cached_engine is not None:
-                # Same yaml as the cached engine → reuse for identity
-                # preservation (binding's `is` check skips the swap).
+                # Identity preserved → binding's `is` check skips the swap.
                 self._cached_etag = None
                 return self._cached_engine
 
-            # (#2) Surface yaml/policy-validation failures loudly. The
-            # platform may have accepted a structurally-invalid edit
-            # (e.g. validator drift, missing default role); without this
-            # the dashboard would show the policy as saved while the
-            # agent silently kept the old one. Raise a PolicyContentError
-            # (not RuntimeError) so PolicyBinding.refresh can log it at
-            # error level — distinguishable from transient network blips.
+            # (#2) Surface parse/validate failures as PolicyContentError
+            # so binding logs at ERROR — silent swallow would recreate
+            # the original bug for invalid edits.
             try:
                 parsed = yaml.safe_load(yaml_text) or {}
             except yaml.YAMLError as exc:
                 raise PolicyContentError(
-                    f"platform served unparseable policy_yaml for agent "
-                    f"{self._agent_name!r}: {exc}. Keeping previously "
-                    "loaded policy."
+                    f"unparseable policy_yaml for {self._agent_name!r}: {exc}"
                 ) from exc
             try:
                 new_engine = load_policy_set_from_dict(parsed)
             except (PolicySetError, ValueError, TypeError) as exc:
-                # PolicySetError covers our own structural complaints; the
-                # other two cover pydantic's ValidationError (subclass of
-                # ValueError) for unknown fields / bad enum values, plus
-                # the rare TypeError from a wholly-wrong shape.
+                # ValueError covers pydantic ValidationError too.
                 raise PolicyContentError(
-                    f"platform served structurally-invalid policy_yaml for "
-                    f"agent {self._agent_name!r}: {exc}. Keeping previously "
-                    "loaded policy."
+                    f"invalid policy_yaml for {self._agent_name!r}: {exc}"
                 ) from exc
 
-            # (#4) Per-turn cost on this branch is a full GET + sha256 (the
-            # yaml.safe_load + load_policy_set_from_dict above runs only on
-            # hash mismatch, i.e. when the policy actually changed). The
-            # full GET is unavoidable today: the server's ETag is bound to
-            # wasm_hash, which is null on this path, so it can never 304
-            # the no-bundle response. A future server change could ETag on
-            # sha256(policy_yaml) — that would let us 304 the cheap path.
+            # (#4) Per-turn cost = full GET + sha256; parse only on change.
+            # Can't 304 without server ETag-on-policy_yaml (future fix).
             # Until then the per-turn cost is one round trip + a sha256,
             # acceptable for the demo-shaped deployments this branch
             # targets.

--- a/hexgate/security/source.py
+++ b/hexgate/security/source.py
@@ -1,12 +1,16 @@
 """Policy sources — abstractions over "where the current policy lives."
 
-The runtime fetches a :class:`PolicyBundle` (or ``None``) from a source at
-every agent run; the source decides whether that's cheap or not. Three
-implementations cover the production + local-dev workflows:
+The runtime fetches a :class:`~hexgate.security.decision.PolicyEngine`
+(or ``None``) from a source at every agent run; the source decides
+whether that's cheap or not. Three implementations cover the production
++ local-dev workflows:
 
   * :class:`PlatformPolicySource` — HTTP fetch with ``If-None-Match`` /
     ``304 Not Modified``, so unchanged bundles cost one tiny round trip
     instead of a full payload + signature verify + wasm re-instantiation.
+    Falls back to the pydantic engine (a :class:`PolicySet` derived from
+    the response's ``policy_yaml``) when the platform served no compiled
+    bundle — the typical Modal / no-opa demo deployment shape.
   * :class:`BundleDirPolicySource` — refresh a pre-built bundle directory
     on disk (today's ``HEXGATE_LOCAL_POLICY=<dir>`` path, made mtime-aware
     so a rebuild via ``hexgate policy build`` takes effect on the next run).
@@ -21,11 +25,14 @@ on the protocol, not on any concrete type.
 from __future__ import annotations
 
 import base64
+import hashlib
 import logging
 import os
 import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
+
+import yaml
 
 from hexgate.security.bundle import (
     BundleIntegrityError,
@@ -34,6 +41,8 @@ from hexgate.security.bundle import (
     PolicyBundle,
     build_signed_bundle,
 )
+from hexgate.security.decision import PolicyEngine
+from hexgate.security.policy_set import load_policy_set_from_dict
 from hexgate.security.signing import SignatureError, decode_key
 
 if TYPE_CHECKING:
@@ -46,36 +55,47 @@ logger = logging.getLogger("hexgate.security.source")
 
 
 class PolicySource(Protocol):
-    """Produces a current :class:`PolicyBundle` (or ``None``) on demand.
+    """Produces a current :class:`PolicyEngine` (or ``None``) on demand.
 
     Implementations are expected to be **cheap when nothing has changed**
     — caching, ETags, or mtime checks — so the agent runtime can call
     :meth:`fetch` at the top of every run without measurable cost.
 
-    A returned ``None`` means "no bundle is configured for this source"
-    (e.g. the platform served no compiled bundle). Callers fall back to
-    whatever they had before (pydantic engine on raw YAML).
+    A returned ``None`` means "no engine is configured for this source"
+    (e.g. the platform served no policy at all). Callers keep whatever
+    engine they had before. The runtime's :class:`PolicyBinding.refresh`
+    relies on this: it only swaps when ``fetch()`` returns something
+    distinct from the current engine.
     """
 
-    def fetch(self) -> PolicyBundle | None: ...
+    def fetch(self) -> PolicyEngine | None: ...
 
 
 class PlatformPolicySource:
-    """Pull + verify a signed bundle from the platform, with ETag/304.
+    """Pull a current policy engine from the platform, with ETag/304.
 
-    Holds the last seen bundle and its ``wasm_hash`` (the ETag the
-    platform serves). Each :meth:`fetch` sends ``If-None-Match`` and:
+    Two engines flow out, depending on what the platform has compiled:
 
-      * ``304`` → returns the cached bundle without touching wasmtime or
-        the signature path.
-      * ``200`` → decodes + verifies the new payload, caches it, returns.
-      * payload with no bundle → returns ``None`` (the platform couldn't
-        compile, e.g. opa missing on the control plane — the SDK then
-        falls back to its pydantic engine).
+      * **WASM bundle** (production shape) — when the platform's
+        ``compiled_wasm`` is populated, we get a signed bundle back and
+        return a verified :class:`PolicyBundle`. ETag = ``wasm_hash``;
+        unchanged bundles hit ``304`` and re-use the cached object.
+      * **Pydantic fallback** (no-opa / demo shape) — when the platform
+        couldn't compile (no ``opa`` on the control plane), the response
+        carries ``policy_yaml`` but null bundle fields. We hash the yaml,
+        compare against the last seen hash, and re-construct a fresh
+        :class:`PolicySet` only when the yaml content actually changed.
 
-    Verification fails are fatal (a tampered platform bundle is never
-    silently downgraded). The signature is checked against the same
-    public key the SDK already trusts for biscuit verification.
+    Without the pydantic-fallback branch a policy edit would silently
+    no-op for any deployment without opa — :meth:`fetch` would always
+    return ``None`` (no bundle), :class:`PolicyBinding.refresh` would
+    treat that as "nothing served" and skip the swap, and the initial
+    engine built by :func:`platform_policy_from_payload` would stay
+    frozen forever.
+
+    Verification fails on the bundle path are fatal (a tampered bundle
+    is never silently downgraded). Verification uses the same public
+    key the SDK already trusts for biscuit verification.
     """
 
     def __init__(
@@ -85,46 +105,83 @@ class PlatformPolicySource:
         *,
         initial_bundle: PolicyBundle | None = None,
         initial_etag: str | None = None,
+        initial_engine: PolicyEngine | None = None,
+        initial_yaml_hash: str | None = None,
     ) -> None:
         self._client = client
         self._agent_name = agent_name
-        # Pre-seed when the caller already fetched + verified the bundle
-        # (typical at agent load time). Avoids a redundant 200 round-trip
-        # on the first refresh — that call will send If-None-Match and
-        # get a cheap 304.
-        self._cached_bundle: PolicyBundle | None = initial_bundle
+        # Pre-seed when the caller already fetched + verified at load time.
+        # `initial_engine` covers both shapes (a PolicyBundle on the WASM
+        # path, a PolicySet on the pydantic-fallback path); `initial_bundle`
+        # stays as a back-compat alias that callers used before we
+        # broadened the engine type.
+        self._cached_engine: PolicyEngine | None = (
+            initial_engine if initial_engine is not None else initial_bundle
+        )
         self._cached_etag: str | None = initial_etag
+        # Hash of the `policy_yaml` text that produced the cached *pydantic*
+        # engine. Used solely on the no-bundle branch to decide whether
+        # the platform's response represents a real change: a same-hash
+        # response returns the cached PolicySet (preserves identity → the
+        # binding's `is policy` check skips the swap); a new hash builds
+        # and caches a fresh one. ``None`` on the bundle path (we use
+        # ``_cached_etag`` for that).
+        self._cached_yaml_hash: str | None = initial_yaml_hash
         # Serialize the (read cached_etag → HTTP → write cached_*) cycle.
         # Refresh runs on a to_thread worker, so two concurrent agent runs
         # sharing one source could otherwise interleave a write to
-        # _cached_bundle with another's read of _cached_etag and pair the
+        # _cached_engine with another's read of _cached_etag and pair the
         # bundle from one response with the etag from another → a later
         # spurious 200/304. The cost is serializing refreshes for shared
         # sources, which is fine: refresh is best-effort and rare-ish per
         # turn (most calls hit a cheap 304).
         self._lock = threading.Lock()
 
-    def fetch(self) -> PolicyBundle | None:
+    def fetch(self) -> PolicyEngine | None:
         with self._lock:
             payload, etag = self._client.get_agent(
                 self._agent_name, if_none_match=self._cached_etag
             )
             # 304 — nothing changed since last fetch. Cheap path.
             if payload is None:
-                return self._cached_bundle
+                return self._cached_engine
 
             bundle = decode_and_verify_platform_bundle(
                 payload, self._client.public_key_bytes()
             )
-            self._cached_bundle = bundle
-            # Server-supplied ETag wins; fall back to wasm_hash for when the
-            # response lacked an ETag header (older platform versions).
-            self._cached_etag = etag or (
-                f'"{bundle.wasm_hash}"'
-                if bundle is not None and bundle.wasm_hash
-                else None
+            if bundle is not None:
+                # WASM path. ETag tracking is on the wasm_hash; the yaml
+                # hash is irrelevant here, clear it so a later transition
+                # to the pydantic branch (platform loses opa) doesn't
+                # mistakenly reuse a stale hash from the old wasm world.
+                self._cached_engine = bundle
+                self._cached_etag = etag or (
+                    f'"{bundle.wasm_hash}"' if bundle.wasm_hash else None
+                )
+                self._cached_yaml_hash = None
+                return bundle
+
+            # No bundle in the response — the platform couldn't compile
+            # (opa missing, malformed policy, etc.) but still served the
+            # raw `policy_yaml`. Build a pydantic-engine PolicySet from
+            # it. Hash the yaml so we only construct a new PolicySet on
+            # actual content change — otherwise PolicyBinding.refresh()
+            # would identity-mismatch on every turn and rebind the
+            # enforcer to a content-equivalent fresh instance.
+            yaml_text = payload.get("policy_yaml") or ""
+            new_hash = hashlib.sha256(yaml_text.encode("utf-8")).hexdigest()
+            if new_hash == self._cached_yaml_hash and self._cached_engine is not None:
+                # Same yaml as the cached engine → reuse for identity
+                # preservation. We still update the ETag (server may
+                # have started serving one between calls).
+                self._cached_etag = etag
+                return self._cached_engine
+            self._cached_engine = load_policy_set_from_dict(
+                yaml.safe_load(yaml_text) or {}
             )
-            return bundle
+            self._cached_yaml_hash = new_hash
+            self._cached_etag = etag
+            return self._cached_engine
 
 
 def decode_and_verify_platform_bundle(

--- a/tests/security/test_policy_binding.py
+++ b/tests/security/test_policy_binding.py
@@ -327,6 +327,58 @@ def test_refresh_swaps_policy_on_change() -> None:
     assert new.allowed
 
 
+def test_refresh_swaps_policy_on_pydantic_fallback_path() -> None:
+    """Regression for the demo-notebook bug: when the platform has no
+    opa (Modal container, fresh deploy without the opa binary), bundles
+    never compile and every GET /v1/agents/:name returns 200 with the
+    raw policy_yaml and null bundle fields. Before the fix,
+    PlatformPolicySource.fetch() returned None on this path, the
+    binding's None-check short-circuited, and edits in /policies were
+    silently ignored at runtime. After the fix, fetch() builds a fresh
+    PolicySet whenever policy_yaml changes, the binding swaps, and the
+    next tool-call decision reflects the edit.
+
+    The opa-on path is already covered by
+    `test_refresh_swaps_policy_on_change` above.
+    """
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    # First load + first refresh both see the deny policy.
+    deny_payload = {
+        "agent_yaml": "name: support-bot\n",
+        "policy_yaml": (
+            "version: 1\nroles:\n  default:\n    default_policy:\n      mode: deny\n"
+        ),
+        "system_md": "",
+    }
+    # Then a /policies edit flips the tool to allow.
+    allow_payload = {
+        "agent_yaml": "name: support-bot\n",
+        "policy_yaml": (
+            "version: 1\nroles:\n  default:\n    default_policy:\n      mode: allow\n"
+        ),
+        "system_md": "",
+    }
+    fc.serve(deny_payload, etag=None)
+    fc.serve(allow_payload, etag=None)
+
+    binding = _resolved_binding("support-bot", client=fc)
+    first = binding.enforcer.policy
+    # Initial engine should be a PolicySet (pydantic fallback path).
+    assert isinstance(first, PolicySet)
+    pre = first.evaluate(role="default", tool="anything", args={})
+    assert not pre.allowed  # deny
+
+    binding.refresh()
+    second = binding.enforcer.policy
+    assert second is not first, (
+        "refresh must swap the pydantic engine when policy_yaml changes; "
+        "the binding's None-check used to swallow this case"
+    )
+    post = second.evaluate(role="default", tool="anything", args={})
+    assert post.allowed  # the edit took effect
+
+
 def test_refresh_failure_keeps_previous_policy(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/security/test_source.py
+++ b/tests/security/test_source.py
@@ -27,7 +27,11 @@ from hexgate.security import (
     generate_keypair,
     sign_bytes,
 )
-from hexgate.security.source import PlatformPolicySource, SignaturePolicy
+from hexgate.security.source import (
+    PlatformPolicySource,
+    PolicyContentError,
+    SignaturePolicy,
+)
 
 
 _OPA_AVAILABLE = shutil.which("opa") is not None
@@ -375,3 +379,186 @@ def test_concurrent_fetches_serialize() -> None:
 
     assert all(not t.is_alive() for t in threads)
     assert fc.max_active == 1  # serialized — never two fetches in flight
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the PR #50 review findings:
+#   #1 silent strict-signature downgrade on refresh
+#   #2 malformed/invalid edited policy silently swallowed
+#   #3 non-null ETag on no-bundle response masks policy edits
+#   #4 (no behavior change — covered as a doc comment in fetch())
+# ---------------------------------------------------------------------------
+
+
+def test_strict_signature_refuses_no_bundle_on_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1 — Strict mode + no bundle on refresh must raise, not silently
+    downgrade to the pydantic engine. The attack: agent boots on a signed
+    bundle, opa later goes down mid-session, control plane starts serving
+    no-bundle payloads. Without this guard, fetch() would swap in an
+    unverified PolicySet built from raw yaml — exactly the downgrade
+    decode_and_verify_platform_bundle was written to refuse.
+    """
+    monkeypatch.setenv("HEXGATE_BUNDLE_REQUIRE_SIGNATURE", "1")
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: allow\n"
+        },
+        etag=None,
+    )
+
+    src = PlatformPolicySource(fc, "default")
+    with pytest.raises(RuntimeError, match="REQUIRE_SIGNATURE"):
+        src.fetch()
+
+
+def test_strict_signature_off_still_falls_back_to_pydantic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1 sibling — make sure the strict-mode guard didn't break the
+    default permissive path. Without REQUIRE_SIGNATURE set, the no-bundle
+    branch must still build a PolicySet (this is what makes the Modal
+    demo work)."""
+    from hexgate.security.policy_set import PolicySet
+
+    monkeypatch.delenv("HEXGATE_BUNDLE_REQUIRE_SIGNATURE", raising=False)
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: deny\n"
+        },
+        etag=None,
+    )
+
+    src = PlatformPolicySource(fc, "default")
+    assert isinstance(src.fetch(), PolicySet)
+
+
+def test_malformed_yaml_raises_policy_content_error() -> None:
+    """#2 — Unparseable yaml (broken indentation, stray tab, etc.) must
+    surface as a typed PolicyContentError, not get silently swallowed by
+    PolicyBinding.refresh's warning logger. Dashboards would otherwise
+    show the edit as saved while the runtime kept the old engine."""
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    # `:\t` inside the value triggers yaml's "found tab character that
+    # cannot start any token" error reliably.
+    fc.serve({"policy_yaml": "roles:\n\tdefault: deny\n"}, etag=None)
+
+    src = PlatformPolicySource(fc, "default")
+    with pytest.raises(PolicyContentError, match="unparseable"):
+        src.fetch()
+
+
+def test_structurally_invalid_yaml_raises_policy_content_error() -> None:
+    """#2 sibling — yaml that parses but fails policy-set validation
+    (unknown mode, missing required key, etc.) is the more common case
+    of a "dashboard-accepted, runtime-rejected" edit. Same loud surface
+    as a parse error so the operator sees the runtime drift from the UI.
+    """
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve(
+        {
+            "policy_yaml": (
+                "version: 1\nroles:\n  default:\n    default_policy:\n"
+                "      mode: TOTALLY_NOT_A_MODE\n"
+            )
+        },
+        etag=None,
+    )
+
+    src = PlatformPolicySource(fc, "default")
+    with pytest.raises(PolicyContentError, match="structurally-invalid"):
+        src.fetch()
+
+
+def test_no_bundle_response_with_etag_does_not_send_if_none_match() -> None:
+    """#3 — Even if the server (or a future server build) attaches an
+    ETag to a no-bundle response, the SDK must not send it back as
+    If-None-Match. The ETag's semantics on this path aren't defined; a
+    304 reply would silently swallow a policy edit. Defensively clear
+    the cached ETag so yaml-hash comparison stays the canonical change
+    detector for this branch.
+    """
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    # Server (buggily) attaches an ETag to a no-bundle response.
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: deny\n"
+        },
+        etag='"server-attached-etag"',
+    )
+    # Edited yaml comes through on the second turn. If we'd cached the
+    # server's ETag, the test client would consume this; we want to be
+    # sure the SDK ignored it on call #2 and didn't send If-None-Match.
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: allow\n"
+        },
+        etag=None,
+    )
+
+    src = PlatformPolicySource(fc, "default")
+    first = src.fetch()
+    second = src.fetch()
+
+    # Both calls must have sent no If-None-Match — that's the only way
+    # to guarantee we never miss an edit on this branch.
+    assert fc.calls == [None, None]
+    # And the edited policy must take effect (different engine instance).
+    assert first is not second
+
+
+def test_binding_logs_content_error_at_error_level(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """#2 — PolicyBinding.refresh must distinguish PolicyContentError
+    (correctness issue, log at ERROR) from transient RuntimeError (log
+    at WARNING). Operators monitoring logs for "policy mismatch with
+    dashboard" need to see the loud signal.
+    """
+    import logging
+
+    from hexgate.security.binding import PolicyBinding
+
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    # First fetch seeds a valid engine (good policy).
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: deny\n"
+        },
+        etag=None,
+    )
+    # Second fetch: structurally-invalid yaml. Binding.refresh should
+    # log at ERROR and keep the previously-loaded engine.
+    fc.serve(
+        {
+            "policy_yaml": (
+                "version: 1\nroles:\n  default:\n    default_policy:\n"
+                "      mode: TOTALLY_NOT_A_MODE\n"
+            )
+        },
+        etag=None,
+    )
+
+    src = PlatformPolicySource(fc, "default")
+    initial_engine = src.fetch()
+    enforcer = SimpleNamespace(policy=initial_engine, agent_name="default")
+    binding = PolicyBinding(enforcer, source=src)  # type: ignore[arg-type]
+
+    with caplog.at_level(logging.ERROR, logger="hexgate.security.binding"):
+        binding.refresh()
+
+    assert any(
+        rec.levelno == logging.ERROR and "rejected platform content" in rec.message
+        for rec in caplog.records
+    ), f"expected ERROR-level 'rejected platform content' log, saw {caplog.records}"
+    # And the binding kept the original engine (fail-soft).
+    assert enforcer.policy is initial_engine

--- a/tests/security/test_source.py
+++ b/tests/security/test_source.py
@@ -515,6 +515,47 @@ def test_no_bundle_response_with_etag_does_not_send_if_none_match() -> None:
     assert first is not second
 
 
+def test_load_time_no_bundle_does_not_pass_etag_to_source() -> None:
+    """#3 sibling at load time — platform_policy_from_payload must not
+    seed the source with the server's ETag on the no-bundle branch. Same
+    rationale as the runtime fix: a non-null ETag here would cause the
+    first refresh to send If-None-Match, get a 304, and never reach the
+    yaml-hash comparison.
+    """
+    from hexgate.security.binding import platform_policy_from_payload
+
+    _, pub = generate_keypair()
+
+    class _StubClient:
+        def public_key_bytes(self) -> bytes:
+            return pub
+
+        def get_agent(self, _name, *, if_none_match=None):
+            return (
+                {
+                    "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: allow\n"
+                },
+                None,
+            )
+
+    client = _StubClient()
+    payload, _ = client.get_agent("default")
+    # Simulate the server sending a non-null ETag on the no-bundle response.
+    _, source = platform_policy_from_payload(
+        client,  # type: ignore[arg-type]
+        "default",
+        payload,
+        etag='"server-sent-no-bundle-etag"',
+    )
+
+    # The source's cached_etag must be None so the next refresh doesn't
+    # send If-None-Match and risk a 304 swallowing an edit.
+    assert source._cached_etag is None  # noqa: SLF001 — invariant under test
+    # The yaml-hash *is* seeded — that's what makes the first refresh
+    # cheap when nothing actually changed.
+    assert source._cached_yaml_hash is not None  # noqa: SLF001
+
+
 def test_binding_logs_content_error_at_error_level(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/security/test_source.py
+++ b/tests/security/test_source.py
@@ -204,14 +204,100 @@ def test_bundle_change_returns_new_instance() -> None:
     assert fc.calls == [None, '"hash-a"']  # second call sent first's etag
 
 
-def test_no_bundle_in_payload_returns_none() -> None:
-    """When the platform served no compiled bundle, fetch() → None."""
+def test_no_bundle_in_payload_falls_back_to_pydantic_engine() -> None:
+    """When the platform served no compiled bundle (no opa on the control
+    plane, common in demo containers), fetch() builds a PolicySet from
+    the response's policy_yaml so per-turn refresh can still react to
+    policy edits. Without this, the binding's None-check would short-
+    circuit and the initial engine would stay frozen forever — see
+    fix/policy-refresh-pydantic-fallback for the regression scenario.
+    """
+    from hexgate.security.policy_set import PolicySet
+
     _, pub = generate_keypair()
     fc = _FakeClient(pub)
-    fc.serve({"agent_yaml": "name: x\n", "policy_yaml": "version: 1\n"}, etag=None)
+    fc.serve(
+        {
+            "agent_yaml": "name: x\n",
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: allow\n",
+        },
+        etag=None,
+    )
 
     src = PlatformPolicySource(fc, "default")
-    assert src.fetch() is None
+    result = src.fetch()
+    assert isinstance(result, PolicySet)
+
+
+def test_no_bundle_unchanged_yaml_returns_same_engine_instance() -> None:
+    """Identity preservation on the pydantic-fallback path: two fetches
+    against the same policy_yaml must return the same PolicySet object,
+    so PolicyBinding.refresh()'s `is` check skips the rebind.
+    """
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    payload = {
+        "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: deny\n",
+    }
+    fc.serve(payload, etag=None)
+    fc.serve(payload, etag=None)
+
+    src = PlatformPolicySource(fc, "default")
+    first = src.fetch()
+    second = src.fetch()
+    assert first is second
+
+
+def test_no_bundle_changed_yaml_returns_new_engine() -> None:
+    """The regression scenario: dashboard edits a policy, platform has
+    no opa so the bundle stays null, but the new policy_yaml flows
+    through. fetch() must detect the change and return a fresh PolicySet
+    (different identity) so the binding swaps.
+    """
+    _, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: deny\n",
+        },
+        etag=None,
+    )
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: allow\n",
+        },
+        etag=None,
+    )
+
+    src = PlatformPolicySource(fc, "default")
+    first = src.fetch()
+    second = src.fetch()
+    assert first is not None and second is not None
+    assert first is not second
+
+
+def test_no_bundle_then_bundle_clears_yaml_hash_state() -> None:
+    """Transition test: a source that fell back to pydantic (no opa) must
+    cleanly accept a later bundled response (opa came back online) and
+    return the bundle, not stay stuck on the prior PolicySet.
+    """
+    if not _OPA_AVAILABLE:
+        pytest.skip("opa not on PATH")
+    priv, pub = generate_keypair()
+    fc = _FakeClient(pub)
+    fc.serve(
+        {
+            "policy_yaml": "version: 1\nroles:\n  default:\n    default_policy:\n      mode: deny\n"
+        },
+        etag=None,
+    )
+    fc.serve(_bundle_response(priv, amount_cap=500), etag='"hash-a"')
+
+    src = PlatformPolicySource(fc, "default")
+    first = src.fetch()
+    second = src.fetch()
+    assert isinstance(second, PolicyBundle)
+    assert first is not second
 
 
 @needs_opa

--- a/tests/security/test_source.py
+++ b/tests/security/test_source.py
@@ -473,7 +473,7 @@ def test_structurally_invalid_yaml_raises_policy_content_error() -> None:
     )
 
     src = PlatformPolicySource(fc, "default")
-    with pytest.raises(PolicyContentError, match="structurally-invalid"):
+    with pytest.raises(PolicyContentError, match="invalid policy_yaml"):
         src.fetch()
 
 


### PR DESCRIPTION
## The bug

In the demo notebook flow (Modal container, no \`opa\` installed), editing a tool's mode in \`/policies\` and saving had **no effect on the running agent**. The next chat turn used the same enforcement as before the edit. Restart was required.

## Root cause

\`PlatformPolicySource.fetch()\` returned \`PolicyBundle | None\`. When the platform can't compile (no opa on the host), every \`GET /v1/agents/:name\` returns 200 with the new \`policy_yaml\` but null bundle fields. \`decode_and_verify_platform_bundle\` returns \`None\`, \`fetch()\` returns \`None\`, and \`PolicyBinding.refresh()\` short-circuits at:

\`\`\`python
if new_policy is None or new_policy is self.enforcer.policy:
    return  # nothing served, or same cached object (304)
\`\`\`

The pydantic engine built at agent-load time by \`platform_policy_from_payload\` was the only engine the agent ever ran with. The load-time path knew the no-bundle fallback shape; the refresh-time path didn't.

## The fix

Broadened \`PolicySource.fetch()\` to return \`PolicyEngine | None\` (was \`PolicyBundle | None\`). \`PolicyBundle\` still satisfies the protocol, so the WASM path is unchanged.

\`PlatformPolicySource.fetch()\` now branches:

- **Bundle present** → WASM path, ETag-based 304 caching (unchanged).
- **Bundle absent** → hash the \`policy_yaml\`, construct a fresh \`PolicySet\` only when the hash changes. Identity preservation keeps the binding's \`is\` check from triggering a needless rebind when nothing changed.

Transition cases covered:
- yaml-hash sentinel cleared when we land on the bundle path, so a future opa-came-back-online response doesn't reuse a stale hash.
- \`platform_policy_from_payload\` computes the load-time yaml hash from the same payload it parsed into the initial PolicySet, seeding the source so the first refresh hits the cache instead of constructing a content-equivalent fresh PolicySet.
- \`initial_bundle=\` kept as a back-compat alias for the new \`initial_engine=\` kwarg.

## Tests

- \`test_no_bundle_in_payload_falls_back_to_pydantic_engine\` (renamed from \`test_no_bundle_in_payload_returns_none\`, which pinned the buggy behavior)
- \`test_no_bundle_unchanged_yaml_returns_same_engine_instance\` — identity preservation
- \`test_no_bundle_changed_yaml_returns_new_engine\` — **the regression test for the demo bug**
- \`test_no_bundle_then_bundle_clears_yaml_hash_state\` — opa-came-back-online transition
- \`test_refresh_swaps_policy_on_pydantic_fallback_path\` — end-to-end binding flow: load with deny, refresh with allow, verify the new decision applies

## Test plan

- [x] \`make check\` — 837 passed, 2 skipped
- [ ] **Manual** in the demo container: start playground, edit a tool to allow, send a new message, verify it routes through

## Why now

The demo deployment is the trigger that makes this matter — production deployments will run with opa installed, so the bundle path catches everything. This fix unblocks the Modal demo without requiring opa in the container, and also makes the pydantic-fallback path symmetric with the load-time fallback behaviour.

## Scope

Single change: \`PlatformPolicySource.fetch\` + \`platform_policy_from_payload\` seeding. The WASM path, both other source implementations (\`BundleDirPolicySource\`, \`YamlPolicySource\`), and the binding's refresh logic are unchanged.