### PR TITLE
feat(platform/api) Add audit/anomalies API endpoint

### DIFF
--- a/platform/api/audit.py
+++ b/platform/api/audit.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 import json
 import logging
 from datetime import datetime, timedelta, timezone
+from collections import deque
 
 from clickhouse_connect.driver.client import Client
 
-from schemas import DecisionEvent
+from schemas import AnomalySeverity, AuditAnomaly, AuditOutcome, DecisionEvent
 
 _log = logging.getLogger(__name__)
 
@@ -42,6 +43,12 @@ MAX_HINT_BYTES = 4 * 1024
 # older than retention — rows past TTL would be merged away on arrival.
 CLOCK_SKEW_FUTURE = timedelta(minutes=5)
 RETENTION_WINDOW = timedelta(days=90)
+
+_ANOMALY_MIN_REQUESTS = 5
+_TIMEDELTA_ANOMALY_HOURS = 1
+_WINDOW_TD = timedelta(hours=_TIMEDELTA_ANOMALY_HOURS)
+_DENY_RATE_MEDIUM = 0.3
+_DENY_RATE_HIGH = 0.5
 
 
 def validate_event_window(occurred_at: datetime) -> None:
@@ -158,7 +165,7 @@ def bucket_minutes_for_timedelta(delta: timedelta) -> int:
 
 
 def _zero_counts() -> dict[str, int]:
-    return {"all": 0, "allow": 0, "deny": 0, "needs_approval": 0}
+    return {"all": 0, **{e.value: 0 for e in AuditOutcome}}
 
 
 def _date_range_valid(start: datetime | None, end: datetime | None) -> bool:
@@ -338,7 +345,7 @@ def timeseries(
     points: dict[object, dict] = {}
     for t, outcome, n in result.result_rows:
         point = points.setdefault(
-            t, {"bucket": t, "allow": 0, "deny": 0, "needs_approval": 0}
+            t, {"bucket": t, **{e.value: 0 for e in AuditOutcome}}
         )
         if outcome in point:
             point[outcome] = int(n)
@@ -429,6 +436,127 @@ def list_decisions(
         )
 
     return {"rows": rows, "total": total, "limit": limit, "offset": offset}
+
+
+def _sliding_window_anomalies(
+    rows: list[tuple],
+) -> list[AuditAnomaly]:
+    """Emits one anomaly per above-threshold burst (not per qualifying window) so the full
+    peak window is captured rather than the first qualifying moment."""
+    list_anomalies: list[AuditAnomaly] = []
+    curr_user, curr_deny, window, best_burst = "", 0, deque(), None
+
+    def _flush(burst: dict | None) -> None:
+        if burst:
+            list_anomalies.append(AuditAnomaly(**burst))
+
+    for user, timestamp, decision in rows:
+        if user != curr_user:
+            _flush(best_burst)
+            curr_user = user
+            curr_deny = 0
+            window.clear()
+            best_burst = None
+
+        while window and timestamp - window[0][0] > _WINDOW_TD:
+            _, old_decision = window.popleft()
+            curr_deny -= int(old_decision == AuditOutcome.DENY)
+
+        window.append((timestamp, decision))
+        curr_deny += int(decision == AuditOutcome.DENY)
+        window_length = len(window)
+        deny_rate = curr_deny / window_length
+
+        if window_length >= _ANOMALY_MIN_REQUESTS and deny_rate >= _DENY_RATE_HIGH:
+            severity = AnomalySeverity.HIGH
+        elif window_length >= _ANOMALY_MIN_REQUESTS and deny_rate >= _DENY_RATE_MEDIUM:
+            severity = AnomalySeverity.MEDIUM
+        else:
+            severity = None
+
+        if severity:
+            candidate = dict(
+                user_id=curr_user,
+                severity=severity,
+                deny=curr_deny,
+                all=window_length,
+                deny_rate=deny_rate,
+                first_seen=window[0][0],
+                last_seen=window[-1][0],
+            )
+            if best_burst is None or (deny_rate, window_length) >= (
+                best_burst["deny_rate"],
+                best_burst["all"],
+            ):
+                best_burst = candidate
+        elif best_burst:
+            # After eviction the window already shrank to just the current
+            # event, so reseed it. After a rate-drop the window still holds
+            # many live events that belong to neither burst; discard them all.
+            last = window[-1] if len(window) == 1 else None
+            _flush(best_burst)
+            window.clear()
+            curr_deny = 0
+            if last:
+                window.append(last)
+                curr_deny = int(last[1] == AuditOutcome.DENY)
+            best_burst = None
+
+    _flush(best_burst)
+    return list_anomalies
+
+
+def anomalies(
+    client: Client,
+    *,
+    project_id: str,
+    since_hours: int,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+) -> list[AuditAnomaly]:
+    """
+    Return a list of per-user anomaly summaries for the given time window.
+
+    An anomaly is defined as an abnormal rate of denied requests for a user in a 1-hour window with more than
+    ANOMALY_MIN_REQUESTS requests. The severity of the anomaly is determined by the deny rate:
+    - High: deny rate >= 0.5
+    - Medium: 0.3 <= deny rate < 0.5
+
+    The current implementation loads all the data into memory and processes it in Python.
+    Time complexity and space complexity are both O(n), with n the number of requests in the given time window.
+    For large datasets, chunks of data can be processed in batches to avoid memory issues.
+    An other approach is to pre-compute the anomalies in ClickHouse with a periodical job, and only compute the new anomalies in the API call.
+
+    These optimizations should be implemented once the data volume grows and performance issues arise.
+    """
+
+    # Find qualifying users with more than ANOMALY_MIN_REQUESTS requests in the given time window
+    where, params = _scope(
+        project_id,
+        since_hours,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    where_sql = " AND ".join(where)
+    params["min_requests"] = _ANOMALY_MIN_REQUESTS
+    qualifying_users_sql = (
+        f"SELECT user_id FROM policy_decision WHERE {where_sql} "
+        "GROUP BY user_id HAVING count() >= {min_requests:UInt32}"
+    )
+
+    result_qualifying_users = client.query(qualifying_users_sql, parameters=params)
+    qualifying_user_ids = [row[0] for row in result_qualifying_users.result_rows]
+    if not qualifying_user_ids:
+        return []
+
+    params["uids"] = qualifying_user_ids
+    anomalies_sql = (
+        "SELECT user_id, occurred_at, outcome FROM policy_decision "
+        f"WHERE {where_sql} AND user_id IN ({{uids:Array(String)}}) "
+        "ORDER BY user_id, occurred_at"
+    )
+    result = client.query(anomalies_sql, parameters=params)
+    return _sliding_window_anomalies(result.result_rows)
 
 
 def _ensure_utc(dt: datetime | None) -> datetime | None:

--- a/platform/api/main.py
+++ b/platform/api/main.py
@@ -5,7 +5,6 @@ import hashlib
 import logging
 import os
 from contextlib import asynccontextmanager
-from typing import Literal
 from urllib.parse import unquote
 
 from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError
@@ -37,6 +36,7 @@ from audit import (
     WINDOW_HOURS,
     AuditEventOutOfWindow,
     AuditPayloadTooLarge,
+    anomalies,
     prepare_date_range,
     insert_decision,
     list_decisions,
@@ -59,7 +59,9 @@ from schemas import (
     AgentManifestView,
     AgentRead,
     AgentUpdate,
+    AuditAnomaly,
     AuditDecisionPage,
+    AuditOutcome,
     AuditSummary,
     AuditTimeseriesPoint,
     AuditWindow,
@@ -1234,7 +1236,7 @@ async def api_audit_decisions(
     agent: str | None = None,
     role: str | None = None,
     tool: str | None = None,
-    outcome: Literal["allow", "deny", "needs_approval"] | None = None,
+    outcome: AuditOutcome | None = None,
     session_id: str | None = None,
     limit: int = 25,
     offset: int = 0,
@@ -1262,6 +1264,33 @@ async def api_audit_decisions(
     except ClickHouseError:
         raise _audit_unavailable()
     return page
+
+
+@v1.get(
+    "/projects/{project_id}/audit/anomalies",
+    response_model=list[AuditAnomaly],
+    dependencies=[Depends(require_org_member)],
+    tags=["audit"],
+)
+async def api_audit_anomalies(
+    project_id: str,
+    window: AuditWindow = "24h",
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    clickhouse_client=Depends(require_clickhouse),
+) -> list[AuditAnomaly]:
+    start_date, end_date = prepare_date_range(start_date, end_date)
+    try:
+        return await asyncio.to_thread(
+            anomalies,
+            clickhouse_client,
+            project_id=project_id,
+            since_hours=WINDOW_HOURS[window],
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except ClickHouseError:
+        raise _audit_unavailable()
 
 
 @v1.get("/agents/{name}", response_model=AgentRead)

--- a/platform/api/schemas.py
+++ b/platform/api/schemas.py
@@ -362,11 +362,17 @@ class AuditEnvelope(BaseModel):
         return v if v.tzinfo is not None else v.replace(tzinfo=timezone.utc)
 
 
+class AuditOutcome(StrEnum):
+    ALLOW = "allow"
+    DENY = "deny"
+    NEEDS_APPROVAL = "needs_approval"
+
+
 class DecisionEvent(AuditEnvelope):
     """One policy decision; mirrors the policy_decision table."""
 
     tool_name: str = Field(min_length=1, max_length=256)
-    outcome: Literal["allow", "deny", "needs_approval"]
+    outcome: AuditOutcome
     role: str = Field(default="", max_length=256)
     error_type: str = Field(default="", max_length=64)
     reason: str = Field(default="", max_length=4096)
@@ -437,7 +443,7 @@ class AuditDecisionRow(BaseModel):
     user_id: str = ""
     tool_name: str
     role: str = ""
-    outcome: str
+    outcome: AuditOutcome
     error_type: str = ""
     reason: str = ""
     violations: list[str] = Field(default_factory=list)
@@ -452,3 +458,18 @@ class AuditDecisionPage(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class AnomalySeverity(StrEnum):
+    HIGH = "high"
+    MEDIUM = "medium"
+
+
+class AuditAnomaly(BaseModel):
+    user_id: str
+    severity: AnomalySeverity
+    deny: int
+    all: int
+    deny_rate: float
+    first_seen: datetime
+    last_seen: datetime

--- a/platform/api/tests/test_audit.py
+++ b/platform/api/tests/test_audit.py
@@ -21,7 +21,12 @@ from pydantic import ValidationError
 
 import audit
 import main
-from audit import CLOCK_SKEW_FUTURE, list_decisions, summarize
+from audit import (
+    CLOCK_SKEW_FUTURE,
+    list_decisions,
+    summarize,
+    _sliding_window_anomalies,
+)
 from keystore import FileKeyStore
 from main import (
     app,
@@ -31,7 +36,7 @@ from main import (
     require_project,
     require_user,
 )
-from schemas import DecisionEvent
+from schemas import AnomalySeverity, AuditOutcome, DecisionEvent
 
 from audit import prepare_date_range
 
@@ -562,13 +567,14 @@ def test_list_decisions_empty_first_page_skips_count() -> None:
 # Dashboard read endpoints — require_org_member gating
 # ---------------------------------------------------------------------------
 
-# All three project-scoped reads share one trust envelope (require_org_member,
+# All four project-scoped reads share one trust envelope (require_org_member,
 # same as the other dashboard reads); membership semantics (403 non-member,
 # 404 unknown project) are covered against a real DB in test_auth.py.
 _AUDIT_READ_PATHS = [
     "/v1/projects/proj_test/audit/summary",
     "/v1/projects/proj_test/audit/timeseries",
     "/v1/projects/proj_test/audit/decisions",
+    "/v1/projects/proj_test/audit/anomalies",
 ]
 
 
@@ -821,3 +827,300 @@ def test_when_end_date_is_in_the_future_then_end_date_is_clamped_to_now() -> Non
     future_end = datetime(2099, 12, 31, tzinfo=timezone.utc)
     _, end = prepare_date_range(None, future_end)
     assert end <= datetime.now(timezone.utc) + CLOCK_SKEW_FUTURE
+
+
+# ---------------------------------------------------------------------------
+# _sliding_window_anomalies() — pure sliding-window burst detector
+# ---------------------------------------------------------------------------
+
+
+class TestSlidingWindowAnomalies:
+    BASE = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    D = AuditOutcome.DENY
+    A = AuditOutcome.ALLOW
+
+    @staticmethod
+    def rows(
+        user: str,
+        outcomes: list,
+        *,
+        gap_minutes: int = 5,
+        base: datetime = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    ) -> list[tuple]:
+        return [
+            (user, base + timedelta(minutes=i * gap_minutes), outcome)
+            for i, outcome in enumerate(outcomes)
+        ]
+
+    def test_when_rows_are_empty_then_returns_empty_list(self):
+        assert _sliding_window_anomalies([]) == []
+
+    def test_when_window_size_is_below_min_requests_then_no_anomaly(self):
+        rows = self.rows("alice", [self.D, self.D, self.D, self.D])
+        assert _sliding_window_anomalies(rows) == []
+
+    def test_when_deny_rate_is_below_30_percent_then_no_anomaly(self):
+        rows = self.rows("alice", [self.D, self.A, self.A, self.A, self.A])
+        assert _sliding_window_anomalies(rows) == []
+
+    def test_when_user_has_no_burst_then_no_emission_on_user_change(self):
+        rows = self.rows("alice", [self.A] * 5) + self.rows("bob", [self.A] * 3)
+        assert _sliding_window_anomalies(rows) == []
+
+    def test_when_deny_rate_is_above_50_percent_then_severity_is_high(self):
+        rows = self.rows("alice", [self.D] * 5)
+        result = _sliding_window_anomalies(rows)
+        assert len(result) == 1
+        assert result[0].user_id == "alice"
+        assert result[0].severity == AnomalySeverity.HIGH
+        assert result[0].deny == 5
+        assert result[0].all == 5
+        assert result[0].deny_rate == pytest.approx(1.0)
+        assert result[0].first_seen == self.BASE
+        assert result[0].last_seen == self.BASE + timedelta(minutes=20)
+
+    def test_when_deny_rate_is_between_30_and_50_percent_then_severity_is_medium(self):
+        rows = self.rows("alice", [self.D, self.D, self.A, self.A, self.A])
+        result = _sliding_window_anomalies(rows)
+        assert len(result) == 1
+        assert result[0].severity == AnomalySeverity.MEDIUM
+        assert result[0].deny == 2
+        assert result[0].all == 5
+
+    def test_when_deny_rate_drops_below_threshold_then_anomaly_is_emitted(self):
+        burst = self.rows("alice", [self.D] * 5, gap_minutes=2, base=self.BASE)
+        cooldown = self.rows(
+            "alice",
+            [self.A] * 12,
+            gap_minutes=2,
+            base=self.BASE + timedelta(minutes=10),
+        )
+        result = _sliding_window_anomalies(burst + cooldown)
+        assert len(result) == 1
+        assert result[0].severity == AnomalySeverity.HIGH
+
+    def test_when_deny_rate_increases_within_burst_then_peak_is_captured(self):
+        # At event 5: 3/5 = 60%; at event 6: 4/6 ≈ 66.7% → best_burst updated
+        burst = self.rows(
+            "alice",
+            [self.D, self.D, self.D, self.A, self.A, self.D],
+            gap_minutes=5,
+            base=self.BASE,
+        )
+        cooldown = self.rows(
+            "alice",
+            [self.A] * 12,
+            gap_minutes=2,
+            base=self.BASE + timedelta(minutes=30),
+        )
+        result = _sliding_window_anomalies(burst + cooldown)
+        assert len(result) == 1
+        assert result[0].deny_rate == pytest.approx(4 / 6)
+        assert result[0].deny == 4
+        assert result[0].all == 6
+
+    def test_when_deny_rate_decreases_within_burst_then_peak_is_not_overwritten(self):
+        # Peak at 5/5 = 100%; rate drops with allows but stays above threshold
+        burst = self.rows("alice", [self.D] * 5, gap_minutes=5, base=self.BASE)
+        dip = self.rows(
+            "alice", [self.A] * 5, gap_minutes=5, base=self.BASE + timedelta(minutes=25)
+        )
+        cooldown = self.rows(
+            "alice",
+            [self.A] * 12,
+            gap_minutes=2,
+            base=self.BASE + timedelta(minutes=55),
+        )
+        result = _sliding_window_anomalies(burst + dip + cooldown)
+        assert len(result) == 1
+        assert result[0].deny_rate == pytest.approx(1.0)
+
+    def test_when_deny_events_expire_from_window_then_burst_is_flushed(self):
+        burst = self.rows("alice", [self.D] * 5, gap_minutes=5, base=self.BASE)
+        late = [("alice", self.BASE + timedelta(hours=2), self.A)]
+        result = _sliding_window_anomalies(burst + late)
+        assert len(result) == 1
+        assert result[0].deny == 5
+
+    def test_when_allow_events_expire_from_window_then_deny_count_is_unchanged(self):
+        early = self.rows(
+            "alice",
+            [self.A, self.A, self.A, self.A, self.D, self.D, self.D, self.D, self.D],
+            gap_minutes=5,
+            base=self.BASE,
+        )
+        late = [("alice", self.BASE + timedelta(hours=2), self.D)]
+        result = _sliding_window_anomalies(early + late)
+        assert len(result) == 1
+        assert result[0].severity == AnomalySeverity.HIGH
+
+    def test_when_two_bursts_are_separated_by_gap_then_two_anomalies_are_emitted(self):
+        burst1 = self.rows("alice", [self.D] * 5, gap_minutes=5, base=self.BASE)
+        bridge = [("alice", self.BASE + timedelta(hours=2), self.A)]
+        burst2 = self.rows(
+            "alice",
+            [self.D] * 5,
+            gap_minutes=5,
+            base=self.BASE + timedelta(hours=2, minutes=10),
+        )
+        result = _sliding_window_anomalies(burst1 + bridge + burst2)
+        assert len(result) == 2
+        assert all(r.user_id == "alice" for r in result)
+        assert all(r.severity == AnomalySeverity.HIGH for r in result)
+        assert result[1].first_seen > result[0].last_seen
+
+    def test_when_burst_ends_by_eviction_and_boundary_event_is_deny_then_it_seeds_next_burst(
+        self,
+    ):
+        # Burst 1: 5 denies. 2 hours pass — eviction clears the entire window.
+        # The next event is a DENY: window_length=1, below threshold, so the burst
+        # is flushed. That DENY must be re-seeded into the cleared window so it
+        # contributes curr_deny=1 toward a second burst. Without re-seeding, the
+        # following 4 DENYs reach only window_length=4 and no second anomaly fires.
+        burst1 = self.rows("alice", [self.D] * 5, gap_minutes=5, base=self.BASE)
+        seed_deny = [("alice", self.BASE + timedelta(hours=2), self.D)]
+        burst2 = self.rows(
+            "alice",
+            [self.D] * 4,
+            gap_minutes=5,
+            base=self.BASE + timedelta(hours=2, minutes=5),
+        )
+        result = _sliding_window_anomalies(burst1 + seed_deny + burst2)
+        assert len(result) == 2
+        assert result[1].deny == 5
+        assert result[1].all == 5
+
+    def test_when_burst_ends_by_rate_drop_then_live_window_events_are_discarded(self):
+        # Burst 1: 5 denies then 12 allows drop the rate below threshold at
+        # T+32min. All 17 events are still inside the 1-hour window when the
+        # flush fires, but they belong to neither burst and must be discarded.
+        # Without discarding them, those allows inflate the denominator of the
+        # next burst and suppress its deny rate, masking the second anomaly.
+        burst1 = self.rows("alice", [self.D] * 5, gap_minutes=2, base=self.BASE)
+        cooldown = self.rows(
+            "alice",
+            [self.A] * 12,
+            gap_minutes=2,
+            base=self.BASE + timedelta(minutes=10),
+        )
+        burst2 = self.rows(
+            "alice",
+            [self.D] * 5,
+            gap_minutes=2,
+            base=self.BASE + timedelta(minutes=34),
+        )
+        result = _sliding_window_anomalies(burst1 + cooldown + burst2)
+        assert len(result) == 2
+        assert result[1].deny == 5
+        assert result[1].all == 5
+
+    def test_when_window_slides_at_constant_rate_then_last_seen_advances(self):
+        # 5 DENYs at T+0..T+20 hit threshold (rate=1.0, all=5). Then 4 more
+        # DENYs at T+65..T+80 — each evicts one old DENY, keeping rate=1.0
+        # and all=5. With strict >, best_burst would never update and last_seen
+        # would freeze at T+20. With >=, each new candidate replaces the old
+        # one and last_seen advances to T+80.
+        burst = self.rows("alice", [self.D] * 5, gap_minutes=5, base=self.BASE)
+        slide = self.rows(
+            "alice",
+            [self.D] * 4,
+            gap_minutes=5,
+            base=self.BASE + timedelta(minutes=65),
+        )
+        result = _sliding_window_anomalies(burst + slide)
+        assert len(result) == 1
+        assert result[0].last_seen == self.BASE + timedelta(minutes=80)
+
+    def test_when_multiple_users_each_have_bursts_then_one_anomaly_per_user(self):
+        rows = self.rows("alice", [self.D] * 5, base=self.BASE) + self.rows(
+            "bob", [self.D, self.D, self.A, self.A, self.A], base=self.BASE
+        )
+        result = _sliding_window_anomalies(rows)
+        assert len(result) == 2
+        by_user = {r.user_id: r for r in result}
+        assert by_user["alice"].severity == AnomalySeverity.HIGH
+        assert by_user["bob"].severity == AnomalySeverity.MEDIUM
+
+    def test_when_user_changes_with_active_burst_then_burst_is_flushed(self):
+        rows = self.rows("alice", [self.D] * 5, base=self.BASE) + self.rows(
+            "bob", [self.A] * 3, base=self.BASE
+        )
+        result = _sliding_window_anomalies(rows)
+        assert len(result) == 1
+        assert result[0].user_id == "alice"
+
+
+# ---------------------------------------------------------------------------
+# anomalies() — two-pass ClickHouse wiring
+# ---------------------------------------------------------------------------
+
+
+class TestAnomalies:
+    BASE = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    @staticmethod
+    def _client(
+        qualifying_rows: list[tuple],
+        decision_rows: list[tuple],
+    ) -> MagicMock:
+        pass1, pass2 = MagicMock(), MagicMock()
+        pass1.result_rows = qualifying_rows
+        pass2.result_rows = decision_rows
+        client = MagicMock()
+        client.query.side_effect = [pass1, pass2]
+        return client
+
+    @staticmethod
+    def _burst(
+        user: str,
+        n: int = 5,
+        base: datetime = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+    ) -> list[tuple]:
+        return [
+            (user, base + timedelta(minutes=i * 5), AuditOutcome.DENY) for i in range(n)
+        ]
+
+    def test_when_no_qualifying_users_then_returns_empty_list_and_skips_second_query(
+        self,
+    ):
+        client = MagicMock()
+        client.query.return_value.result_rows = []
+        result = audit.anomalies(client, project_id="p1", since_hours=24)
+        assert result == []
+        client.query.assert_called_once()
+
+    def test_when_qualifying_users_exist_then_anomalies_are_returned(self):
+        client = self._client(
+            qualifying_rows=[("bob",)],
+            decision_rows=self._burst("bob"),
+        )
+        result = audit.anomalies(client, project_id="p1", since_hours=24)
+        assert len(result) == 1
+        assert result[0].user_id == "bob"
+        assert result[0].severity == AnomalySeverity.HIGH
+        assert client.query.call_count == 2
+
+    def test_pure_deny_burst_reports_full_window_size(self):
+        # 20 denies all within 1 minute — all at 100% deny rate.  The best_burst
+        # must grow with each event (tie-break by window size), not freeze at
+        # the first qualifying window of 5.
+        base = self.BASE
+        rows = [
+            ("bob", base + timedelta(seconds=i * 3), AuditOutcome.DENY)
+            for i in range(20)
+        ]
+        client = self._client(qualifying_rows=[("bob",)], decision_rows=rows)
+        result = audit.anomalies(client, project_id="p1", since_hours=24)
+        assert len(result) == 1
+        assert result[0].deny == 20
+        assert result[0].all == 20
+
+
+def test_audit_anomalies_clickhouse_error_returns_503(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    app.dependency_overrides[require_org_member] = lambda: MagicMock()
+    fake_clickhouse.query.side_effect = ClickHouseError("unavailable")
+    r = client.get("/v1/projects/proj_test/audit/anomalies")
+    assert r.status_code == 503
+    assert "unavailable" in r.json()["detail"]


### PR DESCRIPTION
## What is changing
A new API endpoint is added for anomaly detection.
A sliding-window function is added to detect per-user anomalies.
An anomaly is defined by 50% of denies in a 1-hour time window containing more than 5 decisions.
The approach is straightforward and not fully optimised for simplicity, refer to code comments for more details.

## Test
make check-all