### PR TITLE
docs(claude) Add CLAUDE.md files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Hexgate — Claude Code Instructions
+
+## Tech Stack
+- Python ≥ 3.13 (`uv`), FastAPI (`platform/api/`), ClickHouse (Docker)
+- React, Vite, pnpm (`platform/dashboard/`)
+- Ruff (Python). WASM via `wasmtime`.
+
+## Cross-package
+After you make changes across multiple packages, run: `make check-all`  # all packages
+
+## Repo Layout
+hexgate/              # SDK source
+platform/api/         # FastAPI control plane (separate uv project)
+platform/api/tests/   # API tests
+platform/dashboard/   # React/Vite frontend
+tests/                # hexgate package tests (agents, cli, security, tracing, streaming…)
+
+## AI Constraints (CRITICAL)
+- NEVER fabricate code examples, config snippets, or file contents. If unknown, read the file first.
+- Verify third-party or config behavior against actual files in this repo before generating code.
+
+## Rules & Constants
+- **Branches:** `{initials}/{type}/{short_description}` (e.g., `vl/feat/web_search`)
+- **Commits:** `type(scope): description` (lowercase, imperative, no period). Scopes: `platform-api`, `dashboard`, `sdk`, `cli`, `clickhouse`. Types: `feat`, `fix`, `docs`, `build`, `refactor`, `test`.
+- **Envs:** All prefixed with `HEXGATE_`. Never commit private keys.

--- a/hexgate/CLAUDE.md
+++ b/hexgate/CLAUDE.md
@@ -1,0 +1,3 @@
+# SDK — Claude Code Instructions
+
+After you make changes, run: `make lint && make fmt-check && make coverage`  # lint + fmt-check + tests with coverage

--- a/platform/api/CLAUDE.md
+++ b/platform/api/CLAUDE.md
@@ -1,0 +1,8 @@
+# API — Claude Code Instructions
+
+After you make changes, run: `make fmt-check && make platform-api-check`  # fmt-check + lint + tests with coverage
+
+## Fixed UUIDs (`services.py`)
+- Org: `00000000-0000-0000-0000-000000000001`
+- User: `00000000-0000-0000-0000-000000000002`
+- Project: `00000000-0000-0000-0000-000000000003`

--- a/platform/dashboard/CLAUDE.md
+++ b/platform/dashboard/CLAUDE.md
@@ -1,0 +1,10 @@
+# Dashboard — Claude Code Instructions
+
+After you make changes, run: `make dashboard-fmt && make dashboard-fmt-check && make dashboard-lint && make dashboard-typecheck`  # format + CI fmt gate + lint + typecheck
+
+## Formatting Rules (CRITICAL)
+TSX output MUST conform exactly to Prettier config to pass `make dashboard-fmt-check`:
+- Double quotes
+- Trailing commas
+- 2-space indent
+- 80-char line width


### PR DESCRIPTION
## What is changing?
Add lightweight CLAUDE.md files with general instructions and commands.

Feel free to suggest changes.

Reference: https://code.claude.com/docs/en/memory#choose-where-to-put-claude-md-files

## Tests 
Ran /code-review to optimise and check the instructions.

