### PR TITLE
feat(dashboard): Add anomaly detection card

### DIFF
--- a/platform/dashboard/src/components/audit/pieces.tsx
+++ b/platform/dashboard/src/components/audit/pieces.tsx
@@ -5,9 +5,12 @@ import {
   CircleDashed,
   Download,
   List,
+  TriangleAlert,
   X,
 } from "lucide-react";
 import type {
+  AnomalySeverity,
+  AuditAnomaly,
   AuditBreakdownRow,
   AuditDecisionRow,
   AuditOutcome,
@@ -174,9 +177,10 @@ export function ActiveChips({ f, setF }: { f: Filters; setF: SetFilters }) {
     agent: "agent",
     role: "role",
     tool: "tool",
+    user: "user",
     outcome: "outcome",
   };
-  const chips = (["agent", "role", "tool", "outcome"] as const).filter(
+  const chips = (["agent", "role", "tool", "user", "outcome"] as const).filter(
     (k) => f[k],
   );
   if (!chips.length) return null;
@@ -208,6 +212,7 @@ export function ActiveChips({ f, setF }: { f: Filters; setF: SetFilters }) {
             customMode: false,
             start_date: null,
             end_date: null,
+            user: "",
           }))
         }
       >
@@ -469,6 +474,102 @@ export function EventsTable({
           </Button>
         </div>
       )}
+    </Card>
+  );
+}
+
+// ————————————————————————————————————————————— Anomalies card
+
+function fmtBurst(first: string, last: string): string {
+  const f = new Date(first);
+  const l = new Date(last);
+  const date = (d: Date) =>
+    d.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+  const time = (d: Date) =>
+    d.toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  return date(f) === date(l)
+    ? `${date(f)}, ${time(f)} → ${time(l)}`
+    : `${date(f)}, ${time(f)} → ${date(l)}, ${time(l)}`;
+}
+
+function SeverityBadge({ severity }: { severity: AnomalySeverity }) {
+  return severity === "high" ? (
+    <Badge className="bg-deny/15 text-deny hover:bg-deny/15">High</Badge>
+  ) : (
+    <Badge className="bg-approval/15 text-approval hover:bg-approval/15">
+      Medium
+    </Badge>
+  );
+}
+
+export function AnomaliesCard({
+  rows,
+  onRowClick,
+}: {
+  rows: AuditAnomaly[];
+  onRowClick: (from: Date, to: Date, userId: string) => void;
+}) {
+  return (
+    <Card className="overflow-hidden p-0">
+      <div className="flex items-center gap-2 border-b border-border px-5 py-4">
+        <TriangleAlert className="size-4 text-approval" />
+        <div className="text-[15px] font-semibold">
+          Anomalies · {rows.length} detected
+        </div>
+      </div>
+      <div className="overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[90px]">Severity</TableHead>
+              <TableHead>User</TableHead>
+              <TableHead className="w-[80px]">Denies</TableHead>
+              <TableHead className="w-[90px]">Deny rate</TableHead>
+              <TableHead>When</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row) => (
+              <TableRow
+                key={`${row.user_id}-${row.first_seen}`}
+                className="cursor-pointer"
+                onClick={() =>
+                  onRowClick(
+                    new Date(row.first_seen),
+                    new Date(row.last_seen),
+                    row.user_id,
+                  )
+                }
+              >
+                <TableCell>
+                  <SeverityBadge severity={row.severity} />
+                </TableCell>
+                <TableCell className="font-mono text-[12.5px]">
+                  {row.user_id}
+                </TableCell>
+                <TableCell>
+                  {row.deny}
+                  <span className="ml-1 text-xs text-muted-foreground">
+                    / {row.all}
+                  </span>
+                </TableCell>
+                <TableCell>{(row.deny_rate * 100).toFixed(0)}%</TableCell>
+                <TableCell className="font-mono text-xs text-muted-foreground">
+                  {fmtBurst(row.first_seen, row.last_seen)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
     </Card>
   );
 }

--- a/platform/dashboard/src/lib/api.ts
+++ b/platform/dashboard/src/lib/api.ts
@@ -255,7 +255,14 @@ export interface AuditScope {
   tool?: string;
   start_date?: string;
   end_date?: string;
+  user?: string;
 }
+
+/** Narrow scope accepted by the anomalies endpoint (cross-user by design). */
+export type AnomalyScope = Pick<
+  AuditScope,
+  "window" | "start_date" | "end_date"
+>;
 
 /** List filters: scope + table-only outcome/session_id + paging. */
 export interface AuditDecisionFilters extends AuditScope {
@@ -263,6 +270,19 @@ export interface AuditDecisionFilters extends AuditScope {
   session_id?: string;
   limit?: number;
   offset?: number;
+}
+
+export type AnomalySeverity = "high" | "medium";
+
+/** One per-user anomaly burst from GET /audit/anomalies. */
+export interface AuditAnomaly {
+  user_id: string;
+  severity: AnomalySeverity;
+  deny: number;
+  all: number;
+  deny_rate: number;
+  first_seen: string;
+  last_seen: string;
 }
 
 function qs(params: Record<string, string | number | undefined>): string {
@@ -331,5 +351,10 @@ export const api = {
   listAuditDecisions: (filters: AuditDecisionFilters, projectId: string) =>
     request<AuditDecisionPage>(
       `/v1/projects/${projectId}/audit/decisions${qs({ ...filters })}`,
+    ),
+
+  getAuditAnomalies: (scope: AnomalyScope, projectId: string) =>
+    request<AuditAnomaly[]>(
+      `/v1/projects/${projectId}/audit/anomalies${qs({ ...scope })}`,
     ),
 };

--- a/platform/dashboard/src/lib/audit-filters.ts
+++ b/platform/dashboard/src/lib/audit-filters.ts
@@ -20,6 +20,7 @@ export interface AuditFilters {
   agent: string;
   role: string;
   tool: string;
+  user: string;
   outcome: "" | AuditOutcome;
   range: "24h" | "7d" | "30d" | "90d";
   customMode: boolean;
@@ -42,6 +43,7 @@ export const EMPTY_AUDIT_FILTERS: AuditFilters = {
   agent: "",
   role: "",
   tool: "",
+  user: "",
   outcome: "",
   range: "30d",
   customMode: false,

--- a/platform/dashboard/src/routes/Audit.test.tsx
+++ b/platform/dashboard/src/routes/Audit.test.tsx
@@ -18,7 +18,7 @@ import { act, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { AuditDecisionRow } from "@/lib/api";
+import type { AuditAnomaly, AuditDecisionRow } from "@/lib/api";
 import { useActive } from "@/lib/active";
 import { EMPTY_AUDIT_FILTERS, useAuditFilters } from "@/lib/audit-filters";
 import { AuditPage } from "@/routes/Audit";
@@ -65,6 +65,16 @@ const ROW: AuditDecisionRow = {
   arguments: { path: "/etc/passwd" },
 };
 
+const ANOMALY: AuditAnomaly = {
+  user_id: "bob",
+  severity: "high",
+  deny: 8,
+  all: 10,
+  deny_rate: 0.8,
+  first_seen: "2026-06-01T09:00:00Z",
+  last_seen: "2026-06-01T10:00:00Z",
+};
+
 /** Sibling event in the same session — only reachable via the drawer's
  * "Same session" list (the main table stub returns ROW alone). */
 const SIBLING: AuditDecisionRow = {
@@ -81,7 +91,7 @@ const SIBLING: AuditDecisionRow = {
  * every requested URL (path + query) so tests can assert what filter
  * state actually reached the API.
  */
-function stubFetch(): string[] {
+function stubFetch(anomalies: AuditAnomaly[] = []): string[] {
   const calls: string[] = [];
   const json = (body: unknown) =>
     new Response(JSON.stringify(body), {
@@ -131,6 +141,8 @@ function stubFetch(): string[] {
           }
           return json({ rows: [ROW], total: 1, limit: 40, offset: 0 });
         }
+        case `/v1/projects/${PROJECT}/audit/anomalies`:
+          return json(anomalies);
         default:
           return new Response("not found", { status: 404 });
       }
@@ -426,6 +438,76 @@ describe("AuditPage", () => {
       });
       expect(useAuditFilters.getState().filters.start_date).toBeNull();
       expect(useAuditFilters.getState().filters.end_date).toBeNull();
+    });
+  });
+
+  describe("AnomaliesCard", () => {
+    it("renders when the API returns anomalies", async () => {
+      stubFetch([ANOMALY]);
+      renderWithProviders(<AuditPage />);
+
+      expect(await screen.findByText(/1 detected/)).toBeInTheDocument();
+      expect(screen.getByText("bob")).toBeInTheDocument();
+      expect(screen.getByText("High")).toBeInTheDocument();
+      expect(screen.getByText("80%")).toBeInTheDocument();
+    });
+
+    it("row click sets date range and user filter; user= appears in decisions query", async () => {
+      const calls = stubFetch([ANOMALY]);
+      const user = userEvent.setup();
+      renderWithProviders(<AuditPage />);
+
+      await user.click(await screen.findByText("bob"));
+
+      await waitFor(() => {
+        expect(useAuditFilters.getState().filters.user).toBe("bob");
+        expect(useAuditFilters.getState().filters.customMode).toBe(true);
+        expect(useAuditFilters.getState().filters.start_date).not.toBeNull();
+      });
+      await waitFor(() => {
+        expect(
+          calls.some(
+            (u) => u.includes("/audit/decisions") && u.includes("user=bob"),
+          ),
+        ).toBe(true);
+      });
+      expect(screen.getByText("Clear all")).toBeInTheDocument();
+    });
+
+    it("renders a Medium badge for medium-severity anomalies", async () => {
+      stubFetch([{ ...ANOMALY, severity: "medium" }]);
+      renderWithProviders(<AuditPage />);
+
+      expect(await screen.findByText("Medium")).toBeInTheDocument();
+      expect(screen.queryByText("High")).not.toBeInTheDocument();
+    });
+
+    it("renders a multi-day range when the burst spans two calendar days", async () => {
+      // Noon-to-noon (48 h apart) guarantees different calendar days in any timezone.
+      stubFetch([
+        {
+          ...ANOMALY,
+          first_seen: "2026-06-01T12:00:00Z",
+          last_seen: "2026-06-03T12:00:00Z",
+        },
+      ]);
+      renderWithProviders(<AuditPage />);
+
+      await screen.findByText("bob");
+      // Multi-day format shows the year twice (once per date); same-day shows it once.
+      expect(
+        screen.getByText(
+          (t) => (t.match(/\d{4}/g) ?? []).length >= 2 && t.includes("→"),
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it("does not render when the API returns no anomalies", async () => {
+      stubFetch();
+      renderWithProviders(<AuditPage />);
+
+      await screen.findByText("blocked by policy");
+      expect(screen.queryByText(/detected/)).not.toBeInTheDocument();
     });
   });
 });

--- a/platform/dashboard/src/routes/Audit.tsx
+++ b/platform/dashboard/src/routes/Audit.tsx
@@ -8,7 +8,7 @@ import {
   Lightbulb,
   X,
 } from "lucide-react";
-import { endOfDay, format } from "date-fns";
+import { endOfDay, format, startOfDay } from "date-fns";
 import { api, type AuditDecisionRow, type AuditOutcome } from "@/lib/api";
 import { useActive, useProjectScoped } from "@/lib/active";
 import { useProjects } from "@/lib/projects";
@@ -37,6 +37,7 @@ import {
 import { fmtTs } from "@/components/audit/fmt";
 import {
   ActiveChips,
+  AnomaliesCard,
   BreakdownCard,
   EventsTable,
   FilterBar,
@@ -337,6 +338,7 @@ export function AuditPage() {
     tool: f.tool || undefined,
     start_date: f.start_date ? f.start_date.toISOString() : undefined,
     end_date: f.end_date ? f.end_date.toISOString() : undefined,
+    user: f.user || undefined,
   };
 
   // Range-only (unscoped) summary: filter dropdown options + the "X of Y"
@@ -389,6 +391,20 @@ export function AuditPage() {
         { window: f.range, session_id: sel!.session_id, limit: 12 },
         projectId as string,
       ),
+  });
+  // Intentionally excludes user/agent/role/tool: the anomaly endpoint ranks
+  // all users and must not be pre-filtered to a single one.
+  const anomalyScope = {
+    window: scope.window,
+    start_date: scope.start_date,
+    end_date: scope.end_date,
+  };
+  const anomaliesQ = useQuery({
+    queryKey: ["audit", "anomalies", projectId, anomalyScope],
+    enabled: !!projectId,
+    queryFn: () => api.getAuditAnomalies(anomalyScope, projectId as string),
+    placeholderData: keepPreviousData,
+    refetchInterval: 30_000,
   });
 
   const summary = summaryQ.data;
@@ -647,6 +663,23 @@ export function AuditPage() {
             />
           </Card>
         </div>
+
+        {!!anomaliesQ.data?.length && (
+          <div className="mb-4">
+            <AnomaliesCard
+              rows={anomaliesQ.data}
+              onRowClick={(from, to, userId) =>
+                setF((p) => ({
+                  ...p,
+                  customMode: true,
+                  start_date: startOfDay(from),
+                  end_date: endOfDay(to),
+                  user: userId,
+                }))
+              }
+            />
+          </div>
+        )}
 
         <div className="mb-4">
           <BreakdownCard


### PR DESCRIPTION
## What is changing
The anomaly detection card is added to the audit dashboard.
When clicking on an anomaly, a user filter and a date filter are applied to the whole page:
- date filter: day of the anomaly
- user filter: user responsible for the detected anomaly

The anomaly endpoint only accepts time range filter, so a narrower AnomalyScope is created.

https://github.com/user-attachments/assets/2b5403e1-56a3-4a9b-8e1d-91bcb463f59e



## Tests
make check-all