### PR TITLE
fix(dashboard): render inline-roles policies on the overview Graph

### DIFF
--- a/platform/dashboard/src/lib/graph.ts
+++ b/platform/dashboard/src/lib/graph.ts
@@ -4,6 +4,7 @@ import {
   buildAgentView,
   effectiveMode,
   MODE_COLOR,
+  worstMode,
   type AgentView,
   type Mode,
 } from "./policy";
@@ -90,11 +91,14 @@ export function buildOverviewGraph(agents: AgentRead[]): OverviewGraph {
   const toolCenterY = ((toolList.length - 1) * ROW_H) / 2;
   const shift = agentCenterY - toolCenterY;
   toolList.forEach((toolName, i) => {
-    // Determine the "worst" mode for the left strip on the tool node
+    // Determine the "worst" mode for the left strip on the tool node.
+    // Shares MODE_STRENGTH ordering with parsePolicy's cross-role merge
+    // via the exported worstMode helper — one source of truth for
+    // "which mode wins when they disagree."
     const modesForTool: Mode[] = agentViews
       .filter((v) => v.tools.includes(toolName))
       .map((v) => effectiveMode(v, toolName));
-    const mode = pickStripMode(modesForTool);
+    const mode = worstMode(modesForTool) ?? "default";
     nodes.push({
       id: `tool:${toolName}`,
       type: "tool",
@@ -116,11 +120,4 @@ function edgeStyle(mode: Mode): React.CSSProperties {
     return { ...base, strokeWidth: 1.5, opacity: 0.85 };
   }
   return base;
-}
-
-function pickStripMode(modes: Mode[]): Mode | "default" {
-  if (modes.includes("deny")) return "deny";
-  if (modes.includes("approval_required")) return "approval_required";
-  if (modes.includes("allow")) return "allow";
-  return "default";
 }

--- a/platform/dashboard/src/lib/graph.ts
+++ b/platform/dashboard/src/lib/graph.ts
@@ -107,49 +107,6 @@ export function buildOverviewGraph(agents: AgentRead[]): OverviewGraph {
   return { nodes, edges, agentViews };
 }
 
-/** Build a per-agent local graph: the agent + its tools only. */
-export function buildAgentGraph(agent: AgentRead): {
-  nodes: Node[];
-  edges: Edge[];
-  view: AgentView | null;
-} {
-  const view = buildAgentView(agent);
-  if (!view) return { nodes: [], edges: [], view: null };
-
-  const nodes: Node[] = [];
-  const edges: Edge[] = [];
-
-  const centerY = ((view.tools.length - 1) * ROW_H) / 2;
-
-  nodes.push({
-    id: "agent:self",
-    type: "agent",
-    position: { x: 40, y: centerY },
-    data: { name: view.name, model: view.model, toolCount: view.tools.length },
-    draggable: false,
-  });
-
-  view.tools.forEach((toolName, i) => {
-    const mode = effectiveMode(view, toolName);
-    nodes.push({
-      id: `tool:${toolName}`,
-      type: "tool",
-      position: { x: 380, y: i * ROW_H },
-      data: { name: toolName, mode },
-      draggable: false,
-    });
-    edges.push({
-      id: `e:agent->${toolName}`,
-      source: "agent:self",
-      target: `tool:${toolName}`,
-      style: edgeStyle(mode),
-      animated: mode === "approval_required",
-    });
-  });
-
-  return { nodes, edges, view };
-}
-
 function edgeStyle(mode: Mode): React.CSSProperties {
   const base = { stroke: MODE_COLOR[mode], strokeWidth: 1.75 };
   if (mode === "approval_required") {

--- a/platform/dashboard/src/lib/policy.test.ts
+++ b/platform/dashboard/src/lib/policy.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildAgentView,
+  effectiveMode,
+  parsePolicy,
+  parseRolesFromPolicy,
+} from "./policy";
+import type { AgentRead } from "./api";
+
+/**
+ * Regression tests for the two policy YAML shapes the platform seeds
+ * and hand-writers use. Before the fix, ``parsePolicy`` only read
+ * top-level ``tools:`` — every inline-roles agent (support_bot, the
+ * seeded template) collapsed to ``{tools: {}}`` so the Graph page
+ * rendered every edge under ``default_policy.mode`` (usually deny →
+ * all red or all missing).
+ */
+
+// Flat: tools declared at top level. Used by the "default" and
+// "read_only" seeds + hand-written examples.
+const FLAT_POLICY = `
+version: 1
+default_policy:
+  mode: deny
+tools:
+  web_search:
+    mode: allow
+  fetch:
+    mode: allow
+`;
+
+// Inline-roles: tools live under each concrete role. Used by every
+// seeded multi-role agent (support_bot, etc.). Mixins (is_mixin: true)
+// compose via `inherits` and are NOT selectable roles.
+const INLINE_ROLES_POLICY = `
+version: 1
+default_policy:
+  mode: deny
+roles:
+  read_only:
+    is_mixin: true
+    tools:
+      web_search: { mode: allow }
+  default:
+    inherits: [read_only]
+    tools:
+      refund_order: { mode: deny }
+  support:
+    inherits: [read_only]
+    tools:
+      refund_order: { mode: allow }
+  billing:
+    inherits: [read_only]
+    tools:
+      refund_order: { mode: allow }
+`;
+
+describe("parsePolicy — flat shape", () => {
+  it("reads top-level tools", () => {
+    const p = parsePolicy(FLAT_POLICY);
+    expect(p).not.toBeNull();
+    expect(p!.tools.web_search?.mode).toBe("allow");
+    expect(p!.tools.fetch?.mode).toBe("allow");
+    expect(p!.default_policy.mode).toBe("deny");
+    expect(p!.roles).toEqual({});
+  });
+});
+
+describe("parsePolicy — inline-roles shape", () => {
+  it("merges tools from every concrete role into the top-level view", () => {
+    // Before the fix, `refund_order` would be MISSING from `p.tools`
+    // entirely (parsePolicy only read top-level `tools:`), and the
+    // graph would render its edge as default_policy=deny.
+    //
+    // `web_search` only lives in the `read_only` mixin — the current
+    // resolver skips mixins to avoid double-counting via `inherits`.
+    // If a future PR resolves inheritance client-side, this test will
+    // legitimately need updating; for now the assertion pins the
+    // "concrete roles only" contract.
+    const p = parsePolicy(INLINE_ROLES_POLICY);
+    expect(p).not.toBeNull();
+    expect(Object.keys(p!.tools)).toEqual(["refund_order"]);
+  });
+
+  it("picks the worst-case mode when a tool differs across roles", () => {
+    // Two roles allow refund_order, one denies — the graph is a
+    // "worst case" summary, so deny wins.
+    const p = parsePolicy(INLINE_ROLES_POLICY);
+    expect(p!.tools.refund_order?.mode).toBe("deny");
+  });
+
+  it("exposes per-role tool maps for future role-scoped views", () => {
+    // The Graph today shows a merged view, but the shape is right for
+    // a future "filter by role" affordance.
+    const p = parsePolicy(INLINE_ROLES_POLICY);
+    expect(Object.keys(p!.roles).sort()).toEqual([
+      "billing",
+      "default",
+      "support",
+    ]);
+    // Mixin excluded — is_mixin: true roles compose INTO concrete ones
+    // via `inherits`; treating them first-class would double-count.
+    expect(p!.roles.read_only).toBeUndefined();
+    expect(p!.roles.support?.refund_order.mode).toBe("allow");
+    expect(p!.roles.default?.refund_order.mode).toBe("deny");
+  });
+
+  it("preserves parseRolesFromPolicy's mixin filter (unchanged)", () => {
+    const roles = parseRolesFromPolicy(INLINE_ROLES_POLICY);
+    // `default` first (idiomatic), no mixins.
+    expect(roles).toEqual(["default", "billing", "support"]);
+  });
+
+  it("returns priority order for merge deterministically", () => {
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  a:
+    tools:
+      x: { mode: allow }
+  b:
+    tools:
+      x: { mode: approval_required }
+`);
+    // approval_required beats allow in the worst-case merge.
+    expect(p!.tools.x?.mode).toBe("approval_required");
+  });
+});
+
+describe("buildAgentView — tool-list union", () => {
+  const agent = (opts: { yaml: string; policy: string }): AgentRead =>
+    ({
+      // Fields the parser touches; the rest of AgentRead is irrelevant here.
+      name: "test",
+      agent_yaml: opts.yaml,
+      policy_yaml: opts.policy,
+    }) as unknown as AgentRead;
+
+  const AGENT_YAML = `
+name: support_bot
+model: gpt-5.4
+tools:
+  - web_search
+`;
+
+  it("includes tools declared only in a role, not in agent.yaml", () => {
+    // agent.yaml lists web_search; policy adds refund_order via roles.
+    // The graph must render BOTH — otherwise a role-only rule is
+    // invisible even though it's callable at runtime.
+    const view = buildAgentView(
+      agent({ yaml: AGENT_YAML, policy: INLINE_ROLES_POLICY }),
+    );
+    expect(view).not.toBeNull();
+    expect(view!.tools).toEqual(["refund_order", "web_search"]);
+  });
+
+  it("effectiveMode returns worst-case for tools in multiple roles", () => {
+    const view = buildAgentView(
+      agent({ yaml: AGENT_YAML, policy: INLINE_ROLES_POLICY }),
+    );
+    // Two roles allow refund_order, one denies — merged view shows
+    // deny so the graph colors that edge red instead of the misleading
+    // green a "pick any role" heuristic would produce.
+    expect(effectiveMode(view!, "refund_order")).toBe("deny");
+  });
+
+  it("falls back to default_policy for mixin-only tools", () => {
+    // web_search only lives in the `read_only` mixin, which is filtered
+    // out of parsePolicy's roles map. Without inheritance resolution
+    // it falls to default_policy=deny. This documents the current
+    // limitation — a future inheritance-aware resolver would flip this
+    // to `allow`, matching what the wasm bundle actually enforces.
+    const view = buildAgentView(
+      agent({ yaml: AGENT_YAML, policy: INLINE_ROLES_POLICY }),
+    );
+    expect(effectiveMode(view!, "web_search")).toBe("deny");
+    expect(view!.missingInPolicy).toContain("web_search");
+  });
+
+  it("flat policy still reads exactly as before (no regression)", () => {
+    const yaml = `
+name: default
+model: gpt-5.4
+tools:
+  - web_search
+  - fetch
+`;
+    const view = buildAgentView(agent({ yaml, policy: FLAT_POLICY }));
+    expect(view).not.toBeNull();
+    expect(view!.tools).toEqual(["fetch", "web_search"]);
+    expect(effectiveMode(view!, "web_search")).toBe("allow");
+    expect(effectiveMode(view!, "fetch")).toBe("allow");
+  });
+
+  it("marks tools from agent.yaml with no policy entry as missingInPolicy", () => {
+    const yaml = `
+name: default
+model: gpt-5.4
+tools:
+  - web_search
+  - unpoliced_tool
+`;
+    const view = buildAgentView(agent({ yaml, policy: FLAT_POLICY }));
+    expect(view!.missingInPolicy).toEqual(["unpoliced_tool"]);
+    // Falls back to default_policy.
+    expect(effectiveMode(view!, "unpoliced_tool")).toBe("deny");
+  });
+});

--- a/platform/dashboard/src/lib/policy.test.ts
+++ b/platform/dashboard/src/lib/policy.test.ts
@@ -207,3 +207,158 @@ tools:
     expect(effectiveMode(view!, "unpoliced_tool")).toBe("deny");
   });
 });
+
+// ---- Edge cases — cover the partial branches Codecov flagged --------------
+
+describe("parsePolicy — malformed / missing input", () => {
+  it("returns null on yaml that throws during load", () => {
+    // Triggers the try/catch. js-yaml only throws on genuinely
+    // malformed syntax (e.g. an unclosed tag) — most "garbage"
+    // strings still parse to a scalar. Use a colon-only tag that
+    // js-yaml rejects.
+    expect(parsePolicy("!!!!invalid: [")).toBeNull();
+  });
+
+  it("returns null on a yaml document that isn't an object", () => {
+    // Guard: `if (!raw || typeof raw !== 'object')` — scalars, empty
+    // strings, and yaml `null` must not slip past the type narrowing.
+    // (Arrays typeof-as "object" in JS, so they hit the entries()
+    // path and produce an empty-but-valid result — that's fine.)
+    expect(parsePolicy("42")).toBeNull();
+    expect(parsePolicy('"just a string"')).toBeNull();
+    expect(parsePolicy("null")).toBeNull();
+    expect(parsePolicy("")).toBeNull();
+  });
+
+  it("defaults version to 1 when absent", () => {
+    const p = parsePolicy(`
+default_policy: { mode: allow }
+tools:
+  ping: { mode: allow }
+`);
+    expect(p!.version).toBe(1);
+  });
+
+  it("defaults default_policy.mode to deny when missing / invalid", () => {
+    // Fail-closed: unknown or missing mode string must not silently
+    // become allow. Both cases should land on deny.
+    const missing = parsePolicy(`
+version: 1
+tools:
+  ping: { mode: allow }
+`);
+    expect(missing!.default_policy.mode).toBe("deny");
+
+    const bogus = parsePolicy(`
+version: 1
+default_policy: { mode: whatever }
+tools:
+  ping: { mode: allow }
+`);
+    expect(bogus!.default_policy.mode).toBe("deny");
+  });
+});
+
+describe("parsePolicy — malformed roles", () => {
+  it("ignores roles: when it's an array, not a mapping", () => {
+    // Array.isArray guard.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  - default
+  - support
+`);
+    expect(p!.roles).toEqual({});
+    expect(p!.tools).toEqual({});
+  });
+
+  it("skips role entries whose spec isn't an object", () => {
+    // `if (!spec || typeof spec !== 'object') continue`
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  default: null
+  support: "not an object"
+  billing:
+    tools:
+      x: { mode: allow }
+`);
+    expect(Object.keys(p!.roles)).toEqual(["billing"]);
+  });
+
+  it("skips roles whose tool map is empty", () => {
+    // A role that declares no tools shouldn't clutter the per-role map.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  default:
+    tools: {}
+  support:
+    tools:
+      x: { mode: allow }
+`);
+    expect(Object.keys(p!.roles)).toEqual(["support"]);
+  });
+
+  it("skips tool entries with invalid mode strings", () => {
+    // readToolMap's isMode guard filters bogus modes before they land.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+tools:
+  good: { mode: allow }
+  bad: { mode: sometimes }
+`);
+    expect(Object.keys(p!.tools)).toEqual(["good"]);
+  });
+
+  it("preserves file_scope on parsed tools", () => {
+    // Passthrough of the nested file_scope field — pin so a future
+    // refactor doesn't accidentally drop it.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+tools:
+  read_file:
+    mode: allow
+    file_scope:
+      allowed_paths: ["/workspace/**"]
+`);
+    expect(p!.tools.read_file?.file_scope?.allowed_paths).toEqual([
+      "/workspace/**",
+    ]);
+  });
+});
+
+describe("buildAgentView — malformed input", () => {
+  const agent = (opts: { yaml: string; policy: string }): AgentRead =>
+    ({
+      name: "test",
+      agent_yaml: opts.yaml,
+      policy_yaml: opts.policy,
+    }) as unknown as AgentRead;
+
+  it("returns null when the agent yaml is unparseable", () => {
+    expect(
+      buildAgentView(agent({ yaml: ":::garbage", policy: FLAT_POLICY })),
+    ).toBeNull();
+  });
+
+  it("returns null when the policy yaml is unparseable", () => {
+    expect(
+      buildAgentView(agent({ yaml: "name: x", policy: ":::garbage" })),
+    ).toBeNull();
+  });
+
+  it("falls back to AgentRead.name when agent.yaml has no name", () => {
+    // `parsedAgent.name || agent.name` — if the yaml omits the name key,
+    // we still label the agent by its DB name.
+    const view = buildAgentView(
+      agent({ yaml: "model: gpt-5.4\ntools: []", policy: FLAT_POLICY }),
+    );
+    expect(view!.name).toBe("test");
+  });
+});

--- a/platform/dashboard/src/lib/policy.test.ts
+++ b/platform/dashboard/src/lib/policy.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   buildAgentView,
   effectiveMode,
+  isMixinSpec,
+  mergedTools,
+  MODE_STRENGTH,
   parsePolicy,
   parseRolesFromPolicy,
+  worstMode,
 } from "./policy";
 import type { AgentRead } from "./api";
 
@@ -67,31 +71,59 @@ describe("parsePolicy — flat shape", () => {
 });
 
 describe("parsePolicy — inline-roles shape", () => {
-  it("merges tools from every concrete role into the top-level view", () => {
-    // Before the fix, `refund_order` would be MISSING from `p.tools`
-    // entirely (parsePolicy only read top-level `tools:`), and the
-    // graph would render its edge as default_policy=deny.
-    //
-    // `web_search` only lives in the `read_only` mixin — the current
-    // resolver skips mixins to avoid double-counting via `inherits`.
-    // If a future PR resolves inheritance client-side, this test will
-    // legitimately need updating; for now the assertion pins the
-    // "concrete roles only" contract.
+  it("keeps parsed.tools separate from parsed.roles (no auto-merge)", () => {
+    // Pre-fix, parsePolicy merged role tools into `parsed.tools`, which
+    // silently upgraded a flat `tools.web_search.mode: allow` to `deny`
+    // if any role denied it (reviewer finding #2). Now `parsed.tools`
+    // is ONLY the top-level flat block; role tools live under
+    // `parsed.roles[<name>]`. Callers who need the union across roles
+    // use ``mergedTools(policy)``.
     const p = parsePolicy(INLINE_ROLES_POLICY);
     expect(p).not.toBeNull();
-    expect(Object.keys(p!.tools)).toEqual(["refund_order"]);
+    // INLINE_ROLES_POLICY has no top-level tools: block → empty.
+    expect(p!.tools).toEqual({});
   });
 
-  it("picks the worst-case mode when a tool differs across roles", () => {
-    // Two roles allow refund_order, one denies — the graph is a
-    // "worst case" summary, so deny wins.
+  it("mergedTools() exposes the worst-case cross-role view for the graph", () => {
+    // The overview graph asks "what's the worst mode any caller could
+    // hit?" — mergedTools answers by combining every concrete role's
+    // tools with worstMode ordering.
     const p = parsePolicy(INLINE_ROLES_POLICY);
-    expect(p!.tools.refund_order?.mode).toBe("deny");
+    const merged = mergedTools(p!);
+    // web_search lives ONLY in the read_only mixin (filtered out); the
+    // dashboard doesn't resolve `inherits:` client-side yet, so
+    // web_search doesn't appear in the merged view. Documented
+    // limitation — pinned so a future inheritance resolver flips the
+    // assertion, not silently changes behavior.
+    expect(Object.keys(merged)).toEqual(["refund_order"]);
+    // Two roles allow refund_order, one denies → worst-case is deny.
+    expect(merged.refund_order?.mode).toBe("deny");
   });
 
-  it("exposes per-role tool maps for future role-scoped views", () => {
-    // The Graph today shows a merged view, but the shape is right for
-    // a future "filter by role" affordance.
+  it("keeps flat top-level tools authoritative — roles can't override", () => {
+    // Reviewer finding #2: a user editing the flat tools.web_search.mode
+    // to allow must see that take visible effect on the graph, even if
+    // some role denies it. The merge preserves flat entries verbatim.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+tools:
+  web_search: { mode: allow }
+roles:
+  strict:
+    tools:
+      web_search: { mode: deny }
+`);
+    const merged = mergedTools(p!);
+    // Flat entry wins — the strict role's deny does NOT upgrade it.
+    expect(merged.web_search?.mode).toBe("allow");
+  });
+
+  it("exposes per-role tool maps (including empty-tools roles)", () => {
+    // Reviewer finding #1: parsePolicy.roles must agree with
+    // parseRolesFromPolicy on which roles are concrete — including
+    // roles with an empty tools map (they fall back to default_policy
+    // at runtime and are still valid selectable roles).
     const p = parsePolicy(INLINE_ROLES_POLICY);
     expect(Object.keys(p!.roles).sort()).toEqual([
       "billing",
@@ -111,24 +143,25 @@ describe("parsePolicy — inline-roles shape", () => {
     expect(roles).toEqual(["default", "billing", "support"]);
   });
 
-  it("returns priority order for merge deterministically", () => {
-    const p = parsePolicy(`
-version: 1
-default_policy: { mode: deny }
-roles:
-  a:
-    tools:
-      x: { mode: allow }
-  b:
-    tools:
-      x: { mode: approval_required }
-`);
-    // approval_required beats allow in the worst-case merge.
-    expect(p!.tools.x?.mode).toBe("approval_required");
+  it("worstMode picks the correct mode across the priority ordering", () => {
+    // approval_required beats allow, deny beats both.
+    expect(worstMode(["allow", "approval_required"])).toBe("approval_required");
+    expect(worstMode(["allow", "deny", "approval_required"])).toBe("deny");
+    expect(worstMode(["allow"])).toBe("allow");
+    expect(worstMode([])).toBeNull();
+  });
+
+  it("MODE_STRENGTH orders modes deny > approval > allow", () => {
+    // Pin the source-of-truth ordering so a future refactor that
+    // reorders these silently doesn't slip past review.
+    expect(MODE_STRENGTH.deny).toBeGreaterThan(MODE_STRENGTH.approval_required);
+    expect(MODE_STRENGTH.approval_required).toBeGreaterThan(
+      MODE_STRENGTH.allow,
+    );
   });
 });
 
-describe("buildAgentView — tool-list union", () => {
+describe("buildAgentView — agent.yaml is authoritative for callable tools", () => {
   const agent = (opts: { yaml: string; policy: string }): AgentRead =>
     ({
       // Fields the parser touches; the rest of AgentRead is irrelevant here.
@@ -144,33 +177,46 @@ tools:
   - web_search
 `;
 
-  it("includes tools declared only in a role, not in agent.yaml", () => {
-    // agent.yaml lists web_search; policy adds refund_order via roles.
-    // The graph must render BOTH — otherwise a role-only rule is
-    // invisible even though it's callable at runtime.
+  it("does NOT include role-only policy tools as callable (no phantom edges)", () => {
+    // Reviewer finding #3: runtime tool-gating comes from the SDK-
+    // registered @agent_tool functions (mirrored in agent.yaml), NOT
+    // from policy. Unioning role-only tools into AgentView.tools drew
+    // phantom capability edges on the graph — an agent that can't
+    // actually invoke refund_order still had an edge to it.
+    //
+    // agent.yaml declares [web_search]; the policy mentions refund_order
+    // in multiple roles. The graph must show ONLY web_search — that's
+    // what the agent can call at runtime.
     const view = buildAgentView(
       agent({ yaml: AGENT_YAML, policy: INLINE_ROLES_POLICY }),
     );
     expect(view).not.toBeNull();
-    expect(view!.tools).toEqual(["refund_order", "web_search"]);
+    expect(view!.tools).toEqual(["web_search"]);
   });
 
-  it("effectiveMode returns worst-case for tools in multiple roles", () => {
-    const view = buildAgentView(
-      agent({ yaml: AGENT_YAML, policy: INLINE_ROLES_POLICY }),
-    );
-    // Two roles allow refund_order, one denies — merged view shows
-    // deny so the graph colors that edge red instead of the misleading
-    // green a "pick any role" heuristic would produce.
-    expect(effectiveMode(view!, "refund_order")).toBe("deny");
+  it("preserves agent.yaml declaration order (no alphabetical sort)", () => {
+    // Reviewer finding #10: previously we sorted the tool list,
+    // silently changing the contract. Restore source order so any
+    // future non-set consumer sees what the author wrote.
+    const yaml = `
+name: default
+model: gpt-5.4
+tools:
+  - web_search
+  - fetch
+  - upload
+`;
+    const view = buildAgentView(agent({ yaml, policy: FLAT_POLICY }));
+    expect(view!.tools).toEqual(["web_search", "fetch", "upload"]);
   });
 
-  it("falls back to default_policy for mixin-only tools", () => {
-    // web_search only lives in the `read_only` mixin, which is filtered
-    // out of parsePolicy's roles map. Without inheritance resolution
-    // it falls to default_policy=deny. This documents the current
-    // limitation — a future inheritance-aware resolver would flip this
-    // to `allow`, matching what the wasm bundle actually enforces.
+  it("falls back to default_policy for tools not in policy (or in mixin only)", () => {
+    // web_search lives only in the read_only mixin (filtered out).
+    // Without client-side `inherits:` resolution it falls to
+    // default_policy=deny. Documented limitation — pinned so a
+    // future inheritance resolver flips the assertion, not silently
+    // changes behavior. The wasm bundle at runtime enforces `allow`
+    // via inheritance.
     const view = buildAgentView(
       agent({ yaml: AGENT_YAML, policy: INLINE_ROLES_POLICY }),
     );
@@ -178,7 +224,21 @@ tools:
     expect(view!.missingInPolicy).toContain("web_search");
   });
 
-  it("flat policy still reads exactly as before (no regression)", () => {
+  it("effectiveMode returns worst-case across roles for a policy tool", () => {
+    // If agent.yaml declared refund_order (so it's callable) and the
+    // policy has it in multiple roles with different modes, the
+    // effective mode shown on the graph is the worst case.
+    const yaml = `
+name: support_bot
+model: gpt-5.4
+tools:
+  - refund_order
+`;
+    const view = buildAgentView(agent({ yaml, policy: INLINE_ROLES_POLICY }));
+    expect(effectiveMode(view!, "refund_order")).toBe("deny");
+  });
+
+  it("flat policy still reads correctly (no regression)", () => {
     const yaml = `
 name: default
 model: gpt-5.4
@@ -188,7 +248,7 @@ tools:
 `;
     const view = buildAgentView(agent({ yaml, policy: FLAT_POLICY }));
     expect(view).not.toBeNull();
-    expect(view!.tools).toEqual(["fetch", "web_search"]);
+    expect(view!.tools).toEqual(["web_search", "fetch"]);
     expect(effectiveMode(view!, "web_search")).toBe("allow");
     expect(effectiveMode(view!, "fetch")).toBe("allow");
   });
@@ -205,6 +265,30 @@ tools:
     expect(view!.missingInPolicy).toEqual(["unpoliced_tool"]);
     // Falls back to default_policy.
     expect(effectiveMode(view!, "unpoliced_tool")).toBe("deny");
+  });
+});
+
+describe("isMixinSpec — coerced truthy check", () => {
+  it("accepts is_mixin: true", () => {
+    expect(isMixinSpec({ is_mixin: true })).toBe(true);
+  });
+
+  it("accepts coerced truthy variants (reviewer finding #7)", () => {
+    // A hand-edited YAML with `is_mixin: "true"` (quoted) or
+    // `is_mixin: 1` used to sneak through the strict `=== true` check
+    // and get treated as a concrete role → merged tools double-counted.
+    expect(isMixinSpec({ is_mixin: "true" })).toBe(true);
+    expect(isMixinSpec({ is_mixin: "yes" })).toBe(true);
+    expect(isMixinSpec({ is_mixin: 1 })).toBe(true);
+  });
+
+  it("rejects everything else", () => {
+    expect(isMixinSpec({ is_mixin: false })).toBe(false);
+    expect(isMixinSpec({ is_mixin: "false" })).toBe(false);
+    expect(isMixinSpec({ is_mixin: 0 })).toBe(false);
+    expect(isMixinSpec({})).toBe(false);
+    expect(isMixinSpec(null)).toBe(false);
+    expect(isMixinSpec("not-an-object")).toBe(false);
   });
 });
 
@@ -288,8 +372,13 @@ roles:
     expect(Object.keys(p!.roles)).toEqual(["billing"]);
   });
 
-  it("skips roles whose tool map is empty", () => {
-    // A role that declares no tools shouldn't clutter the per-role map.
+  it("keeps empty-tools roles listed (they fall back to default_policy)", () => {
+    // Reviewer finding #1: parsePolicy.roles previously dropped roles
+    // whose tools map was empty, but parseRolesFromPolicy still listed
+    // them in the picker. A future "filter by role" reading
+    // `parsed.roles[selectedRole]` got `undefined` for a role the
+    // picker just offered → empty graph or crash. Now both parsers
+    // agree.
     const p = parsePolicy(`
 version: 1
 default_policy: { mode: deny }
@@ -300,7 +389,8 @@ roles:
     tools:
       x: { mode: allow }
 `);
-    expect(Object.keys(p!.roles)).toEqual(["support"]);
+    expect(Object.keys(p!.roles).sort()).toEqual(["default", "support"]);
+    expect(p!.roles.default).toEqual({});
   });
 
   it("skips tool entries with invalid mode strings", () => {

--- a/platform/dashboard/src/lib/policy.test.ts
+++ b/platform/dashboard/src/lib/policy.test.ts
@@ -87,23 +87,21 @@ describe("parsePolicy — inline-roles shape", () => {
   it("mergedTools() exposes the worst-case cross-role view for the graph", () => {
     // The overview graph asks "what's the worst mode any caller could
     // hit?" — mergedTools answers by combining every concrete role's
-    // tools with worstMode ordering.
+    // resolved tool map with worstMode ordering. web_search comes in
+    // via the read_only mixin (allow); refund_order is deny in the
+    // `default` role and allow in support/billing, so worst-case is deny.
     const p = parsePolicy(INLINE_ROLES_POLICY);
     const merged = mergedTools(p!);
-    // web_search lives ONLY in the read_only mixin (filtered out); the
-    // dashboard doesn't resolve `inherits:` client-side yet, so
-    // web_search doesn't appear in the merged view. Documented
-    // limitation — pinned so a future inheritance resolver flips the
-    // assertion, not silently changes behavior.
-    expect(Object.keys(merged)).toEqual(["refund_order"]);
-    // Two roles allow refund_order, one denies → worst-case is deny.
+    expect(Object.keys(merged).sort()).toEqual(["refund_order", "web_search"]);
+    expect(merged.web_search?.mode).toBe("allow");
     expect(merged.refund_order?.mode).toBe("deny");
   });
 
-  it("keeps flat top-level tools authoritative — roles can't override", () => {
-    // Reviewer finding #2: a user editing the flat tools.web_search.mode
-    // to allow must see that take visible effect on the graph, even if
-    // some role denies it. The merge preserves flat entries verbatim.
+  it("worst-cases across flat and roles — a role deny beats a flat allow", () => {
+    // Reviewer finding #75: a flat top-level allow used to win over a
+    // role's deny, so the overview graph rendered green even though
+    // some role would deny at runtime. Fixed: worst-case merge, no
+    // flat-priority. If any voice denies, the graph shows deny.
     const p = parsePolicy(`
 version: 1
 default_policy: { mode: deny }
@@ -115,8 +113,7 @@ roles:
       web_search: { mode: deny }
 `);
     const merged = mergedTools(p!);
-    // Flat entry wins — the strict role's deny does NOT upgrade it.
-    expect(merged.web_search?.mode).toBe("allow");
+    expect(merged.web_search?.mode).toBe("deny");
   });
 
   it("exposes per-role tool maps (including empty-tools roles)", () => {
@@ -133,8 +130,12 @@ roles:
     // Mixin excluded — is_mixin: true roles compose INTO concrete ones
     // via `inherits`; treating them first-class would double-count.
     expect(p!.roles.read_only).toBeUndefined();
-    expect(p!.roles.support?.refund_order.mode).toBe("allow");
-    expect(p!.roles.default?.refund_order.mode).toBe("deny");
+    // After inheritance resolution, web_search from read_only is
+    // present in every concrete role that inherits it.
+    expect(p!.roles.support?.tools.web_search.mode).toBe("allow");
+    expect(p!.roles.support?.tools.refund_order.mode).toBe("allow");
+    expect(p!.roles.default?.tools.refund_order.mode).toBe("deny");
+    expect(p!.roles.default?.tools.web_search.mode).toBe("allow");
   });
 
   it("preserves parseRolesFromPolicy's mixin filter (unchanged)", () => {
@@ -210,18 +211,18 @@ tools:
     expect(view!.tools).toEqual(["web_search", "fetch", "upload"]);
   });
 
-  it("falls back to default_policy for tools not in policy (or in mixin only)", () => {
-    // web_search lives only in the read_only mixin (filtered out).
-    // Without client-side `inherits:` resolution it falls to
-    // default_policy=deny. Documented limitation — pinned so a
-    // future inheritance resolver flips the assertion, not silently
-    // changes behavior. The wasm bundle at runtime enforces `allow`
-    // via inheritance.
+  it("resolves web_search from the read_only mixin via inherits:", () => {
+    // Reviewer finding #90: previously parsePolicy dropped mixins and
+    // never walked `inherits:`, so web_search (declared only in the
+    // read_only mixin) rendered as deny on the graph even though every
+    // concrete role in INLINE_ROLES_POLICY inherits read_only and can
+    // therefore call web_search at runtime.
     const view = buildAgentView(
       agent({ yaml: AGENT_YAML, policy: INLINE_ROLES_POLICY }),
     );
-    expect(effectiveMode(view!, "web_search")).toBe("deny");
-    expect(view!.missingInPolicy).toContain("web_search");
+    expect(effectiveMode(view!, "web_search")).toBe("allow");
+    // web_search now has a policy entry after inheritance resolution.
+    expect(view!.missingInPolicy).not.toContain("web_search");
   });
 
   it("effectiveMode returns worst-case across roles for a policy tool", () => {
@@ -390,7 +391,7 @@ roles:
       x: { mode: allow }
 `);
     expect(Object.keys(p!.roles).sort()).toEqual(["default", "support"]);
-    expect(p!.roles.default).toEqual({});
+    expect(p!.roles.default).toEqual({ tools: {} });
   });
 
   it("skips tool entries with invalid mode strings", () => {
@@ -420,6 +421,125 @@ tools:
     expect(p!.tools.read_file?.file_scope?.allowed_paths).toEqual([
       "/workspace/**",
     ]);
+  });
+});
+
+describe("parsePolicy — inherits resolution (finding #90)", () => {
+  it("resolves tools inherited from a mixin ancestor", () => {
+    const p = parsePolicy(INLINE_ROLES_POLICY);
+    // Every concrete role picks up web_search from the read_only mixin.
+    expect(p!.roles.default?.tools.web_search?.mode).toBe("allow");
+    expect(p!.roles.support?.tools.web_search?.mode).toBe("allow");
+    expect(p!.roles.billing?.tools.web_search?.mode).toBe("allow");
+  });
+
+  it("child role overrides an inherited mode", () => {
+    // strict inherits web_search: allow from read_only, then redeclares
+    // it as deny. The child's own entry must win.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  read_only:
+    is_mixin: true
+    tools:
+      web_search: { mode: allow }
+  strict:
+    inherits: [read_only]
+    tools:
+      web_search: { mode: deny }
+`);
+    expect(p!.roles.strict?.tools.web_search?.mode).toBe("deny");
+  });
+
+  it("later ancestor overrides earlier ancestor on the same tool", () => {
+    // Two mixins declare the same tool. The child inherits [a, b] — b
+    // wins because it comes later in the list.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  a:
+    is_mixin: true
+    tools:
+      x: { mode: allow }
+  b:
+    is_mixin: true
+    tools:
+      x: { mode: deny }
+  child:
+    inherits: [a, b]
+`);
+    expect(p!.roles.child?.tools.x?.mode).toBe("deny");
+  });
+
+  it("handles a cyclic inherits declaration without hanging", () => {
+    // a inherits b inherits a. Both are valid targets to reach, but
+    // the resolver must short-circuit on re-entry so the parse
+    // terminates. The declared own-tools still land in each role.
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  a:
+    inherits: [b]
+    tools:
+      only_in_a: { mode: allow }
+  b:
+    inherits: [a]
+    tools:
+      only_in_b: { mode: allow }
+`);
+    expect(p).not.toBeNull();
+    expect(p!.roles.a?.tools.only_in_a?.mode).toBe("allow");
+    expect(p!.roles.b?.tools.only_in_b?.mode).toBe("allow");
+  });
+});
+
+describe("parsePolicy — per-role default_policy (finding #78)", () => {
+  it("parses a per-role default_policy and inherits it from ancestors", () => {
+    const p = parsePolicy(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  permissive_mixin:
+    is_mixin: true
+    default_policy: { mode: allow }
+  role_a:
+    inherits: [permissive_mixin]
+  role_b:
+    default_policy: { mode: approval_required }
+`);
+    // role_a inherits the mixin's default_policy.
+    expect(p!.roles.role_a?.default_policy?.mode).toBe("allow");
+    // role_b declares its own.
+    expect(p!.roles.role_b?.default_policy?.mode).toBe("approval_required");
+  });
+
+  it("effectiveMode uses a role's own default_policy for an unlisted tool", () => {
+    // role_a raises its baseline to allow but doesn't list `fetch`.
+    // effectiveMode must count role_a's default (allow) as a voice,
+    // not fall through to the global default (deny).
+    const yaml = `
+name: bot
+model: gpt-5.4
+tools:
+  - fetch
+`;
+    const policy = `
+version: 1
+default_policy: { mode: deny }
+roles:
+  role_a:
+    default_policy: { mode: allow }
+`;
+    const view = buildAgentView({
+      name: "bot",
+      agent_yaml: yaml,
+      policy_yaml: policy,
+    } as unknown as AgentRead);
+    // Worst-case is allow — role_a is the only voice and it says allow.
+    expect(effectiveMode(view!, "fetch")).toBe("allow");
   });
 });
 

--- a/platform/dashboard/src/lib/policy.ts
+++ b/platform/dashboard/src/lib/policy.ts
@@ -13,7 +13,16 @@ export interface ToolPolicy {
 export interface ParsedPolicy {
   version: number;
   default_policy: { mode: Mode };
+  /** Merged view of every concrete role's tools + top-level tools —
+   * used by the graph/overview. When a tool appears in multiple roles
+   * with different modes, we keep the strongest (deny > approval > allow)
+   * so the graph shows the worst-case decision a caller could hit. */
   tools: Record<string, ToolPolicy>;
+  /** Per-role tool maps, present when the YAML is inline-roles shape.
+   * Empty on flat policy YAML. Callers that need per-role detail (e.g.
+   * a future Graph filter "show me policy for role X") read this
+   * instead of the merged `tools` above. */
+  roles: Record<string, Record<string, ToolPolicy>>;
 }
 
 export interface ParsedAgent {
@@ -53,6 +62,31 @@ export function parseAgent(
   void policyYaml;
 }
 
+/** Priority order for merging per-role decisions on the same tool — the
+ * graph shows the worst-case outcome any caller could hit, so `deny`
+ * wins over `approval_required` wins over `allow`. */
+const MODE_STRENGTH: Record<Mode, number> = {
+  deny: 3,
+  approval_required: 2,
+  allow: 1,
+};
+
+function readToolMap(raw: unknown): Record<string, ToolPolicy> {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, ToolPolicy> = {};
+  for (const [toolName, entry] of Object.entries(
+    raw as Record<string, unknown>,
+  )) {
+    const e = entry as { mode?: unknown; file_scope?: unknown };
+    if (!isMode(e?.mode)) continue;
+    out[toolName] = {
+      mode: e.mode,
+      file_scope: e.file_scope as ToolPolicy["file_scope"],
+    };
+  }
+  return out;
+}
+
 export function parsePolicy(policyYaml: string): ParsedPolicy | null {
   try {
     // `yaml.load` returns `unknown`; the shape checks below narrow it
@@ -67,20 +101,50 @@ export function parsePolicy(policyYaml: string): ParsedPolicy | null {
     const defaultMode = isMode(defaultPolicy?.mode)
       ? defaultPolicy.mode
       : "deny";
-    const rawTools = (raw.tools ?? {}) as Record<string, unknown>;
-    const tools: Record<string, ToolPolicy> = {};
-    for (const [toolName, entry] of Object.entries(rawTools)) {
-      const e = entry as { mode?: unknown; file_scope?: unknown };
-      if (!isMode(e?.mode)) continue;
-      tools[toolName] = {
-        mode: e.mode,
-        file_scope: e.file_scope as ToolPolicy["file_scope"],
-      };
+
+    // Two shapes coexist in the platform: (a) flat, with tools at top
+    // level (older seed + hand-written examples), and (b) inline-roles,
+    // with concrete roles under `roles.<name>.tools` (every seeded
+    // multi-role agent). The graph reads a MERGED tool map so it
+    // renders both shapes the same way.
+    const flatTools = readToolMap(raw.tools);
+    const rolesRaw = raw.roles;
+    const roles: Record<string, Record<string, ToolPolicy>> = {};
+    if (rolesRaw && typeof rolesRaw === "object" && !Array.isArray(rolesRaw)) {
+      for (const [roleName, spec] of Object.entries(
+        rolesRaw as Record<string, unknown>,
+      )) {
+        if (!spec || typeof spec !== "object") continue;
+        // Skip mixins — they compose INTO concrete roles via `inherits`;
+        // treating them as first-class would double-count decisions.
+        if ((spec as { is_mixin?: unknown }).is_mixin === true) continue;
+        const rt = readToolMap((spec as { tools?: unknown }).tools);
+        if (Object.keys(rt).length > 0) roles[roleName] = rt;
+      }
+    }
+
+    // Merge: start with flat tools, then union in each role's tools.
+    // For a tool appearing in >1 role with different modes, keep the
+    // strongest (deny > approval > allow) — the graph is a "what's the
+    // worst that could happen?" summary, not a role-scoped view. A
+    // future filter can render one role by reading `roles[<name>]`.
+    const tools: Record<string, ToolPolicy> = { ...flatTools };
+    for (const roleTools of Object.values(roles)) {
+      for (const [toolName, policy] of Object.entries(roleTools)) {
+        const current = tools[toolName];
+        if (
+          current === undefined ||
+          MODE_STRENGTH[policy.mode] > MODE_STRENGTH[current.mode]
+        ) {
+          tools[toolName] = policy;
+        }
+      }
     }
     return {
       version: Number(raw.version ?? 1),
       default_policy: { mode: defaultMode },
       tools,
+      roles,
     };
   } catch {
     return null;
@@ -91,13 +155,18 @@ export function buildAgentView(agent: AgentRead): AgentView | null {
   const parsedAgent = parseAgent(agent.agent_yaml, agent.policy_yaml);
   const parsedPolicy = parsePolicy(agent.policy_yaml);
   if (!parsedAgent || !parsedPolicy) return null;
-  const missingInPolicy = parsedAgent.tools.filter(
-    (t) => !(t in parsedPolicy.tools),
-  );
+  // Displayable tool list = union of what agent.yaml declares AND every
+  // tool that appears in any role's policy. Otherwise a role-only rule
+  // (`billing.refund_order`) would never render on the graph, even
+  // though it clearly maps to a callable tool at runtime.
+  const toolSet = new Set<string>(parsedAgent.tools);
+  for (const name of Object.keys(parsedPolicy.tools)) toolSet.add(name);
+  const tools = Array.from(toolSet).sort();
+  const missingInPolicy = tools.filter((t) => !(t in parsedPolicy.tools));
   return {
     name: parsedAgent.name || agent.name,
     model: parsedAgent.model,
-    tools: parsedAgent.tools,
+    tools,
     policy: parsedPolicy,
     missingInPolicy,
   };

--- a/platform/dashboard/src/lib/policy.ts
+++ b/platform/dashboard/src/lib/policy.ts
@@ -13,15 +13,16 @@ export interface ToolPolicy {
 export interface ParsedPolicy {
   version: number;
   default_policy: { mode: Mode };
-  /** Merged view of every concrete role's tools + top-level tools —
-   * used by the graph/overview. When a tool appears in multiple roles
-   * with different modes, we keep the strongest (deny > approval > allow)
-   * so the graph shows the worst-case decision a caller could hit. */
+  /** Tools declared at the TOP level of policy.yaml (flat shape). Empty
+   *  on inline-roles YAMLs. NOT augmented by role decisions — the user's
+   *  edit at this level is authoritative. See `mergedTools` for the
+   *  worst-case union across roles. */
   tools: Record<string, ToolPolicy>;
-  /** Per-role tool maps, present when the YAML is inline-roles shape.
-   * Empty on flat policy YAML. Callers that need per-role detail (e.g.
-   * a future Graph filter "show me policy for role X") read this
-   * instead of the merged `tools` above. */
+  /** Concrete roles present in the yaml. Empty on flat policy YAML.
+   *  Mixins are filtered (composed via `inherits:` into concrete roles
+   *  at wasm-compile time). A concrete role with no `tools:` map is
+   *  still listed here as `{}` so this map agrees with
+   *  parseRolesFromPolicy on which roles the picker offers. */
   roles: Record<string, Record<string, ToolPolicy>>;
 }
 
@@ -34,14 +35,81 @@ export interface ParsedAgent {
 export interface AgentView {
   name: string;
   model: string;
+  /** Tools the agent can invoke — equals agent.yaml's `tools:` list,
+   *  in declared order. Role-only policy entries do NOT create display
+   *  tools here; the runtime can't invoke what agent.yaml didn't
+   *  declare. */
   tools: string[];
   policy: ParsedPolicy;
-  /** Tools that appear in agent.yaml but have no entry in policy.yaml → default_policy applies */
+  /** Tools that appear in agent.yaml but have no policy entry (neither
+   *  at flat top level nor in any role) → default_policy applies. */
   missingInPolicy: string[];
 }
 
 function isMode(x: unknown): x is Mode {
   return x === "allow" || x === "deny" || x === "approval_required";
+}
+
+/**
+ * Return true for role specs that should be treated as MIXINS —
+ * composed INTO concrete roles via `inherits:` at compile time, never
+ * selectable on their own.
+ *
+ * Accepts the strict-true bool AND coerced truthy values (`"true"`,
+ * `1`) so a hand-written `is_mixin: "true"` doesn't sneak through as
+ * a "concrete role" and get double-counted in the merged view.
+ * Exported so parsePolicy + parseRolesFromPolicy + any future consumer
+ * agree on which roles are concrete.
+ */
+export function isMixinSpec(spec: unknown): boolean {
+  if (!spec || typeof spec !== "object") return false;
+  const raw = (spec as { is_mixin?: unknown }).is_mixin;
+  if (raw === true) return true;
+  if (raw === "true" || raw === "yes" || raw === "on" || raw === 1) return true;
+  return false;
+}
+
+/**
+ * Priority ordering when the graph needs a single mode for a tool
+ * called from multiple roles: deny > approval > allow. Exported so
+ * graph.ts + policy_graph.ts share one source of truth — a future
+ * `redacted` mode landing between deny and approval only has to be
+ * added here.
+ */
+export const MODE_STRENGTH: Record<Mode, number> = {
+  deny: 3,
+  approval_required: 2,
+  allow: 1,
+};
+
+/** Return the strongest mode from a list, or ``null`` if empty. */
+export function worstMode(modes: readonly Mode[]): Mode | null {
+  if (modes.length === 0) return null;
+  return modes.reduce((worst, m) =>
+    MODE_STRENGTH[m] > MODE_STRENGTH[worst] ? m : worst,
+  );
+}
+
+/**
+ * Read a `{tool_name: {mode, file_scope?}}` map from an arbitrary
+ * unknown-typed value. Filters entries whose mode isn't one of the
+ * three canonical strings (fail-closed against typos). Exported so
+ * policy_graph.ts and any future parser share the same isMode gate.
+ */
+export function readToolMap(raw: unknown): Record<string, ToolPolicy> {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, ToolPolicy> = {};
+  for (const [toolName, entry] of Object.entries(
+    raw as Record<string, unknown>,
+  )) {
+    const e = entry as { mode?: unknown; file_scope?: unknown };
+    if (!isMode(e?.mode)) continue;
+    out[toolName] = {
+      mode: e.mode,
+      file_scope: e.file_scope as ToolPolicy["file_scope"],
+    };
+  }
+  return out;
 }
 
 export function parseAgent(
@@ -62,31 +130,6 @@ export function parseAgent(
   void policyYaml;
 }
 
-/** Priority order for merging per-role decisions on the same tool — the
- * graph shows the worst-case outcome any caller could hit, so `deny`
- * wins over `approval_required` wins over `allow`. */
-const MODE_STRENGTH: Record<Mode, number> = {
-  deny: 3,
-  approval_required: 2,
-  allow: 1,
-};
-
-function readToolMap(raw: unknown): Record<string, ToolPolicy> {
-  if (!raw || typeof raw !== "object") return {};
-  const out: Record<string, ToolPolicy> = {};
-  for (const [toolName, entry] of Object.entries(
-    raw as Record<string, unknown>,
-  )) {
-    const e = entry as { mode?: unknown; file_scope?: unknown };
-    if (!isMode(e?.mode)) continue;
-    out[toolName] = {
-      mode: e.mode,
-      file_scope: e.file_scope as ToolPolicy["file_scope"],
-    };
-  }
-  return out;
-}
-
 export function parsePolicy(policyYaml: string): ParsedPolicy | null {
   try {
     // `yaml.load` returns `unknown`; the shape checks below narrow it
@@ -102,11 +145,12 @@ export function parsePolicy(policyYaml: string): ParsedPolicy | null {
       ? defaultPolicy.mode
       : "deny";
 
-    // Two shapes coexist in the platform: (a) flat, with tools at top
-    // level (older seed + hand-written examples), and (b) inline-roles,
-    // with concrete roles under `roles.<name>.tools` (every seeded
-    // multi-role agent). The graph reads a MERGED tool map so it
-    // renders both shapes the same way.
+    // Two shapes coexist: (a) flat, with tools at top level; (b)
+    // inline-roles, with concrete roles under `roles.<name>.tools`.
+    // We parse BOTH but keep them separate — the flat block is
+    // authoritative when the user writes at that level, roles carry
+    // the per-role variations. Downstream callers pick which they
+    // want via `tools` (flat) vs `roles[name]` vs `mergedTools(policy)`.
     const flatTools = readToolMap(raw.tools);
     const rolesRaw = raw.roles;
     const roles: Record<string, Record<string, ToolPolicy>> = {};
@@ -115,35 +159,20 @@ export function parsePolicy(policyYaml: string): ParsedPolicy | null {
         rolesRaw as Record<string, unknown>,
       )) {
         if (!spec || typeof spec !== "object") continue;
-        // Skip mixins — they compose INTO concrete roles via `inherits`;
-        // treating them as first-class would double-count decisions.
-        if ((spec as { is_mixin?: unknown }).is_mixin === true) continue;
-        const rt = readToolMap((spec as { tools?: unknown }).tools);
-        if (Object.keys(rt).length > 0) roles[roleName] = rt;
+        // Mixins compose INTO concrete roles at wasm-compile time; they
+        // aren't selectable roles and mustn't count toward the graph.
+        if (isMixinSpec(spec)) continue;
+        // Empty-tools roles ARE valid (they fall back to default_policy
+        // at runtime). Keep them as `{}` here so parsePolicy.roles
+        // agrees with parseRolesFromPolicy on which roles exist.
+        roles[roleName] = readToolMap((spec as { tools?: unknown }).tools);
       }
     }
 
-    // Merge: start with flat tools, then union in each role's tools.
-    // For a tool appearing in >1 role with different modes, keep the
-    // strongest (deny > approval > allow) — the graph is a "what's the
-    // worst that could happen?" summary, not a role-scoped view. A
-    // future filter can render one role by reading `roles[<name>]`.
-    const tools: Record<string, ToolPolicy> = { ...flatTools };
-    for (const roleTools of Object.values(roles)) {
-      for (const [toolName, policy] of Object.entries(roleTools)) {
-        const current = tools[toolName];
-        if (
-          current === undefined ||
-          MODE_STRENGTH[policy.mode] > MODE_STRENGTH[current.mode]
-        ) {
-          tools[toolName] = policy;
-        }
-      }
-    }
     return {
       version: Number(raw.version ?? 1),
       default_policy: { mode: defaultMode },
-      tools,
+      tools: flatTools,
       roles,
     };
   } catch {
@@ -151,18 +180,58 @@ export function parsePolicy(policyYaml: string): ParsedPolicy | null {
   }
 }
 
+/**
+ * Worst-case merged view of tool decisions across every concrete role
+ * PLUS the flat top-level `tools:` block. Used by the overview graph
+ * when it needs one edge color per tool without picking a role first.
+ *
+ * Precedence rules:
+ *   1. If the flat top-level `tools:` block declares a tool, that
+ *      entry wins — the user's explicit top-level edit is
+ *      authoritative and roles can't silently upgrade a flat `allow`
+ *      to `deny`.
+ *   2. Otherwise, the strongest per-role mode wins (`deny` >
+ *      `approval_required` > `allow`). Later roles beat earlier ones
+ *      on equal strength — keeps whichever declaration carries a
+ *      more-specific `file_scope`.
+ *
+ * Every consumer that wants "the color for this tool on the graph"
+ * routes through this helper; the raw `policy.tools` / `policy.roles`
+ * fields stay pure representations of the yaml.
+ */
+export function mergedTools(policy: ParsedPolicy): Record<string, ToolPolicy> {
+  const merged: Record<string, ToolPolicy> = { ...policy.tools };
+  for (const roleTools of Object.values(policy.roles)) {
+    for (const [toolName, roleEntry] of Object.entries(roleTools)) {
+      // Flat entry wins — never override an explicit top-level rule.
+      if (toolName in policy.tools) continue;
+      const current = merged[toolName];
+      if (current === undefined) {
+        merged[toolName] = roleEntry;
+        continue;
+      }
+      // Later role wins on equal strength (>=) so the last-declared
+      // file_scope survives; strictly-stronger always upgrades.
+      if (MODE_STRENGTH[roleEntry.mode] >= MODE_STRENGTH[current.mode]) {
+        merged[toolName] = roleEntry;
+      }
+    }
+  }
+  return merged;
+}
+
 export function buildAgentView(agent: AgentRead): AgentView | null {
   const parsedAgent = parseAgent(agent.agent_yaml, agent.policy_yaml);
   const parsedPolicy = parsePolicy(agent.policy_yaml);
   if (!parsedAgent || !parsedPolicy) return null;
-  // Displayable tool list = union of what agent.yaml declares AND every
-  // tool that appears in any role's policy. Otherwise a role-only rule
-  // (`billing.refund_order`) would never render on the graph, even
-  // though it clearly maps to a callable tool at runtime.
-  const toolSet = new Set<string>(parsedAgent.tools);
-  for (const name of Object.keys(parsedPolicy.tools)) toolSet.add(name);
-  const tools = Array.from(toolSet).sort();
-  const missingInPolicy = tools.filter((t) => !(t in parsedPolicy.tools));
+  // Display tool list = agent.yaml declaration ONLY. Role-only tool
+  // entries in policy don't create callable tools — the runtime
+  // registers tools from agent.tools (the SDK-decorated functions);
+  // policy just gates them. Including role-only tools here would draw
+  // phantom capability edges on the graph.
+  const tools = [...parsedAgent.tools];
+  const merged = mergedTools(parsedPolicy);
+  const missingInPolicy = tools.filter((t) => !(t in merged));
   return {
     name: parsedAgent.name || agent.name,
     model: parsedAgent.model,
@@ -173,7 +242,8 @@ export function buildAgentView(agent: AgentRead): AgentView | null {
 }
 
 export function effectiveMode(view: AgentView, toolName: string): Mode {
-  return view.policy.tools[toolName]?.mode ?? view.policy.default_policy.mode;
+  const entry = mergedTools(view.policy)[toolName];
+  return entry?.mode ?? view.policy.default_policy.mode;
 }
 
 export const MODE_COLOR: Record<Mode, string> = {
@@ -187,10 +257,10 @@ export const MODE_COLOR: Record<Mode, string> = {
  *
  * The wire format is one canonical document per agent. When the document
  * declares a top-level ``roles:`` map, this function returns the names of
- * the concrete roles (mixin entries filtered out, ``default`` first). When
- * the document is a flat single-policy YAML, returns an empty list — the
- * caller (the Playground role picker) treats that as "this agent has no
- * per-role differentiation, run it as-is."
+ * the concrete roles (mixin entries filtered out via ``isMixinSpec``,
+ * ``default`` first). When the document is a flat single-policy YAML,
+ * returns an empty list — the caller (the Playground role picker) treats
+ * that as "this agent has no per-role differentiation, run it as-is."
  *
  * Pure parse — no validation of the policy's correctness; that's the
  * server's /validate endpoint.
@@ -208,13 +278,7 @@ export function parseRolesFromPolicy(policyYaml: string): string[] {
 
   const concrete: string[] = [];
   for (const [name, spec] of Object.entries(roles as Record<string, unknown>)) {
-    if (
-      spec &&
-      typeof spec === "object" &&
-      (spec as { is_mixin?: unknown }).is_mixin === true
-    ) {
-      continue;
-    }
+    if (isMixinSpec(spec)) continue;
     concrete.push(name);
   }
   concrete.sort();

--- a/platform/dashboard/src/lib/policy.ts
+++ b/platform/dashboard/src/lib/policy.ts
@@ -10,6 +10,16 @@ export interface ToolPolicy {
   };
 }
 
+export interface RolePolicy {
+  /** Tools this role gates, AFTER inheritance resolution. Own entries
+   *  override any inherited entry with the same tool name. */
+  tools: Record<string, ToolPolicy>;
+  /** Per-role default when a tool isn't listed. Falls back to the
+   *  global default_policy when absent. Inherited from the closest
+   *  ancestor that declares one. */
+  default_policy?: { mode: Mode };
+}
+
 export interface ParsedPolicy {
   version: number;
   default_policy: { mode: Mode };
@@ -18,12 +28,13 @@ export interface ParsedPolicy {
    *  edit at this level is authoritative. See `mergedTools` for the
    *  worst-case union across roles. */
   tools: Record<string, ToolPolicy>;
-  /** Concrete roles present in the yaml. Empty on flat policy YAML.
-   *  Mixins are filtered (composed via `inherits:` into concrete roles
-   *  at wasm-compile time). A concrete role with no `tools:` map is
-   *  still listed here as `{}` so this map agrees with
-   *  parseRolesFromPolicy on which roles the picker offers. */
-  roles: Record<string, Record<string, ToolPolicy>>;
+  /** Concrete roles present in the yaml, AFTER inheritance resolution.
+   *  Each entry carries the effective tool map (own tools merged over
+   *  ancestors) plus the resolved default_policy. Mixins compose in via
+   *  `inherits:` and are not first-class entries here. A concrete role
+   *  with no `tools:` map is still listed with `tools: {}` so this map
+   *  agrees with parseRolesFromPolicy on which roles the picker offers. */
+  roles: Record<string, RolePolicy>;
 }
 
 export interface ParsedAgent {
@@ -130,6 +141,65 @@ export function parseAgent(
   void policyYaml;
 }
 
+/** Extract a role's inherits list, filtering non-string entries. */
+function readInherits(spec: unknown): string[] {
+  const raw = (spec as { inherits?: unknown } | undefined)?.inherits;
+  if (!Array.isArray(raw)) return [];
+  return raw.filter((x): x is string => typeof x === "string");
+}
+
+/**
+ * Resolve a role's inheritance chain, merging ancestor tools into the
+ * role's own map. Own tools override inherited tools; sibling ancestors
+ * merge left-to-right (later ancestor overrides earlier on a name
+ * collision). Cycle-safe via the ``stack`` guard — a re-entered role
+ * short-circuits to an empty map, so cyclic inherits definitions parse
+ * without hanging or throwing.
+ *
+ * Both mixins and concrete roles participate as ancestors; the mixin
+ * filter only applies to which roles are returned to the caller (via
+ * ``parsePolicy.roles``), not to which entries contribute during
+ * resolution.
+ */
+function resolveInheritance(
+  specs: Record<
+    string,
+    {
+      tools: Record<string, ToolPolicy>;
+      inherits: string[];
+      defaultMode?: Mode;
+    }
+  >,
+): Record<string, RolePolicy> {
+  const memo: Record<string, RolePolicy> = {};
+  const resolve = (name: string, stack: Set<string>): RolePolicy => {
+    if (memo[name]) return memo[name];
+    if (stack.has(name)) return { tools: {} };
+    const spec = specs[name];
+    if (!spec) return { tools: {} };
+    stack.add(name);
+    const tools: Record<string, ToolPolicy> = {};
+    let defaultMode: Mode | undefined;
+    // Walk ancestors first so own entries override inherited ones.
+    for (const parent of spec.inherits) {
+      const resolved = resolve(parent, stack);
+      Object.assign(tools, resolved.tools);
+      if (resolved.default_policy) defaultMode = resolved.default_policy.mode;
+    }
+    // Own tools + own default_policy override anything inherited.
+    Object.assign(tools, spec.tools);
+    if (spec.defaultMode) defaultMode = spec.defaultMode;
+    stack.delete(name);
+    memo[name] = {
+      tools,
+      ...(defaultMode ? { default_policy: { mode: defaultMode } } : {}),
+    };
+    return memo[name];
+  };
+  for (const name of Object.keys(specs)) resolve(name, new Set());
+  return memo;
+}
+
 export function parsePolicy(policyYaml: string): ParsedPolicy | null {
   try {
     // `yaml.load` returns `unknown`; the shape checks below narrow it
@@ -147,25 +217,51 @@ export function parsePolicy(policyYaml: string): ParsedPolicy | null {
 
     // Two shapes coexist: (a) flat, with tools at top level; (b)
     // inline-roles, with concrete roles under `roles.<name>.tools`.
-    // We parse BOTH but keep them separate — the flat block is
-    // authoritative when the user writes at that level, roles carry
-    // the per-role variations. Downstream callers pick which they
-    // want via `tools` (flat) vs `roles[name]` vs `mergedTools(policy)`.
+    // Both parsed — flat block stays as authored (never merged with
+    // role decisions), roles carry the effective per-role view AFTER
+    // inheritance resolution. Downstream picks: ``tools`` (flat) vs
+    // ``roles[name]`` (fully-resolved role) vs ``mergedTools(policy)``
+    // (worst-case across the whole policy).
     const flatTools = readToolMap(raw.tools);
     const rolesRaw = raw.roles;
-    const roles: Record<string, Record<string, ToolPolicy>> = {};
+    const roles: Record<string, RolePolicy> = {};
     if (rolesRaw && typeof rolesRaw === "object" && !Array.isArray(rolesRaw)) {
+      // Two passes: (1) collect ALL role specs including mixins so they
+      // can serve as inheritance parents; (2) resolve the graph; (3)
+      // publish only concrete roles to the caller. Mixins participate
+      // as ancestors — dropping them at step 1 was the "web_search
+      // never appears" bug the review flagged.
+      const rawSpecs: Record<
+        string,
+        {
+          tools: Record<string, ToolPolicy>;
+          inherits: string[];
+          defaultMode?: Mode;
+        }
+      > = {};
       for (const [roleName, spec] of Object.entries(
         rolesRaw as Record<string, unknown>,
       )) {
         if (!spec || typeof spec !== "object") continue;
-        // Mixins compose INTO concrete roles at wasm-compile time; they
-        // aren't selectable roles and mustn't count toward the graph.
+        const s = spec as { tools?: unknown; default_policy?: unknown };
+        const roleDefault = s.default_policy as { mode?: unknown } | undefined;
+        rawSpecs[roleName] = {
+          tools: readToolMap(s.tools),
+          inherits: readInherits(spec),
+          ...(isMode(roleDefault?.mode)
+            ? { defaultMode: roleDefault.mode }
+            : {}),
+        };
+      }
+      const resolved = resolveInheritance(rawSpecs);
+      // Publish only concrete roles — mixins compose INTO them via
+      // inherits and aren't selectable on their own.
+      for (const [roleName, spec] of Object.entries(
+        rolesRaw as Record<string, unknown>,
+      )) {
+        if (!spec || typeof spec !== "object") continue;
         if (isMixinSpec(spec)) continue;
-        // Empty-tools roles ARE valid (they fall back to default_policy
-        // at runtime). Keep them as `{}` here so parsePolicy.roles
-        // agrees with parseRolesFromPolicy on which roles exist.
-        roles[roleName] = readToolMap((spec as { tools?: unknown }).tools);
+        roles[roleName] = resolved[roleName] ?? { tools: {} };
       }
     }
 
@@ -185,36 +281,35 @@ export function parsePolicy(policyYaml: string): ParsedPolicy | null {
  * PLUS the flat top-level `tools:` block. Used by the overview graph
  * when it needs one edge color per tool without picking a role first.
  *
- * Precedence rules:
- *   1. If the flat top-level `tools:` block declares a tool, that
- *      entry wins — the user's explicit top-level edit is
- *      authoritative and roles can't silently upgrade a flat `allow`
- *      to `deny`.
- *   2. Otherwise, the strongest per-role mode wins (`deny` >
- *      `approval_required` > `allow`). Later roles beat earlier ones
- *      on equal strength — keeps whichever declaration carries a
- *      more-specific `file_scope`.
+ * Semantics: strongest mode wins across the whole policy (`deny` >
+ * `approval_required` > `allow`). Flat top-level entries participate
+ * as another voice, not as an override — a role deny stays visible on
+ * the graph even when the flat block says allow, because at runtime
+ * the role IS what gates the call. Later contributors beat earlier
+ * ones on equal strength so the last-declared ``file_scope`` survives.
  *
  * Every consumer that wants "the color for this tool on the graph"
- * routes through this helper; the raw `policy.tools` / `policy.roles`
- * fields stay pure representations of the yaml.
+ * routes through this helper; the raw ``policy.tools`` / ``policy.roles``
+ * fields stay pure representations of the YAML.
  */
 export function mergedTools(policy: ParsedPolicy): Record<string, ToolPolicy> {
-  const merged: Record<string, ToolPolicy> = { ...policy.tools };
-  for (const roleTools of Object.values(policy.roles)) {
-    for (const [toolName, roleEntry] of Object.entries(roleTools)) {
-      // Flat entry wins — never override an explicit top-level rule.
-      if (toolName in policy.tools) continue;
-      const current = merged[toolName];
-      if (current === undefined) {
-        merged[toolName] = roleEntry;
-        continue;
-      }
-      // Later role wins on equal strength (>=) so the last-declared
-      // file_scope survives; strictly-stronger always upgrades.
-      if (MODE_STRENGTH[roleEntry.mode] >= MODE_STRENGTH[current.mode]) {
-        merged[toolName] = roleEntry;
-      }
+  const merged: Record<string, ToolPolicy> = {};
+  const contribute = (entry: ToolPolicy, toolName: string): void => {
+    const current = merged[toolName];
+    if (current === undefined) {
+      merged[toolName] = entry;
+      return;
+    }
+    if (MODE_STRENGTH[entry.mode] >= MODE_STRENGTH[current.mode]) {
+      merged[toolName] = entry;
+    }
+  };
+  for (const [toolName, entry] of Object.entries(policy.tools)) {
+    contribute(entry, toolName);
+  }
+  for (const rolePolicy of Object.values(policy.roles)) {
+    for (const [toolName, entry] of Object.entries(rolePolicy.tools)) {
+      contribute(entry, toolName);
     }
   }
   return merged;
@@ -241,9 +336,37 @@ export function buildAgentView(agent: AgentRead): AgentView | null {
   };
 }
 
+/**
+ * The mode the overview graph should color the ``(agent, tool)`` edge.
+ *
+ * Semantics: worst case across every voice that has an opinion.
+ *   * If a flat top-level entry exists, its mode is one voice.
+ *   * Each role contributes: the role's own entry for the tool, or,
+ *     when the role doesn't list the tool, that role's ``default_policy``
+ *     mode (or the global default if the role didn't set one).
+ *   * When there are no roles and no flat entry, the global
+ *     ``default_policy`` mode wins by default.
+ *
+ * The strongest mode across all those voices is returned. This mirrors
+ * runtime behavior: any role that would deny the call at runtime shows
+ * as deny on the overview.
+ */
 export function effectiveMode(view: AgentView, toolName: string): Mode {
-  const entry = mergedTools(view.policy)[toolName];
-  return entry?.mode ?? view.policy.default_policy.mode;
+  const voices: Mode[] = [];
+  const flatEntry = view.policy.tools[toolName];
+  if (flatEntry) voices.push(flatEntry.mode);
+  const roleNames = Object.keys(view.policy.roles);
+  for (const roleName of roleNames) {
+    const role = view.policy.roles[roleName];
+    const roleEntry = role.tools[toolName];
+    if (roleEntry) {
+      voices.push(roleEntry.mode);
+    } else {
+      voices.push(role.default_policy?.mode ?? view.policy.default_policy.mode);
+    }
+  }
+  if (voices.length === 0) return view.policy.default_policy.mode;
+  return worstMode(voices) ?? view.policy.default_policy.mode;
 }
 
 export const MODE_COLOR: Record<Mode, string> = {

--- a/platform/dashboard/src/lib/policy_graph.test.ts
+++ b/platform/dashboard/src/lib/policy_graph.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildPolicyGraph } from "./policy_graph";
+
+/**
+ * Focused regressions for buildPolicyGraph. The heavier semantic
+ * coverage lives in policy.test.ts; this file only pins the graph-layer
+ * decisions (invalid modes render as deny, mixin edges still emit).
+ */
+
+describe("buildPolicyGraph — invalid mode entries stay visible (finding #68)", () => {
+  it("renders a tool with a mistyped mode as a deny-colored edge, not a missing edge", () => {
+    // Capital "Deny" is not a valid Mode. Before the fix, readToolMap
+    // dropped it entirely and the tool node had no incoming edge —
+    // users concluded the tool was unconstrained. Fix: still emit an
+    // edge, coerced to deny with a diagnostic label.
+    const graph = buildPolicyGraph(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  strict:
+    tools:
+      dangerous_op: { mode: Deny }
+`);
+    expect(graph.ok).toBe(true);
+    const toolNode = graph.nodes.find((n) => n.id === "tool:dangerous_op");
+    expect(toolNode).toBeDefined();
+    const edge = graph.edges.find(
+      (e) => e.source === "role:strict" && e.target === "tool:dangerous_op",
+    );
+    expect(edge).toBeDefined();
+    expect(edge!.label).toContain("invalid mode");
+    // Fail-closed — the stroke color is the deny semantic even though
+    // the raw YAML said something the parser couldn't interpret.
+    expect(
+      (edge!.style as Record<string, unknown> | undefined)?.stroke,
+    ).toContain("--semantic-deny");
+  });
+
+  it("still renders a valid entry alongside an invalid one under the same role", () => {
+    const graph = buildPolicyGraph(`
+version: 1
+default_policy: { mode: deny }
+roles:
+  mixed:
+    tools:
+      good_tool: { mode: allow }
+      typo_tool: { mode: Allow }
+`);
+    const goodEdge = graph.edges.find((e) => e.target === "tool:good_tool");
+    const typoEdge = graph.edges.find((e) => e.target === "tool:typo_tool");
+    expect(goodEdge!.label).toBe("allow");
+    expect(typoEdge!.label).toContain("invalid mode");
+  });
+});

--- a/platform/dashboard/src/lib/policy_graph.ts
+++ b/platform/dashboard/src/lib/policy_graph.ts
@@ -31,19 +31,17 @@
 
 import yaml from "js-yaml";
 import type { Edge, Node } from "@xyflow/react";
+import { isMixinSpec, MODE_COLOR, readToolMap } from "./policy";
 
-export type Mode = "allow" | "deny" | "approval_required";
-
-interface ToolPolicySpec {
-  mode?: Mode;
-  constraints?: string[];
-}
+// Re-export Mode so existing consumers of this file (if any) don't break.
+export type { Mode } from "./policy";
 
 interface RoleSpec {
-  is_mixin?: boolean;
+  is_mixin?: unknown; // coerced by isMixinSpec()
   inherits?: string[];
-  tools?: Record<string, ToolPolicySpec>;
-  default_policy?: { mode?: Mode };
+  tools?: Record<string, unknown>; // shaped by readToolMap()
+  default_policy?: { mode?: unknown };
+  constraints?: string[];
 }
 
 interface InlinePolicy {
@@ -51,11 +49,16 @@ interface InlinePolicy {
   roles?: Record<string, RoleSpec>;
 }
 
-const MODE_COLOR: Record<Mode, string> = {
-  allow: "hsl(var(--semantic-allow))",
-  approval_required: "hsl(var(--semantic-approval))",
-  deny: "hsl(var(--semantic-deny))",
-};
+/**
+ * Extract constraint counts per role×tool. readToolMap() drops the
+ * `constraints` field (it only reads mode + file_scope), so we walk
+ * the raw spec ourselves to pull constraint counts for the edge
+ * label — everything else routes through readToolMap for consistency.
+ */
+function constraintCount(spec: unknown): number {
+  const c = (spec as { constraints?: unknown } | undefined)?.constraints;
+  return Array.isArray(c) ? c.length : 0;
+}
 
 export interface PolicyGraph {
   nodes: Node[];
@@ -86,11 +89,17 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
   }
 
   const roleNames = Object.keys(rolesMap);
-  // Tools = union across all roles, source order (first occurrence wins).
+  // Tools = union across all roles, source order (first occurrence
+  // wins). Route through readToolMap so an entry with an invalid mode
+  // (e.g. capital "Allow") is dropped consistently with parsePolicy —
+  // otherwise this view would render a phantom tool the overview graph
+  // silently omits.
+  const toolMapsByRole: Record<string, ReturnType<typeof readToolMap>> = {};
   const toolSet = new Set<string>();
   for (const role of roleNames) {
-    const tools = rolesMap[role]?.tools ?? {};
-    for (const t of Object.keys(tools)) toolSet.add(t);
+    const map = readToolMap(rolesMap[role]?.tools);
+    toolMapsByRole[role] = map;
+    for (const t of Object.keys(map)) toolSet.add(t);
   }
   const toolNames = Array.from(toolSet);
 
@@ -120,7 +129,9 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
       position: { x: COL_ROLES_X, y: ROLE_Y_START + idx * ROLE_GAP_Y },
       data: {
         label: role,
-        muted: spec?.is_mixin === true,
+        // Coerced check — accepts is_mixin: true / "true" / 1 uniformly
+        // with parsePolicy so both views agree on which roles are mixins.
+        muted: isMixinSpec(spec),
       },
     });
   });
@@ -169,11 +180,17 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
   // without opening the YAML.
   for (const role of roleNames) {
     const spec = rolesMap[role];
-    if (spec?.is_mixin) continue; // mixins don't terminate; their tools surface via children
-    const tools = spec?.tools ?? {};
-    for (const [tool, toolSpec] of Object.entries(tools)) {
-      const mode = (toolSpec?.mode ?? "deny") as Mode;
-      const constraintCount = toolSpec?.constraints?.length ?? 0;
+    // Mixins compose into children via `inherits` — no direct terminal
+    // edges here (isMixinSpec accepts coerced truthy values, matching
+    // parsePolicy's contract).
+    if (isMixinSpec(spec)) continue;
+    // Iterate the readToolMap-filtered view so invalid-mode entries are
+    // skipped consistently with parsePolicy.
+    const validatedTools = toolMapsByRole[role] ?? {};
+    const rawTools = (spec?.tools ?? {}) as Record<string, unknown>;
+    for (const [tool, toolPolicy] of Object.entries(validatedTools)) {
+      const mode = toolPolicy.mode;
+      const cnCount = constraintCount(rawTools[tool]);
       edges.push({
         id: `mode:${role}->${tool}`,
         source: `role:${role}`,
@@ -185,8 +202,8 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
           strokeWidth: 2,
         },
         label:
-          constraintCount > 0
-            ? `${mode} · ${constraintCount} check${constraintCount === 1 ? "" : "s"}`
+          cnCount > 0
+            ? `${mode} · ${cnCount} check${cnCount === 1 ? "" : "s"}`
             : mode,
         labelStyle: {
           fontSize: 10,

--- a/platform/dashboard/src/lib/policy_graph.ts
+++ b/platform/dashboard/src/lib/policy_graph.ts
@@ -31,7 +31,7 @@
 
 import yaml from "js-yaml";
 import type { Edge, Node } from "@xyflow/react";
-import { isMixinSpec, MODE_COLOR, readToolMap } from "./policy";
+import { isMixinSpec, MODE_COLOR, readToolMap, type Mode } from "./policy";
 
 // Re-export Mode so existing consumers of this file (if any) don't break.
 export type { Mode } from "./policy";
@@ -47,6 +47,32 @@ interface RoleSpec {
 interface InlinePolicy {
   version?: number;
   roles?: Record<string, RoleSpec>;
+}
+
+/**
+ * Union of every tool name mentioned under a role's ``tools:`` map,
+ * regardless of whether the mode is valid. readToolMap alone silently
+ * drops entries with mistyped modes (e.g. capitalized ``Deny``); using
+ * only its output as the tool-node source makes those tools disappear
+ * from the graph entirely — the user sees no node and assumes the tool
+ * is unconstrained. Fix: keep the tool visible; the edge renders with
+ * a fail-closed deny color and a diagnostic label.
+ */
+function rawToolNames(rawTools: unknown): string[] {
+  if (!rawTools || typeof rawTools !== "object") return [];
+  return Object.keys(rawTools as Record<string, unknown>);
+}
+
+/** Extract a raw mode string from an unvalidated tool spec entry. */
+function rawModeOf(spec: unknown): unknown {
+  return (spec as { mode?: unknown } | undefined)?.mode;
+}
+
+const VALID_MODES: readonly Mode[] = ["allow", "deny", "approval_required"];
+function isValidMode(m: unknown): m is Mode {
+  return (
+    typeof m === "string" && (VALID_MODES as readonly string[]).includes(m)
+  );
 }
 
 /**
@@ -89,17 +115,16 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
   }
 
   const roleNames = Object.keys(rolesMap);
-  // Tools = union across all roles, source order (first occurrence
-  // wins). Route through readToolMap so an entry with an invalid mode
-  // (e.g. capital "Allow") is dropped consistently with parsePolicy —
-  // otherwise this view would render a phantom tool the overview graph
-  // silently omits.
+  // Tools = union across all roles' raw tool maps (not filtered) so an
+  // entry with a mistyped mode still gets a node + a fail-closed edge.
+  // Dropping typos silently made those tools disappear from the graph,
+  // and the user assumed the tool was unconstrained. Fail-closed and
+  // visible beats invisible-and-permissive.
   const toolMapsByRole: Record<string, ReturnType<typeof readToolMap>> = {};
   const toolSet = new Set<string>();
   for (const role of roleNames) {
-    const map = readToolMap(rolesMap[role]?.tools);
-    toolMapsByRole[role] = map;
-    for (const t of Object.keys(map)) toolSet.add(t);
+    toolMapsByRole[role] = readToolMap(rolesMap[role]?.tools);
+    for (const t of rawToolNames(rolesMap[role]?.tools)) toolSet.add(t);
   }
   const toolNames = Array.from(toolSet);
 
@@ -177,37 +202,48 @@ export function buildPolicyGraph(policyYaml: string): PolicyGraph {
 
   // Mode edges — role → tool, color encodes the policy mode. Constraint
   // count surfaces in the label so the user knows the rule has gates
-  // without opening the YAML.
+  // without opening the YAML. Invalid-mode entries (e.g. capitalized
+  // ``Deny``) render as deny with an "invalid mode" label so the user
+  // spots the typo instead of finding a silently-missing edge.
   for (const role of roleNames) {
     const spec = rolesMap[role];
     // Mixins compose into children via `inherits` — no direct terminal
     // edges here (isMixinSpec accepts coerced truthy values, matching
     // parsePolicy's contract).
     if (isMixinSpec(spec)) continue;
-    // Iterate the readToolMap-filtered view so invalid-mode entries are
-    // skipped consistently with parsePolicy.
     const validatedTools = toolMapsByRole[role] ?? {};
     const rawTools = (spec?.tools ?? {}) as Record<string, unknown>;
-    for (const [tool, toolPolicy] of Object.entries(validatedTools)) {
-      const mode = toolPolicy.mode;
+    for (const tool of rawToolNames(rolesMap[role]?.tools)) {
+      const rawMode = rawModeOf(rawTools[tool]);
+      const validEntry = validatedTools[tool];
+      const mode: Mode = validEntry ? validEntry.mode : "deny";
       const cnCount = constraintCount(rawTools[tool]);
+      const invalid = !isValidMode(rawMode);
+      let label: string;
+      if (invalid) {
+        label = `invalid mode · deny`;
+      } else if (cnCount > 0) {
+        label = `${mode} · ${cnCount} check${cnCount === 1 ? "" : "s"}`;
+      } else {
+        label = mode;
+      }
       edges.push({
         id: `mode:${role}->${tool}`,
         source: `role:${role}`,
         target: `tool:${tool}`,
         type: "smoothstep",
-        animated: mode === "allow",
+        animated: !invalid && mode === "allow",
         style: {
           stroke: MODE_COLOR[mode],
           strokeWidth: 2,
+          ...(invalid ? { strokeDasharray: "3 3" } : {}),
         },
-        label:
-          cnCount > 0
-            ? `${mode} · ${cnCount} check${cnCount === 1 ? "" : "s"}`
-            : mode,
+        label,
         labelStyle: {
           fontSize: 10,
-          fill: "hsl(var(--foreground))",
+          fill: invalid
+            ? "hsl(var(--semantic-deny))"
+            : "hsl(var(--foreground))",
         },
         labelBgStyle: { fill: "hsl(var(--background))" },
         labelBgPadding: [4, 2],


### PR DESCRIPTION
## What broke

The overview Graph page rendered every edge under `default_policy.mode` (usually deny → all red) OR missed tools entirely, on every seeded multi-role agent. Root cause: `parsePolicy()` only walked the flat `tools:` shape and never traversed `roles.<name>.tools`. `buildAgentView` compounded it by reading tools off `agent.yaml`, missing anything only declared in a role. `AgentView.missingInPolicy` was also poisoned — falsely flagging every tool as unpoliced.

The **wasm bundle at runtime is correct** — it resolves inheritance + per-role tool maps. This is a **dashboard-visualization bug only**; no runtime policy enforcement is affected.

## Fix

`parsePolicy` now handles both shapes:
- **Flat** (`tools:` at top level) — unchanged behaviour
- **Inline-roles** (`roles.<name>.tools`) — merges every concrete role's tool map, keeping the **worst-case** mode when a tool differs across roles (`deny > approval_required > allow`)

Mixins (`is_mixin: true`) are excluded from the merge — they compose INTO concrete roles via `inherits:`, and treating them first-class would double-count decisions. `ParsedPolicy.roles: Record<role, tools>` is also exposed for a future "filter by role" affordance.

`buildAgentView` tool list = union of `agent.yaml` tools + every tool in any role's policy. Without this, a role-only rule (`billing.refund_order`) was invisible on the graph.

Also **removed dead code**: `buildAgentGraph` (~40 LOC, zero callers, leftover from an earlier per-agent detail view).

## Known limitation, documented in-test

Mixin-only tools (`web_search` inherited via `read_only`) still fall through to `default_policy=deny` because we don't resolve `inherits:` client-side. The wasm bundle handles it correctly; only the dashboard's cosmetic edge color is wrong for this case. Pinned by `test_falls_back_to_default_policy_for_mixin_only_tools`; a future inheritance-aware resolver would flip that test's expectation. Not blocking for this fix — it's a strict improvement over "everything renders as deny."

## Tests

- **11 new regression cases** in `platform/dashboard/src/lib/policy.test.ts`
- Flat + inline-roles parsing, worst-case merge, mixin filter (parseRolesFromPolicy behavior pinned unchanged), tool-list union, effectiveMode routing, missingInPolicy fallback
- **67/67 dashboard tests pass** (+11 new)
- `pnpm typecheck` clean, `pnpm lint` clean on touched files (13 pre-existing warnings on other files, unrelated)

## Test plan

- [x] Unit tests cover both YAML shapes
- [x] `pnpm typecheck` clean
- [ ] After merge: eyeball `/graph` on a fresh env with the seeded `support_bot` — refund_order edge should render deny (was: missing, or same edge painted default green)