### PR TITLE
refactor(hexgate): HEXGATE_KEY -> HEXGATE_API_KEY rename, HEXGATE_API_URL default to saas.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,3 +8,9 @@ LANGFUSE_HOST=https://cloud.langfuse.com
 
 HEXGATE_DEFAULT_MODEL=openai:gpt-5.4
 HEXGATE_DEFAULT_SEARCH_ENGINE=linkup
+
+# Platform credential + URL. Unset URL defaults to Hexgate Cloud
+# (https://app.hexgate.ai). For local platform runs, point it at localhost —
+# a key only verifies against the platform instance that minted it.
+HEXGATE_API_KEY=
+# HEXGATE_API_URL=http://localhost:8000

--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ AGENT_SPEC ?= examples.customer_bot:agent
 
 .PHONY: serve
 serve: ## Run `hexgate serve` on the customer_bot demo (override with AGENT_SPEC=)
-# Reads HEXGATE_KEY from asianf/.env at startup. Uvicorn-style spec —
+# Reads HEXGATE_API_KEY from asianf/.env at startup. Uvicorn-style spec —
 # the agent name + tools come from the loaded object, no env vars to
 # keep in sync.
 	$(UV) hexgate serve $(AGENT_SPEC)
@@ -303,7 +303,7 @@ demo-platform: ## Print 3-terminal instructions for the full platform demo
 	@echo ""
 	@echo "  Terminal 3 — your local agent bridged to the platform:"
 	@echo "      1. Open  http://localhost:5173/tokens  and mint a dev token"
-	@echo "      2. Add to asianf/.env:  HEXGATE_KEY=fty_live_..."
+	@echo "      2. Add to asianf/.env:  HEXGATE_API_KEY=fty_live_..."
 	@echo "      3. make serve  (or: hexgate serve <your.module:agent>)"
 	@echo ""
 	@echo "Then chat with the live agent at  http://localhost:5173/playground"

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Same enforcement seam, same `User` scope. The difference is whose system of reco
 
 | What dev sets | What changes |
 |---|---|
-| `HEXGATE_API_KEY=fty_live_<project>_…` | Wakes up the platform path. Without it, adapters / `load_agent` fall back to local / builtin. (Formerly `HEXGATE_KEY`, still honored with a deprecation warning.) |
+| `HEXGATE_API_KEY=fty_live_<project>_…` | Wakes up the platform path. Without it, adapters / `load_agent` fall back to local / builtin. (Renamed from `HEXGATE_KEY`, which is no longer read.) |
 | `HEXGATE_API_URL=http://localhost:8000` *(optional)* | Platform endpoint. Defaults to localhost. |
 | `HEXGATE_LOCAL_POLICY=./policy.yaml` *or* `./bundle/` | Dev escape hatch: enforce a policy from disk, hot-reload on save. Wins over the platform's bundle. |
 | `HEXGATE_BUNDLE_SIGN_KEY_PATH=./keys/dev.private` *(optional)* | Sign locally-recompiled yaml so `bundle.is_signed` reads True. |

--- a/README.md
+++ b/README.md
@@ -332,13 +332,18 @@ Same enforcement seam, same `User` scope. The difference is whose system of reco
 | What dev sets | What changes |
 |---|---|
 | `HEXGATE_API_KEY=fty_live_<project>_…` | Wakes up the platform path. Without it, adapters / `load_agent` fall back to local / builtin. (Renamed from `HEXGATE_KEY`, which is no longer read.) |
-| `HEXGATE_API_URL=http://localhost:8000` *(optional)* | Platform endpoint. Defaults to localhost. |
+| `HEXGATE_API_URL=https://app.hexgate.ai` *(optional)* | Platform endpoint. Defaults to Hexgate Cloud (`https://app.hexgate.ai`). Set to `http://localhost:8000` only when self-hosting the platform locally — your key must be minted by whichever platform this points at. |
 | `HEXGATE_LOCAL_POLICY=./policy.yaml` *or* `./bundle/` | Dev escape hatch: enforce a policy from disk, hot-reload on save. Wins over the platform's bundle. |
 | `HEXGATE_BUNDLE_SIGN_KEY_PATH=./keys/dev.private` *(optional)* | Sign locally-recompiled yaml so `bundle.is_signed` reads True. |
 | `HEXGATE_BUNDLE_PUBKEY_PATH=./keys/prod.public` *(optional)* | Verify a pre-built bundle dir against this pubkey on every reload. |
 | `HEXGATE_BUNDLE_REQUIRE_SIGNATURE=true` *(optional)* | Strict mode — refuse any unsigned or unverifiable bundle at startup. |
 
 No config object to instantiate, no `enforce_policy(...)` call to remember on the platform path. The adapter / loader threads it all through.
+
+**Connecting to Hexgate.** The key and the URL are coupled: a `fty_live_…` key only verifies against the platform instance that minted it.
+
+- **Hosted (default):** set `HEXGATE_API_KEY` to the key from [app.hexgate.ai](https://app.hexgate.ai). Leave `HEXGATE_API_URL` unset — it defaults to `https://app.hexgate.ai`.
+- **Self-hosted / local platform:** additionally set `HEXGATE_API_URL=http://localhost:8000` (or your host), and use a key minted by *that* platform.
 
 ### Where enforcement actually happens
 
@@ -1290,7 +1295,7 @@ Bridges your local agent runtime to the dashboard via the platform's WebSocket r
 ```bash
 # in asianf/.env
 HEXGATE_API_KEY=fty_live_<project>_<biscuit>
-HEXGATE_API_URL=http://localhost:8000       # optional, defaults to localhost:8000
+HEXGATE_API_URL=http://localhost:8000       # optional; only when self-hosting the platform locally
 
 # pick an agent module:attr — uvicorn-style spec
 uv run hexgate serve examples.customer_bot:agent

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ cp .env.sample .env
 hexgate chat --agent example_agent
 ```
 
-Required keys for the example CLI flow:
+Keys the built-in example agent uses (bootstrap no longer hard-requires them — each is only needed if you actually invoke the piece that reads it, which raises a clear error at that point):
 
-- `OPENAI_API_KEY`
-- `LINKUP_API_KEY`
-- `TAVILY_API_KEY`
+- `OPENAI_API_KEY` — the default `openai:gpt-5.4` model (skip it if you pass your own model)
+- `LINKUP_API_KEY` — the built-in `web_search` tool
+- `TAVILY_API_KEY` — the built-in `fetch` tool
 
 Run `hexgate --help` to see all subcommands (`chat`, `serve`, `register`), and `hexgate <subcommand> --help` for the flags each one accepts.
 
@@ -1066,13 +1066,12 @@ Worth being explicit about the gaps so operators know where to layer their own c
 
 ## 🔧 Environment
 
-Copy `.env.sample` to `.env` and set:
+Copy `.env.sample` to `.env`. None of these are required to boot — set the ones whose feature you use (each raises a clear error at use-time if missing):
 
-- `OPENAI_API_KEY`
-- `LINKUP_API_KEY`
-- `TAVILY_API_KEY`
-- `LANGFUSE_SECRET_KEY`
-- `LANGFUSE_PUBLIC_KEY`
+- `OPENAI_API_KEY` — default model
+- `LINKUP_API_KEY` — built-in `web_search` tool
+- `TAVILY_API_KEY` — built-in `fetch` tool
+- `LANGFUSE_SECRET_KEY` / `LANGFUSE_PUBLIC_KEY` — tracing (optional)
 - optional `LANGFUSE_HOST`
 
 Policy-bundle enforcement (see [Policy Bundles](#-policy-bundles--compile-sign-enforce-wasm)) reads a few more, all optional:

--- a/README.md
+++ b/README.md
@@ -107,11 +107,11 @@ cp .env.sample .env
 hexgate chat --agent example_agent
 ```
 
-Keys the built-in example agent uses (bootstrap no longer hard-requires them — each is only needed if you actually invoke the piece that reads it, which raises a clear error at that point):
+Keys the built-in example agent uses (bootstrap no longer hard-requires them — each is only needed if you invoke the piece that reads it):
 
-- `OPENAI_API_KEY` — the default `openai:gpt-5.4` model (skip it if you pass your own model)
-- `LINKUP_API_KEY` — the built-in `web_search` tool
-- `TAVILY_API_KEY` — the built-in `fetch` tool
+- `OPENAI_API_KEY` — the default `openai:gpt-5.4` model. Skip it if you pass your own model; if it's missing, the model provider raises a key-named error when the agent is built.
+- `LINKUP_API_KEY` — the built-in `web_search` tool, which raises a clear error the first time it runs without a key.
+- `TAVILY_API_KEY` — the built-in `fetch` tool, same as above.
 
 Run `hexgate --help` to see all subcommands (`chat`, `serve`, `register`), and `hexgate <subcommand> --help` for the flags each one accepts.
 
@@ -1066,7 +1066,7 @@ Worth being explicit about the gaps so operators know where to layer their own c
 
 ## 🔧 Environment
 
-Copy `.env.sample` to `.env`. None of these are required to boot — set the ones whose feature you use (each raises a clear error at use-time if missing):
+Copy `.env.sample` to `.env`. None of these are required to boot — set the ones whose feature you use. A missing key surfaces when that feature runs: the built-in tools raise their own clear error at call time, and the model provider raises a key-named error when the agent is built.
 
 - `OPENAI_API_KEY` — default model
 - `LINKUP_API_KEY` — built-in `web_search` tool

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ The included local agent lives in `examples/example_agent/`, and the CLI can als
 
 The two Quick Starts above aren't competing — they answer different questions.
 
-**Inner loop — `hexgate chat`.** A single-process REPL against a local or builtin agent. No platform, no Docker, no browser. The chat command sets `HEXGATE_LOCAL_MODE=1` automatically so audit stays on your machine even if `HEXGATE_KEY` lives in your `.env` from an earlier session. Denies and approval-required calls render as inline panels in the terminal — same `Decision` data the platform would log, surfaced where you're iterating. Reach for `chat` when you're authoring a policy YAML, tweaking a tool, or shaping a system prompt.
+**Inner loop — `hexgate chat`.** A single-process REPL against a local or builtin agent. No platform, no Docker, no browser. The chat command sets `HEXGATE_LOCAL_MODE=1` automatically so audit stays on your machine even if `HEXGATE_API_KEY` lives in your `.env` from an earlier session. Denies and approval-required calls render as inline panels in the terminal — same `Decision` data the platform would log, surfaced where you're iterating. Reach for `chat` when you're authoring a policy YAML, tweaking a tool, or shaping a system prompt.
 
 **Team loop — `hexgate serve` + dashboard Playground.** Same agent code, but the policy + decisions round-trip through the platform. You get auditable decisions in ClickHouse, the shared Playground UI, and live policy edits via the dashboard. Reach for `serve` when you're collaborating on an agent's behaviour, debugging a production-like trace, or demoing.
 
@@ -163,7 +163,7 @@ make dashboard
 
 # Terminal 3 — mint a token, then serve your local agent
 #   1. Open http://localhost:5173/tokens, click "Mint new token", copy the value.
-#   2. Add to asianf/.env:  HEXGATE_KEY=fty_live_...
+#   2. Add to asianf/.env:  HEXGATE_API_KEY=fty_live_...
 #   3. Pick the agent's Python entrypoint (module:attr — uvicorn-style)
 #      and let `hexgate serve` take over:
 make serve                                          # default — examples.customer_bot:agent
@@ -296,7 +296,7 @@ Dev wrote an OpenAI Agents / LangChain / Google ADK / Pydantic AI agent. They wr
 from hexgate.adapters.openai import HexgateRunner   # or .langchain.wrap_langchain_agent, .google.HexgateRunner, .pydantic_ai.wrap_pydantic_agent
 from hexgate.runtime import User
 
-runner = HexgateRunner()                            # picks up HEXGATE_KEY from env
+runner = HexgateRunner()                            # picks up HEXGATE_API_KEY from env
 await runner.run(
     my_agent,
     "refund 30",
@@ -331,7 +331,7 @@ Same enforcement seam, same `User` scope. The difference is whose system of reco
 
 | What dev sets | What changes |
 |---|---|
-| `HEXGATE_KEY=fty_live_<project>_…` | Wakes up the platform path. Without it, adapters / `load_agent` fall back to local / builtin. |
+| `HEXGATE_API_KEY=fty_live_<project>_…` | Wakes up the platform path. Without it, adapters / `load_agent` fall back to local / builtin. (Formerly `HEXGATE_KEY`, still honored with a deprecation warning.) |
 | `HEXGATE_API_URL=http://localhost:8000` *(optional)* | Platform endpoint. Defaults to localhost. |
 | `HEXGATE_LOCAL_POLICY=./policy.yaml` *or* `./bundle/` | Dev escape hatch: enforce a policy from disk, hot-reload on save. Wins over the platform's bundle. |
 | `HEXGATE_BUNDLE_SIGN_KEY_PATH=./keys/dev.private` *(optional)* | Sign locally-recompiled yaml so `bundle.is_signed` reads True. |
@@ -353,7 +353,7 @@ Walk through one tool call:
 `_policy_source` is set automatically by the loader based on env:
 
 - `HEXGATE_LOCAL_POLICY` set → `YamlPolicySource` or `BundleDirPolicySource` (mtime-driven refresh)
-- `HEXGATE_KEY` set, no local override → `PlatformPolicySource` (ETag / `304 Not Modified` refresh)
+- `HEXGATE_API_KEY` set, no local override → `PlatformPolicySource` (ETag / `304 Not Modified` refresh)
 - Neither → no source attached; enforcement uses whatever was loaded once
 
 **Scope of the per-turn refresh:** only the policy bundle. `system_prompt`, the manifest's tool list, and the model id are read once at agent construction and stay fixed for the lifetime of the process. Edit those on the dashboard and the change lands at the next `hexgate serve` restart — not at the next turn. The split is deliberate: policy is the operator's primary lever (and the one that needs to be auditable per-decision), while the manifest is an author-time concept.
@@ -363,7 +363,7 @@ Walk through one tool call:
 1. **Per-call identity stays explicit.** `User` is the one piece the adapter can't infer from env, because it's per-request, not per-process. One line wrapping each call (`user=User(...)` kwarg on adapters, `async with User(...)` for native).
 2. **`approval_required` tools.** If the policy uses that mode, dev decides what happens — pass `approval_handler=` (True / False / callable) when wrapping. Default for `hexgate serve` is auto-approve; for `hexgate chat` it prompts the TTY. Native code gets whatever the dev wires.
 
-Everything else — fetch, verify, hot-reload, role selection, signature check, decision rendering, tracing — the runtime handles. Set `HEXGATE_KEY` and wrap, or set `HEXGATE_LOCAL_POLICY` and wrap. That's the surface.
+Everything else — fetch, verify, hot-reload, role selection, signature check, decision rendering, tracing — the runtime handles. Set `HEXGATE_API_KEY` and wrap, or set `HEXGATE_LOCAL_POLICY` and wrap. That's the surface.
 
 ## 📦 What You Can Import
 
@@ -425,7 +425,7 @@ The four integrations differ in shape because the underlying SDKs do:
 
 Role resolution happens **at call time** from the active `User` contextvar — one wrapped agent serves many users concurrently because the scope is per-call. The original agent object is left intact (or, for LangChain BYO-graph tools, mutated by design so the same `tools` list flows through `create_react_agent`); the wrapper holds the policy.
 
-All adapters resolve the API key the same way: from the explicit `api_key=` argument, falling back to the `HEXGATE_KEY` environment variable.
+All adapters resolve the API key the same way: from the explicit `api_key=` argument, falling back to the `HEXGATE_API_KEY` environment variable.
 
 ### OpenAI Agents SDK — `HexgateRunner`
 
@@ -455,7 +455,7 @@ async def main():
         model="gpt-4o-mini",
     )
 
-    runner = HexgateRunner()  # picks up HEXGATE_KEY from env
+    runner = HexgateRunner()  # picks up HEXGATE_API_KEY from env
     result = await runner.run(
         agent,
         "What's the weather in Cherbourg?",
@@ -515,7 +515,7 @@ async def main():
     agent = wrap_langchain_agent(
         agent=graph,
         tools=TOOLS,          # same list passed to create_react_agent — wrapped in place
-        api_key="sk-...",     # or rely on HEXGATE_KEY
+        api_key="sk-...",     # or rely on HEXGATE_API_KEY
     )
 
     result = await agent.ainvoke(
@@ -591,7 +591,7 @@ async def main():
         agent=agent,
         app_name="google_runner_example",
         session_service=session_service,
-    )  # picks up HEXGATE_KEY from env
+    )  # picks up HEXGATE_API_KEY from env
 
     user_msg = types.Content(
         role="user", parts=[types.Part(text="What is the weather in New Delhi?")]
@@ -643,7 +643,7 @@ async def main():
 
     agent = wrap_pydantic_agent(
         agent=agent,
-        api_key="sk-...",  # or rely on HEXGATE_KEY
+        api_key="sk-...",  # or rely on HEXGATE_API_KEY
     )
 
     result = await agent.run(
@@ -1147,7 +1147,7 @@ Register a code-defined agent's manifest with the Hexgate platform. `--agent`
 takes a Python import path of the form `module.path:attribute`, the same shape
 as ASGI/WSGI entrypoints. The CLI imports the module, grabs the agent object,
 and POSTs its manifest to `${HEXGATE_API_URL}/v1/agents` using
-`${HEXGATE_KEY}` as the bearer token:
+`${HEXGATE_API_KEY}` as the bearer token:
 
 ```bash
 hexgate register --agent examples.customer_bot:agent
@@ -1289,7 +1289,7 @@ Bridges your local agent runtime to the dashboard via the platform's WebSocket r
 
 ```bash
 # in asianf/.env
-HEXGATE_KEY=fty_live_<project>_<biscuit>
+HEXGATE_API_KEY=fty_live_<project>_<biscuit>
 HEXGATE_API_URL=http://localhost:8000       # optional, defaults to localhost:8000
 
 # pick an agent module:attr — uvicorn-style spec
@@ -1329,7 +1329,7 @@ There's no longer a `HEXGATE_AGENT_NAME` env var, `--agent` flag, or
 `--use` flag — the spec carries everything. If you've been setting
 `HEXGATE_AGENT_NAME` in `.env`, drop it.
 
-### How `load_agent()` resolves with `HEXGATE_KEY`
+### How `load_agent()` resolves with `HEXGATE_API_KEY`
 
 ```python
 from hexgate import load_agent
@@ -1337,8 +1337,8 @@ from hexgate import load_agent
 agent, handler = load_agent("read_only")     # explicit name required
 ```
 
-When `HEXGATE_KEY` is set, `load_agent(name)` fetches the named agent from
-the platform (via `load_hexgate_agent`). When `HEXGATE_KEY` is not set, it
+When `HEXGATE_API_KEY` is set, `load_agent(name)` fetches the named agent from
+the platform (via `load_hexgate_agent`). When `HEXGATE_API_KEY` is not set, it
 falls back to local / registered / builtin resolution — no platform call.
 
 The legacy `HEXGATE_AGENT_NAME` env-var fallback was removed in Phase 7;

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -36,7 +36,7 @@ and the loop restarts with the new object; the dashboard picks it up on its next
 | File | Role |
 |------|------|
 | `boot.py` | Process orchestrator: start API → mint token (→ key file) → start marimo → block |
-| `provision.py` | Mints a `HEXGATE_KEY` for the seeded project (shares the container's SQLite + keystore) |
+| `provision.py` | Mints a `HEXGATE_API_KEY` for the seeded project (shares the container's SQLite + keystore) |
 | `serve_manager.py` | Runs the `hexgate serve` loop in-kernel, bound to the live `agent` object; `apply()` on Start |
 | `demo_notebook.py` | The marimo notebook: define tools + agent in real cells, Start, playground link |
 | `smoke_test.py` + `_mock_llm.py` | Full-path smoke test with a mock LLM (`make demo-smoke`) — no real key |

--- a/deploy/boot.py
+++ b/deploy/boot.py
@@ -5,7 +5,7 @@ Starts, in order, in one process tree:
   1. Platform API (uvicorn ``main:app``) on :8000 — its lifespan creates a
      fresh SQLite, seeds one org/user/project/agents, and (with HEXGATE_DEMO=1)
      serves the built dashboard same-origin + exposes /v1/demo-login.
-  2. A minted HEXGATE_KEY for the seeded project (see provision.py).
+  2. A minted HEXGATE_API_KEY for the seeded project (see provision.py).
   3. ``hexgate serve <AGENT_SPEC>`` — dials out to the local API's /v1/serve
      and runs the agent, streaming events back through the relay.
   4. marimo (the notebook UI the visitor lands on) on :2718.
@@ -104,7 +104,7 @@ def start_services(dash_url: str | None = None) -> dict[str, str]:
     from provision import provision_serve_token  # noqa: E402  (path set above)
 
     SERVE_KEY_FILE.write_text(provision_serve_token())
-    print("[boot] minted HEXGATE_KEY for seeded project", flush=True)
+    print("[boot] minted HEXGATE_API_KEY for seeded project", flush=True)
     # serve itself runs in the notebook kernel (serve_manager), bound to the
     # live agent object. boot only hands it the key (file) + HEXGATE_API_URL (env).
     return env

--- a/deploy/provision.py
+++ b/deploy/provision.py
@@ -2,7 +2,7 @@
 
 Run once per container before (or alongside) the API process. Shares the
 container's SQLite file and on-disk keystore with the API, so the minted
-``HEXGATE_KEY`` verifies against the same signing key the API serves with.
+``HEXGATE_API_KEY`` verifies against the same signing key the API serves with.
 
 Everything here is idempotent — ``init_db`` + ``ensure_default_seed`` +
 ``ensure_keypair`` are no-ops on a warm DB, so it's safe to run before
@@ -41,10 +41,10 @@ async def _mint() -> str:
 
 
 def provision_serve_token() -> str:
-    """Return a fresh ``fty_live_...`` HEXGATE_KEY scoped to the seeded project."""
+    """Return a fresh ``fty_live_...`` HEXGATE_API_KEY scoped to the seeded project."""
     return asyncio.run(_mint())
 
 
 if __name__ == "__main__":
-    # Print the token so a shell caller can capture it: HEXGATE_KEY=$(python provision.py)
+    # Print the token so a shell caller can capture it: HEXGATE_API_KEY=$(python provision.py)
     sys.stdout.write(provision_serve_token())

--- a/deploy/serve_manager.py
+++ b/deploy/serve_manager.py
@@ -12,7 +12,7 @@ This is the same flow as `hexgate serve <spec>`:
 only with a live object instead of a `module:attr` spec, run off-thread.
 
 BYOK: the visitor's OpenAI key is set into this process's env (their own key,
-their own throwaway container). HEXGATE_KEY (platform/relay auth) is read from
+their own throwaway container). HEXGATE_API_KEY (platform/relay auth) is read from
 the file boot.py wrote.
 """
 
@@ -32,16 +32,16 @@ _status: str = "stopped"
 
 
 def _ensure_platform_env() -> None:
-    """HexgateConfig.from_env() reads HEXGATE_KEY / HEXGATE_API_URL — make sure
+    """HexgateConfig.from_env() reads HEXGATE_API_KEY / HEXGATE_API_URL — make sure
     they're present in this process (boot.py writes the key to a file).
 
     The minted key in KEY_FILE is the source of truth for *this* container's
-    freshly-seeded project, so it **overrides** any stale HEXGATE_KEY inherited
+    freshly-seeded project, so it **overrides** any stale HEXGATE_API_KEY inherited
     from the shell / `.env` (otherwise auto-register 401s against the wrong
     project). `bootstrap()`'s later dotenv load won't clobber it — python-dotenv
     doesn't override existing env vars by default."""
     if KEY_FILE.is_file():
-        os.environ["HEXGATE_KEY"] = KEY_FILE.read_text().strip()
+        os.environ["HEXGATE_API_KEY"] = KEY_FILE.read_text().strip()
     os.environ.setdefault("HEXGATE_API_URL", "http://127.0.0.1:8000")
 
 

--- a/deploy/serve_manager.py
+++ b/deploy/serve_manager.py
@@ -52,16 +52,14 @@ def status() -> str:
 
 
 def _demo_settings():
-    """Settings for the demo WITHOUT bootstrap()'s all-three-keys validation.
+    """Settings for the demo without bootstrap()'s repo-relative ``.env`` load.
 
-    ``hexgate.bootstrap.bootstrap()`` calls ``Settings.validate_required_keys()``,
-    which hard-requires OPENAI_API_KEY **and** LINKUP_API_KEY **and**
-    TAVILY_API_KEY — even for an agent that never web-searches. That made the
-    notebook refuse to start in a fresh container (no dev ``.env`` to supply the
-    search keys). BYOK only needs the OpenAI key; the web_search/fetch tools
-    still raise a clear error at *call* time if their Linkup/Tavily key is
-    missing. So do bootstrap's real work (configure audit + load settings) and
-    skip the eager search-key check.
+    ``bootstrap()`` reads a ``.env`` next to the hexgate package, which doesn't
+    exist in a fresh BYOK container — the notebook injects keys straight into
+    the process env instead. So do bootstrap's other real work (configure audit
+    + load settings) and skip the file load. Missing provider keys are fine:
+    the web_search/fetch tools raise a clear error at *call* time if their key
+    is absent.
     """
     from hexgate import audit
     from hexgate.config.settings import Settings

--- a/docs/adapters/openai.mdx
+++ b/docs/adapters/openai.mdx
@@ -14,7 +14,7 @@ description: "Wrap an Agent with HexgateRunner — drop-in replacement for agent
 from hexgate.adapters.openai import HexgateRunner
 from hexgate.runtime import User
 
-runner = HexgateRunner()                            # picks up HEXGATE_KEY
+runner = HexgateRunner()                            # picks up HEXGATE_API_KEY
 result = await runner.run(
     agent,
     "What's the weather in Cherbourg?",

--- a/docs/cli/register.mdx
+++ b/docs/cli/register.mdx
@@ -15,4 +15,4 @@ hexgate register --agent my_app.agents:my_agent --description "Customer support 
 
 `--agent` takes a Python import path `module.path:attribute`. The CLI imports
 the module, grabs the agent object, and POSTs its manifest to
-`${HEXGATE_API_URL}/v1/agents` using `${HEXGATE_KEY}` as the bearer token.
+`${HEXGATE_API_URL}/v1/agents` using `${HEXGATE_API_KEY}` as the bearer token.

--- a/docs/concepts/audit-trail.mdx
+++ b/docs/concepts/audit-trail.mdx
@@ -9,7 +9,7 @@ description: "Every Decision posted to ClickHouse via /v1/audit/decisions."
 
 ## TL;DR
 
-When `HEXGATE_KEY` is set and local mode is off, every `Decision` the enforcer
+When `HEXGATE_API_KEY` is set and local mode is off, every `Decision` the enforcer
 returns is fired-and-forgotten to `/v1/audit/decisions`. The platform's
 ClickHouse table stores one row per decision; the dashboard's audit page
 visualises them. Local mode (set by `hexgate chat`) keeps events on your

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -107,20 +107,22 @@ This is the bootstrap layer. It loads environment variables and returns a valida
 Key snippet:
 
 ```python
-def bootstrap(env_file: str = ".env") -> Settings:
+def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
     env_path = Path(__file__).parent.parent / env_file
-    load_dotenv(env_path, override=True)
-    settings = Settings.from_env()
-    settings.validate_required_keys()
-    return settings
+    load_dotenv(env_path, override=False)
+    audit.configure()
+    return Settings.from_env()
 ```
 
 Role:
 
 - resolve the `.env` path relative to the repo
-- load env vars into the process
+- load env vars into the process (shell wins over `.env`)
 - create typed settings
-- fail early if required keys are missing
+
+Provider keys (OpenAI / Linkup / Tavily) are **not** validated here — each is
+optional and only raises at use-time by the tool or model provider that reads
+it, so an agent that uses none of them boots without any of those keys set.
 
 ### `hexgate/demo.py`
 
@@ -214,20 +216,12 @@ model=os.getenv("HEXGATE_DEFAULT_MODEL", "openai:gpt-5.4"),
 search_engine=os.getenv("HEXGATE_DEFAULT_SEARCH_ENGINE", "linkup"),
 ```
 
-```python
-if not self.openai_api_key:
-    missing.append("OPENAI_API_KEY")
-if not self.linkup_api_key:
-    missing.append("LINKUP_API_KEY")
-if not self.tavily_api_key:
-    missing.append("TAVILY_API_KEY")
-```
-
 Responsibilities:
 
 - gather all env-based configuration in one place
 - provide defaults for model and Langfuse host
-- validate the minimum keys needed by the runtime
+- leave every provider key optional — missing keys resolve to `None` and are
+  enforced lazily by whatever reads them, not eagerly at bootstrap
 
 ### `hexgate/prompts/agent_system.md`
 

--- a/docs/internals/audit-pipeline.md
+++ b/docs/internals/audit-pipeline.md
@@ -181,7 +181,8 @@ synchronous.
 - Resolves `api_key` from the argument or `HEXGATE_API_KEY`; returns `None` (audit
   inert) when no key is resolvable.
 - Resolves `base_url` from the argument or `HEXGATE_API_URL`, defaulting to
-  `http://localhost:8000`. The endpoint is `<base_url>/v1/audit/decisions`.
+  Hexgate Cloud (`https://app.hexgate.ai`); set `http://localhost:8000` when
+  self-hosting. The endpoint is `<base_url>/v1/audit/decisions`.
 - **Keyed by api_key.** Senders live in a registry `dict[str, AuditSender]`.
   Calling `configure()` again with the **same** key returns the existing sender
   (idempotent); a **different** key gets its own sender with its own bearer

--- a/docs/internals/audit-pipeline.md
+++ b/docs/internals/audit-pipeline.md
@@ -178,7 +178,7 @@ synchronous.
 
 `configure(api_key=None, base_url=None) -> AuditSender | None`:
 
-- Resolves `api_key` from the argument or `HEXGATE_KEY`; returns `None` (audit
+- Resolves `api_key` from the argument or `HEXGATE_API_KEY`; returns `None` (audit
   inert) when no key is resolvable.
 - Resolves `base_url` from the argument or `HEXGATE_API_URL`, defaulting to
   `http://localhost:8000`. The endpoint is `<base_url>/v1/audit/decisions`.
@@ -196,7 +196,7 @@ local runs work without an explicit key.
 #### Local mode (`HEXGATE_LOCAL_MODE`)
 
 Setting `HEXGATE_LOCAL_MODE=1` makes `configure()` return `None` even when
-`HEXGATE_KEY` is present in env. `bootstrap(local_only=True)` sets the var
+`HEXGATE_API_KEY` is present in env. `bootstrap(local_only=True)` sets the var
 *before* the first `configure()` call, and `hexgate chat` passes
 `local_only=True` — so the inner-loop REPL never posts audit events even if
 a key has been lingering in `.env` from an earlier platform session.
@@ -207,7 +207,7 @@ value parser accepts `1` / `true` / `yes` / `on` (case-insensitive).
 
 There are now two clean operating modes, not three:
 
-| Mode | `HEXGATE_KEY` | `HEXGATE_LOCAL_MODE` | Policy from | Audit |
+| Mode | `HEXGATE_API_KEY` | `HEXGATE_LOCAL_MODE` | Policy from | Audit |
 |------|---------------|----------------------|-------------|-------|
 | **Local** | (irrelevant) | `1`, or unset with no key | YAML / disk / builtin | suppressed |
 | **Platform-managed** | set | unset | platform fetch | emitted |
@@ -217,7 +217,7 @@ the first time `configure()` is called with both a key and local mode active
 — exactly the case where the suppression would be surprising. The "no key
 anywhere" case stays quiet.
 
-A separate WARNING fires from `bootstrap()` itself when both `HEXGATE_KEY`
+A separate WARNING fires from `bootstrap()` itself when both `HEXGATE_API_KEY`
 and `HEXGATE_LOCAL_POLICY` are set — that combination is almost always a
 forgotten env entry from an earlier session, and surfacing it at startup
 saves a later debugging detour.

--- a/docs/internals/policy-binding-spec.md
+++ b/docs/internals/policy-binding-spec.md
@@ -42,7 +42,7 @@
 ## 1. Problem statement
 
 Today only the loader path (`load_hexgate_agent` / `load_agent` with
-`HEXGATE_KEY`, `hexgate/agents/loader.py:528`) delivers the full governance
+`HEXGATE_API_KEY`, `hexgate/agents/loader.py:528`) delivers the full governance
 loop: pull the signed policy bundle from the platform, verify it, enforce it
 on every tool call, and re-pull (ETag/304) at the top of every run.
 
@@ -50,7 +50,7 @@ Every other construction path falls short:
 
 | Surface | Pull | Enforce | Per-run refresh |
 |---|---|---|---|
-| `load_hexgate_agent` / `load_agent` + `HEXGATE_KEY` | ✅ verified bundle | ✅ `GuardedTool` | ✅ ETag/304 |
+| `load_hexgate_agent` / `load_agent` + `HEXGATE_API_KEY` | ✅ verified bundle | ✅ `GuardedTool` | ✅ ETag/304 |
 | `create_agent(...)` (programmatic) | ❌ | ❌ | no-op |
 | `create_agent(...)` + `enforce_policy(p)` | ❌ (static `p`) | ✅ | no-op (no source) |
 | `wrap_openai_agent` / `HexgateRunner` (openai) | ❌ placeholder **allow-all** | ✅ (allow-all) | ❌ |
@@ -153,7 +153,7 @@ def resolve(
     cls,
     agent_name: str,
     *,
-    api_key: str | None = None,          # explicit → HEXGATE_KEY env
+    api_key: str | None = None,          # explicit → HEXGATE_API_KEY env
     client: HexgateClient | None = None, # reuse an existing client (loader path)
     prefetched: tuple[dict, str | None] | None = None,  # (payload, etag) reuse
     fallback: PolicyEngine | None = None,
@@ -172,7 +172,7 @@ its behavior and its tests stay identical):
    `BundleDirPolicySource` (mtime-refreshed pre-built bundle) or
    `YamlPolicySource` (auto-recompile on save), exactly as today
    (`hexgate/security/source.py:165,256`). The platform is not contacted.
-2. **Platform** — when an `api_key`/`HEXGATE_KEY`/`client` is available:
+2. **Platform** — when an `api_key`/`HEXGATE_API_KEY`/`client` is available:
    1. Build or reuse the `HexgateClient` (Biscuit signature verified lazily
       on first use, `cloud/client.py:177`).
    2. `payload, etag = client.get_agent(agent_name)` — or use `prefetched`
@@ -313,7 +313,7 @@ Semantics of `bind_policy`:
 
 | value | behavior |
 |---|---|
-| `None` (default, **auto**) | bind iff (`HEXGATE_KEY` set **or** `HEXGATE_LOCAL_POLICY` set) **and** `name` is provided; otherwise return the bare agent exactly as today |
+| `None` (default, **auto**) | bind iff (`HEXGATE_API_KEY` set **or** `HEXGATE_LOCAL_POLICY` set) **and** `name` is provided; otherwise return the bare agent exactly as today |
 | `True` | bind or **raise** (`name` required; no key and no local override → raise) |
 | `False` | today's behavior, unconditionally (escape hatch for unit tests of bare graphs) |
 
@@ -476,7 +476,7 @@ The governing rule, inherited from the loader and made universal:
 
 | Event | When | Behavior |
 |---|---|---|
-| `HEXGATE_KEY` malformed / Biscuit signature invalid | resolve | raise (`HexgateError`) |
+| `HEXGATE_API_KEY` malformed / Biscuit signature invalid | resolve | raise (`HexgateError`) |
 | Platform unreachable | resolve | raise — caller decides; never run on a policy we never had |
 | Platform unreachable | refresh | warn + keep previous verified policy (unbounded staleness — see §8.3) |
 | Bundle signature/integrity fails | resolve | raise; never downgrade to pydantic engine |
@@ -493,14 +493,14 @@ The governing rule, inherited from the loader and made universal:
 ## 6. Security invariants (must hold after the refactor)
 
 1. **Single trust root.** The platform's Ed25519 root key signs both
-   Biscuits (`HEXGATE_KEY`) and bundle manifests; the SDK verifies both
+   Biscuits (`HEXGATE_API_KEY`) and bundle manifests; the SDK verifies both
    against the same key (explicit → `HEXGATE_PUBLIC_KEY` → JWKS TOFU).
 2. **No silent downgrade.** A served-but-unverifiable bundle is fatal at
    resolve and inert at refresh. The pydantic fallback is only reachable
    when the platform *affirmatively served no bundle*, and
    `HEXGATE_BUNDLE_REQUIRE_SIGNATURE` closes even that.
 3. **No silent allow-all.** Removing `build_policy_set` removes the last
-   construction path that runs ungoverned with a `HEXGATE_KEY` present.
+   construction path that runs ungoverned with a `HEXGATE_API_KEY` present.
    Ungoverned operation requires an explicit `fallback=` or
    `bind_policy=False` in the caller's code.
 4. **Verification happens before caching.** `PlatformPolicySource` only
@@ -541,7 +541,7 @@ text), `bundle_signature_b64`.
    names; surfaced by the §5 uncovered-tools warning.
 2. **Adapters: missing/unreachable platform now raises at wrap/construct**
    instead of silently running open. Escape hatch: `fallback=`.
-3. **`create_agent` with `HEXGATE_KEY` set + a `name`** now binds by default
+3. **`create_agent` with `HEXGATE_API_KEY` set + a `name`** now binds by default
    (auto mode). Programmatic callers who want a bare graph in a keyed
    environment pass `bind_policy=False`.
 
@@ -644,7 +644,7 @@ Each phase lands green and independently shippable.
 |---|---|---|
 | Eager vs lazy first fetch | **Eager** in `resolve()` | loud failures at construction; refresh's fail-soft would otherwise leave the first run unguarded or bricked |
 | 404 at resolve | **auto-register by default at adapter/`create_agent` surfaces**, raise otherwise | platform mints a safe default policy + signed bundle (`71586c2`); matches `hexgate serve` UX; idempotent re-registers protect dashboard edits |
-| Adapters' default without platform | **raise** (no more silent allow-all) | a present `HEXGATE_KEY` signals governance intent; ungoverned must be explicit (`fallback=`) |
+| Adapters' default without platform | **raise** (no more silent allow-all) | a present `HEXGATE_API_KEY` signals governance intent; ungoverned must be explicit (`fallback=`) |
 | Refresh failure | **warn + keep previous verified policy** | availability over freshness; tamper still cannot install itself |
 | Refresh granularity | **per run/turn** | matches `stream_agent` today; per-tool-call adds a network call to the hot path for negligible win |
 | Sync entry points | direct blocking `refresh()` | ~ms HTTP on a thread already doing sync I/O; `to_thread` only for async paths |

--- a/docs/two-paths.mdx
+++ b/docs/two-paths.mdx
@@ -9,7 +9,7 @@ The two quickstarts aren't competing — they answer different questions.
 
 A single-process REPL against a local or builtin agent. No platform, no Docker,
 no browser. The chat command sets `HEXGATE_LOCAL_MODE=1` automatically so audit
-stays on your machine even if `HEXGATE_KEY` lives in your `.env` from an earlier
+stays on your machine even if `HEXGATE_API_KEY` lives in your `.env` from an earlier
 session. Denies and approval-required calls render as inline panels in the
 terminal — same `Decision` data the platform would log, surfaced where you're
 iterating.

--- a/examples/customer_bot.py
+++ b/examples/customer_bot.py
@@ -10,7 +10,7 @@ registering.
 Workflow
 --------
 1. Run platform API + dashboard, sign in, create/select a project, mint a
-   token. Add it to ``asianf/.env`` as ``HEXGATE_KEY=fty_live_...``.
+   token. Add it to ``asianf/.env`` as ``HEXGATE_API_KEY=fty_live_...``.
 
 2. Serve the agent — one command. ``hexgate serve`` auto-registers the
    manifest on first run (the platform generates a starter role-aware

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -4,7 +4,6 @@ active role. Langfuse propagation mirrors User identity into spans.
 """
 
 import asyncio
-import os
 from contextlib import contextmanager
 from typing import Any, AsyncGenerator, Generator
 
@@ -17,6 +16,7 @@ from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
 from hexgate.adapters.google.wrapper import wrap_google_agent
+from hexgate.config.env import resolve_api_key
 from hexgate.runtime import User
 
 
@@ -32,10 +32,10 @@ class HexgateRunner:
         api_key: str | None = None,
         **runner_kwargs: Any,
     ):
-        self.api_key = api_key or os.getenv("HEXGATE_KEY")
+        self.api_key = resolve_api_key(api_key)
         if self.api_key is None:
             raise ValueError(
-                "HEXGATE_KEY is not set. Pass api_key= explicitly or set HEXGATE_KEY environment variable."
+                "HEXGATE_API_KEY is not set. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
             )
         # Policy resolves at construction (the loud-failure point); the
         # Runner is built once — refresh swaps the enforcer's policy

--- a/hexgate/adapters/langchain/wrapper.py
+++ b/hexgate/adapters/langchain/wrapper.py
@@ -11,13 +11,12 @@ proxy at the top of every call.
 
 from __future__ import annotations
 
-import os
-
 from langchain_core.tools import BaseTool
 from langgraph.graph.state import CompiledStateGraph
 
 from hexgate.adapters.langchain.agent import HexgateLangchainAgent
 from hexgate.adapters.langchain.tools import install_enforcer_on_tools
+from hexgate.config.env import resolve_api_key
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
 
@@ -33,14 +32,14 @@ def wrap_langchain_agent(
     Mutates ``tools`` in place so the graph keeps its references.
     The returned proxy takes ``user`` per invocation; role resolves at
     call time from the active :class:`User`. ``api_key`` falls back to
-    ``HEXGATE_KEY``. ``NEEDS_APPROVAL`` outcomes render as structured
+    ``HEXGATE_API_KEY``. ``NEEDS_APPROVAL`` outcomes render as structured
     errors — wire any host-side approval flow outside the SDK. The
     enforced policy is the platform's; unlisted tools are denied.
     """
-    resolved_key = api_key if api_key else os.getenv("HEXGATE_KEY")
+    resolved_key = resolve_api_key(api_key)
     if not resolved_key:
         raise ValueError(
-            "No API key provided. Pass api_key= explicitly or set HEXGATE_KEY environment variable."
+            "No API key provided. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
         )
 
     agent_name = getattr(agent, "name", "default")

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -8,7 +8,6 @@ enforcer, so a refresh swap reaches every clone.
 """
 
 import asyncio
-import os
 from contextlib import contextmanager
 
 import nest_asyncio
@@ -26,6 +25,7 @@ from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
 from hexgate.adapters.openai.wrapper import wrap_openai_agent
+from hexgate.config.env import resolve_api_key
 from hexgate.runtime import User
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -35,10 +35,10 @@ class HexgateRunner:
     """Runner for OpenAI agents with Hexgate tool policy and observability."""
 
     def __init__(self, api_key: str | None = None):
-        self.api_key = api_key or os.getenv("HEXGATE_KEY")
+        self.api_key = resolve_api_key(api_key)
         if self.api_key is None:
             raise ValueError(
-                "HEXGATE_KEY is not set. Pass api_key= explicitly or set HEXGATE_KEY environment variable."
+                "HEXGATE_API_KEY is not set. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
             )
         # Cached per agent name — keeps the ETag memory alive across runs.
         self._bindings: dict[str, PolicyBinding] = {}

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -11,13 +11,13 @@ proxy at the top of every run.
 from __future__ import annotations
 
 import copy
-import os
 
 from pydantic_ai import Agent
 from pydantic_ai.tools import Tool
 
 from hexgate.adapters.pydantic_ai.agent import HexgatePydanticAgent
 from hexgate.adapters.pydantic_ai.tools import wrap_tools
+from hexgate.config.env import resolve_api_key
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
 
@@ -56,13 +56,13 @@ def wrap_pydantic_agent(
     ``user`` per call; role resolves at call time from the active
     :class:`User`. ``NEEDS_APPROVAL`` raises :class:`ModelRetry` with
     an ``[approval_required]`` marker. ``api_key`` falls back to
-    ``HEXGATE_KEY``. The enforced policy is the platform's; unlisted
+    ``HEXGATE_API_KEY``. The enforced policy is the platform's; unlisted
     tools are denied.
     """
-    resolved_key = api_key or os.getenv("HEXGATE_KEY")
+    resolved_key = resolve_api_key(api_key)
     if not resolved_key:
         raise ValueError(
-            "No API key provided. Pass api_key= explicitly or set HEXGATE_KEY environment variable."
+            "No API key provided. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
         )
 
     agent_name = getattr(agent, "name", None) or "default"

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -32,6 +32,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from pydantic import BaseModel
 
+from hexgate.config.env import resolve_api_key
 from hexgate.runtime import (
     LocalWorkspace,
     ToolUseContext,
@@ -554,7 +555,7 @@ def create_agent(
 
     ``bind_policy``: ``True`` always binds (raises without a name); ``False``
     never binds; ``None`` (auto) binds only on an explicit governance signal —
-    ``HEXGATE_LOCAL_POLICY`` set, or ``HEXGATE_KEY`` **plus**
+    ``HEXGATE_LOCAL_POLICY`` set, or ``HEXGATE_API_KEY`` **plus**
     ``HEXGATE_BIND_AGENTS=1`` (the platform path is opt-in, so a key present
     for another agent can't surprise-404 an unregistered prototype at
     construction). Binding gates the tools and attaches a refresh source, like
@@ -622,11 +623,11 @@ def _should_bind_policy(bind_policy: bool | None, name: str | None) -> bool:
 
     ``True`` always binds; ``False`` never binds. ``None`` (auto) binds only on
     an *explicit* governance signal — never on the mere presence of
-    ``HEXGATE_KEY``:
+    ``HEXGATE_API_KEY``:
 
       * ``HEXGATE_LOCAL_POLICY`` set → bind. A deliberate local override with
         no platform round-trip, so it can't surprise-404 at construction.
-      * ``HEXGATE_KEY`` set **and** ``HEXGATE_BIND_AGENTS`` truthy → bind. The
+      * ``HEXGATE_API_KEY`` set **and** ``HEXGATE_BIND_AGENTS`` truthy → bind. The
         platform path is opt-in: a key present for some *other* agent must not
         silently turn an unregistered ``create_agent(name=...)`` into a
         construction-time 404. Set ``HEXGATE_BIND_AGENTS=1`` to opt in, or pass
@@ -658,9 +659,7 @@ def _should_bind_policy(bind_policy: bool | None, name: str | None) -> bool:
         return True
     from hexgate.security.source import _truthy
 
-    return bool(os.environ.get("HEXGATE_KEY")) and _truthy(
-        os.environ.get("HEXGATE_BIND_AGENTS")
-    )
+    return bool(resolve_api_key()) and _truthy(os.environ.get("HEXGATE_BIND_AGENTS"))
 
 
 def _bind_policy(
@@ -677,7 +676,7 @@ def _bind_policy(
     from hexgate.security.binding import resolve_policy
 
     client = None
-    if os.environ.get("HEXGATE_KEY"):
+    if resolve_api_key():
         from hexgate.cloud.client import HexgateClient, HexgateConfig
 
         client = HexgateClient(HexgateConfig.from_env())

--- a/hexgate/agents/loader.py
+++ b/hexgate/agents/loader.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Callable, Mapping
 from importlib.resources import files
 from pathlib import Path
@@ -21,6 +20,7 @@ from hexgate.agents.factory import (
 )
 from hexgate.agents.models import AgentSpec
 from hexgate.cloud.client import HexgateClient, HexgateConfig
+from hexgate.config.env import resolve_api_key
 from hexgate.security import AgentPolicy, PolicyBundle, load_policy
 
 # HEXGATE_LOCAL_POLICY resolution lives in hexgate.security.source (single
@@ -555,14 +555,14 @@ def load_agent(
     approval_handler: ApprovalHandler | None = None,
     decision_observer: "DecisionObserver | None" = None,
 ) -> tuple[AgentGraph, CallbackHandler]:
-    """Load an agent from Hexgate (when HEXGATE_KEY is set), local, or builtin.
+    """Load an agent from Hexgate (when HEXGATE_API_KEY is set), local, or builtin.
 
     ``name`` is required for every path post-Phase 7 — the
     HEXGATE_AGENT_NAME env-var fallback was removed when ``hexgate
     serve`` moved to the uvicorn-style ``module:attr`` spec.
 
     Pass ``local_only=True`` to force resolution from local / registered /
-    builtin sources even when ``HEXGATE_KEY`` is set in the environment.
+    builtin sources even when ``HEXGATE_API_KEY`` is set in the environment.
     Useful for terminal-chat workflows that don't need cloud-fetched policy.
 
     ``decision_observer`` is forwarded to every enforced loader (local,
@@ -570,7 +570,7 @@ def load_agent(
     contextvar so the call sites stay explicit — ``hexgate chat`` is
     the only caller passing it today.
     """
-    if not local_only and os.environ.get("HEXGATE_KEY"):
+    if not local_only and resolve_api_key():
         # load_hexgate_agent dropped its reserved ``user_id`` placeholder
         # in phase 3.5 — per-request user identity comes from a User scope
         # at invocation time, not from the loader.

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -19,7 +19,7 @@ from uuid import UUID, uuid4
 
 import httpx
 
-from hexgate.config.env import resolve_api_key
+from hexgate.config.env import API_URL_ENV, DEFAULT_API_URL, resolve_api_key
 
 if TYPE_CHECKING:
     # Annotation-only: Decision is used solely as a type hint below, so it stays
@@ -273,7 +273,6 @@ class AuditSender:
 
 
 _AUDIT_PATH = "/v1/audit/decisions"
-_DEFAULT_API_URL = "http://localhost:8000"
 
 # Setting this env var to a truthy value (``1``/``true``/``yes``/``on``,
 # case-insensitive) makes ``configure()`` a no-op even when ``HEXGATE_API_KEY``
@@ -347,7 +346,7 @@ def configure(
     existing = _senders.get(resolved_key)
     if existing is not None:
         return existing
-    resolved_url = base_url or os.environ.get("HEXGATE_API_URL", _DEFAULT_API_URL)
+    resolved_url = base_url or os.environ.get(API_URL_ENV, DEFAULT_API_URL)
     sender = AuditSender(
         endpoint=f"{resolved_url.rstrip('/')}{_AUDIT_PATH}",
         api_key=resolved_key,

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -19,6 +19,8 @@ from uuid import UUID, uuid4
 
 import httpx
 
+from hexgate.config.env import resolve_api_key
+
 if TYPE_CHECKING:
     # Annotation-only: Decision is used solely as a type hint below, so it stays
     # out of the runtime import graph (PEP 563 keeps it lazy). audit.py is a
@@ -274,7 +276,7 @@ _AUDIT_PATH = "/v1/audit/decisions"
 _DEFAULT_API_URL = "http://localhost:8000"
 
 # Setting this env var to a truthy value (``1``/``true``/``yes``/``on``,
-# case-insensitive) makes ``configure()`` a no-op even when ``HEXGATE_KEY``
+# case-insensitive) makes ``configure()`` a no-op even when ``HEXGATE_API_KEY``
 # is present. ``bootstrap(local_only=True)`` sets it; ``hexgate chat``
 # passes ``local_only=True``. The check happens on every ``configure()``
 # call (not cached) so an adapter wrapper that re-``configure``s after
@@ -316,7 +318,7 @@ def configure(
 ) -> AuditSender | None:
     """Get-or-create the audit sender for ``api_key``. Idempotent per key.
 
-    Both args fall back to ``HEXGATE_KEY`` / ``HEXGATE_API_URL`` env vars.
+    Both args fall back to ``HEXGATE_API_KEY`` / ``HEXGATE_API_URL`` env vars.
     Reuses the existing sender when the same key was already configured;
     distinct keys get distinct senders. Returns ``None`` when no api_key is
     resolvable — audit stays inert.
@@ -330,7 +332,7 @@ def configure(
     if _local_mode_active():
         # Only log when a key was actually present — otherwise the
         # message is just noise during a no-key local run.
-        resolved = api_key or os.environ.get("HEXGATE_KEY")
+        resolved = resolve_api_key(api_key)
         if resolved and not _logged_local_mode_suppressed:
             _log.info(
                 "audit suppressed: %s=1 (a key is configured but local "
@@ -339,7 +341,7 @@ def configure(
             )
             _logged_local_mode_suppressed = True
         return None
-    resolved_key = api_key or os.environ.get("HEXGATE_KEY")
+    resolved_key = resolve_api_key(api_key)
     if not resolved_key:
         return None
     existing = _senders.get(resolved_key)
@@ -355,13 +357,13 @@ def configure(
 
 
 def get_sender(api_key: str | None = None) -> AuditSender | None:
-    """Return the audit sender for ``api_key`` (or ``HEXGATE_KEY``), if configured.
+    """Return the audit sender for ``api_key`` (or ``HEXGATE_API_KEY``), if configured.
 
     Production code should use the sender injected into
     :class:`~hexgate.security.enforcer.PolicyEnforcer`; this lookup exists for
     diagnostics and is unambiguous only when scoped to a key.
     """
-    resolved_key = api_key or os.environ.get("HEXGATE_KEY")
+    resolved_key = resolve_api_key(api_key)
     if not resolved_key:
         return None
     return _senders.get(resolved_key)

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -19,7 +19,7 @@ from uuid import UUID, uuid4
 
 import httpx
 
-from hexgate.config.env import API_URL_ENV, DEFAULT_API_URL, resolve_api_key
+from hexgate.config.env import resolve_api_key, resolve_api_url
 
 if TYPE_CHECKING:
     # Annotation-only: Decision is used solely as a type hint below, so it stays
@@ -346,9 +346,9 @@ def configure(
     existing = _senders.get(resolved_key)
     if existing is not None:
         return existing
-    resolved_url = base_url or os.environ.get(API_URL_ENV, DEFAULT_API_URL)
+    resolved_url = resolve_api_url(base_url)
     sender = AuditSender(
-        endpoint=f"{resolved_url.rstrip('/')}{_AUDIT_PATH}",
+        endpoint=f"{resolved_url}{_AUDIT_PATH}",
         api_key=resolved_key,
     )
     _senders[resolved_key] = sender

--- a/hexgate/bootstrap.py
+++ b/hexgate/bootstrap.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from hexgate import audit
+from hexgate.config.env import resolve_api_key
 from hexgate.config.settings import Settings
 
 _log = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
     emitted shortly before exit are lost unless the teardown path
     explicitly drains with ``await audit.shutdown()``.
 
-    The ``HEXGATE_KEY + HEXGATE_LOCAL_POLICY`` combination almost always
+    The ``HEXGATE_API_KEY + HEXGATE_LOCAL_POLICY`` combination almost always
     means a dev forgot to clean up their env between an "I'm trying the
     platform" session and an "I'm iterating on a YAML policy" session.
     Log a single WARNING line so the surprise lands at startup, not three
@@ -51,9 +52,9 @@ def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
     if local_only:
         # Set BEFORE audit.configure() so the first call sees the gate.
         os.environ[audit._LOCAL_MODE_ENV] = "1"
-    if os.environ.get("HEXGATE_KEY") and os.environ.get("HEXGATE_LOCAL_POLICY"):
+    if resolve_api_key() and os.environ.get("HEXGATE_LOCAL_POLICY"):
         _log.warning(
-            "HEXGATE_KEY and HEXGATE_LOCAL_POLICY are both set; the local "
+            "HEXGATE_API_KEY and HEXGATE_LOCAL_POLICY are both set; the local "
             "policy override wins. Unset one to remove the ambiguity."
         )
     audit.configure()

--- a/hexgate/bootstrap.py
+++ b/hexgate/bootstrap.py
@@ -58,6 +58,4 @@ def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
             "policy override wins. Unset one to remove the ambiguity."
         )
     audit.configure()
-    settings = Settings.from_env()
-    settings.validate_required_keys()
-    return settings
+    return Settings.from_env()

--- a/hexgate/cli/_common.py
+++ b/hexgate/cli/_common.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import importlib
 import importlib.util
+import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -37,6 +38,36 @@ class AgentRuntime:
     agent_source: str
     model: str
     tools_by_name: dict[str, object]
+
+
+# Built-in tools that build_runtime wires into every agent, and the env var
+# each reads at call time. Keys are optional (the tools raise a clear error
+# when actually invoked), so a missing one is a startup *warning*, not a fail.
+_TOOL_ENV_KEYS = {"web_search": "LINKUP_API_KEY", "fetch": "TAVILY_API_KEY"}
+
+
+def _warn_missing_tool_keys(tools: list[Any]) -> None:
+    """Warn at startup when a wired-in tool's API key is unset.
+
+    ``build_runtime`` adds web_search/fetch to every agent, but their keys are
+    read only when the model calls the tool — so a missing key would otherwise
+    surface mid-conversation (and get paraphrased by the LLM). Surfacing it up
+    front restores discoverability without hard-failing a session that never
+    invokes the tool."""
+    missing = [
+        (t.name, _TOOL_ENV_KEYS[t.name])
+        for t in tools
+        if getattr(t, "name", None) in _TOOL_ENV_KEYS
+        and not os.environ.get(_TOOL_ENV_KEYS[t.name])
+    ]
+    if not missing:
+        return
+    console = Console(stderr=True)
+    for tool_name, env_key in missing:
+        console.print(
+            f"[yellow]⚠ {env_key} is unset — the built-in '{tool_name}' tool "
+            f"will error if the agent calls it.[/]"
+        )
 
 
 def build_runtime(
@@ -87,6 +118,7 @@ def build_runtime(
         )
 
     tools = [web_search, fetch]
+    _warn_missing_tool_keys(tools)
     resolved_model = model or settings.model
     agent, handler = load_agent(
         agent_name,

--- a/hexgate/cli/_common.py
+++ b/hexgate/cli/_common.py
@@ -19,6 +19,7 @@ from rich.text import Text
 
 from hexgate.agents.factory import AgentGraph, ApprovalHandler, CallbackHandler
 from hexgate.agents.loader import load_agent, resolve_agent_source
+from hexgate.config.env import resolve_api_key
 from hexgate.config.settings import Settings
 from hexgate.security.decision import Decision
 from hexgate.tools import fetch, web_search
@@ -64,7 +65,7 @@ def build_runtime(
       ``hexgate serve`` already accepts.
 
     ``local_only=True`` keeps the loader off the Hexgate Cloud path even
-    when ``HEXGATE_KEY`` is present in the environment — what terminal
+    when ``HEXGATE_API_KEY`` is present in the environment — what terminal
     chat uses, since it doesn't need cloud-fetched policy or a serve
     tunnel. ``hexgate serve`` passes ``local_only=False`` so policy edits
     in the dashboard land at the next turn boundary. ``approval_handler``
@@ -72,8 +73,6 @@ def build_runtime(
     ``decision_observer`` likewise threads through — ``hexgate chat``
     uses it to render denies / approvals in the REPL.
     """
-    import os
-
     # Spec form (``module.path:attr``) — handled out-of-band from the
     # name resolver. A colon in a plain id is already discouraged
     # (YAML-loaded agent names with colons invite trouble), so the
@@ -105,7 +104,7 @@ def build_runtime(
         getattr(tool, "name", getattr(tool, "__name__", "tool")): tool
         for tool in runtime_tools
     }
-    if not local_only and os.environ.get("HEXGATE_KEY"):
+    if not local_only and resolve_api_key():
         agent_source = "hexgate"
     else:
         agent_source = resolve_agent_source(agent_name, base_dir)
@@ -191,7 +190,7 @@ def build_runtime_from_local_agent(
          raw LangGraph errors out with a clear message (the user should
          wrap with ``create_agent(...)`` or pass ``--tools`` to the legacy
          register flow).
-      2. If ``auto_register`` and ``HEXGATE_KEY`` is set: POST the manifest
+      2. If ``auto_register`` and ``HEXGATE_API_KEY`` is set: POST the manifest
          to ``/v1/agents``. Idempotent — server short-circuits when the
          content_hash hasn't changed. Print "Registered" / "unchanged" so
          the operator sees what just happened.
@@ -207,8 +206,6 @@ def build_runtime_from_local_agent(
     HexgateAgent and ``agent_name`` is the manifest's name (matches what
     we'll announce to the relay's ``hello`` message).
     """
-    import os
-
     from hexgate.agents.factory import enforce_policy
     from hexgate.cli.register.manifest import create_manifest
     from hexgate.cli.register.register import post_manifest
@@ -219,7 +216,7 @@ def build_runtime_from_local_agent(
     manifest = create_manifest(agent_obj, description=description)
     agent_name = manifest.name
 
-    if auto_register and os.environ.get("HEXGATE_KEY"):
+    if auto_register and resolve_api_key():
         # Idempotent POST. ``created`` flag in the response distinguishes
         # "first registered" from "manifest unchanged" so we can give the
         # operator a meaningful console line.

--- a/hexgate/cli/chat.py
+++ b/hexgate/cli/chat.py
@@ -349,7 +349,7 @@ def main(args: argparse.Namespace) -> int:
     # wild calling tools and we somehow miss draining between turns.
     pending_decisions: deque[Decision] = deque(maxlen=64)
 
-    # Terminal chat deliberately ignores HEXGATE_KEY: there's no playground to
+    # Terminal chat deliberately ignores HEXGATE_API_KEY: there's no playground to
     # feed and policy enforcement still works via the agent's own YAML or
     # registered factory. The serve subcommand keeps the cloud path.
     runtime = build_runtime(

--- a/hexgate/cli/register/register.py
+++ b/hexgate/cli/register/register.py
@@ -7,6 +7,7 @@ from urllib import error, request
 
 from hexgate.cli.register.manifest import create_manifest
 from hexgate.cli.register.models import AgentManifest, AgentType
+from hexgate.config.env import resolve_api_key
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
@@ -24,9 +25,9 @@ def post_manifest(
     serve``'s auto-register flow) can build the manifest themselves —
     inspect it, log its name, then ship it.
     """
-    api_key = os.environ.get("HEXGATE_KEY")
+    api_key = resolve_api_key()
     if api_key is None:
-        raise ValueError("HEXGATE_KEY must be set")
+        raise ValueError("HEXGATE_API_KEY must be set")
     api_url = os.environ.get("HEXGATE_API_URL", DEFAULT_API_URL)
 
     payload = json.dumps({"manifest": manifest.model_dump()}).encode("utf-8")

--- a/hexgate/cli/register/register.py
+++ b/hexgate/cli/register/register.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import json
-import os
 from typing import TYPE_CHECKING
 from urllib import error, request
 
 from hexgate.cli.register.manifest import create_manifest
 from hexgate.cli.register.models import AgentManifest, AgentType
-from hexgate.config.env import API_URL_ENV, DEFAULT_API_URL, resolve_api_key
+from hexgate.config.env import resolve_api_key, resolve_api_url
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
@@ -27,7 +26,7 @@ def post_manifest(
     api_key = resolve_api_key()
     if api_key is None:
         raise ValueError("HEXGATE_API_KEY must be set")
-    api_url = os.environ.get(API_URL_ENV, DEFAULT_API_URL)
+    api_url = resolve_api_url()
 
     payload = json.dumps({"manifest": manifest.model_dump()}).encode("utf-8")
     req = request.Request(

--- a/hexgate/cli/register/register.py
+++ b/hexgate/cli/register/register.py
@@ -7,12 +7,11 @@ from urllib import error, request
 
 from hexgate.cli.register.manifest import create_manifest
 from hexgate.cli.register.models import AgentManifest, AgentType
-from hexgate.config.env import resolve_api_key
+from hexgate.config.env import API_URL_ENV, DEFAULT_API_URL, resolve_api_key
 
 if TYPE_CHECKING:
     from langchain_core.tools import BaseTool
 
-DEFAULT_API_URL = "http://localhost:8000"
 DEFAULT_REGISTER_TIMEOUT = 5.0
 
 
@@ -28,7 +27,7 @@ def post_manifest(
     api_key = resolve_api_key()
     if api_key is None:
         raise ValueError("HEXGATE_API_KEY must be set")
-    api_url = os.environ.get("HEXGATE_API_URL", DEFAULT_API_URL)
+    api_url = os.environ.get(API_URL_ENV, DEFAULT_API_URL)
 
     payload = json.dumps({"manifest": manifest.model_dump()}).encode("utf-8")
     req = request.Request(

--- a/hexgate/cloud/attenuate.py
+++ b/hexgate/cloud/attenuate.py
@@ -1,7 +1,7 @@
 """Attenuate a verified Hexgate token with user-scoped facts and checks.
 
 In production the dev's backend calls :func:`attenuate_for_user` on each
-inbound request, taking the project-wide token from ``HEXGATE_KEY`` and
+inbound request, taking the project-wide token from ``HEXGATE_API_KEY`` and
 appending a per-user block before forwarding to the agent runner. The
 new envelope still chains to the platform's root public key — biscuit's
 ``append`` protocol handles the signature linkage with an ephemeral

--- a/hexgate/cloud/biscuit.py
+++ b/hexgate/cloud/biscuit.py
@@ -87,7 +87,7 @@ def verify_biscuit(token_b64: str, public_key_bytes: bytes) -> None:
 
     ``biscuit-python`` is imported lazily so importing this module doesn't
     pay the native-library load cost when the SDK is used purely offline
-    (e.g., loading local agents without ``HEXGATE_KEY``).
+    (e.g., loading local agents without ``HEXGATE_API_KEY``).
     """
     from biscuit_auth import (
         Algorithm,

--- a/hexgate/cloud/client.py
+++ b/hexgate/cloud/client.py
@@ -29,7 +29,7 @@ from hexgate.cloud.biscuit import (
     parse_envelope,
     verify_biscuit,
 )
-from hexgate.config.env import API_URL_ENV, DEFAULT_API_URL, resolve_api_key
+from hexgate.config.env import resolve_api_key, resolve_api_url
 
 DEFAULT_TIMEOUT = 10.0
 # Tight timeout for the conditional-GET hot path (refresh_policy runs at
@@ -96,7 +96,7 @@ class HexgateConfig:
                 "HEXGATE_API_KEY not set — export it or pass api_key= explicitly"
             )
 
-        url = (base_url or os.environ.get(API_URL_ENV) or DEFAULT_API_URL).rstrip("/")
+        url = resolve_api_url(base_url)
 
         # Display-only — never raises. A key whose envelope doesn't carry
         # the project prefix is still usable; we just won't be able to

--- a/hexgate/cloud/client.py
+++ b/hexgate/cloud/client.py
@@ -1,6 +1,6 @@
 """HTTP client for the Hexgate control plane.
 
-The client trusts ``HEXGATE_KEY`` only after verifying its Biscuit signature
+The client trusts ``HEXGATE_API_KEY`` only after verifying its Biscuit signature
 against the platform's public key. The public key is resolved in this order:
 
 1. Explicit ``public_key`` arg passed to ``HexgateConfig``.
@@ -29,6 +29,7 @@ from hexgate.cloud.biscuit import (
     parse_envelope,
     verify_biscuit,
 )
+from hexgate.config.env import resolve_api_key
 
 DEFAULT_BASE_URL = "http://localhost:8000"
 DEFAULT_TIMEOUT = 10.0
@@ -90,10 +91,10 @@ class HexgateConfig:
         callers either ask the platform (``GET /v1/me/key``) or display
         a placeholder. URLs never use it any more.
         """
-        key = api_key or os.environ.get("HEXGATE_KEY")
+        key = resolve_api_key(api_key)
         if not key:
             raise HexgateError(
-                "HEXGATE_KEY not set — export it or pass api_key= explicitly"
+                "HEXGATE_API_KEY not set — export it or pass api_key= explicitly"
             )
 
         url = (
@@ -213,7 +214,7 @@ class HexgateClient:
         try:
             _, _, biscuit_b64 = parse_envelope(self.config.api_key)
         except TokenError as exc:
-            raise HexgateError(f"HEXGATE_KEY is malformed: {exc}") from exc
+            raise HexgateError(f"HEXGATE_API_KEY is malformed: {exc}") from exc
 
         pub = self._resolve_public_key()
         try:
@@ -221,7 +222,7 @@ class HexgateClient:
             self._facts = extract_facts(biscuit_b64, pub)
         except TokenSignatureError as exc:
             raise HexgateError(
-                "HEXGATE_KEY signature does not chain to the platform's public key. "
+                "HEXGATE_API_KEY signature does not chain to the platform's public key. "
                 "Either the key is from a different platform, or it has been tampered with."
             ) from exc
         self._verified = True

--- a/hexgate/cloud/client.py
+++ b/hexgate/cloud/client.py
@@ -29,9 +29,8 @@ from hexgate.cloud.biscuit import (
     parse_envelope,
     verify_biscuit,
 )
-from hexgate.config.env import resolve_api_key
+from hexgate.config.env import API_URL_ENV, DEFAULT_API_URL, resolve_api_key
 
-DEFAULT_BASE_URL = "http://localhost:8000"
 DEFAULT_TIMEOUT = 10.0
 # Tight timeout for the conditional-GET hot path (refresh_policy runs at
 # the top of every chat turn). The default 10s would stall every turn up
@@ -97,9 +96,7 @@ class HexgateConfig:
                 "HEXGATE_API_KEY not set — export it or pass api_key= explicitly"
             )
 
-        url = (
-            base_url or os.environ.get("HEXGATE_API_URL") or DEFAULT_BASE_URL
-        ).rstrip("/")
+        url = (base_url or os.environ.get(API_URL_ENV) or DEFAULT_API_URL).rstrip("/")
 
         # Display-only — never raises. A key whose envelope doesn't carry
         # the project prefix is still usable; we just won't be able to

--- a/hexgate/config/env.py
+++ b/hexgate/config/env.py
@@ -17,6 +17,12 @@ API_KEY_ENV = "HEXGATE_API_KEY"
 LEGACY_API_KEY_ENV = "HEXGATE_KEY"
 API_URL_ENV = "HEXGATE_API_URL"
 
+# Defaults to Hexgate Cloud: the common case is a hosted key, so an unset
+# URL should "just work" for it. Self-hosters / local platform runs set
+# HEXGATE_API_URL=http://localhost:8000 explicitly. The key and URL are
+# coupled — a key only verifies against the platform instance that minted it.
+DEFAULT_API_URL = "https://app.hexgate.ai"
+
 _log = logging.getLogger(__name__)
 _warned_legacy = False
 

--- a/hexgate/config/env.py
+++ b/hexgate/config/env.py
@@ -1,0 +1,46 @@
+"""Resolution for the platform API credential env var.
+
+``HEXGATE_KEY`` was renamed to ``HEXGATE_API_KEY`` — for symmetry with
+``HEXGATE_API_URL`` and with the ``api_key`` parameter it feeds, and to
+disambiguate it from the signing-key family (``HEXGATE_KEYSTORE_PATH``,
+``HEXGATE_PUBLIC_KEY``). The legacy name is still honored, with a one-time
+warning, so existing ``.env`` files keep working; drop the fallback once
+downstream configs have migrated.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+API_KEY_ENV = "HEXGATE_API_KEY"
+LEGACY_API_KEY_ENV = "HEXGATE_KEY"
+API_URL_ENV = "HEXGATE_API_URL"
+
+_log = logging.getLogger(__name__)
+_warned_legacy = False
+
+
+def resolve_api_key(explicit: str | None = None) -> str | None:
+    """Resolve the platform API key.
+
+    Precedence: ``explicit`` arg → ``HEXGATE_API_KEY`` → deprecated
+    ``HEXGATE_KEY``. Returns ``None`` when none is set. Emits a one-time
+    warning when the resolved value came from the deprecated env var.
+    """
+    if explicit:
+        return explicit
+    key = os.environ.get(API_KEY_ENV)
+    if key:
+        return key
+    legacy = os.environ.get(LEGACY_API_KEY_ENV)
+    if legacy:
+        global _warned_legacy
+        if not _warned_legacy:
+            _log.warning(
+                "HEXGATE_KEY is deprecated and will be removed in a future "
+                "release; rename it to HEXGATE_API_KEY."
+            )
+            _warned_legacy = True
+        return legacy
+    return None

--- a/hexgate/config/env.py
+++ b/hexgate/config/env.py
@@ -3,9 +3,9 @@
 ``HEXGATE_KEY`` was renamed to ``HEXGATE_API_KEY`` — for symmetry with
 ``HEXGATE_API_URL`` and with the ``api_key`` parameter it feeds, and to
 disambiguate it from the signing-key family (``HEXGATE_KEYSTORE_PATH``,
-``HEXGATE_PUBLIC_KEY``). The legacy name is still honored, with a one-time
-warning, so existing ``.env`` files keep working; drop the fallback once
-downstream configs have migrated.
+``HEXGATE_PUBLIC_KEY``). The old name is no longer read; a one-time warning
+fires when it is set alone so the rename is obvious rather than silently
+treated as "no key".
 """
 
 from __future__ import annotations
@@ -22,25 +22,22 @@ _warned_legacy = False
 
 
 def resolve_api_key(explicit: str | None = None) -> str | None:
-    """Resolve the platform API key.
+    """Resolve the platform API key: ``explicit`` arg → ``HEXGATE_API_KEY``.
 
-    Precedence: ``explicit`` arg → ``HEXGATE_API_KEY`` → deprecated
-    ``HEXGATE_KEY``. Returns ``None`` when none is set. Emits a one-time
-    warning when the resolved value came from the deprecated env var.
+    Returns ``None`` when neither is set. If the retired ``HEXGATE_KEY`` is
+    set while ``HEXGATE_API_KEY`` is not, emit a one-time warning pointing at
+    the rename — the legacy value is not used.
     """
     if explicit:
         return explicit
     key = os.environ.get(API_KEY_ENV)
     if key:
         return key
-    legacy = os.environ.get(LEGACY_API_KEY_ENV)
-    if legacy:
+    if os.environ.get(LEGACY_API_KEY_ENV):
         global _warned_legacy
         if not _warned_legacy:
             _log.warning(
-                "HEXGATE_KEY is deprecated and will be removed in a future "
-                "release; rename it to HEXGATE_API_KEY."
+                "HEXGATE_KEY is set but no longer read; rename it to HEXGATE_API_KEY."
             )
             _warned_legacy = True
-        return legacy
     return None

--- a/hexgate/config/env.py
+++ b/hexgate/config/env.py
@@ -1,20 +1,16 @@
-"""Resolution for the platform API credential env var.
+"""Resolution for the platform API credential and URL env vars.
 
-``HEXGATE_KEY`` was renamed to ``HEXGATE_API_KEY`` — for symmetry with
-``HEXGATE_API_URL`` and with the ``api_key`` parameter it feeds, and to
-disambiguate it from the signing-key family (``HEXGATE_KEYSTORE_PATH``,
-``HEXGATE_PUBLIC_KEY``). The old name is no longer read; a one-time warning
-fires when it is set alone so the rename is obvious rather than silently
-treated as "no key".
+``HEXGATE_API_KEY`` names the platform credential (for symmetry with
+``HEXGATE_API_URL`` and the ``api_key`` parameter it feeds, and to
+disambiguate it from the signing-key family — ``HEXGATE_KEYSTORE_PATH``,
+``HEXGATE_PUBLIC_KEY``).
 """
 
 from __future__ import annotations
 
-import logging
 import os
 
 API_KEY_ENV = "HEXGATE_API_KEY"
-LEGACY_API_KEY_ENV = "HEXGATE_KEY"
 API_URL_ENV = "HEXGATE_API_URL"
 
 # Defaults to Hexgate Cloud: the common case is a hosted key, so an unset
@@ -23,27 +19,20 @@ API_URL_ENV = "HEXGATE_API_URL"
 # coupled — a key only verifies against the platform instance that minted it.
 DEFAULT_API_URL = "https://app.hexgate.ai"
 
-_log = logging.getLogger(__name__)
-_warned_legacy = False
-
 
 def resolve_api_key(explicit: str | None = None) -> str | None:
     """Resolve the platform API key: ``explicit`` arg → ``HEXGATE_API_KEY``.
 
-    Returns ``None`` when neither is set. If the retired ``HEXGATE_KEY`` is
-    set while ``HEXGATE_API_KEY`` is not, emit a one-time warning pointing at
-    the rename — the legacy value is not used.
+    Returns ``None`` when neither is set.
     """
     if explicit:
         return explicit
-    key = os.environ.get(API_KEY_ENV)
-    if key:
-        return key
-    if os.environ.get(LEGACY_API_KEY_ENV):
-        global _warned_legacy
-        if not _warned_legacy:
-            _log.warning(
-                "HEXGATE_KEY is set but no longer read; rename it to HEXGATE_API_KEY."
-            )
-            _warned_legacy = True
-    return None
+    return os.environ.get(API_KEY_ENV)
+
+
+def resolve_api_url(explicit: str | None = None) -> str:
+    """Resolve the platform API URL: ``explicit`` arg → ``HEXGATE_API_URL`` →
+    ``DEFAULT_API_URL``. Empty values fall through to the next source, and the
+    result has any trailing slash stripped so callers can append paths.
+    """
+    return (explicit or os.environ.get(API_URL_ENV) or DEFAULT_API_URL).rstrip("/")

--- a/hexgate/config/settings.py
+++ b/hexgate/config/settings.py
@@ -9,11 +9,13 @@ from dataclasses import dataclass
 
 @dataclass(slots=True)
 class Settings:
-    """Runtime settings loaded from environment."""
+    """Runtime settings loaded from environment.
 
-    openai_api_key: str | None
-    linkup_api_key: str | None
-    tavily_api_key: str | None
+    Provider credentials (OpenAI / Linkup / Tavily) are intentionally absent:
+    each is consumed lazily by the tool or model provider that reads it
+    straight from the environment, and is only required if that piece runs.
+    """
+
     langfuse_public_key: str | None
     langfuse_secret_key: str | None
     langfuse_host: str
@@ -24,9 +26,6 @@ class Settings:
     def from_env(cls) -> "Settings":
         """Create settings from process environment."""
         return cls(
-            openai_api_key=os.getenv("OPENAI_API_KEY"),
-            linkup_api_key=os.getenv("LINKUP_API_KEY"),
-            tavily_api_key=os.getenv("TAVILY_API_KEY"),
             langfuse_public_key=os.getenv("LANGFUSE_PUBLIC_KEY"),
             langfuse_secret_key=os.getenv("LANGFUSE_SECRET_KEY"),
             langfuse_host=os.getenv("LANGFUSE_HOST", "https://cloud.langfuse.com"),

--- a/hexgate/config/settings.py
+++ b/hexgate/config/settings.py
@@ -33,18 +33,3 @@ class Settings:
             model=os.getenv("HEXGATE_DEFAULT_MODEL", "openai:gpt-5.4"),
             search_engine=os.getenv("HEXGATE_DEFAULT_SEARCH_ENGINE", "linkup"),
         )
-
-    def validate_required_keys(self) -> None:
-        """Validate the minimal keys required for the runtime."""
-        missing = []
-        if not self.openai_api_key:
-            missing.append("OPENAI_API_KEY")
-        if not self.linkup_api_key:
-            missing.append("LINKUP_API_KEY")
-        if not self.tavily_api_key:
-            missing.append("TAVILY_API_KEY")
-
-        if missing:
-            raise RuntimeError(
-                "Missing required environment variables: " + ", ".join(missing)
-            )

--- a/hexgate/security/binding.py
+++ b/hexgate/security/binding.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from hexgate.config.env import resolve_api_key
 from hexgate.security.policy_set import load_policy_set_from_dict
 from hexgate.security.source import (
     _LOCAL_POLICY_ENV_VAR,
@@ -69,7 +70,7 @@ def resolve_policy(
     """Resolve the current policy for ``agent_name``.
 
     Precedence: ``HEXGATE_LOCAL_POLICY`` override → platform (``client``
-    or ``api_key``/``HEXGATE_KEY``) → raise. Eager and fail-loud; a
+    or ``api_key``/``HEXGATE_API_KEY``) → raise. Eager and fail-loud; a
     platform 404 propagates as ``HexgateError``.
     """
     if not agent_name:
@@ -83,7 +84,7 @@ def resolve_policy(
         bundle, source = override
         return ResolvedPolicy(bundle, source)
 
-    if client is None and (api_key or os.environ.get("HEXGATE_KEY")):
+    if client is None and resolve_api_key(api_key):
         from hexgate.cloud.client import HexgateClient, HexgateConfig
 
         client = HexgateClient(HexgateConfig.from_env(api_key=api_key))
@@ -100,7 +101,7 @@ def resolve_policy(
         return ResolvedPolicy(engine, source)
 
     raise PolicyBindingError(
-        f"no policy available for agent {agent_name!r}: HEXGATE_KEY is "
+        f"no policy available for agent {agent_name!r}: HEXGATE_API_KEY is "
         f"not set and {_LOCAL_POLICY_ENV_VAR} is not set. Set a "
         "credential, point the override at a policy, or construct "
         "PolicyBinding(PolicyEnforcer(engine)) explicitly."

--- a/hexgate/security/enforcer.py
+++ b/hexgate/security/enforcer.py
@@ -124,7 +124,7 @@ def build_enforcer(
     The one place that pairs an engine with its audit sink, so the six
     surfaces (``HexgateAgent.enforce_policy``, the four adapters, the
     OpenAI runner) don't each repeat the ``audit.configure`` wiring.
-    ``api_key=None`` falls back to ``HEXGATE_KEY`` (audit stays inert when
+    ``api_key=None`` falls back to ``HEXGATE_API_KEY`` (audit stays inert when
     neither resolves). ``decision_observer`` threads the local-process
     decision hook (see :class:`PolicyEnforcer`); ``None`` is silent.
     """

--- a/platform/DEPLOY.md
+++ b/platform/DEPLOY.md
@@ -163,5 +163,5 @@ both):
 
 ```bash
 export HEXGATE_API_URL=https://app.hexgate.ai     # or app.staging.hexgate.ai
-export HEXGATE_KEY=fty_live_...                    # token minted in that env's dashboard
+export HEXGATE_API_KEY=fty_live_...                    # token minted in that env's dashboard
 ```

--- a/platform/dashboard/src/routes/Playground.tsx
+++ b/platform/dashboard/src/routes/Playground.tsx
@@ -161,7 +161,7 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
             <div className="mt-2 text-muted-foreground">
               Run{" "}
               <span className="font-mono text-foreground">hexgate serve</span>{" "}
-              with your HEXGATE_KEY to expose an agent session here.
+              with your HEXGATE_API_KEY to expose an agent session here.
             </div>
           </div>
         )}

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -162,7 +162,6 @@ def test_constructor_raises_when_no_api_key_available(
 ) -> None:
     """Reject construction when neither argument nor env var supplies a key."""
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
     with pytest.raises(ValueError, match="HEXGATE_API_KEY is not set"):
         HexgateRunner(

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -127,8 +127,8 @@ def test_constructor_uses_explicit_api_key(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_constructor_falls_back_to_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Resolve the API key from HEXGATE_KEY when no explicit key is given."""
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    """Resolve the API key from HEXGATE_API_KEY when no explicit key is given."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
     _install_fake_runner(monkeypatch)
 
     runner = HexgateRunner(
@@ -144,7 +144,7 @@ def test_constructor_prefers_explicit_api_key_over_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The explicit api_key argument wins when both sources are populated."""
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
     _install_fake_runner(monkeypatch)
 
     runner = HexgateRunner(
@@ -161,9 +161,10 @@ def test_constructor_raises_when_no_api_key_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reject construction when neither argument nor env var supplies a key."""
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
-    with pytest.raises(ValueError, match="HEXGATE_KEY is not set"):
+    with pytest.raises(ValueError, match="HEXGATE_API_KEY is not set"):
         HexgateRunner(
             agent=_make_agent(),
             app_name="app",

--- a/tests/adapters/langchain/test_wrapper.py
+++ b/tests/adapters/langchain/test_wrapper.py
@@ -87,7 +87,7 @@ def test_wrap_returns_hexgate_proxy_with_supplied_tool_names(
 def test_wrap_falls_back_to_env_var(
     monkeypatch: pytest.MonkeyPatch, resolved: dict[str, Any]
 ) -> None:
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
 
     wrapped = wrap_langchain_agent(agent=_FakeCompiledGraph(), tools=[])
 
@@ -97,7 +97,7 @@ def test_wrap_falls_back_to_env_var(
 def test_wrap_prefers_explicit_api_key_over_env(
     monkeypatch: pytest.MonkeyPatch, resolved: dict[str, Any]
 ) -> None:
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
 
     wrapped = wrap_langchain_agent(
         agent=_FakeCompiledGraph(), tools=[], api_key="explicit"
@@ -109,7 +109,8 @@ def test_wrap_prefers_explicit_api_key_over_env(
 def test_wrap_raises_when_no_api_key_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
     with pytest.raises(ValueError, match="No API key provided"):
         wrap_langchain_agent(agent=_FakeCompiledGraph(), tools=[])
@@ -118,7 +119,7 @@ def test_wrap_raises_when_no_api_key_available(
 def test_wrap_treats_empty_api_key_string_as_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HEXGATE_KEY", "")
+    monkeypatch.setenv("HEXGATE_API_KEY", "")
 
     with pytest.raises(ValueError, match="No API key provided"):
         wrap_langchain_agent(agent=_FakeCompiledGraph(), tools=[], api_key="")

--- a/tests/adapters/langchain/test_wrapper.py
+++ b/tests/adapters/langchain/test_wrapper.py
@@ -110,7 +110,6 @@ def test_wrap_raises_when_no_api_key_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
     with pytest.raises(ValueError, match="No API key provided"):
         wrap_langchain_agent(agent=_FakeCompiledGraph(), tools=[])

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -119,7 +119,6 @@ def test_constructor_raises_when_no_api_key_available(
 ) -> None:
     """Reject construction when neither argument nor env var supplies a key."""
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
     with pytest.raises(ValueError, match="HEXGATE_API_KEY is not set"):
         HexgateRunner()

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -95,8 +95,8 @@ def test_constructor_uses_explicit_api_key() -> None:
 
 
 def test_constructor_falls_back_to_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Resolve the API key from HEXGATE_KEY when no explicit key is given."""
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    """Resolve the API key from HEXGATE_API_KEY when no explicit key is given."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
 
     runner = HexgateRunner()
 
@@ -107,7 +107,7 @@ def test_constructor_prefers_explicit_api_key_over_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The explicit api_key argument wins when both sources are populated."""
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
 
     runner = HexgateRunner(api_key="explicit")
 
@@ -118,9 +118,10 @@ def test_constructor_raises_when_no_api_key_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reject construction when neither argument nor env var supplies a key."""
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
-    with pytest.raises(ValueError, match="HEXGATE_KEY is not set"):
+    with pytest.raises(ValueError, match="HEXGATE_API_KEY is not set"):
         HexgateRunner()
 
 

--- a/tests/adapters/pydantic_ai/test_wrapper.py
+++ b/tests/adapters/pydantic_ai/test_wrapper.py
@@ -171,7 +171,6 @@ def test_wrap_pydantic_agent_raises_when_no_api_key_available(
 ) -> None:
     """Reject construction when neither argument nor env var supplies a key."""
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
     with pytest.raises(ValueError, match="No API key provided"):
         wrap_pydantic_agent(agent=_make_agent())

--- a/tests/adapters/pydantic_ai/test_wrapper.py
+++ b/tests/adapters/pydantic_ai/test_wrapper.py
@@ -146,8 +146,8 @@ def test_wrap_pydantic_agent_does_not_mutate_original_agent() -> None:
 def test_wrap_pydantic_agent_falls_back_to_env_var(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Resolve the API key from HEXGATE_KEY when no explicit key is given."""
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    """Resolve the API key from HEXGATE_API_KEY when no explicit key is given."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
     agent = _make_agent()
 
     wrapped = wrap_pydantic_agent(agent=agent)
@@ -158,8 +158,8 @@ def test_wrap_pydantic_agent_falls_back_to_env_var(
 def test_wrap_pydantic_agent_prefers_explicit_api_key_over_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The explicit api_key argument wins over HEXGATE_KEY when both are set."""
-    monkeypatch.setenv("HEXGATE_KEY", "from-env")
+    """The explicit api_key argument wins over HEXGATE_API_KEY when both are set."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
 
     wrapped = wrap_pydantic_agent(agent=_make_agent(), api_key="explicit")
 
@@ -170,7 +170,8 @@ def test_wrap_pydantic_agent_raises_when_no_api_key_available(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Reject construction when neither argument nor env var supplies a key."""
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
 
     with pytest.raises(ValueError, match="No API key provided"):
         wrap_pydantic_agent(agent=_make_agent())
@@ -179,8 +180,8 @@ def test_wrap_pydantic_agent_raises_when_no_api_key_available(
 def test_wrap_pydantic_agent_raises_when_api_key_is_empty_string(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Treat an empty HEXGATE_KEY env var the same as missing."""
-    monkeypatch.setenv("HEXGATE_KEY", "")
+    """Treat an empty HEXGATE_API_KEY env var the same as missing."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "")
 
     with pytest.raises(ValueError, match="No API key provided"):
         wrap_pydantic_agent(agent=_make_agent(), api_key="")

--- a/tests/agents/test_create_agent_binding.py
+++ b/tests/agents/test_create_agent_binding.py
@@ -74,7 +74,8 @@ def _hermetic(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         factory, "get_langfuse_handler", lambda **kwargs: "handler-instance"
     )
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_LOCAL_POLICY", raising=False)
     monkeypatch.delenv("HEXGATE_BIND_AGENTS", raising=False)
     monkeypatch.delenv("HEXGATE_LOCAL_MODE", raising=False)
@@ -88,7 +89,7 @@ def _patch_platform(monkeypatch: pytest.MonkeyPatch, client: _FakeClient) -> Non
     """
     import hexgate.cloud.client as client_mod
 
-    monkeypatch.setenv("HEXGATE_KEY", "fty_test_demo_dummybiscuit")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_test_demo_dummybiscuit")
     monkeypatch.setenv("HEXGATE_BIND_AGENTS", "1")
     monkeypatch.setattr(client_mod, "HexgateClient", lambda config: client)
 
@@ -99,7 +100,7 @@ def _patch_platform(monkeypatch: pytest.MonkeyPatch, client: _FakeClient) -> Non
 
 
 def test_auto_mode_without_governance_env_returns_bare_agent() -> None:
-    """No HEXGATE_KEY / HEXGATE_LOCAL_POLICY → today's bare graph."""
+    """No HEXGATE_API_KEY / HEXGATE_LOCAL_POLICY → today's bare graph."""
     agent, handler = factory.create_agent(
         model="openai:gpt-5.4", tools=[echo], name="support-bot"
     )
@@ -113,7 +114,7 @@ def test_auto_mode_without_name_skips_even_with_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Nameless agents have nothing to resolve against — silent skip."""
-    monkeypatch.setenv("HEXGATE_KEY", "fty_test_demo_dummybiscuit")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_test_demo_dummybiscuit")
 
     agent, _ = factory.create_agent(model="openai:gpt-5.4", tools=[echo])
 
@@ -124,12 +125,12 @@ def test_auto_mode_without_name_skips_even_with_key(
 def test_auto_mode_bare_key_does_not_bind_without_opt_in(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A HEXGATE_KEY present for some *other* agent must not auto-bind a
+    """A HEXGATE_API_KEY present for some *other* agent must not auto-bind a
     named prototype — that would surprise-404 at construction. The platform
     bind path needs HEXGATE_BIND_AGENTS=1 (or an explicit bind_policy=True)."""
     import hexgate.cloud.client as client_mod
 
-    monkeypatch.setenv("HEXGATE_KEY", "fty_test_demo_dummybiscuit")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_test_demo_dummybiscuit")
     monkeypatch.delenv("HEXGATE_BIND_AGENTS", raising=False)
     # The platform must never be contacted — fail hard if a client is built.
     monkeypatch.setattr(
@@ -157,7 +158,7 @@ def test_auto_mode_respects_hexgate_local_mode(
     import hexgate.cloud.client as client_mod
     from hexgate import audit
 
-    monkeypatch.setenv("HEXGATE_KEY", "fty_test_demo_dummybiscuit")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_test_demo_dummybiscuit")
     monkeypatch.setenv("HEXGATE_BIND_AGENTS", "1")
     monkeypatch.setenv(audit._LOCAL_MODE_ENV, "1")
     # The platform must never be contacted — fail hard if a client is built.
@@ -205,7 +206,7 @@ def test_bind_policy_false_skips_even_with_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The explicit escape hatch for bare graphs in keyed environments."""
-    monkeypatch.setenv("HEXGATE_KEY", "fty_test_demo_dummybiscuit")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_test_demo_dummybiscuit")
 
     agent, _ = factory.create_agent(
         model="openai:gpt-5.4", tools=[echo], name="support-bot", bind_policy=False
@@ -228,7 +229,7 @@ def test_bind_policy_true_requires_name() -> None:
 def test_bind_wraps_tools_and_attaches_source_and_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Auto mode + HEXGATE_KEY + name → guarded tools, seeded source, client."""
+    """Auto mode + HEXGATE_API_KEY + name → guarded tools, seeded source, client."""
     fc = _FakeClient()
     fc.serve({"policy_yaml": _POLICY_YAML}, etag='"hash-a"')
     _patch_platform(monkeypatch, fc)

--- a/tests/agents/test_create_agent_binding.py
+++ b/tests/agents/test_create_agent_binding.py
@@ -75,7 +75,6 @@ def _hermetic(monkeypatch: pytest.MonkeyPatch) -> None:
         factory, "get_langfuse_handler", lambda **kwargs: "handler-instance"
     )
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_LOCAL_POLICY", raising=False)
     monkeypatch.delenv("HEXGATE_BIND_AGENTS", raising=False)
     monkeypatch.delenv("HEXGATE_LOCAL_MODE", raising=False)

--- a/tests/audit/test_configure.py
+++ b/tests/audit/test_configure.py
@@ -15,7 +15,8 @@ def _isolate_audit_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Reset the sender registry + clear HEXGATE_* env between tests."""
     audit_mod._senders.clear()
     audit_mod._logged_local_mode_suppressed = False
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_API_URL", raising=False)
     monkeypatch.delenv(audit_mod._LOCAL_MODE_ENV, raising=False)
     yield
@@ -37,14 +38,14 @@ def test_explicit_api_key_uses_default_url() -> None:
 def test_env_api_key_picked_up_when_not_explicit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setenv("HEXGATE_KEY", "env_key")
+    monkeypatch.setenv("HEXGATE_API_KEY", "env_key")
     sender = audit_mod.configure()
     assert sender is not None
     assert sender._endpoint == "http://localhost:8000/v1/audit/decisions"
 
 
 def test_explicit_api_key_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HEXGATE_KEY", "env_key")
+    monkeypatch.setenv("HEXGATE_API_KEY", "env_key")
     sender = audit_mod.configure("explicit_key")
     assert sender._client.headers["Authorization"] == "Bearer explicit_key"
 
@@ -94,7 +95,7 @@ def test_local_mode_env_suppresses_configure(
     even when an api_key is in env. The gate is the whole point of local
     mode: a key in .env (left over from a platform session) must not cause
     cloud writes the next time the dev runs `hexgate chat`."""
-    monkeypatch.setenv("HEXGATE_KEY", "real_key")
+    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
     monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, truthy)
     assert audit_mod.configure() is None
     assert audit_mod.get_sender("real_key") is None
@@ -107,7 +108,7 @@ def test_local_mode_falsy_does_not_suppress(
     """Explicit falsy values behave as if unset — symmetry with the
     truthy parametrize prevents a future refactor from accidentally
     making `HEXGATE_LOCAL_MODE=0` count as 'on'."""
-    monkeypatch.setenv("HEXGATE_KEY", "real_key")
+    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
     monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, falsy)
     sender = audit_mod.configure()
     assert sender is not None
@@ -128,7 +129,7 @@ def test_local_mode_logs_suppression_once(
 ) -> None:
     """A single INFO line at the first suppression; further configure()
     calls stay silent so a busy startup doesn't repeat itself."""
-    monkeypatch.setenv("HEXGATE_KEY", "real_key")
+    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
     monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
     with caplog.at_level(logging.INFO, logger="hexgate.audit"):
         audit_mod.configure()

--- a/tests/audit/test_configure.py
+++ b/tests/audit/test_configure.py
@@ -31,7 +31,7 @@ def test_returns_none_when_no_key_anywhere() -> None:
 def test_explicit_api_key_uses_default_url() -> None:
     sender = audit_mod.configure("explicit_key")
     assert sender is not None
-    assert sender._endpoint == "http://localhost:8000/v1/audit/decisions"
+    assert sender._endpoint == "https://app.hexgate.ai/v1/audit/decisions"
 
 
 def test_env_api_key_picked_up_when_not_explicit(
@@ -40,7 +40,7 @@ def test_env_api_key_picked_up_when_not_explicit(
     monkeypatch.setenv("HEXGATE_API_KEY", "env_key")
     sender = audit_mod.configure()
     assert sender is not None
-    assert sender._endpoint == "http://localhost:8000/v1/audit/decisions"
+    assert sender._endpoint == "https://app.hexgate.ai/v1/audit/decisions"
 
 
 def test_explicit_api_key_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/audit/test_configure.py
+++ b/tests/audit/test_configure.py
@@ -16,7 +16,6 @@ def _isolate_audit_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     audit_mod._senders.clear()
     audit_mod._logged_local_mode_suppressed = False
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_API_URL", raising=False)
     monkeypatch.delenv(audit_mod._LOCAL_MODE_ENV, raising=False)
     yield

--- a/tests/audit/test_integration.py
+++ b/tests/audit/test_integration.py
@@ -1,7 +1,7 @@
 """End-to-end audit emission against a live platform + ClickHouse.
 
 Requires: `make clickhouse-up` and `make platform-api` running, and
-`HEXGATE_KEY` set to a token minted via the dashboard.
+`HEXGATE_API_KEY` set to a token minted via the dashboard.
 
 Opt in with: `pytest -m integration`.
 """
@@ -21,12 +21,12 @@ from hexgate.security.decision import Decision, DecisionOutcome
 pytestmark = pytest.mark.integration
 
 PLATFORM_URL = os.environ.get("HEXGATE_API_URL", "http://localhost:8000").rstrip("/")
-TOKEN = os.environ.get("HEXGATE_KEY")
+TOKEN = os.environ.get("HEXGATE_API_KEY")
 
 
 def _need_token() -> None:
     if not TOKEN:
-        pytest.skip("HEXGATE_KEY not set; mint a token via the dashboard")
+        pytest.skip("HEXGATE_API_KEY not set; mint a token via the dashboard")
 
 
 def _event() -> AuditEvent:

--- a/tests/cli/test_chat.py
+++ b/tests/cli/test_chat.py
@@ -372,9 +372,6 @@ def test_drain_decisions_noop_on_empty_deque() -> None:
 def _test_settings() -> Settings:
     """Minimal Settings instance for runtime tests."""
     return Settings(
-        openai_api_key="k",
-        linkup_api_key="k",
-        tavily_api_key="k",
         langfuse_public_key=None,
         langfuse_secret_key=None,
         langfuse_host="https://cloud.langfuse.com",

--- a/tests/cli/test_common.py
+++ b/tests/cli/test_common.py
@@ -1,0 +1,45 @@
+"""Tests for shared CLI runtime helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate.cli._common import _warn_missing_tool_keys
+from hexgate.tools import fetch, web_search
+
+
+def test_warns_for_each_unset_tool_key(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("LINKUP_API_KEY", raising=False)
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    _warn_missing_tool_keys([web_search, fetch])
+
+    err = capsys.readouterr().err
+    assert "LINKUP_API_KEY" in err
+    assert "TAVILY_API_KEY" in err
+
+
+def test_silent_when_keys_present(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("LINKUP_API_KEY", "x")
+    monkeypatch.setenv("TAVILY_API_KEY", "y")
+
+    _warn_missing_tool_keys([web_search, fetch])
+
+    assert capsys.readouterr().err == ""
+
+
+def test_warns_only_for_the_missing_key(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setenv("LINKUP_API_KEY", "x")
+    monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+
+    _warn_missing_tool_keys([web_search, fetch])
+
+    err = capsys.readouterr().err
+    assert "TAVILY_API_KEY" in err
+    assert "LINKUP_API_KEY" not in err

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -432,7 +432,7 @@ def _patched_runtime_deps(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     monkeypatch.setattr(
         "hexgate.tracing.langfuse.get_langfuse_handler", fake_get_handler
     )
-    monkeypatch.setenv("HEXGATE_KEY", "fty_live_test_secret")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_live_test_secret")
     return captured
 
 

--- a/tests/cloud/test_client.py
+++ b/tests/cloud/test_client.py
@@ -59,7 +59,6 @@ def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear the HEXGATE_* env keys so resolution tests don't leak state."""
     for key in (
         "HEXGATE_API_KEY",
-        "HEXGATE_KEY",  # legacy alias — clear so it can't leak into resolution
         "HEXGATE_API_URL",
         "HEXGATE_PROJECT_ID",
         "HEXGATE_PUBLIC_KEY",

--- a/tests/cloud/test_client.py
+++ b/tests/cloud/test_client.py
@@ -83,6 +83,16 @@ def test_config_uses_explicit_args(clean_env: None) -> None:
     assert config.project_id == "overridden"
 
 
+def test_config_defaults_to_hexgate_cloud(
+    monkeypatch: pytest.MonkeyPatch,
+    clean_env: None,
+) -> None:
+    """Unset HEXGATE_API_URL resolves to Hexgate Cloud, not localhost."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_live_proj_secret")
+    config = HexgateConfig.from_env()
+    assert config.base_url == "https://app.hexgate.ai"
+
+
 def test_config_strips_trailing_slash_from_base_url(clean_env: None) -> None:
     """A trailing ``/`` on HEXGATE_API_URL would double up in path concatenation."""
     config = HexgateConfig.from_env(

--- a/tests/cloud/test_client.py
+++ b/tests/cloud/test_client.py
@@ -58,7 +58,8 @@ def _b64url(b: bytes) -> str:
 def clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear the HEXGATE_* env keys so resolution tests don't leak state."""
     for key in (
-        "HEXGATE_KEY",
+        "HEXGATE_API_KEY",
+        "HEXGATE_KEY",  # legacy alias — clear so it can't leak into resolution
         "HEXGATE_API_URL",
         "HEXGATE_PROJECT_ID",
         "HEXGATE_PUBLIC_KEY",
@@ -97,7 +98,7 @@ def test_config_resolves_project_from_env(
     clean_env: None,
 ) -> None:
     """HEXGATE_PROJECT_ID overrides whatever the key prefix encodes."""
-    monkeypatch.setenv("HEXGATE_KEY", "fty_live_key-proj_secret")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_live_key-proj_secret")
     monkeypatch.setenv("HEXGATE_PROJECT_ID", "env-proj")
     config = HexgateConfig.from_env()
     assert config.project_id == "env-proj"
@@ -108,14 +109,14 @@ def test_config_resolves_project_from_key_prefix(
     clean_env: None,
 ) -> None:
     """When neither arg nor env give a project, parse it from the key prefix."""
-    monkeypatch.setenv("HEXGATE_KEY", "fty_live_my-cool-project_secret")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_live_my-cool-project_secret")
     config = HexgateConfig.from_env()
     assert config.project_id == "my-cool-project"
 
 
 def test_config_raises_when_key_missing(clean_env: None) -> None:
-    """No HEXGATE_KEY is fail-fast, not silent default."""
-    with pytest.raises(HexgateError, match="HEXGATE_KEY not set"):
+    """No HEXGATE_API_KEY is fail-fast, not silent default."""
+    with pytest.raises(HexgateError, match="HEXGATE_API_KEY not set"):
         HexgateConfig.from_env()
 
 
@@ -130,7 +131,7 @@ def test_config_allows_unresolvable_project(
     it through URLs. A missing project_id surfaces as ``None``,
     not an error.
     """
-    monkeypatch.setenv("HEXGATE_KEY", "completely_unparseable_key")
+    monkeypatch.setenv("HEXGATE_API_KEY", "completely_unparseable_key")
     config = HexgateConfig.from_env()
     assert config.project_id is None
     # The key still goes through verbatim — the server is the
@@ -163,7 +164,7 @@ def test_config_public_key_from_env(
 ) -> None:
     """HEXGATE_PUBLIC_KEY env (urlsafe-b64) decodes into raw bytes."""
     _, pub = keys
-    monkeypatch.setenv("HEXGATE_KEY", "fty_live_proj_secret")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_live_proj_secret")
     monkeypatch.setenv("HEXGATE_PUBLIC_KEY", _b64url(pub))
     config = HexgateConfig.from_env()
     assert config.public_key == pub
@@ -176,7 +177,7 @@ def test_config_public_key_env_handles_missing_padding(
 ) -> None:
     """urlsafe_b64decode requires padding, but operators may strip it."""
     _, pub = keys
-    monkeypatch.setenv("HEXGATE_KEY", "fty_live_proj_secret")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_live_proj_secret")
     encoded = base64.urlsafe_b64encode(pub).decode("ascii").rstrip("=")
     monkeypatch.setenv("HEXGATE_PUBLIC_KEY", encoded)
     config = HexgateConfig.from_env()
@@ -188,7 +189,7 @@ def test_config_invalid_pubkey_env_raises(
     clean_env: None,
 ) -> None:
     """Non-base64 HEXGATE_PUBLIC_KEY is a startup-time misconfiguration."""
-    monkeypatch.setenv("HEXGATE_KEY", "fty_live_proj_secret")
+    monkeypatch.setenv("HEXGATE_API_KEY", "fty_live_proj_secret")
     monkeypatch.setenv("HEXGATE_PUBLIC_KEY", "!!!not-base64!!!")
     with pytest.raises(HexgateError, match="not valid base64"):
         HexgateConfig.from_env()

--- a/tests/config/test_env.py
+++ b/tests/config/test_env.py
@@ -1,17 +1,12 @@
-import logging
-
 import pytest
 
-from hexgate.config import env
-from hexgate.config.env import resolve_api_key
+from hexgate.config.env import DEFAULT_API_URL, resolve_api_key, resolve_api_url
 
 
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
-    # Reset the one-time warning gate so each test observes it fresh.
-    monkeypatch.setattr(env, "_warned_legacy", False)
+    monkeypatch.delenv("HEXGATE_API_URL", raising=False)
 
 
 def test_explicit_arg_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -24,32 +19,31 @@ def test_reads_primary_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resolve_api_key() == "primary"
 
 
-def test_legacy_key_is_not_used(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A lone HEXGATE_KEY resolves to None — the legacy value is ignored."""
-    monkeypatch.setenv("HEXGATE_KEY", "legacy")
-    assert resolve_api_key() is None
-
-
-def test_legacy_key_warns_once(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    monkeypatch.setenv("HEXGATE_KEY", "legacy")
-    with caplog.at_level(logging.WARNING, logger="hexgate.config.env"):
-        resolve_api_key()
-        resolve_api_key()
-    warnings = [r for r in caplog.records if "HEXGATE_KEY is set" in r.message]
-    assert len(warnings) == 1
-
-
-def test_no_legacy_warning_when_primary_set(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    monkeypatch.setenv("HEXGATE_API_KEY", "primary")
-    monkeypatch.setenv("HEXGATE_KEY", "legacy")
-    with caplog.at_level(logging.WARNING, logger="hexgate.config.env"):
-        assert resolve_api_key() == "primary"
-    assert not any("HEXGATE_KEY is set" in r.message for r in caplog.records)
-
-
 def test_returns_none_when_unset() -> None:
     assert resolve_api_key() is None
+
+
+def test_url_explicit_arg_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_URL", "http://from-env")
+    assert resolve_api_url("http://explicit") == "http://explicit"
+
+
+def test_url_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_URL", "http://localhost:8000")
+    assert resolve_api_url() == "http://localhost:8000"
+
+
+def test_url_defaults_when_unset() -> None:
+    assert resolve_api_url() == DEFAULT_API_URL
+
+
+def test_url_empty_string_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("HEXGATE_API_URL", "")
+    assert resolve_api_url() == DEFAULT_API_URL
+
+
+def test_url_strips_trailing_slash(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_URL", "http://localhost:8000/")
+    assert resolve_api_url() == "http://localhost:8000"

--- a/tests/config/test_env.py
+++ b/tests/config/test_env.py
@@ -10,7 +10,7 @@ from hexgate.config.env import resolve_api_key
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
     monkeypatch.delenv("HEXGATE_KEY", raising=False)
-    # Reset the one-time deprecation-warning gate so each test observes it fresh.
+    # Reset the one-time warning gate so each test observes it fresh.
     monkeypatch.setattr(env, "_warned_legacy", False)
 
 
@@ -24,19 +24,31 @@ def test_reads_primary_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert resolve_api_key() == "primary"
 
 
-def test_primary_wins_over_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("HEXGATE_API_KEY", "primary")
+def test_legacy_key_is_not_used(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A lone HEXGATE_KEY resolves to None — the legacy value is ignored."""
     monkeypatch.setenv("HEXGATE_KEY", "legacy")
-    assert resolve_api_key() == "primary"
+    assert resolve_api_key() is None
 
 
-def test_falls_back_to_legacy_with_warning(
+def test_legacy_key_warns_once(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     monkeypatch.setenv("HEXGATE_KEY", "legacy")
     with caplog.at_level(logging.WARNING, logger="hexgate.config.env"):
-        assert resolve_api_key() == "legacy"
-    assert any("HEXGATE_KEY is deprecated" in r.message for r in caplog.records)
+        resolve_api_key()
+        resolve_api_key()
+    warnings = [r for r in caplog.records if "HEXGATE_KEY is set" in r.message]
+    assert len(warnings) == 1
+
+
+def test_no_legacy_warning_when_primary_set(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("HEXGATE_API_KEY", "primary")
+    monkeypatch.setenv("HEXGATE_KEY", "legacy")
+    with caplog.at_level(logging.WARNING, logger="hexgate.config.env"):
+        assert resolve_api_key() == "primary"
+    assert not any("HEXGATE_KEY is set" in r.message for r in caplog.records)
 
 
 def test_returns_none_when_unset() -> None:

--- a/tests/config/test_env.py
+++ b/tests/config/test_env.py
@@ -1,0 +1,43 @@
+import logging
+
+import pytest
+
+from hexgate.config import env
+from hexgate.config.env import resolve_api_key
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    # Reset the one-time deprecation-warning gate so each test observes it fresh.
+    monkeypatch.setattr(env, "_warned_legacy", False)
+
+
+def test_explicit_arg_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_KEY", "from-env")
+    assert resolve_api_key("explicit") == "explicit"
+
+
+def test_reads_primary_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_KEY", "primary")
+    assert resolve_api_key() == "primary"
+
+
+def test_primary_wins_over_legacy(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_KEY", "primary")
+    monkeypatch.setenv("HEXGATE_KEY", "legacy")
+    assert resolve_api_key() == "primary"
+
+
+def test_falls_back_to_legacy_with_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("HEXGATE_KEY", "legacy")
+    with caplog.at_level(logging.WARNING, logger="hexgate.config.env"):
+        assert resolve_api_key() == "legacy"
+    assert any("HEXGATE_KEY is deprecated" in r.message for r in caplog.records)
+
+
+def test_returns_none_when_unset() -> None:
+    assert resolve_api_key() is None

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -26,36 +26,14 @@ def test_from_env_reads_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.search_engine == "linkup"
 
 
-def test_validate_required_keys_raises_for_missing_keys() -> None:
-    """Raise a helpful error when required keys are missing."""
-    settings = Settings(
-        openai_api_key=None,
-        linkup_api_key=None,
-        tavily_api_key=None,
-        langfuse_public_key=None,
-        langfuse_secret_key=None,
-        langfuse_host="https://cloud.langfuse.com",
-        model="openai:gpt-5.4",
-        search_engine="linkup",
-    )
+def test_from_env_leaves_unset_keys_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing provider keys resolve to None — bootstrap never hard-fails on
+    them; the tool or model provider raises at use-time instead."""
+    for key in ("OPENAI_API_KEY", "LINKUP_API_KEY", "TAVILY_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
 
-    with pytest.raises(
-        RuntimeError, match="OPENAI_API_KEY, LINKUP_API_KEY, TAVILY_API_KEY"
-    ):
-        settings.validate_required_keys()
+    settings = Settings.from_env()
 
-
-def test_validate_required_keys_accepts_present_keys() -> None:
-    """Allow valid settings through without raising."""
-    settings = Settings(
-        openai_api_key="openai-key",
-        linkup_api_key="linkup-key",
-        tavily_api_key="tavily-key",
-        langfuse_public_key=None,
-        langfuse_secret_key=None,
-        langfuse_host="https://cloud.langfuse.com",
-        model="openai:gpt-5.4",
-        search_engine="linkup",
-    )
-
-    settings.validate_required_keys()
+    assert settings.openai_api_key is None
+    assert settings.linkup_api_key is None
+    assert settings.tavily_api_key is None

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -9,31 +9,23 @@ from hexgate.config.settings import Settings
 
 def test_from_env_reads_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """Build settings from environment variables and defaults."""
-    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
-    monkeypatch.setenv("LINKUP_API_KEY", "linkup-key")
-    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
     monkeypatch.delenv("LANGFUSE_HOST", raising=False)
     monkeypatch.delenv("HEXGATE_DEFAULT_MODEL", raising=False)
     monkeypatch.delenv("HEXGATE_DEFAULT_SEARCH_ENGINE", raising=False)
 
     settings = Settings.from_env()
 
-    assert settings.openai_api_key == "openai-key"
-    assert settings.linkup_api_key == "linkup-key"
-    assert settings.tavily_api_key == "tavily-key"
     assert settings.langfuse_host == "https://cloud.langfuse.com"
     assert settings.model == "openai:gpt-5.4"
     assert settings.search_engine == "linkup"
 
 
-def test_from_env_leaves_unset_keys_none(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Missing provider keys resolve to None — bootstrap never hard-fails on
-    them; the tool or model provider raises at use-time instead."""
-    for key in ("OPENAI_API_KEY", "LINKUP_API_KEY", "TAVILY_API_KEY"):
-        monkeypatch.delenv(key, raising=False)
+def test_from_env_reads_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env vars override the model/search defaults."""
+    monkeypatch.setenv("HEXGATE_DEFAULT_MODEL", "anthropic:claude-opus-4-8")
+    monkeypatch.setenv("HEXGATE_DEFAULT_SEARCH_ENGINE", "tavily")
 
     settings = Settings.from_env()
 
-    assert settings.openai_api_key is None
-    assert settings.linkup_api_key is None
-    assert settings.tavily_api_key is None
+    assert settings.model == "anthropic:claude-opus-4-8"
+    assert settings.search_engine == "tavily"

--- a/tests/security/test_enforcer.py
+++ b/tests/security/test_enforcer.py
@@ -132,11 +132,12 @@ def test_build_enforcer_pairs_engine_with_agent_name_and_audit(
     from hexgate.security.enforcer import build_enforcer
     from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     engine = PolicySet({DEFAULT_ROLE_NAME: AgentPolicy()})
     enforcer = build_enforcer(engine, agent_name="support-bot")
 
     assert enforcer.policy is engine
     assert enforcer.agent_name == "support-bot"
-    # No api_key + no HEXGATE_KEY → audit inert (configure returns None).
+    # No api_key + no HEXGATE_API_KEY → audit inert (configure returns None).
     assert enforcer._audit_sender is None

--- a/tests/security/test_enforcer.py
+++ b/tests/security/test_enforcer.py
@@ -133,7 +133,6 @@ def test_build_enforcer_pairs_engine_with_agent_name_and_audit(
     from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     engine = PolicySet({DEFAULT_ROLE_NAME: AgentPolicy()})
     enforcer = build_enforcer(engine, agent_name="support-bot")
 

--- a/tests/security/test_policy_binding.py
+++ b/tests/security/test_policy_binding.py
@@ -154,7 +154,6 @@ def _resolved_binding(agent_name: str, **kwargs) -> PolicyBinding:
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resolution must be driven by each test, not the developer's shell."""
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_LOCAL_POLICY", raising=False)
     monkeypatch.delenv("HEXGATE_BUNDLE_REQUIRE_SIGNATURE", raising=False)
     monkeypatch.delenv("HEXGATE_BUNDLE_PUBKEY_PATH", raising=False)

--- a/tests/security/test_policy_binding.py
+++ b/tests/security/test_policy_binding.py
@@ -153,7 +153,8 @@ def _resolved_binding(agent_name: str, **kwargs) -> PolicyBinding:
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """Resolution must be driven by each test, not the developer's shell."""
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_LOCAL_POLICY", raising=False)
     monkeypatch.delenv("HEXGATE_BUNDLE_REQUIRE_SIGNATURE", raising=False)
     monkeypatch.delenv("HEXGATE_BUNDLE_PUBKEY_PATH", raising=False)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -43,7 +43,6 @@ def _isolate_audit_and_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     audit._senders.clear()
     audit._logged_local_mode_suppressed = False
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_API_URL", raising=False)
     monkeypatch.delenv("HEXGATE_LOCAL_POLICY", raising=False)
     monkeypatch.delenv(audit._LOCAL_MODE_ENV, raising=False)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -58,9 +58,6 @@ def test_bootstrap_loads_requested_env_file(monkeypatch: pytest.MonkeyPatch) -> 
     settings = bootstrap.bootstrap("test.env")
 
     assert seen["path"] == Path(bootstrap.__file__).parent.parent / "test.env"
-    assert settings.openai_api_key == "openai-key"
-    assert settings.linkup_api_key == "linkup-key"
-    assert settings.tavily_api_key == "tavily-key"
     assert settings.langfuse_public_key == "public-key"
     assert settings.langfuse_secret_key == "secret-key"
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -42,7 +42,8 @@ def _isolate_audit_and_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Reset audit + the env vars bootstrap touches between tests."""
     audit._senders.clear()
     audit._logged_local_mode_suppressed = False
-    monkeypatch.delenv("HEXGATE_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_KEY", raising=False)  # legacy alias
     monkeypatch.delenv("HEXGATE_API_URL", raising=False)
     monkeypatch.delenv("HEXGATE_LOCAL_POLICY", raising=False)
     monkeypatch.delenv(audit._LOCAL_MODE_ENV, raising=False)
@@ -76,7 +77,7 @@ def test_local_only_sets_env_var_before_audit_configure(
     """``local_only=True`` must set HEXGATE_LOCAL_MODE BEFORE audit.configure
     runs — otherwise an adapter wrapper re-configuring right after would
     spin up a real sender against a key still in env."""
-    _stub_dotenv_with_required_keys(monkeypatch, HEXGATE_KEY="key_in_dotenv")
+    _stub_dotenv_with_required_keys(monkeypatch, HEXGATE_API_KEY="key_in_dotenv")
 
     # Spy: when audit.configure runs, the env var must already be set.
     observed_env: dict[str, str | None] = {}
@@ -108,18 +109,18 @@ def test_local_only_false_leaves_env_var_unset(
 def test_bootstrap_warns_when_key_and_local_policy_both_set(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """Both HEXGATE_KEY and HEXGATE_LOCAL_POLICY almost always means a
+    """Both HEXGATE_API_KEY and HEXGATE_LOCAL_POLICY almost always means a
     dev forgot to clean their env. Log a single WARNING at startup so
     the surprise lands now, not three debug sessions later."""
     _stub_dotenv_with_required_keys(
         monkeypatch,
-        HEXGATE_KEY="lingering_key",
+        HEXGATE_API_KEY="lingering_key",
         HEXGATE_LOCAL_POLICY="/tmp/some-bundle",
     )
     with caplog.at_level(logging.WARNING, logger="hexgate.bootstrap"):
         bootstrap.bootstrap("test.env", local_only=True)
     msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("HEXGATE_KEY and HEXGATE_LOCAL_POLICY" in m for m in msgs)
+    assert any("HEXGATE_API_KEY and HEXGATE_LOCAL_POLICY" in m for m in msgs)
 
 
 def test_bootstrap_no_warning_when_only_one_set(
@@ -133,4 +134,4 @@ def test_bootstrap_no_warning_when_only_one_set(
     with caplog.at_level(logging.WARNING, logger="hexgate.bootstrap"):
         bootstrap.bootstrap("test.env", local_only=True)
     msgs = [r.message for r in caplog.records]
-    assert not any("HEXGATE_KEY and HEXGATE_LOCAL_POLICY" in m for m in msgs)
+    assert not any("HEXGATE_API_KEY and HEXGATE_LOCAL_POLICY" in m for m in msgs)

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -15,9 +15,9 @@ from hexgate import audit, bootstrap
 def _stub_dotenv_with_required_keys(
     monkeypatch: pytest.MonkeyPatch, **extra: str
 ) -> dict[str, Path]:
-    """Replace ``load_dotenv`` with a stub that populates the keys
-    ``Settings.validate_required_keys()`` checks. Returns a dict the
-    caller can inspect for the captured env path."""
+    """Replace ``load_dotenv`` with a stub that populates the provider keys
+    a typical CLI run reads into ``Settings``. Returns a dict the caller can
+    inspect for the captured env path."""
     seen: dict[str, Path] = {}
 
     def fake_load_dotenv(path: Path, override: bool) -> None:


### PR DESCRIPTION
Consolidates the SDK's environment-variable handling behind a new `hexgate/config/env.py` resolver.

## Changes

- **Rename `HEXGATE_KEY` → `HEXGATE_API_KEY`** across code, tests, docs, deploy scripts, and examples — for symmetry with `HEXGATE_API_URL` and the `api_key` param, and to disambiguate from the signing-key family (`HEXGATE_KEYSTORE_PATH`, `HEXGATE_PUBLIC_KEY`).
- **`HEXGATE_API_URL` now defaults to Hexgate Cloud** (`https://app.hexgate.ai`) instead of `localhost:8000`, centralized in a single constant. Self-hosters set it to `http://localhost:8000`.
- **Bootstrap no longer hard-requires `OPENAI_API_KEY` / `LINKUP_API_KEY` / `TAVILY_API_KEY`** — each is enforced lazily by the tool or model provider that reads it. Removed the now-empty `Settings.validate_required_keys()`.

## Migration

- Rename `HEXGATE_KEY` → `HEXGATE_API_KEY` in your `.env` / secret store.
- SaaS users can drop `HEXGATE_API_URL`; self-hosters point it at their local platform.

Tests: 842 passing, lint + format clean.
