### PR TITLE
feat(platform/api): wire Resend for real verification + reset emails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,12 @@ jobs:
       # Pin a known-good version so an upstream OPA change can't break CI overnight.
       - name: Install OPA
         run: |
-          curl -fsSL -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
+          # --retry-all-errors covers curl 56 (recv reset mid-download) and
+          # other transient TCP hiccups against openpolicyagent.org's CDN
+          # that --retry alone won't catch. ~3min worst case before the job
+          # gives up, much better than a one-shot fail forcing a re-run.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+            -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
           opa version
@@ -94,7 +99,12 @@ jobs:
       # ETag header. Same pin as the SDK job.
       - name: Install OPA
         run: |
-          curl -fsSL -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
+          # --retry-all-errors covers curl 56 (recv reset mid-download) and
+          # other transient TCP hiccups against openpolicyagent.org's CDN
+          # that --retry alone won't catch. ~3min worst case before the job
+          # gives up, much better than a one-shot fail forcing a re-run.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+            -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
           opa version

--- a/README.md
+++ b/README.md
@@ -243,6 +243,22 @@ Integration tests (`pytest -m integration`) round-trip rows through the live Cli
 
 The dashboard's `/policies` page lets you edit each agent's policy. `hexgate serve` re-fetches at every turn boundary, so your edits take effect on the next chat message without a restart.
 
+### Outbound email (Resend)
+
+Verification emails and password-reset links go through [Resend](https://resend.com). The platform API has two senders:
+
+- **Dev (default)** — `StderrEmailSender` prints the mail body (including the magic link) to stderr. No keys needed; click the link out of the terminal to exercise the flow end-to-end.
+- **Production** — `ResendEmailSender`, picked up automatically when both `RESEND_API_KEY` and `HEXGATE_EMAIL_FROM` are set. The from-address must be on a verified Resend domain.
+
+```bash
+# platform/api/.env
+RESEND_API_KEY=re_…
+HEXGATE_EMAIL_FROM="Hexgate <noreply@yourdomain.com>"
+HEXGATE_DASHBOARD_URL=https://app.yourdomain.com   # ← link host inside the email
+```
+
+Partial config (only one var set) keeps the dev stderr sender so an operator notices the misconfig in the startup log line instead of silently failing every send at delivery. Resend API failures are logged at error level but never 5xx the calling endpoint — the user can request a new link.
+
 ## ✨ Core Primitives
 
 The two main primitives are:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -66,7 +66,8 @@
               "platform/control-plane",
               "platform/dashboard",
               "platform/live-demo",
-              "platform/audit-clickhouse"
+              "platform/audit-clickhouse",
+              "platform/email"
             ]
           },
           {

--- a/docs/platform/email.mdx
+++ b/docs/platform/email.mdx
@@ -1,0 +1,64 @@
+---
+title: "Outbound email (Resend)"
+description: "Verification + password-reset emails — Resend in production, stderr in dev."
+---
+
+<Note>
+**Page stub.** Full content lives in the
+[README — Outbound email](https://github.com/HexamindOrganisation/hexgate#outbound-email-resend).
+</Note>
+
+The platform mails verification and password-reset links through
+[Resend](https://resend.com). Two senders, picked at boot:
+
+- **Dev** — `StderrEmailSender` prints mail bodies (including the magic
+  link) to stderr. No keys needed.
+- **Production** — `ResendEmailSender`, used automatically when both
+  `RESEND_API_KEY` and `HEXGATE_EMAIL_FROM` are set.
+
+## Production config
+
+```bash
+# platform/api/.env
+RESEND_API_KEY=re_…
+HEXGATE_EMAIL_FROM="Hexgate <noreply@yourdomain.com>"
+HEXGATE_DASHBOARD_URL=https://app.yourdomain.com
+```
+
+The from-address must live on a verified domain in your Resend account —
+see [Resend → Domains](https://resend.com/domains). `HEXGATE_DASHBOARD_URL`
+controls the host inside the link the user clicks; misconfiguring it
+sends users to localhost.
+
+## What gets sent
+
+| Endpoint | Email | Body link |
+|---|---|---|
+| `POST /v1/auth/register` | (none — verification is decoupled) | — |
+| `POST /v1/auth/request-verify-token` | "Verify your Hexgate account" | `{dash}/verify-email/{token}` |
+| `POST /v1/auth/forgot-password` | "Reset your Hexgate password" | `{dash}/reset-password/{token}` |
+
+Both link routes are pre-mounted on the dashboard and consume the token
+via the FastAPI-Users `/v1/auth/verify` and `/v1/auth/reset-password`
+endpoints, respectively.
+
+## Failure handling
+
+Provider failures (network, 5xx, invalid from-address) are logged at
+ERROR level but **never** 5xx the calling endpoint — the user gets a
+successful submit, the operator sees the log line, and the user can
+click "Resend email" on the verification banner. Same shape for
+password reset.
+
+Partial config (only `RESEND_API_KEY` set, no `HEXGATE_EMAIL_FROM` or
+vice versa) is treated as dev mode and keeps `StderrEmailSender` —
+better to surface "stderr sender active" at startup than to silently
+have every send rejected by Resend at delivery time.
+
+## Testing
+
+`platform/api/tests/test_mailer.py` covers the Resend sender in
+isolation by patching `resend.Emails.send`. The auth-flow tests in
+`test_auth.py` use a list-capturing sender via the `outbox` fixture so
+they read the would-have-been-mailed token directly — no Resend in the
+test loop.

--- a/platform/api/.env.sample
+++ b/platform/api/.env.sample
@@ -33,3 +33,10 @@ HEXGATE_CLICKHOUSE_SECURE=
 # --- Google OAuth (optional) -------------------------------------------
 HEXGATE_GOOGLE_CLIENT_ID=
 HEXGATE_GOOGLE_CLIENT_SECRET=
+
+# --- Outbound email (Resend) -------------------------------------------
+# Both unset = dev mode: verification + reset emails print to stderr.
+# Set both to send real mail. The from-address must be on a verified
+# Resend domain (see https://resend.com/domains).
+RESEND_API_KEY=
+HEXGATE_EMAIL_FROM=

--- a/platform/api/auth.py
+++ b/platform/api/auth.py
@@ -222,11 +222,17 @@ class UserManager(BaseUserManager[User, str]):
             f"    {link}\n\n"
             f"If it wasn't you, ignore this email — your password stays put.\n"
         )
-        await get_email_sender().send(
-            to=user.email,
-            subject="Reset your Hexgate password",
-            body=body,
-        )
+        try:
+            await get_email_sender().send(
+                to=user.email,
+                subject="Reset your Hexgate password",
+                body=body,
+            )
+        except Exception:
+            # Mailer logs with the recipient redacted; we just need to
+            # stop the exception from 5xx-ing /v1/auth/forgot-password.
+            # User can request a new link; operator sees the mailer log.
+            logger.exception("password-reset email could not be sent")
 
     async def on_after_request_verify(
         self, user: User, token: str, request: Request | None = None
@@ -245,11 +251,16 @@ class UserManager(BaseUserManager[User, str]):
             f"Unverified accounts can sign in but won't be able to invite\n"
             f"teammates or mint API tokens until verification completes.\n"
         )
-        await get_email_sender().send(
-            to=user.email,
-            subject="Verify your Hexgate account",
-            body=body,
-        )
+        try:
+            await get_email_sender().send(
+                to=user.email,
+                subject="Verify your Hexgate account",
+                body=body,
+            )
+        except Exception:
+            # Don't 5xx /v1/auth/request-verify-token over a Resend
+            # outage — the user can retry from the dashboard banner.
+            logger.exception("verification email could not be sent")
 
 
 async def get_user_manager(

--- a/platform/api/auth.py
+++ b/platform/api/auth.py
@@ -37,7 +37,7 @@ from httpx_oauth.clients.google import GoogleOAuth2
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from db import get_session
-from mailer import get_email_sender
+from mailer import _redact_email, get_email_sender
 from models import OAuthAccount, User
 
 logger = logging.getLogger("hexgate.platform.auth")
@@ -193,7 +193,9 @@ class UserManager(BaseUserManager[User, str]):
         """
         from services import ensure_personal_default_org
 
-        logger.info("user registered: %s (id=%s)", user.email, user.id)
+        # Redact the email — same PII rule the mailer error path uses
+        # (al***@domain). User id is the durable handle for support.
+        logger.info("user registered: %s (id=%s)", _redact_email(user.email), user.id)
         # ``self.user_db.session`` is the same async session the User
         # insert used — but FastAPI-Users has already committed it by
         # the time we get here. Idempotency guarantees of the helper

--- a/platform/api/mailer.py
+++ b/platform/api/mailer.py
@@ -3,21 +3,43 @@
 ``on_after_forgot_password``) and however the platform actually ships
 mail at deploy time.
 
-The contract is one method (``send(to, subject, body)``) so swapping a
-real provider (Resend, Postmark, SES, SMTP) for the dev-mode
-:class:`StderrEmailSender` is a one-line change in the factory. Tests
-swap in a list-capturing sender via :func:`set_email_sender` so they
-can read the tokens that would have been mailed without parsing
-stderr.
+One method (``send(to, subject, body)``) so swapping providers is a
+one-line change at boot. Tests swap in a list-capturing sender via
+:func:`set_email_sender` to read tokens without parsing stderr.
+
+Two implementations:
+  * :class:`StderrEmailSender` — dev default; prints to stderr.
+  * :class:`ResendEmailSender` — production; calls the Resend API.
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import sys
+import threading
 from typing import Protocol
 
 logger = logging.getLogger("hexgate.platform.email")
+
+
+def _redact_email(addr: str) -> str:
+    """Redact for logging — keep domain + first 2 chars of local-part so
+    support can recognize a reported user without dumping addresses into
+    log stores. Short local-parts (<=4) are fully masked since 2 of 3
+    chars is barely a redaction.
+
+      alice@example.com         -> al***@example.com
+      alice.smith+tag@host.io   -> al***@host.io
+      ab@example.com            -> ***@example.com   (too short)
+      noplaceholder             -> ***               (no @)
+    """
+    if "@" not in addr:
+        return "***"
+    local, _, domain = addr.partition("@")
+    if len(local) <= 4:
+        return f"***@{domain}"
+    return f"{local[:2]}***@{domain}"
 
 
 class EmailSender(Protocol):
@@ -57,6 +79,70 @@ class StderrEmailSender:
 
 def _indent(text: str, prefix: str) -> str:
     return "\n".join(prefix + line for line in text.splitlines())
+
+
+# Held while we set resend.api_key and call resend.Emails.send. The SDK
+# reads the key from a module global at request-build time, so the only
+# safe way to use a per-instance key is to serialize "set then send".
+# Throughput cost is irrelevant at our scale (single-digit emails/sec at
+# peak: registration + reset + invite).
+_resend_send_lock = threading.Lock()
+
+
+class ResendEmailSender:
+    """Send via Resend's HTTPS API.
+
+    Wraps the (sync) ``resend.Emails.send`` in :func:`asyncio.to_thread`
+    so the event loop isn't blocked on the provider's HTTP round trip.
+
+    Failures **re-raise** — provider outages and configuration errors
+    must reach the caller so the invitation flow (which logs with
+    org-slug context) and a future health endpoint can observe them.
+    The fastapi-users `on_after_*` hooks wrap us in try/except so the
+    register/reset endpoints still return 200 to the user.
+
+    Production wires this in main.py's lifespan when both
+    ``RESEND_API_KEY`` and ``HEXGATE_EMAIL_FROM`` are set.
+    """
+
+    def __init__(self, *, api_key: str, from_addr: str) -> None:
+        self._api_key = api_key
+        self._from = from_addr
+
+    async def send(self, *, to: str, subject: str, body: str) -> None:
+        try:
+            await asyncio.to_thread(self._send_sync, to, subject, body)
+        except Exception:
+            # PII-safe error log (recipient local-part redacted) so a
+            # Resend outage is grep-able without dumping user emails into
+            # log stores. Re-raise so the caller decides what to do.
+            logger.error(
+                "resend send failed: to_domain=%s subject=%r",
+                _redact_email(to),
+                subject,
+                exc_info=True,
+            )
+            raise
+
+    def _send_sync(self, to: str, subject: str, body: str) -> None:
+        """Synchronous helper that runs on a thread-pool worker.
+
+        The lock + immediate set+send pattern keeps the module-global
+        ``resend.api_key`` from racing across concurrent senders. Only
+        one sender exists today, but the constraint is brittle enough
+        to defend against.
+        """
+        import resend
+
+        params: resend.Emails.SendParams = {
+            "from": self._from,
+            "to": [to],
+            "subject": subject,
+            "text": body,
+        }
+        with _resend_send_lock:
+            resend.api_key = self._api_key
+            resend.Emails.send(params)
 
 
 # Module-level singleton so the UserManager hooks (synchronous code path

--- a/platform/api/mailer.py
+++ b/platform/api/mailer.py
@@ -82,10 +82,20 @@ def _indent(text: str, prefix: str) -> str:
 
 
 # Held while we set resend.api_key and call resend.Emails.send. The SDK
-# reads the key from a module global at request-build time, so the only
-# safe way to use a per-instance key is to serialize "set then send".
-# Throughput cost is irrelevant at our scale (single-digit emails/sec at
-# peak: registration + reset + invite).
+# reads the key from a module global at request-build time, so a per-
+# instance key requires serializing "set then send". Today only one
+# ResendEmailSender ever exists (configured once in main.py's lifespan),
+# so the lock is "belt and suspenders": the key never actually changes,
+# so we never actually race. If we ever instantiate a second sender
+# (multi-tenant), the lock is what keeps the global from being torn
+# between two concurrent sends.
+#
+# Cost: serializes every Resend HTTP call process-wide. Acceptable at
+# our scale (single-digit emails/sec at peak: registration + reset +
+# invite). If volume grows, the right fix is to capture the api_key
+# into the Authorization header under the lock and release before the
+# network call — but that reaches into resend.request.Request private
+# API, so we punt until volume actually motivates it.
 _resend_send_lock = threading.Lock()
 
 

--- a/platform/api/main.py
+++ b/platform/api/main.py
@@ -127,6 +127,42 @@ def _demo_enabled() -> bool:
     )
 
 
+def _configure_email_sender() -> None:
+    """Swap the dev stderr sender for Resend if both env vars are set.
+
+    Three cases, three log levels:
+      * both set → INFO "Resend wired" — production happy path.
+      * neither set → INFO "dev stderr sender" — clean dev mode.
+      * exactly one set → WARNING naming the missing var — operator
+        misconfig; falls back to stderr rather than half-broken Resend.
+    """
+    from mailer import ResendEmailSender, StderrEmailSender, set_email_sender
+
+    api_key = os.environ.get("RESEND_API_KEY", "").strip()
+    from_addr = os.environ.get("HEXGATE_EMAIL_FROM", "").strip()
+    if api_key and from_addr:
+        set_email_sender(ResendEmailSender(api_key=api_key, from_addr=from_addr))
+        _log.info("email: Resend sender wired (from=%s)", from_addr)
+        return
+    # Reset to stderr explicitly so a re-config (test, lifespan-restart)
+    # that clears env vars doesn't leave a stale Resend sender wired.
+    set_email_sender(StderrEmailSender())
+    if api_key or from_addr:
+        missing = "HEXGATE_EMAIL_FROM" if api_key else "RESEND_API_KEY"
+        present = "RESEND_API_KEY" if api_key else "HEXGATE_EMAIL_FROM"
+        _log.warning(
+            "email: partial Resend config — %s is set but %s is not. "
+            "Falling back to dev stderr sender; real mail will NOT be sent.",
+            present,
+            missing,
+        )
+    else:
+        _log.info(
+            "email: dev stderr sender — set RESEND_API_KEY and HEXGATE_EMAIL_FROM "
+            "to deliver real mail (verification + password reset)."
+        )
+
+
 @asynccontextmanager
 async def lifespan(app_: FastAPI):
     await init_db()
@@ -157,6 +193,7 @@ async def lifespan(app_: FastAPI):
         _cookie_secure(),
         _dashboard_url(),
     )
+    _configure_email_sender()
     if _demo_enabled():
         _log.warning(
             "⚠ HEXGATE_DEMO is ON — /v1/demo-login grants a PASSWORDLESS session "
@@ -1773,12 +1810,15 @@ async def api_create_invitation(
         )
     except Exception:
         # Mailer failure — log via the auth logger so it shows up in
-        # the same stderr block operators are already watching.
+        # the same stderr block operators are already watching. Invitee
+        # address is PII-redacted (same rule as mailer.py); the org slug
+        # stays so support can grep by tenant.
         from auth import logger as auth_logger
+        from mailer import _redact_email
 
         auth_logger.exception(
             "failed to send invitation email to %s for org %s",
-            invitation.email,
+            _redact_email(invitation.email),
             org.slug,
         )
 

--- a/platform/api/pyproject.toml
+++ b/platform/api/pyproject.toml
@@ -41,6 +41,10 @@ dependencies = [
     # Users' get_oauth_router consumes any httpx-oauth client uniformly,
     # so swapping providers is one constructor line.
     "httpx-oauth>=0.16",
+    # Transactional email — verify-email + password-reset go through Resend
+    # in production. Dev mode stays on StderrEmailSender (no key needed).
+    # Sync SDK; wrapped via asyncio.to_thread in mailer.py.
+    "resend>=2.4",
 ]
 
 [dependency-groups]

--- a/platform/api/tests/test_mailer.py
+++ b/platform/api/tests/test_mailer.py
@@ -1,0 +1,300 @@
+"""Tests for :mod:`mailer` — the Resend wiring in particular.
+
+The dev-mode :class:`StderrEmailSender` is covered indirectly by the
+auth flow tests (test_auth.py's ``outbox`` fixture swaps a capturing
+sender in). This file is for the production sender: assert it shapes
+the Resend payload correctly, runs the (sync) SDK off the event loop,
+and swallows provider failures so they don't 500 the caller.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+
+import pytest
+
+from mailer import ResendEmailSender, _redact_email
+
+
+# ---- _redact_email -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("alice@example.com", "al***@example.com"),
+        ("alice.smith+tag@host.io", "al***@host.io"),
+        ("abcde@x.y", "ab***@x.y"),  # exactly above the threshold
+        ("abcd@x.y", "***@x.y"),  # at threshold — full mask, 2 of 4 leaks too much
+        ("ab@x.y", "***@x.y"),
+        ("a@x.y", "***@x.y"),
+        ("noatchar", "***"),  # malformed input
+        ("", "***"),
+    ],
+)
+def test_redact_email_cases(raw: str, expected: str) -> None:
+    assert _redact_email(raw) == expected
+
+
+@pytest.fixture
+def fake_resend(monkeypatch: pytest.MonkeyPatch):
+    """Replace ``resend.Emails.send`` with a list-capturing stub.
+
+    Returns the list — tests can append-then-assert on payload shape.
+    """
+    import resend
+
+    calls: list[dict] = []
+
+    def _fake_send(params, options=None):  # noqa: ARG001 — match real signature
+        calls.append(params)
+
+    monkeypatch.setattr(resend.Emails, "send", _fake_send)
+    return calls
+
+
+def test_send_builds_resend_payload(fake_resend: list[dict]) -> None:
+    """The payload Resend sees has the expected from/to/subject/text."""
+    sender = ResendEmailSender(
+        api_key="re_test_key", from_addr="Hexgate <noreply@hexgate.ai>"
+    )
+
+    asyncio.run(
+        sender.send(
+            to="alice@example.com",
+            subject="Verify your Hexgate account",
+            body="Click https://hexgate.ai/verify-email/abc to verify.",
+        )
+    )
+
+    assert len(fake_resend) == 1
+    params = fake_resend[0]
+    assert params["from"] == "Hexgate <noreply@hexgate.ai>"
+    assert params["to"] == ["alice@example.com"]  # list-wrapped per SDK contract
+    assert params["subject"] == "Verify your Hexgate account"
+    assert "verify-email/abc" in params["text"]
+
+
+def test_send_uses_per_instance_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each ResendEmailSender carries its own api_key on the instance.
+    The module global gets set under a lock immediately before each
+    send — a second sender instantiated later doesn't poison the first
+    sender's outgoing calls."""
+    import resend
+
+    monkeypatch.setattr(resend, "api_key", None, raising=False)
+    observed_keys: list[str | None] = []
+
+    def _spy_send(params, options=None):  # noqa: ARG001
+        observed_keys.append(resend.api_key)
+
+    monkeypatch.setattr(resend.Emails, "send", _spy_send)
+    sender_a = ResendEmailSender(api_key="re_key_A", from_addr="a@x.y")
+    sender_b = ResendEmailSender(api_key="re_key_B", from_addr="b@x.y")
+
+    # Constructing sender_b does NOT mutate the global — only send() does.
+    assert resend.api_key is None
+
+    asyncio.run(sender_a.send(to="t@x.y", subject="s", body="b"))
+    asyncio.run(sender_b.send(to="t@x.y", subject="s", body="b"))
+
+    assert observed_keys == ["re_key_A", "re_key_B"]
+
+
+def test_send_runs_off_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SDK is sync; if we called it directly on the loop a slow
+    network would block every other coroutine. Use ``asyncio.to_thread``
+    so it lands on a worker thread — proved here by checking the thread
+    id the fake observes is NOT the main thread."""
+    import resend
+
+    captured_thread: dict[str, int] = {}
+
+    def _fake_send(params, options=None):  # noqa: ARG001
+        captured_thread["tid"] = threading.get_ident()
+
+    monkeypatch.setattr(resend.Emails, "send", _fake_send)
+    sender = ResendEmailSender(api_key="re_test_key", from_addr="x@y.z")
+    asyncio.run(sender.send(to="a@b.c", subject="s", body="b"))
+
+    assert captured_thread["tid"] != threading.get_ident(), (
+        "ResendEmailSender ran the sync SDK on the event loop — would "
+        "block on a real network call"
+    )
+
+
+def test_send_reraises_provider_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Re-raise contract: callers (invitation flow, future health check)
+    need to observe Resend failures. The fastapi-users `on_after_*` hooks
+    wrap us in their own try/except so endpoint 5xx is prevented one
+    level up; we don't double-swallow here."""
+    import resend
+
+    def _exploding_send(params, options=None):  # noqa: ARG001
+        raise RuntimeError("simulated resend outage")
+
+    monkeypatch.setattr(resend.Emails, "send", _exploding_send)
+    sender = ResendEmailSender(api_key="re_test_key", from_addr="x@y.z")
+
+    with caplog.at_level(logging.ERROR, logger="hexgate.platform.email"):
+        with pytest.raises(RuntimeError, match="simulated resend outage"):
+            asyncio.run(sender.send(to="alice@example.com", subject="s", body="b"))
+
+    # An ERROR log went out for grep-ability.
+    assert any(
+        "resend send failed" in rec.getMessage() and rec.levelno == logging.ERROR
+        for rec in caplog.records
+    ), f"expected an ERROR-level 'resend send failed' log, got {caplog.records}"
+
+
+def test_send_error_log_does_not_leak_recipient_local_part(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """PII guard: the recipient's local-part must never reach the logs.
+    Operators get the domain (useful: "all our gmail users failing")
+    but not the address — log stores stay outside the PII boundary."""
+    import resend
+
+    def _exploding_send(params, options=None):  # noqa: ARG001
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(resend.Emails, "send", _exploding_send)
+    sender = ResendEmailSender(api_key="re_test_key", from_addr="x@y.z")
+
+    with caplog.at_level(logging.ERROR, logger="hexgate.platform.email"):
+        with pytest.raises(RuntimeError):
+            asyncio.run(
+                sender.send(
+                    to="alice.smith+tag@example.com",
+                    subject="Verify your account",
+                    body="Click https://app/verify-email/SECRET_TOKEN to verify.",
+                )
+            )
+
+    full_log_text = "\n".join(
+        rec.getMessage() + (rec.exc_text or "") for rec in caplog.records
+    )
+    assert "alice.smith" not in full_log_text, (
+        "recipient local-part leaked into error log — PII violation"
+    )
+    assert "+tag" not in full_log_text, "recipient tag leaked into error log"
+    # Partial-preserve format: first 2 chars + *** + domain. Just enough
+    # for support to recognize a reported user; not enough to be the address.
+    assert "al***@example.com" in full_log_text, (
+        "expected partial-redacted form (al***@domain) — see _redact_email"
+    )
+    # Body must never reach logs — would expose the magic-link token.
+    assert "SECRET_TOKEN" not in full_log_text, (
+        "verification token leaked into error log — security violation"
+    )
+
+
+# ---- boot wiring: _configure_email_sender in main.py ----------------------
+
+
+@pytest.fixture
+def reset_sender():
+    """Snapshot + restore the module-level sender AND resend.api_key so each
+    test starts clean. ResendEmailSender mutates the resend module global
+    inside _send_sync; without restoring it here a later test would see
+    a stray "re_test_key" left by an earlier one."""
+    import mailer
+    import resend
+
+    original_sender = mailer.get_email_sender()
+    original_key = resend.api_key
+    yield
+    mailer.set_email_sender(original_sender)
+    resend.api_key = original_key
+
+
+def test_configure_email_sender_wires_resend_when_both_env_vars_set(
+    monkeypatch: pytest.MonkeyPatch, reset_sender: None
+) -> None:
+    """Both env vars present → real ResendEmailSender, configured with
+    the exact values from the env (not a half-broken fallback)."""
+    from main import _configure_email_sender
+    from mailer import ResendEmailSender, get_email_sender
+
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key_42")
+    monkeypatch.setenv("HEXGATE_EMAIL_FROM", "noreply@hexgate.ai")
+    _configure_email_sender()
+    sender = get_email_sender()
+    assert isinstance(sender, ResendEmailSender)
+    # Pin the env→sender wiring so a typo'd env-var read can't silently
+    # construct an empty ResendEmailSender that passes isinstance.
+    assert sender._from == "noreply@hexgate.ai"  # noqa: SLF001 — invariant under test
+    assert sender._api_key == "re_test_key_42"  # noqa: SLF001
+
+
+def test_configure_email_sender_warns_on_partial_config(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_sender: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Exactly one env var set = operator misconfig. Must log WARNING
+    (distinguishable from clean dev mode) naming the missing var so the
+    fix is obvious without grepping the .env."""
+    import main as main_module
+    from main import _configure_email_sender
+    from mailer import ResendEmailSender, get_email_sender
+
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.delenv("HEXGATE_EMAIL_FROM", raising=False)
+    with caplog.at_level(logging.WARNING, logger=main_module.__name__):
+        _configure_email_sender()
+    assert not isinstance(get_email_sender(), ResendEmailSender)
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warns, "partial config should emit a WARNING-level log"
+    assert "HEXGATE_EMAIL_FROM" in warns[-1].getMessage(), (
+        "warning should name the missing var"
+    )
+
+
+def test_configure_email_sender_clean_dev_mode_logs_info(
+    monkeypatch: pytest.MonkeyPatch,
+    reset_sender: None,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Both unset = clean dev mode. INFO log only — no false alarm
+    that would teach operators to ignore the partial-config warning."""
+    import main as main_module
+    from main import _configure_email_sender
+    from mailer import ResendEmailSender, get_email_sender
+
+    monkeypatch.delenv("RESEND_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_EMAIL_FROM", raising=False)
+    with caplog.at_level(logging.INFO, logger=main_module.__name__):
+        _configure_email_sender()
+    assert not isinstance(get_email_sender(), ResendEmailSender)
+    assert not any(r.levelno == logging.WARNING for r in caplog.records), (
+        "clean dev mode should not emit a WARNING — that's reserved for misconfig"
+    )
+
+
+def test_configure_email_sender_resets_to_stderr_when_env_cleared(
+    monkeypatch: pytest.MonkeyPatch, reset_sender: None
+) -> None:
+    """A re-config (lifespan-restart, test) with env vars cleared must
+    actively reset to StderrEmailSender — otherwise a stale Resend
+    sender keeps shipping mail while the log says 'dev stderr sender'."""
+    from main import _configure_email_sender
+    from mailer import ResendEmailSender, get_email_sender
+
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_key")
+    monkeypatch.setenv("HEXGATE_EMAIL_FROM", "noreply@hexgate.ai")
+    _configure_email_sender()
+    assert isinstance(get_email_sender(), ResendEmailSender)
+
+    monkeypatch.delenv("RESEND_API_KEY")
+    monkeypatch.delenv("HEXGATE_EMAIL_FROM")
+    _configure_email_sender()
+    assert not isinstance(get_email_sender(), ResendEmailSender), (
+        "re-config with env cleared must reset away from ResendEmailSender"
+    )

--- a/platform/api/uv.lock
+++ b/platform/api/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "hexgate"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "../../" }
 dependencies = [
     { name = "bashlex" },
@@ -1074,6 +1074,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "resend" },
     { name = "sqlmodel" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1102,6 +1103,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.5" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "resend", specifier = ">=2.4" },
     { name = "sqlmodel", specifier = ">=0.0.22" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32" },
 ]
@@ -2630,6 +2632,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "resend"
+version = "2.32.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/d5/2c46334104cce931170d756c7478263744b3eb168179c329d90a065f9b6b/resend-2.32.2.tar.gz", hash = "sha256:448001810f32e7aea39bab27318263fdc69f5764be16b7c6241ed7714dc07ea3", size = 46202, upload-time = "2026-06-17T19:47:28.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/e9/64b7f15e4d2b9bc363e1a6e0abc518f7aea4b8dfeab8d15a25e508c31fb2/resend-2.32.2-py2.py3-none-any.whl", hash = "sha256:1a8df5ef54b3a5cb7bb18b745f85fda07f1fa8f79b83dd9a25f6e37fbd625ef2", size = 72664, upload-time = "2026-06-17T19:47:26.915Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wires [Resend](https://resend.com) behind the existing `EmailSender` Protocol seam — verification, password-reset, and invitation emails flow through real delivery in production. Dev mode is unchanged (still prints to stderr). All four high-priority findings from the inline `/code-review` pass are addressed.

## What's behind the seam

```
platform/api/mailer.py
  ├─ EmailSender (Protocol)           — unchanged
  ├─ StderrEmailSender                — dev default, prints to stderr
  └─ ResendEmailSender                — NEW. wraps resend.Emails.send
```

`main.py`'s lifespan picks the sender at boot:

| `RESEND_API_KEY` | `HEXGATE_EMAIL_FROM` | Result | Log level |
|---|---|---|---|
| set | set | `ResendEmailSender` | INFO |
| unset | unset | `StderrEmailSender` (dev) | INFO |
| set XOR set | — | `StderrEmailSender` + warning | **WARNING** naming the missing var |

The three-way differentiation is deliberate: a half-rotated deployment with only `RESEND_API_KEY` set should NOT read as a benign dev-mode notice. The else-branch also explicitly resets to `StderrEmailSender` so a re-config that clears env vars can't leave a stale Resend sender silently shipping mail.

## Failure contract

- **`ResendEmailSender.send` re-raises** after logging ERROR. The `fastapi-users` `on_after_request_verify` + `on_after_forgot_password` hooks wrap the call in `try/except` so the `/v1/auth/...` endpoints still return 200. The invitation flow in `main.py:1796` already had a `try/except` — re-raise restores the org-scoped log signal it was waiting for.
- **Per-instance api_key** on the wrapper, not on the `resend` module global. `_send_sync` sets `resend.api_key` under a module-level lock immediately before each call, so two senders with different keys can't race. Throughput cost is irrelevant at our rate (single-digit emails/sec at peak).
- **PII-redacted error logs**. `_redact_email` keeps the first 2 chars of the local-part + the domain (\`al***@example.com\`); fully masks local-parts shorter than 5 chars; never leaks more than ~40% of an address. Domain is preserved so \"all our gmail users are failing\" stays grep-able. Body is never logged — that would expose the magic-link token. Same helper is reused for the invitation-flow log in \`main.py:1796\`.

## Env config

\`\`\`
# platform/api/.env
RESEND_API_KEY=re_…
HEXGATE_EMAIL_FROM=\"Hexgate <noreply@yourdomain.com>\"
HEXGATE_DASHBOARD_URL=https://app.yourdomain.com   # link host inside the email
\`\`\`

From-address must be on a verified Resend domain (see [Resend → Domains](https://resend.com/domains)).

## Tests

\`platform/api/tests/test_mailer.py\` — 17 cases:

- \`_redact_email\` parametrized over 8 cases (incl. short local-part + malformed input)
- Payload shape (from / to-list / subject / text)
- Per-instance api_key: A's send uses A's key, B's send uses B's
- \`to_thread\` offload verified by observed thread id
- Re-raise contract: \`RuntimeError\` propagates AND ERROR log emitted
- PII redaction: local-part and tag NOT in log; partial form IS; token NOT
- Wiring: assert \`_from\` + \`_api_key\` values (not just \`isinstance\`)
- Three-way log: WARN on partial config, INFO on clean dev mode
- Re-config reset: clearing env vars after wiring Resend reverts to stderr

## Code-review fixes folded in

This PR includes the four findings from \`/code-review xhigh\` on the initial draft:

1. **#1 PII redaction** — recipient redacted in mailer.py and main.py:1796 (invitation flow). Body never logged.
2. **#2 Re-raise** — provider failures now reach the caller; auth hooks wrap them.
3. **#3 Per-instance api_key** — module-global mutation serialized under a lock.
4. **#5 Three-way log discrimination** — partial config emits WARNING.

## Action required before this is useful

Add \`RESEND_API_KEY\` and \`HEXGATE_EMAIL_FROM\` to the production environment. Until then the platform stays on \`StderrEmailSender\` (no behavior change).

## Test plan

- [x] \`platform/api\`: 335 passed, 2 skipped
- [x] SDK: 844 passed, 2 skipped
- [x] \`ruff check\` clean on touched files
- [ ] After merge: configure Resend domain, set the two env vars, register a test account, confirm the link in the inbox routes to the dashboard.