### PR TITLE
ci(tests): retry the OPA download to ride out CDN hiccups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,12 @@ jobs:
       # Pin a known-good version so an upstream OPA change can't break CI overnight.
       - name: Install OPA
         run: |
-          curl -fsSL -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
+          # --retry-all-errors covers curl 56 (recv reset mid-download) and
+          # other transient TCP hiccups against openpolicyagent.org's CDN
+          # that --retry alone won't catch. ~3min worst case before the job
+          # gives up, much better than a one-shot fail forcing a re-run.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+            -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
           opa version
@@ -94,7 +99,12 @@ jobs:
       # ETag header. Same pin as the SDK job.
       - name: Install OPA
         run: |
-          curl -fsSL -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
+          # --retry-all-errors covers curl 56 (recv reset mid-download) and
+          # other transient TCP hiccups against openpolicyagent.org's CDN
+          # that --retry alone won't catch. ~3min worst case before the job
+          # gives up, much better than a one-shot fail forcing a re-run.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60 \
+            -o opa https://openpolicyagent.org/downloads/v0.70.0/opa_linux_amd64_static
           chmod +x opa
           sudo mv opa /usr/local/bin/opa
           opa version


### PR DESCRIPTION
## What broke

CI failed with:
\`\`\`
curl: (56) Failure when receiving data from the peer
\`\`\`
mid-download of \`opa_linux_amd64_static\` from openpolicyagent.org. Curl 56 = TCP receive reset — not an HTTP status, so the default \`--retry\` (which only retries on HTTP 408/429/5xx) doesn't catch it.

## Fix

Add curl retry flags to both \`Install OPA\` steps (\`sdk\` and \`platform-api\` jobs):

\`\`\`
--retry 5 --retry-all-errors --retry-delay 2 --retry-max-time 60
\`\`\`

\`--retry-all-errors\` is the key one — it covers connection-class failures (curl 56, 28, etc.) that the default retry policy ignores. \`--retry-max-time 60\` caps the worst case at ~1 minute per attempt's wall-clock budget, so a job can't hang indefinitely if openpolicyagent.org is fully down.

## Why not switch to GitHub releases / setup-opa action?

Smaller change, less risk. The CDN is the canonical source, and the failure is a transient network blip — retries are the right level. If we see this fail repeatedly even with retries, the next step would be the GitHub releases mirror or the official \`open-policy-agent/setup-opa\` action.

## Heads-up for open PRs

Once merged, rebase the open PRs (#50, #51, #52) onto main to pick this up — that's how they get the resilient OPA install for their CI runs too.

## Test plan

- [x] No behavior change on the happy path.
- [ ] After merge: re-run the failed CI on PR #52 (Resend) and confirm OPA installs cleanly.