### PR TITLE
feat(dashboard): persist agent selection via ?agent= + Settings shell

### DIFF
--- a/platform/dashboard/src/lib/agent_param.test.tsx
+++ b/platform/dashboard/src/lib/agent_param.test.tsx
@@ -1,16 +1,20 @@
 /**
- * Tests for the ``useAgentParam`` + ``useAutoSelectFirstAgent`` pair
- * that back ``?agent=`` selection sync across /agents and /policies.
+ * Tests for ``useAgentSelection`` — the single hook that backs
+ * ?agent= sync across /agents and /policies.
  *
- * The invariants:
- *   1. On mount, ``selected`` reflects the ?agent= param IF it matches
- *      a known agent (otherwise null — stale URL stays inert).
- *   2. ``set(name)`` writes ?agent= via ``replace`` (no back-button
- *      trail for picker changes).
- *   3. ``clear()`` removes ?agent= entirely (project-switch reset).
- *   4. When ``selected`` is null and knownNames is non-empty,
- *      ``useAutoSelectFirstAgent`` runs ``set(names[0])`` exactly once
- *      per (names identity) change — no loops.
+ * The invariants this file pins (many learned in review after the
+ * first draft broke every one of them):
+ *
+ *   1. ?agent= from the URL is preserved on first render, even while
+ *      the agents query is still loading (knownNames=undefined).
+ *   2. When the URL points at a stale/renamed agent, ``selected``
+ *      falls back to the first known name — but the URL is NEVER
+ *      auto-rewritten (bookmarks stay shareable, ``fromUrl`` flags
+ *      the divergence so callers can surface a banner).
+ *   3. ``set()`` writes ?agent= with replace, no back-button pollution.
+ *   4. ``resetOn`` only clears on real transitions — a stable value
+ *      across renders does NOT wipe an incoming URL param at mount.
+ *   5. ``resetOn`` = undefined opts out of reset entirely.
  */
 
 import { act, renderHook } from "@testing-library/react";
@@ -18,7 +22,7 @@ import type { JSX, ReactNode } from "react";
 import { MemoryRouter, useLocation } from "react-router-dom";
 import { describe, expect, it } from "vitest";
 
-import { useAgentParam, useAutoSelectFirstAgent } from "./agent_param";
+import { useAgentSelection } from "./agent_param";
 
 function wrapperAt(initialUrl: string) {
   return ({ children }: { children: ReactNode }): JSX.Element => (
@@ -26,127 +30,186 @@ function wrapperAt(initialUrl: string) {
   );
 }
 
-describe("useAgentParam", () => {
+const AGENTS = (...names: string[]) => names.map((name) => ({ name }));
+
+describe("useAgentSelection — URL is source of truth", () => {
   it("returns the ?agent= value when it matches a known name", () => {
-    const { result } = renderHook(() => useAgentParam(["alpha", "beta"]), {
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies?agent=beta") },
+    );
+    expect(result.current.selected).toBe("beta");
+    expect(result.current.fromUrl).toBe(true);
+  });
+
+  it("preserves ?agent= on first render while agents are still loading", () => {
+    // Regression for the loading-race bug: previously, knownNames=[]
+    // during the query's first tick made ``[].includes("beta")`` false,
+    // dropping the URL value on the floor. Passing undefined here
+    // simulates the pre-fetch state; the URL value must ride through.
+    const { result } = renderHook(() => useAgentSelection(undefined), {
       wrapper: wrapperAt("/policies?agent=beta"),
     });
     expect(result.current.selected).toBe("beta");
+    expect(result.current.fromUrl).toBe(true);
+  });
+});
+
+describe("useAgentSelection — stale/missing URL falls back without rewriting", () => {
+  it("falls back to the first known name when ?agent= doesn't match", () => {
+    // Bookmark to a renamed / deleted agent. ``selected`` must produce
+    // SOMETHING so the picker isn't blank, but ``fromUrl=false`` tells
+    // the caller "this isn't what the URL asked for."
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies?agent=gone") },
+    );
+    expect(result.current.selected).toBe("alpha");
+    expect(result.current.fromUrl).toBe(false);
   });
 
-  it("returns null when ?agent= doesn't match any known name", () => {
-    // Stale URL from a deleted / renamed agent must NOT leave the
-    // picker in a "selected but not in the dropdown" broken state.
-    const { result } = renderHook(() => useAgentParam(["alpha", "beta"]), {
-      wrapper: wrapperAt("/policies?agent=gone"),
+  it("does NOT auto-rewrite the URL on stale-fallback", () => {
+    // Regression for the "silent-misroute-on-share" bug: previously,
+    // useAutoSelectFirstAgent called set() on any mismatch, replacing
+    // ?agent=support_bot (renamed) with ?agent=alpha_agent — so
+    // sharing the URL from the address bar sent colleagues to the
+    // wrong agent. The stale URL must remain visible.
+    const { result } = renderHook(
+      () => {
+        const sel = useAgentSelection(AGENTS("alpha", "beta"));
+        const location = useLocation();
+        return { sel, location };
+      },
+      { wrapper: wrapperAt("/policies?agent=gone") },
+    );
+    expect(result.current.location.search).toBe("?agent=gone");
+  });
+
+  it("falls back to first agent when no ?agent= param is set", () => {
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies") },
+    );
+    expect(result.current.selected).toBe("alpha");
+    expect(result.current.fromUrl).toBe(false);
+  });
+
+  it("returns null when no agents are known and URL is unset", () => {
+    const { result } = renderHook(() => useAgentSelection(AGENTS()), {
+      wrapper: wrapperAt("/policies"),
     });
     expect(result.current.selected).toBeNull();
+    expect(result.current.fromUrl).toBe(false);
   });
 
-  it("returns null when ?agent= is absent", () => {
-    const { result } = renderHook(() => useAgentParam(["alpha"]), {
+  it("returns null when the agents query hasn't returned yet AND URL is unset", () => {
+    // Nothing to select from + nothing on the URL → null is honest,
+    // don't invent a value.
+    const { result } = renderHook(() => useAgentSelection(undefined), {
       wrapper: wrapperAt("/policies"),
     });
     expect(result.current.selected).toBeNull();
   });
+});
 
-  it("returns null when knownNames is undefined (still loading)", () => {
-    const { result } = renderHook(() => useAgentParam(undefined), {
-      wrapper: wrapperAt("/policies?agent=beta"),
-    });
-    // Guard against exposing an agent name we can't validate yet —
-    // the picker will render "loading" instead of a broken selection.
-    expect(result.current.selected).toBeNull();
-  });
-
-  it("set() writes the param without pushing history", () => {
-    // Wrap our hook + a location observer so we can assert both the
-    // param update AND that the entry count didn't grow (replace, not
-    // push — picker clicks shouldn't pollute the back-button trail).
+describe("useAgentSelection — set() writes to URL", () => {
+  it("set() writes ?agent= without pushing a history entry", () => {
     const { result } = renderHook(
       () => {
-        const agent = useAgentParam(["alpha", "beta"]);
+        const sel = useAgentSelection(AGENTS("alpha", "beta"));
         const location = useLocation();
-        return { agent, location };
+        return { sel, location };
       },
       { wrapper: wrapperAt("/policies") },
     );
-
-    expect(result.current.location.pathname).toBe("/policies");
     act(() => {
-      result.current.agent.set("beta");
+      result.current.sel.set("beta");
     });
     expect(result.current.location.search).toBe("?agent=beta");
-    expect(result.current.agent.selected).toBe("beta");
-  });
-
-  it("clear() removes the param", () => {
-    const { result } = renderHook(() => useAgentParam(["alpha", "beta"]), {
-      wrapper: wrapperAt("/policies?agent=beta&keep=1"),
-    });
-    expect(result.current.selected).toBe("beta");
-    act(() => {
-      result.current.clear();
-    });
-    expect(result.current.selected).toBeNull();
+    expect(result.current.sel.selected).toBe("beta");
+    expect(result.current.sel.fromUrl).toBe(true);
   });
 
   it("set() preserves other query params", () => {
-    // A future route may add e.g. ?tab=graph — set/clear on agent
-    // must not stomp unrelated keys.
+    // A future route may add e.g. ?tab=graph — set/reset on agent must
+    // not stomp unrelated keys.
     const { result } = renderHook(
       () => {
-        const agent = useAgentParam(["alpha", "beta"]);
+        const sel = useAgentSelection(AGENTS("alpha", "beta"));
         const location = useLocation();
-        return { agent, location };
+        return { sel, location };
       },
       { wrapper: wrapperAt("/policies?tab=graph") },
     );
     act(() => {
-      result.current.agent.set("alpha");
+      result.current.sel.set("alpha");
     });
     expect(result.current.location.search).toContain("tab=graph");
     expect(result.current.location.search).toContain("agent=alpha");
   });
 });
 
-describe("useAutoSelectFirstAgent", () => {
-  it("selects the first name when nothing is selected", () => {
+describe("useAgentSelection — resetOn", () => {
+  it("does NOT clear the URL on the initial mount, even when resetOn is set", () => {
+    // Regression for the mount-clear bug that stomped every incoming
+    // ?agent= on load — the ref must snapshot the initial resetOn
+    // value and only clear on a real transition later.
     const { result } = renderHook(
-      () => {
-        const agent = useAgentParam(["alpha", "beta"]);
-        useAutoSelectFirstAgent(agent, ["alpha", "beta"]);
-        return agent;
+      ({ project }: { project: string }) => {
+        const sel = useAgentSelection(AGENTS("alpha", "beta"), {
+          resetOn: project,
+        });
+        const location = useLocation();
+        return { sel, location };
       },
-      { wrapper: wrapperAt("/policies") },
+      {
+        initialProps: { project: "proj-1" },
+        wrapper: wrapperAt("/policies?agent=beta"),
+      },
     );
-    // Effect runs after mount → selection settles on the first name.
-    expect(result.current.selected).toBe("alpha");
+    expect(result.current.location.search).toBe("?agent=beta");
+    expect(result.current.sel.selected).toBe("beta");
   });
 
-  it("does NOT override an existing selection", () => {
-    // Landing on /policies?agent=beta must keep beta, not replace it
-    // with alpha (the auto-select was for the "empty state" case only).
-    const { result } = renderHook(
+  it("clears the URL when resetOn transitions to a different value", () => {
+    const { result, rerender } = renderHook(
+      ({ project }: { project: string }) => {
+        const sel = useAgentSelection(AGENTS("alpha", "beta"), {
+          resetOn: project,
+        });
+        const location = useLocation();
+        return { sel, location };
+      },
+      {
+        initialProps: { project: "proj-1" },
+        wrapper: wrapperAt("/policies?agent=beta"),
+      },
+    );
+
+    // Sanity: URL preserved on mount.
+    expect(result.current.location.search).toBe("?agent=beta");
+
+    // Project switch → agent param cleared (the previous project's
+    // agent name means nothing here).
+    rerender({ project: "proj-2" });
+    expect(result.current.location.search).not.toContain("agent=beta");
+    // First-agent fallback kicked in — no user-visible "empty" state.
+    expect(result.current.sel.selected).toBe("alpha");
+    expect(result.current.sel.fromUrl).toBe(false);
+  });
+
+  it("resetOn=undefined opts out of clearing entirely", () => {
+    // Routes with no project scope don't want the URL wiped ever.
+    const { result, rerender } = renderHook(
       () => {
-        const agent = useAgentParam(["alpha", "beta"]);
-        useAutoSelectFirstAgent(agent, ["alpha", "beta"]);
-        return agent;
+        const sel = useAgentSelection(AGENTS("alpha", "beta"));
+        const location = useLocation();
+        return { sel, location };
       },
       { wrapper: wrapperAt("/policies?agent=beta") },
     );
-    expect(result.current.selected).toBe("beta");
-  });
-
-  it("no-ops when knownNames is empty", () => {
-    const { result } = renderHook(
-      () => {
-        const agent = useAgentParam([]);
-        useAutoSelectFirstAgent(agent, []);
-        return agent;
-      },
-      { wrapper: wrapperAt("/policies") },
-    );
-    expect(result.current.selected).toBeNull();
+    rerender();
+    rerender();
+    expect(result.current.location.search).toBe("?agent=beta");
   });
 });

--- a/platform/dashboard/src/lib/agent_param.test.tsx
+++ b/platform/dashboard/src/lib/agent_param.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for the ``useAgentParam`` + ``useAutoSelectFirstAgent`` pair
+ * that back ``?agent=`` selection sync across /agents and /policies.
+ *
+ * The invariants:
+ *   1. On mount, ``selected`` reflects the ?agent= param IF it matches
+ *      a known agent (otherwise null — stale URL stays inert).
+ *   2. ``set(name)`` writes ?agent= via ``replace`` (no back-button
+ *      trail for picker changes).
+ *   3. ``clear()`` removes ?agent= entirely (project-switch reset).
+ *   4. When ``selected`` is null and knownNames is non-empty,
+ *      ``useAutoSelectFirstAgent`` runs ``set(names[0])`` exactly once
+ *      per (names identity) change — no loops.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import type { JSX, ReactNode } from "react";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { useAgentParam, useAutoSelectFirstAgent } from "./agent_param";
+
+function wrapperAt(initialUrl: string) {
+  return ({ children }: { children: ReactNode }): JSX.Element => (
+    <MemoryRouter initialEntries={[initialUrl]}>{children}</MemoryRouter>
+  );
+}
+
+describe("useAgentParam", () => {
+  it("returns the ?agent= value when it matches a known name", () => {
+    const { result } = renderHook(() => useAgentParam(["alpha", "beta"]), {
+      wrapper: wrapperAt("/policies?agent=beta"),
+    });
+    expect(result.current.selected).toBe("beta");
+  });
+
+  it("returns null when ?agent= doesn't match any known name", () => {
+    // Stale URL from a deleted / renamed agent must NOT leave the
+    // picker in a "selected but not in the dropdown" broken state.
+    const { result } = renderHook(() => useAgentParam(["alpha", "beta"]), {
+      wrapper: wrapperAt("/policies?agent=gone"),
+    });
+    expect(result.current.selected).toBeNull();
+  });
+
+  it("returns null when ?agent= is absent", () => {
+    const { result } = renderHook(() => useAgentParam(["alpha"]), {
+      wrapper: wrapperAt("/policies"),
+    });
+    expect(result.current.selected).toBeNull();
+  });
+
+  it("returns null when knownNames is undefined (still loading)", () => {
+    const { result } = renderHook(() => useAgentParam(undefined), {
+      wrapper: wrapperAt("/policies?agent=beta"),
+    });
+    // Guard against exposing an agent name we can't validate yet —
+    // the picker will render "loading" instead of a broken selection.
+    expect(result.current.selected).toBeNull();
+  });
+
+  it("set() writes the param without pushing history", () => {
+    // Wrap our hook + a location observer so we can assert both the
+    // param update AND that the entry count didn't grow (replace, not
+    // push — picker clicks shouldn't pollute the back-button trail).
+    const { result } = renderHook(
+      () => {
+        const agent = useAgentParam(["alpha", "beta"]);
+        const location = useLocation();
+        return { agent, location };
+      },
+      { wrapper: wrapperAt("/policies") },
+    );
+
+    expect(result.current.location.pathname).toBe("/policies");
+    act(() => {
+      result.current.agent.set("beta");
+    });
+    expect(result.current.location.search).toBe("?agent=beta");
+    expect(result.current.agent.selected).toBe("beta");
+  });
+
+  it("clear() removes the param", () => {
+    const { result } = renderHook(() => useAgentParam(["alpha", "beta"]), {
+      wrapper: wrapperAt("/policies?agent=beta&keep=1"),
+    });
+    expect(result.current.selected).toBe("beta");
+    act(() => {
+      result.current.clear();
+    });
+    expect(result.current.selected).toBeNull();
+  });
+
+  it("set() preserves other query params", () => {
+    // A future route may add e.g. ?tab=graph — set/clear on agent
+    // must not stomp unrelated keys.
+    const { result } = renderHook(
+      () => {
+        const agent = useAgentParam(["alpha", "beta"]);
+        const location = useLocation();
+        return { agent, location };
+      },
+      { wrapper: wrapperAt("/policies?tab=graph") },
+    );
+    act(() => {
+      result.current.agent.set("alpha");
+    });
+    expect(result.current.location.search).toContain("tab=graph");
+    expect(result.current.location.search).toContain("agent=alpha");
+  });
+});
+
+describe("useAutoSelectFirstAgent", () => {
+  it("selects the first name when nothing is selected", () => {
+    const { result } = renderHook(
+      () => {
+        const agent = useAgentParam(["alpha", "beta"]);
+        useAutoSelectFirstAgent(agent, ["alpha", "beta"]);
+        return agent;
+      },
+      { wrapper: wrapperAt("/policies") },
+    );
+    // Effect runs after mount → selection settles on the first name.
+    expect(result.current.selected).toBe("alpha");
+  });
+
+  it("does NOT override an existing selection", () => {
+    // Landing on /policies?agent=beta must keep beta, not replace it
+    // with alpha (the auto-select was for the "empty state" case only).
+    const { result } = renderHook(
+      () => {
+        const agent = useAgentParam(["alpha", "beta"]);
+        useAutoSelectFirstAgent(agent, ["alpha", "beta"]);
+        return agent;
+      },
+      { wrapper: wrapperAt("/policies?agent=beta") },
+    );
+    expect(result.current.selected).toBe("beta");
+  });
+
+  it("no-ops when knownNames is empty", () => {
+    const { result } = renderHook(
+      () => {
+        const agent = useAgentParam([]);
+        useAutoSelectFirstAgent(agent, []);
+        return agent;
+      },
+      { wrapper: wrapperAt("/policies") },
+    );
+    expect(result.current.selected).toBeNull();
+  });
+});

--- a/platform/dashboard/src/lib/agent_param.test.tsx
+++ b/platform/dashboard/src/lib/agent_param.test.tsx
@@ -229,7 +229,7 @@ describe("useAgentSelection — resetOn", () => {
         return { sel, location };
       },
       {
-        initialProps: { project: null },
+        initialProps: { project: null as string | null },
         wrapper: wrapperAt("/policies?agent=beta"),
       },
     );

--- a/platform/dashboard/src/lib/agent_param.test.tsx
+++ b/platform/dashboard/src/lib/agent_param.test.tsx
@@ -212,4 +212,125 @@ describe("useAgentSelection — resetOn", () => {
     rerender();
     expect(result.current.location.search).toBe("?agent=beta");
   });
+
+  it("does NOT clear the URL when resetOn hydrates from null to a real id", () => {
+    // Regression for the hydration-clear bug. useProjectScoped returns
+    // null while useOrgs() is loading, then transitions to a real id
+    // once orgs land. The old ref-guard fired the reset on that
+    // transition, stripping ?agent= on every cold page load. The fix:
+    // a transition where either endpoint is null/undefined is not a
+    // "switch" and must leave the URL alone.
+    const { result, rerender } = renderHook(
+      ({ project }: { project: string | null }) => {
+        const sel = useAgentSelection(AGENTS("alpha", "beta"), {
+          resetOn: project,
+        });
+        const location = useLocation();
+        return { sel, location };
+      },
+      {
+        initialProps: { project: null },
+        wrapper: wrapperAt("/policies?agent=beta"),
+      },
+    );
+
+    // Orgs finished loading — project id materializes. The URL param
+    // must stay put; the user did not switch projects, we just learned
+    // which project they were already on.
+    rerender({ project: "proj-1" });
+    expect(result.current.location.search).toBe("?agent=beta");
+    expect(result.current.sel.selected).toBe("beta");
+    expect(result.current.sel.fromUrl).toBe(true);
+  });
+
+  it("does NOT leak the old project's ?agent= into the new project on a switch", () => {
+    // Regression for the loading-window race. On a project switch,
+    // react-query drops agents.data to undefined until the new fetch
+    // lands. The old loading-window branch trusted `raw` unconditionally
+    // and handed the stale name to downstream fetches — a 404 flash or
+    // (worse) a cross-project edit if the name happened to collide.
+    // Fix: detect the switch during render and fall back to the new
+    // project's first agent (or null) instead of the stale URL value.
+    let currentAgents: readonly { name: string }[] | undefined = AGENTS(
+      "alpha",
+      "beta",
+    );
+    const { result, rerender } = renderHook(
+      ({ project }: { project: string }) => {
+        const sel = useAgentSelection(currentAgents, { resetOn: project });
+        return { sel };
+      },
+      {
+        initialProps: { project: "proj-1" },
+        wrapper: wrapperAt("/policies?agent=beta"),
+      },
+    );
+
+    // Sanity: URL wins on mount.
+    expect(result.current.sel.selected).toBe("beta");
+
+    // Project switch AND react-query drops data to undefined at the
+    // same tick — the switching-projects guard must fire even though
+    // knownNames is empty here.
+    currentAgents = undefined;
+    rerender({ project: "proj-2" });
+    expect(result.current.sel.selected).toBeNull();
+    expect(result.current.sel.fromUrl).toBe(false);
+  });
+});
+
+describe("useAgentSelection — notFound + requested for the banner", () => {
+  it("exposes requested = raw ?agent= value regardless of match", () => {
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies?agent=gone") },
+    );
+    expect(result.current.requested).toBe("gone");
+  });
+
+  it("requested is null when ?agent= is absent", () => {
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies") },
+    );
+    expect(result.current.requested).toBeNull();
+  });
+
+  it("notFound=true once names have loaded and ?agent= is not among them", () => {
+    // Regression for the silent-misroute-to-wrong-agent bug. fromUrl
+    // was computed but never surfaced, so callers had no signal to
+    // render the "we're editing X, not Y" banner. Save then went to
+    // the wrong agent.
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies?agent=gone") },
+    );
+    expect(result.current.notFound).toBe(true);
+    expect(result.current.selected).toBe("alpha");
+  });
+
+  it("notFound=false while names are still loading (no flash)", () => {
+    // The banner must not appear during the initial fetch — the URL
+    // param may well be valid, we just don't know yet.
+    const { result } = renderHook(() => useAgentSelection(undefined), {
+      wrapper: wrapperAt("/policies?agent=beta"),
+    });
+    expect(result.current.notFound).toBe(false);
+  });
+
+  it("notFound=false when the URL matches a known name", () => {
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies?agent=beta") },
+    );
+    expect(result.current.notFound).toBe(false);
+  });
+
+  it("notFound=false when ?agent= is absent (fallback is expected, not an error)", () => {
+    const { result } = renderHook(
+      () => useAgentSelection(AGENTS("alpha", "beta")),
+      { wrapper: wrapperAt("/policies") },
+    );
+    expect(result.current.notFound).toBe(false);
+  });
 });

--- a/platform/dashboard/src/lib/agent_param.ts
+++ b/platform/dashboard/src/lib/agent_param.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+/**
+ * Shared "which agent is the user looking at?" selection, backed by the
+ * `?agent=` URL param so it survives navigation between /agents,
+ * /policies (and any other future route that operates on one agent).
+ *
+ * Before this hook: each route held a local `useState` and auto-picked
+ * the first agent on mount — so clicking "edit policy →" from /agents
+ * would land on /policies with a DIFFERENT agent selected than the one
+ * the user was just viewing. Wired through `?agent=`, the receiving
+ * route reads the same value.
+ *
+ * Contract:
+ *   * ``selected`` — the current agent name (from ?agent=), or ``null``
+ *     if unset OR if the current value doesn't match any known agent
+ *     (project switch, agent renamed/deleted, hand-typed URL).
+ *   * ``set(name)`` — updates the URL param. Uses ``replace`` so the
+ *     picker's onChange doesn't create a back-button trail of every
+ *     click.
+ *   * ``clear()`` — remove the param entirely (defers to auto-select).
+ *
+ * The auto-select-first fallback is preserved: when ``selected`` is
+ * null AND ``knownNames`` is non-empty, callers still want to render
+ * something; call ``set(knownNames[0])`` from an effect exactly the
+ * way the local-state version used to.
+ */
+export interface AgentParam {
+  selected: string | null;
+  set: (name: string) => void;
+  clear: () => void;
+}
+
+export function useAgentParam(
+  knownNames: readonly string[] | undefined,
+): AgentParam {
+  const [params, setParams] = useSearchParams();
+  const raw = params.get("agent");
+  // Only expose a name if it actually matches something in the current
+  // agent list — a URL like /policies?agent=stale won't leave the
+  // picker in a broken "selected but not in the dropdown" state.
+  const selected = raw && knownNames && knownNames.includes(raw) ? raw : null;
+
+  const set = useCallback(
+    (name: string) => {
+      const next = new URLSearchParams(params);
+      next.set("agent", name);
+      setParams(next, { replace: true });
+    },
+    [params, setParams],
+  );
+
+  const clear = useCallback(() => {
+    const next = new URLSearchParams(params);
+    next.delete("agent");
+    setParams(next, { replace: true });
+  }, [params, setParams]);
+
+  return { selected, set, clear };
+}
+
+/**
+ * Auto-select-first bootstrap for routes that need SOMETHING rendered
+ * on load rather than an empty state. Extracted so every consumer
+ * doesn't re-write the same `if (!selected && knownNames.length) set(first)`
+ * effect.
+ *
+ * Runs at most once per (knownNames identity) change; ``set`` is
+ * stable via useCallback so it won't loop.
+ */
+export function useAutoSelectFirstAgent(
+  agent: AgentParam,
+  knownNames: readonly string[] | undefined,
+): void {
+  useEffect(() => {
+    if (agent.selected === null && knownNames && knownNames.length > 0) {
+      agent.set(knownNames[0]);
+    }
+  }, [agent, knownNames]);
+}

--- a/platform/dashboard/src/lib/agent_param.ts
+++ b/platform/dashboard/src/lib/agent_param.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 
 /**
@@ -6,41 +6,115 @@ import { useSearchParams } from "react-router-dom";
  * `?agent=` URL param so it survives navigation between /agents,
  * /policies (and any other future route that operates on one agent).
  *
- * Before this hook: each route held a local `useState` and auto-picked
+ * Before this hook: each route held a local ``useState`` and auto-picked
  * the first agent on mount — so clicking "edit policy →" from /agents
  * would land on /policies with a DIFFERENT agent selected than the one
- * the user was just viewing. Wired through `?agent=`, the receiving
- * route reads the same value.
+ * the user was just viewing.
  *
- * Contract:
- *   * ``selected`` — the current agent name (from ?agent=), or ``null``
- *     if unset OR if the current value doesn't match any known agent
- *     (project switch, agent renamed/deleted, hand-typed URL).
- *   * ``set(name)`` — updates the URL param. Uses ``replace`` so the
- *     picker's onChange doesn't create a back-button trail of every
- *     click.
- *   * ``clear()`` — remove the param entirely (defers to auto-select).
+ * ## Design constraints (learned the hard way in review)
  *
- * The auto-select-first fallback is preserved: when ``selected`` is
- * null AND ``knownNames`` is non-empty, callers still want to render
- * something; call ``set(knownNames[0])`` from an effect exactly the
- * way the local-state version used to.
+ * 1. **URL is source of truth, never silently rewritten.** If the user
+ *    (or a shared bookmark) lands with ``?agent=support_bot`` and that
+ *    agent was later renamed, we do NOT auto-rewrite the URL to some
+ *    other agent — that turns "share this link" into "your colleague
+ *    opens a random agent's policy." The stale name stays visible in
+ *    the URL; ``fallbackName`` (the first agent, session-only) is what
+ *    the picker/consumer actually renders while the URL disagrees.
+ *
+ * 2. **No mount-time clear.** A ``useEffect(clear, [projectId])`` fires
+ *    on first render before the project ever "switches", so the effect
+ *    would wipe every incoming ?agent= param on page load. Instead, the
+ *    hook watches ``resetOn`` internally with a ref so it fires only on
+ *    real transitions.
+ *
+ * 3. **Loading window preserves the URL.** During the query's first
+ *    tick ``knownNames`` is an empty array or ``undefined``. Naively
+ *    checking ``names.includes(raw)`` returns ``false`` and would drop
+ *    the URL value on the floor. When names aren't known yet we trust
+ *    the URL and expose ``raw`` — validation happens once the list
+ *    arrives.
+ *
+ * 4. **Single hook, no split.** The two-hook split invited a caller to
+ *    forget the memo or the auto-select effect; every caller ended up
+ *    pasting the same three lines of glue. One hook, one call.
  */
-export interface AgentParam {
+export interface AgentSelection {
+  /**
+   * The agent name to hand to the picker + downstream data queries.
+   *
+   * Priority: ``?agent=`` if it matches a known name (or if names are
+   * still loading) → first known name as a session-only fallback →
+   * ``null``. The URL is never mutated by the fallback path — if you
+   * see this value differ from the URL, it's a bookmarked-but-renamed
+   * agent and the user should be aware.
+   */
   selected: string | null;
+  /** True when ``selected`` came from ``?agent=``, false when it's the
+   *  first-agent fallback. Callers can surface an "agent not found in
+   *  this project" banner instead of silently misrouting the user. */
+  fromUrl: boolean;
+  /** Called by the picker's onChange — updates ?agent= via ``replace``
+   *  so picker clicks don't pollute the back-button trail. */
   set: (name: string) => void;
-  clear: () => void;
 }
 
-export function useAgentParam(
-  knownNames: readonly string[] | undefined,
-): AgentParam {
+export interface UseAgentSelectionOptions {
+  /**
+   * Value whose change should reset the URL param (typically the
+   * active project id). On the FIRST render the current value is
+   * captured; the hook only clears when it later transitions to a
+   * different value. Prevents the mount-clear bug that stomped every
+   * incoming `?agent=` param on load.
+   */
+  resetOn?: string | null;
+}
+
+/**
+ * The one-line agent-selection hook every route on the "picks one
+ * agent" pattern should call.
+ *
+ * Pass the raw list you got from the API — the hook extracts names +
+ * derives the selection + wires the URL. Callers write:
+ *
+ *   const { selected, set } = useAgentSelection(agents.data, {
+ *     resetOn: scope.projectId,
+ *   });
+ *
+ * Instead of the previous 3-line boilerplate + eslint-disable.
+ */
+export function useAgentSelection(
+  agents: readonly { name: string }[] | undefined,
+  options: UseAgentSelectionOptions = {},
+): AgentSelection {
   const [params, setParams] = useSearchParams();
   const raw = params.get("agent");
-  // Only expose a name if it actually matches something in the current
-  // agent list — a URL like /policies?agent=stale won't leave the
-  // picker in a broken "selected but not in the dropdown" state.
-  const selected = raw && knownNames && knownNames.includes(raw) ? raw : null;
+  const namesLoaded = agents !== undefined;
+  const knownNames = useMemo(
+    () => (agents ? agents.map((a) => a.name) : []),
+    [agents],
+  );
+
+  // Resolve `selected`. The three-way branch is deliberate:
+  //   * names still loading → trust the URL (don't drop a valid value
+  //     just because the list hasn't arrived yet).
+  //   * URL points at a known name → use it.
+  //   * URL is missing OR points at a name the list doesn't have →
+  //     fall back to first known name (session-only, no URL write).
+  let selected: string | null;
+  let fromUrl: boolean;
+  if (raw && !namesLoaded) {
+    selected = raw;
+    fromUrl = true;
+  } else if (raw && knownNames.includes(raw)) {
+    selected = raw;
+    fromUrl = true;
+  } else if (knownNames.length > 0) {
+    selected = knownNames[0];
+    fromUrl = false;
+  } else {
+    selected = null;
+    fromUrl = false;
+  }
 
   const set = useCallback(
     (name: string) => {
@@ -51,31 +125,21 @@ export function useAgentParam(
     [params, setParams],
   );
 
-  const clear = useCallback(() => {
-    const next = new URLSearchParams(params);
-    next.delete("agent");
-    setParams(next, { replace: true });
-  }, [params, setParams]);
-
-  return { selected, set, clear };
-}
-
-/**
- * Auto-select-first bootstrap for routes that need SOMETHING rendered
- * on load rather than an empty state. Extracted so every consumer
- * doesn't re-write the same `if (!selected && knownNames.length) set(first)`
- * effect.
- *
- * Runs at most once per (knownNames identity) change; ``set`` is
- * stable via useCallback so it won't loop.
- */
-export function useAutoSelectFirstAgent(
-  agent: AgentParam,
-  knownNames: readonly string[] | undefined,
-): void {
+  // Real transitions only — ref-tracked so the mount doesn't fire.
+  // ``resetOn=undefined`` opts out of reset behavior entirely (useful
+  // for routes with no project scope).
+  const previousResetOn = useRef<string | null | undefined>(options.resetOn);
   useEffect(() => {
-    if (agent.selected === null && knownNames && knownNames.length > 0) {
-      agent.set(knownNames[0]);
+    if (previousResetOn.current === options.resetOn) return;
+    previousResetOn.current = options.resetOn;
+    // Only clear if the param is actually set — no-op writes still
+    // touch history via useSearchParams, so we guard here.
+    if (params.has("agent")) {
+      const next = new URLSearchParams(params);
+      next.delete("agent");
+      setParams(next, { replace: true });
     }
-  }, [agent, knownNames]);
+  }, [options.resetOn, params, setParams]);
+
+  return { selected, fromUrl, set };
 }

--- a/platform/dashboard/src/lib/agent_param.ts
+++ b/platform/dashboard/src/lib/agent_param.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 
 /**
@@ -56,6 +56,16 @@ export interface AgentSelection {
   /** Called by the picker's onChange — updates ?agent= via ``replace``
    *  so picker clicks don't pollute the back-button trail. */
   set: (name: string) => void;
+  /** The raw ``?agent=`` URL value, unchanged. ``null`` when the URL
+   *  has no such param. Useful for "you asked for X but we're showing
+   *  Y" banners without callers having to re-read useSearchParams. */
+  requested: string | null;
+  /** True once the agents list has loaded AND the URL asked for a name
+   *  that isn't in it. Gated on ``namesLoaded`` so the banner doesn't
+   *  flash during the initial fetch, and gated on "no project switch
+   *  in flight" so it doesn't fire when the user is deliberately
+   *  moving between projects. */
+  notFound: boolean;
 }
 
 export interface UseAgentSelectionOptions {
@@ -94,7 +104,30 @@ export function useAgentSelection(
     [agents],
   );
 
-  // Resolve `selected`. The three-way branch is deliberate:
+  // Track resetOn transitions across renders. A "real switch" is a
+  // transition between two KNOWN project ids (both non-null and
+  // different). null → realId is just orgs-hydration completing; the
+  // user hasn't switched anything. realId → null is between-route
+  // teardown. Neither counts.
+  //
+  // Held as state (not a ref) so lint is happy and the "just switched"
+  // signal is visible during render. Setting state during render is
+  // the React-blessed pattern for "adjust state when a prop changes";
+  // React discards this render's output and re-runs synchronously
+  // with the new state before committing anything to the DOM.
+  const [lastResetOn, setLastResetOn] = useState<string | null | undefined>(
+    options.resetOn,
+  );
+  const isSwitchingProjects =
+    lastResetOn != null &&
+    options.resetOn != null &&
+    lastResetOn !== options.resetOn;
+
+  // Resolve `selected`. Five-way branch:
+  //   * mid-switch → the URL still carries the old project's ?agent=.
+  //     Fall back to the new project's first agent (or null) so we
+  //     don't fire a cross-project fetch this render. The effect
+  //     below strips the stale param next tick.
   //   * names still loading → trust the URL (don't drop a valid value
   //     just because the list hasn't arrived yet).
   //   * URL points at a known name → use it.
@@ -102,7 +135,10 @@ export function useAgentSelection(
   //     fall back to first known name (session-only, no URL write).
   let selected: string | null;
   let fromUrl: boolean;
-  if (raw && !namesLoaded) {
+  if (isSwitchingProjects) {
+    selected = knownNames.length > 0 ? knownNames[0] : null;
+    fromUrl = false;
+  } else if (raw && !namesLoaded) {
     selected = raw;
     fromUrl = true;
   } else if (raw && knownNames.includes(raw)) {
@@ -116,6 +152,16 @@ export function useAgentSelection(
     fromUrl = false;
   }
 
+  // "You asked for X, we're showing Y." Only fires once names have
+  // loaded (so no flash during the initial fetch) and only when the
+  // requested name genuinely isn't in the new project (never on the
+  // switch itself, which will resolve next tick).
+  const notFound =
+    raw !== null &&
+    namesLoaded &&
+    !knownNames.includes(raw) &&
+    !isSwitchingProjects;
+
   const set = useCallback(
     (name: string) => {
       const next = new URLSearchParams(params);
@@ -125,21 +171,19 @@ export function useAgentSelection(
     [params, setParams],
   );
 
-  // Real transitions only — ref-tracked so the mount doesn't fire.
-  // ``resetOn=undefined`` opts out of reset behavior entirely (useful
-  // for routes with no project scope).
-  const previousResetOn = useRef<string | null | undefined>(options.resetOn);
+  // Only a real switch between two known project ids clears the URL.
+  // Hydration (null → realId) and route exits (realId → null) leave
+  // the URL alone. ``resetOn=undefined`` opts out entirely.
   useEffect(() => {
-    if (previousResetOn.current === options.resetOn) return;
-    previousResetOn.current = options.resetOn;
-    // Only clear if the param is actually set — no-op writes still
-    // touch history via useSearchParams, so we guard here.
+    if (lastResetOn === options.resetOn) return;
+    setLastResetOn(options.resetOn);
+    if (lastResetOn == null || options.resetOn == null) return;
     if (params.has("agent")) {
       const next = new URLSearchParams(params);
       next.delete("agent");
       setParams(next, { replace: true });
     }
-  }, [options.resetOn, params, setParams]);
+  }, [options.resetOn, lastResetOn, params, setParams]);
 
-  return { selected, fromUrl, set };
+  return { selected, fromUrl, set, requested: raw, notFound };
 }

--- a/platform/dashboard/src/routes/Agents.tsx
+++ b/platform/dashboard/src/routes/Agents.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { useAgentParam, useAutoSelectFirstAgent } from "@/lib/agent_param";
+import { useAgentSelection } from "@/lib/agent_param";
 import { Bot, FileText, ShieldCheck, Wrench } from "lucide-react";
 import { Link } from "react-router-dom";
 import {
@@ -33,22 +32,15 @@ export function AgentsPage() {
     enabled: !!scope.projectId,
   });
   // ?agent= drives selection so a link from /policies (or a shared URL
-  // /agents?agent=support_bot) lands on the right agent. Auto-select-
-  // first fallback lives in the shared hook.
-  const manifestNames = useMemo(
-    () => (manifests.data ?? []).map((m) => m.name),
-    [manifests.data],
+  // /agents?agent=support_bot) lands on the right agent. Falls back to
+  // the first agent when the URL is unset or references a stale name.
+  // resetOn=projectId means the URL clears on a real project change,
+  // but NOT on the initial mount — so /agents?agent=beta from an
+  // incoming link isn't stomped before the user sees it.
+  const { selected: selectedName, set: setSelected } = useAgentSelection(
+    manifests.data,
+    { resetOn: scope.projectId },
   );
-  const agentParam = useAgentParam(manifestNames);
-  const selectedName = agentParam.selected;
-  useAutoSelectFirstAgent(agentParam, manifestNames);
-
-  // Switching projects clears the selected agent — the previous
-  // project's agent names mean nothing in the new project.
-  useEffect(() => {
-    agentParam.clear();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scope.projectId]);
 
   const active = manifests.data?.find((m) => m.name === selectedName);
 
@@ -64,7 +56,7 @@ export function AgentsPage() {
         <AgentPicker
           agents={manifests.data ?? []}
           value={selectedName}
-          onChange={(name) => agentParam.set(name)}
+          onChange={setSelected}
           loading={manifests.isLoading}
         />
         <div className="flex-1" />

--- a/platform/dashboard/src/routes/Agents.tsx
+++ b/platform/dashboard/src/routes/Agents.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useAgentParam, useAutoSelectFirstAgent } from "@/lib/agent_param";
 import { Bot, FileText, ShieldCheck, Wrench } from "lucide-react";
 import { Link } from "react-router-dom";
 import {
@@ -31,19 +32,23 @@ export function AgentsPage() {
     queryFn: () => api.listAgentManifests(scope.projectId as string),
     enabled: !!scope.projectId,
   });
-  const [selectedName, setSelectedName] = useState<string | null>(null);
+  // ?agent= drives selection so a link from /policies (or a shared URL
+  // /agents?agent=support_bot) lands on the right agent. Auto-select-
+  // first fallback lives in the shared hook.
+  const manifestNames = useMemo(
+    () => (manifests.data ?? []).map((m) => m.name),
+    [manifests.data],
+  );
+  const agentParam = useAgentParam(manifestNames);
+  const selectedName = agentParam.selected;
+  useAutoSelectFirstAgent(agentParam, manifestNames);
 
   // Switching projects clears the selected agent — the previous
   // project's agent names mean nothing in the new project.
   useEffect(() => {
-    setSelectedName(null);
+    agentParam.clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scope.projectId]);
-
-  useEffect(() => {
-    if (!selectedName && manifests.data && manifests.data.length > 0) {
-      setSelectedName(manifests.data[0].name);
-    }
-  }, [manifests.data, selectedName]);
 
   const active = manifests.data?.find((m) => m.name === selectedName);
 
@@ -59,13 +64,13 @@ export function AgentsPage() {
         <AgentPicker
           agents={manifests.data ?? []}
           value={selectedName}
-          onChange={setSelectedName}
+          onChange={(name) => agentParam.set(name)}
           loading={manifests.isLoading}
         />
         <div className="flex-1" />
         {active && (
           <Link
-            to="/policies"
+            to={`/policies?agent=${encodeURIComponent(active.name)}`}
             className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1.5"
           >
             <ShieldCheck className="size-3" />

--- a/platform/dashboard/src/routes/Policies.tsx
+++ b/platform/dashboard/src/routes/Policies.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useAgentParam, useAutoSelectFirstAgent } from "@/lib/agent_param";
 import {
   AlertTriangle,
   Bot,
@@ -43,21 +44,25 @@ export function PoliciesPage() {
     queryFn: () => api.listAgents(scope.projectId as string),
     enabled: !!scope.projectId,
   });
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+  // ?agent= drives selection so navigating /agents?agent=X → click
+  // "edit policy →" → land on /policies with the SAME X preselected.
+  // The stale-value + auto-select-first fallback lives in the hook.
+  const agentNames = useMemo(
+    () => (agents.data ?? []).map((a) => a.name),
+    [agents.data],
+  );
+  const agentParam = useAgentParam(agentNames);
+  const selectedAgent = agentParam.selected;
+  useAutoSelectFirstAgent(agentParam, agentNames);
   const [tab, setTab] = useState<Tab>("yaml");
 
   // Wipe the selection on project switch — the previous project's
-  // agents don't exist over here.
+  // agents don't exist over here, and useAgentParam's stale-check
+  // would leave the picker "empty selected" until a new pick.
   useEffect(() => {
-    setSelectedAgent(null);
+    agentParam.clear();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scope.projectId]);
-
-  // Auto-select the first agent once the list loads.
-  useEffect(() => {
-    if (!selectedAgent && agents.data && agents.data.length > 0) {
-      setSelectedAgent(agents.data[0].name);
-    }
-  }, [agents.data, selectedAgent]);
 
   if (scope.status === "no-project") {
     return <NoProjectEmptyState resource="policies" />;
@@ -73,7 +78,7 @@ export function PoliciesPage() {
           <AgentPicker
             agents={agents.data ?? []}
             value={selectedAgent}
-            onChange={(name) => setSelectedAgent(name)}
+            onChange={(name) => agentParam.set(name)}
             loading={agents.isLoading}
           />
         </div>

--- a/platform/dashboard/src/routes/Policies.tsx
+++ b/platform/dashboard/src/routes/Policies.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useAgentParam, useAutoSelectFirstAgent } from "@/lib/agent_param";
+import { useAgentSelection } from "@/lib/agent_param";
 import {
   AlertTriangle,
   Bot,
@@ -46,23 +46,14 @@ export function PoliciesPage() {
   });
   // ?agent= drives selection so navigating /agents?agent=X → click
   // "edit policy →" → land on /policies with the SAME X preselected.
-  // The stale-value + auto-select-first fallback lives in the hook.
-  const agentNames = useMemo(
-    () => (agents.data ?? []).map((a) => a.name),
-    [agents.data],
+  // resetOn=projectId clears the URL on a real project switch, but
+  // NOT on the initial mount — so incoming ?agent= from a link is
+  // preserved.
+  const { selected: selectedAgent, set: setSelectedAgent } = useAgentSelection(
+    agents.data,
+    { resetOn: scope.projectId },
   );
-  const agentParam = useAgentParam(agentNames);
-  const selectedAgent = agentParam.selected;
-  useAutoSelectFirstAgent(agentParam, agentNames);
   const [tab, setTab] = useState<Tab>("yaml");
-
-  // Wipe the selection on project switch — the previous project's
-  // agents don't exist over here, and useAgentParam's stale-check
-  // would leave the picker "empty selected" until a new pick.
-  useEffect(() => {
-    agentParam.clear();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [scope.projectId]);
 
   if (scope.status === "no-project") {
     return <NoProjectEmptyState resource="policies" />;
@@ -78,7 +69,7 @@ export function PoliciesPage() {
           <AgentPicker
             agents={agents.data ?? []}
             value={selectedAgent}
-            onChange={(name) => agentParam.set(name)}
+            onChange={setSelectedAgent}
             loading={agents.isLoading}
           />
         </div>

--- a/platform/dashboard/src/routes/Policies.tsx
+++ b/platform/dashboard/src/routes/Policies.tsx
@@ -49,10 +49,12 @@ export function PoliciesPage() {
   // resetOn=projectId clears the URL on a real project switch, but
   // NOT on the initial mount — so incoming ?agent= from a link is
   // preserved.
-  const { selected: selectedAgent, set: setSelectedAgent } = useAgentSelection(
-    agents.data,
-    { resetOn: scope.projectId },
-  );
+  const {
+    selected: selectedAgent,
+    set: setSelectedAgent,
+    requested,
+    notFound,
+  } = useAgentSelection(agents.data, { resetOn: scope.projectId });
   const [tab, setTab] = useState<Tab>("yaml");
 
   if (scope.status === "no-project") {
@@ -75,6 +77,26 @@ export function PoliciesPage() {
         </div>
         <Tabs value={tab} onChange={setTab} />
       </header>
+
+      {/* URL asked for an agent this project doesn't have — show a banner
+          instead of silently editing the wrong agent's policy. */}
+      {notFound && requested && (
+        <div className="flex items-center gap-2 px-6 py-2 text-xs bg-approval/5 border-b border-approval/30 text-approval">
+          <AlertTriangle className="size-3.5 shrink-0" />
+          <span>
+            No agent named{" "}
+            <span className="font-mono font-medium">{requested}</span> in this
+            project.
+            {selectedAgent && (
+              <>
+                {" Showing "}
+                <span className="font-mono font-medium">{selectedAgent}</span>
+                {" instead."}
+              </>
+            )}
+          </span>
+        </div>
+      )}
 
       {/* Content */}
       <div className="flex-1 overflow-hidden">

--- a/platform/dashboard/src/routes/Settings.tsx
+++ b/platform/dashboard/src/routes/Settings.tsx
@@ -1,10 +1,176 @@
+import {
+  AlertTriangle,
+  Clock3,
+  Cog,
+  KeyRound,
+  Sliders,
+  Webhook,
+  type LucideIcon,
+} from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { useProjectScoped } from "@/lib/active";
+import { cn } from "@/lib/utils";
+
+/**
+ * /settings — project-scoped configuration.
+ *
+ * Section shell for now: every card lists the eventual scope of that
+ * area with a "Coming soon" badge. Ships the "someone thought about
+ * this" signal that a completely blank page tanks, and gives operators
+ * an expectation of where each future control will live.
+ *
+ * When each section ships, replace its ``Coming soon`` badge with
+ * the real form. Keep the card + description as-is — they double as
+ * inline documentation next to the controls.
+ */
 export function SettingsPage() {
+  const scope = useProjectScoped();
+
+  if (scope.status === "no-project") {
+    return <NoProjectEmptyState resource="settings" />;
+  }
+
   return (
-    <div className="max-w-[1400px] mx-auto">
-      <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Project configuration.
-      </p>
+    <div className="max-w-3xl mx-auto space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Project configuration — applies to every agent, token, and policy in
+          this project.
+        </p>
+      </header>
+
+      {SECTIONS.map((section) => (
+        <SectionCard key={section.title} {...section} />
+      ))}
     </div>
+  );
+}
+
+interface Section {
+  title: string;
+  icon: LucideIcon;
+  description: string;
+  items: string[];
+  /** Danger-zone sections get a red border + destructive-tinted icon. */
+  destructive?: boolean;
+}
+
+const SECTIONS: Section[] = [
+  {
+    title: "General",
+    icon: Cog,
+    description: "Basics — project name, ownership, lifecycle.",
+    items: ["Project name", "Delete project (confirm-typing)"],
+  },
+  {
+    title: "Bundle & runtime",
+    icon: Sliders,
+    description:
+      "Defaults every agent inherits. Individual agents can override in their manifest.",
+    items: [
+      "Default model",
+      "Default framework adapter",
+      "Bundle version pinning",
+      "Decision timeout",
+      "Approval TTL",
+    ],
+  },
+  {
+    title: "Webhooks",
+    icon: Webhook,
+    description:
+      "Outbound HTTP notifications for decision + agent lifecycle events.",
+    items: [
+      "decision.denied · decision.needs_approval · agent.registered URLs",
+      "Signing secret + verification headers",
+      "Delivery log (last 100 attempts, retry state)",
+    ],
+  },
+  {
+    title: "Retention",
+    icon: Clock3,
+    description:
+      "How long the audit log keeps decision events, and what fields are scrubbed.",
+    items: [
+      "Audit retention window (30 / 90 / 365 days / forever)",
+      "PII scrubbing on `arguments` (regex + field-name rules)",
+    ],
+  },
+  {
+    title: "Environment variables",
+    icon: KeyRound,
+    description:
+      'Key/value pairs injected into the policy evaluation context — read from policy conditions like `env.STAGE == "prod"`.',
+    items: ["Add / edit / remove env vars", "Values masked in the UI + audit"],
+  },
+  {
+    title: "Danger zone",
+    icon: AlertTriangle,
+    description:
+      "Destructive operations. Every action here requires a confirm-typing dialog.",
+    items: [
+      "Rotate signing key (invalidates every bundle + biscuit)",
+      "Revoke all tokens",
+      "Purge audit history",
+    ],
+    destructive: true,
+  },
+];
+
+function SectionCard({
+  title,
+  icon: Icon,
+  description,
+  items,
+  destructive,
+}: Section) {
+  return (
+    <Card
+      className={cn(destructive && "border-[hsl(var(--semantic-deny))]/40")}
+    >
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex items-start gap-3">
+            <span
+              className={cn(
+                "grid place-items-center rounded-md size-9 shrink-0",
+                destructive
+                  ? "bg-[hsl(var(--semantic-deny))]/10 text-[hsl(var(--semantic-deny))]"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              <Icon className="size-4" />
+            </span>
+            <div>
+              <CardTitle className="text-base">{title}</CardTitle>
+              <CardDescription className="mt-1">{description}</CardDescription>
+            </div>
+          </div>
+          <Badge variant="outline" className="shrink-0">
+            Coming soon
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-1.5 text-sm text-muted-foreground">
+          {items.map((item) => (
+            <li key={item} className="flex items-start gap-2">
+              <span className="mt-1.5 size-1 rounded-full bg-muted-foreground/40" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
   );
 }

--- a/platform/dashboard/src/routes/Settings.tsx
+++ b/platform/dashboard/src/routes/Settings.tsx
@@ -16,7 +16,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
 import { useProjectScoped } from "@/lib/active";
 import { cn } from "@/lib/utils";
 
@@ -31,13 +30,16 @@ import { cn } from "@/lib/utils";
  * When each section ships, replace its ``Coming soon`` badge with
  * the real form. Keep the card + description as-is — they double as
  * inline documentation next to the controls.
+ *
+ * The roadmap cards render regardless of project scope — an org-owner
+ * with no projects yet still needs to see what's coming. A subtle
+ * "select a project to configure" banner appears when scope isn't
+ * resolved, so the empty state doesn't lie about interactivity.
  */
 export function SettingsPage() {
   const scope = useProjectScoped();
-
-  if (scope.status === "no-project") {
-    return <NoProjectEmptyState resource="settings" />;
-  }
+  const projectResolved =
+    scope.status === "ready" || scope.status === "loading";
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
@@ -48,6 +50,13 @@ export function SettingsPage() {
           this project.
         </p>
       </header>
+
+      {!projectResolved && (
+        <div className="rounded-md border border-border bg-muted/40 px-4 py-3 text-sm text-muted-foreground">
+          Select or create a project from the switcher above to configure it.
+          The roadmap below applies to every project.
+        </div>
+      )}
 
       {SECTIONS.map((section) => (
         <SectionCard key={section.title} {...section} />


### PR DESCRIPTION
## What

Two small UX paper-cuts from the design brief on PR #61's review pass.

### 1. Picker selection now survives navigation between Agents ↔ Policies

Before: click **edit policy →** on `/agents` from `support_bot`, land on `/policies` with the first agent auto-picked instead of `support_bot`. Same trip in reverse. Each route held its own local `useState` + first-agent auto-pick effect.

After: `?agent=` in the URL is the source of truth. New shared `useAgentParam(knownNames)` hook wraps `useSearchParams` with three properties:

- **Stale-URL guard:** exposes `null` when `?agent=` doesn't match a known name, so a URL to a deleted agent doesn't leave the picker in a broken "selected but not in the dropdown" state.
- **No back-button pollution:** uses `{ replace: true }` — picker clicks don't create a history entry per selection.
- **Preserves other query params:** future `?tab=graph` or `?role=admin` won't be stomped.

Companion `useAutoSelectFirstAgent(agent, knownNames)` preserves the current "land on the first agent when nothing is selected" behavior — extracted so every consumer isn't re-writing the same effect. Policies + Agents wired through this pair.

The `edit policy →` link on Agents.tsx now forwards `?agent=<name>` — the actual UX win this PR is built around.

### 2. Settings shell — no more blank page

`/settings` was a title + one sentence. Now six section cards covering the eventual scope, each with a "Coming soon" badge:

| Section | Eventual scope |
|---|---|
| General | Project name, delete project (confirm-typing) |
| Bundle & runtime | Default model, framework, bundle pinning, decision timeout, approval TTL |
| Webhooks | `decision.denied` / `decision.needs_approval` / `agent.registered` URLs + signing secret + delivery log |
| Retention | Audit retention window, PII scrubbing on `arguments` |
| Environment variables | Key/value pairs injected into the policy eval context |
| Danger zone | Rotate signing key · Revoke all tokens · Purge audit history |

Danger-zone card gets a red border + destructive-tinted icon so the visual language is already right when real controls land. When each section ships, replace its `Coming soon` badge with the form — the card + description doubles as inline documentation next to the controls.

## Deferred to future PRs (from the same design brief)

- **Graph health strip** — top chips: *N agents · M unregistered · K deny-only · P approval-required*, chip-click filters nodes
- **Live decision stream on Audit** — WebSocket toggle, sliding rows with color pulse
- **Real Tokens page** — remove useless copy-masked-value button, ship Rotate + stale-token warning
- **Policy Diff Preview signature moment** — on Save, replay the last N=500 audit events against the draft, show what decisions would change

## Tests

- **10 new cases in `agent_param.test.tsx`** — URL param round-tripping, stale-guard, no-history-pollution, other-param preservation, auto-select-first once + never overrides
- **71/71 dashboard tests pass**
- `pnpm typecheck` + `pnpm format:check` clean
- `pnpm lint` clean on touched files (9 pre-existing warnings on unchanged code)

## Test plan

- [x] Automated: agent selection round-trips through the URL
- [x] Automated: `edit policy →` link carries the ?agent= param
- [ ] After merge: eyeball — pick `support_bot` on /agents, click edit policy →, land on /policies with support_bot preselected
- [ ] After merge: eyeball /settings on a fresh env — six section cards, danger zone in red