### PR TITLE
feat(playground): route approval_required tool calls to the connected tab

### DIFF
--- a/deploy/serve_manager.py
+++ b/deploy/serve_manager.py
@@ -70,26 +70,31 @@ def _demo_settings():
 
 def _run(agent_obj) -> None:
     global _loop, _task, _status
-    from hexgate.cli._common import (
-        build_approval_handler,
-        build_runtime_from_local_agent,
-    )
-    from hexgate.cli.serve import run_serve
+    from hexgate.cli._common import build_runtime_from_local_agent
+    from hexgate.cli.serve import RelayApprovalHandler, run_serve
     from rich.console import Console
 
     _loop = asyncio.new_event_loop()
     asyncio.set_event_loop(_loop)
     try:
         settings = _demo_settings()
+        # Same default as `hexgate serve` (see hexgate/cli/serve.py): route
+        # NEEDS_APPROVAL to the connected playground tab via the WS relay.
+        # Without this the notebook BYOK container silently auto-approved
+        # every approval_required tool — the demo would ship the wrong
+        # security contract.
+        approval_handler = RelayApprovalHandler()
         runtime = build_runtime_from_local_agent(
             settings,
             agent_obj=agent_obj,
             description=None,
-            approval_handler=build_approval_handler(Console(), "auto-approve"),
+            approval_handler=approval_handler,
             auto_register=True,  # idempotent register of the agent manifest
             console=Console(),
         )
-        _task = _loop.create_task(run_serve(runtime))
+        _task = _loop.create_task(
+            run_serve(runtime, approval_handler=approval_handler)
+        )
         _status = "running"
         _loop.run_until_complete(_task)
     except asyncio.CancelledError:

--- a/docs/concepts/approval-frameworks-compared.mdx
+++ b/docs/concepts/approval-frameworks-compared.mdx
@@ -69,4 +69,3 @@ The other thing worth calling out is that approval is one of three policy outcom
 - `SlackApprovalHandler`: post an approval request to a channel and treat a reaction as the answer.
 - Per-tool RBAC on approvers, so a policy can require a specific role rather than "any human".
 - Auto-approve rules for repeat identical calls, with an audit note. Opt-in, since some regulated tenants explicitly do not want this.
-- Callback plumbing on the OpenAI Agents, Pydantic AI, and Google ADK adapters.

--- a/docs/concepts/approval-frameworks-compared.mdx
+++ b/docs/concepts/approval-frameworks-compared.mdx
@@ -1,74 +1,72 @@
 ---
-title: "Approval — how other frameworks do it"
-description: "An honest comparison of the approval primitive across OpenAI Agents SDK, LangGraph, Pydantic AI, and Claude Code."
+title: "Approval in other frameworks"
+description: "How OpenAI Agents SDK, LangGraph, Pydantic AI, and Claude Code approach human-in-the-loop, and where Hexgate fits."
 ---
 
-Every serious agent framework has an approval story. They differ on what they optimize for — durability, framework-native ergonomics, protocol coupling — and each design has a cost. This page names the tradeoffs we accepted and the ones we didn't.
+Most serious agent frameworks now ship some form of human-in-the-loop approval. They approach it differently depending on what they own (the whole runtime, a graph, just the tool interface). This page walks through each one so you can pick the right primitive for your setup, or understand what Hexgate is trading off if you're already using one of them.
 
-## TL;DR
+## At a glance
 
-| Framework | Primitive | Durable across process restart | State a dev must configure | Concepts to learn |
+| Framework | Primitive | Durable across a restart | State you configure | Concepts you learn |
 |---|---|---|---|---|
-| **Hexgate** | `async fn(decision) -> bool` callback | No (v1) | None — memory-scoped | 1 (the callback) |
-| **OpenAI Agents SDK** | `needs_approval=True` + `RunState.approve()` after `InterruptionEvent` | Yes (serialize `RunState`) | Pick a serialization sink | 4 (needs_approval flag, InterruptionEvent, RunState, approve/reject) |
-| **LangGraph** | `interrupt()` + `Command(resume=...)` | Yes (via checkpointer) | Configure checkpointer (in-memory / SQLite / Postgres) | 4 (interrupt, thread_id, checkpointer, resume) |
-| **Pydantic AI** | Raise `ModelRetry` from the tool | No | None | 2 (ModelRetry exception, retry handling) |
-| **Claude Code** | Terminal prompt in the loop | No | None | 0 (implicit) |
+| Hexgate | `async fn(decision) -> bool` callback | No (v1) | None, memory-scoped | 1 |
+| OpenAI Agents SDK | `needs_approval=True` on the tool, then `RunState.approve()` after an `InterruptionEvent` | Yes, by serializing `RunState` | Pick a serialization sink | 4 |
+| LangGraph | `interrupt()` inside a node, then `Command(resume=...)` | Yes, via the checkpointer | Configure a checkpointer (in-memory, SQLite, Postgres) | 4 |
+| Pydantic AI | Raise `ModelRetry` from the tool | No | None | 2 |
+| Claude Code | Terminal prompt in the run loop | No | None | 0 (implicit) |
 
-## Why we chose a callback
+## OpenAI Agents SDK
 
-Every framework except Hexgate ties approval to some in-house state model — `RunState`, checkpointer threads, `ModelRetry` — because they own the agent loop. Hexgate is a policy layer that sits alongside the agent framework you already picked. We can't hand you our `RunState`; we can hand you a callable slot.
+Mark a tool with `needs_approval=True`. Run the agent. When the model asks to call that tool, the run yields an `InterruptionEvent` and pauses. You call `RunState.approve(tool_call)` or `RunState.reject(tool_call)` and resume. Full details in the [Agents SDK docs](https://openai.github.io/openai-agents-python/human_in_the_loop/).
 
-The cost: no cross-process durability at v1. If the process that called the tool dies, the pending approval dies with it. In exchange: zero infrastructure to configure, one concept to teach, works identically whether you run in a notebook, a CLI, `hexgate serve`, or an API worker.
+The nice thing about this design is that `RunState` serializes cleanly. You can pickle it, hand it to a different process, approve it a day later, and resume. That is genuinely useful when the approver is a person on a mobile app, not a developer at a REPL.
 
-Durability lands as a future `PlatformApprovalHandler` — same callback slot, backed by Postgres. Ships when demand shows up.
+The cost is that the approval intent lives on the tool decorator in code, not in a policy file. Changing what needs approval means editing (and shipping) code. And there are four concepts to hold in your head: the flag on the tool, the interruption event, the run state, and the approve/reject methods.
 
-## Compared to OpenAI Agents SDK
+## LangGraph
 
-Their model: mark a tool with `needs_approval=True`, run the agent, get an `InterruptionEvent`, call `RunState.approve(tool_call)` or `RunState.reject(tool_call)`, resume with the mutated state. Full docs: [openai.github.io/openai-agents-python — human-in-the-loop](https://openai.github.io/openai-agents-python/human_in_the_loop/).
+Inside a node, call `interrupt(payload)`. LangGraph raises a `GraphInterrupt`, the checkpointer persists the graph state under a `thread_id`, and you resume with `graph.invoke(Command(resume=answer), {"configurable": {"thread_id": ...}})`. Full details in the [LangGraph how-to](https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/breakpoints/).
 
-**Where theirs wins.** `RunState` serializes cleanly. Approve a call from a different process — different host, next day — and resume. That is genuinely nice for overnight human review.
+If your app is already LangGraph-native, this is the obvious choice. The checkpointer is pluggable (SQLite, Postgres, Redis) and it persists the whole graph state, not just tool calls. That covers use cases beyond approval, like resuming a long research task after a crash.
 
-**Where ours wins.** Their model requires the tool decorator to declare approval intent; ours reads it from YAML at bind time, so a policy change doesn't touch tool code. Four concepts (`needs_approval`, `InterruptionEvent`, `RunState`, `approve`) collapse to one (`async fn(decision) -> bool`). And approval is one policy outcome among three (`allow` / `deny` / `approval_required`) — not a separate feature grafted on top.
+LangGraph does not ship the notification side of the story though. Nothing pings Slack, sends an email, or wakes a webhook. That's yours to build on top.
 
-## Compared to LangGraph
+## Pydantic AI
 
-Their model: call `interrupt(payload)` inside a node, LangGraph raises a `GraphInterrupt`, the checkpointer persists graph state under a `thread_id`, resume with `graph.invoke(Command(resume=answer), {"configurable": {"thread_id": ...}})`. Full docs: [langchain-ai.github.io/langgraph — human-in-the-loop](https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/breakpoints/).
+Pydantic AI reuses one primitive for several jobs. Raise `ModelRetry` from inside a tool and the agent re-prompts the model with the exception message. You can wedge approval into this by raising `ModelRetry("this needs approval, come back to it later")`, but it's a workaround. Details in the [Pydantic AI tools docs](https://ai.pydantic.dev/tools/).
 
-**Where theirs wins.** The checkpointer is pluggable — SQLite, Postgres, Redis — and covers the whole graph, not just tool calls. If your app is already LangGraph-native, you'll want `interrupt()`.
+Nothing to configure, which is nice. The tradeoff is that approval, retry, and correction all look the same in your logs. If you ever need to audit "which tool calls required approval last quarter", grep will not save you.
 
-**Where ours wins.** No checkpointer to configure and no `thread_id` to manage. LangGraph's out-of-the-box story ships nothing that notifies the approver — you build the Slack post / email / webhook yourself. Our callback IS the notification: the same handler that decides whether to approve also decides how to reach the human.
+## Claude Code
 
-## Compared to Pydantic AI
+Claude Code is a CLI. Every dangerous tool call prints a prompt to the terminal and waits for `y` or `n`. There is no library API because the loop itself owns the UI.
 
-Their model: overload `ModelRetry` — raise it from inside the tool and the agent re-prompts the model with the message. Full docs: [ai.pydantic.dev — tools](https://ai.pydantic.dev/tools/).
+The design lesson here is that "no infrastructure" beats "durable" for the developer-loop case. Most approvals happen at a REPL, in a CLI, in a playground. Nobody is overnight-approving from a notebook, so optimizing for the interactive path first is right.
 
-**Where theirs wins.** Nothing to configure — the exception is the whole feature.
+Hexgate borrowed the startup warning: if the loaded policy declares any tool as `approval_required` and no handler is bound, `hexgate serve` logs a loud message at boot instead of silently auto-approving.
 
-**Where ours wins.** Approval and retry are different domains. `ModelRetry` is grep-invisible when you're auditing "which tools require approval?" — one exception type covers correction, backoff, and human-in-the-loop indistinguishably. Ours emits a distinct `Decision(outcome=NEEDS_APPROVAL)` object into the audit trail; a compliance query for "every approval-required call last quarter" is a straight ClickHouse `SELECT`.
+## Where Hexgate fits
 
-## Compared to Claude Code
+Hexgate sits alongside whichever agent framework you already picked. We do not own the run loop, so we cannot hand you our own `RunState` to serialize. What we can hand you is a callable slot, `async fn(decision) -> bool`, that fires whenever a tool call needs approval.
 
-Their model: the terminal is the approval sink. Every dangerous tool call prints a prompt; the user hits `y` or `n`. No library API; the loop owns the UI.
+That trades cross-process durability for zero infrastructure. If the process that called the tool dies, the pending approval dies with it. In exchange, there is nothing to configure. The same callback works in a notebook, in a CLI, behind `hexgate serve`, or inside an API worker.
 
-**What we stole.** The insight that "no infra" beats "durable" for the developer-loop case. Most approvals happen during dev, in a REPL / CLI / playground; nobody's overnight-approving in a notebook. Optimizing for that path first is right.
+If your approvers are humans clicking a button in a playground or dev tool during the session, this is enough. If they are people who might respond hours later from a mobile app, you probably want either LangGraph's checkpointer or the durable `PlatformApprovalHandler` on our roadmap (same callback slot, backed by Postgres).
 
-**Where ours differs.** Claude Code IS a CLI. Hexgate is a library — we ship the same callback slot to notebook, CLI, `hexgate serve`, FastAPI worker, and (eventually) Postgres-backed background jobs. Same primitive; the sink changes.
+The other thing worth calling out is that approval is one of three policy outcomes (`allow`, `deny`, `approval_required`), all declared in YAML. In frameworks where approval is a separate feature grafted onto the tool interface, changing what needs approval is a code edit. In Hexgate it's a policy change.
 
-We also copied their startup warning: if your policy declares `approval_required` but you passed no handler, `hexgate serve` shouts about it at boot instead of silently auto-approving (which is exactly the bug that motivated the callback in the first place).
+## Things to watch
 
-## Points of vigilance
+- **`approval_handler=True` is a footgun.** It approves everything. Grep for it in CI.
+- **No cross-process durability at v1.** If the serving process dies, the pending prompt is lost. Hexgate fails the tool call closed, but the human never sees the request.
+- **The handler runs inside the agent turn.** A slow handler stalls the whole turn including streaming tokens. Wrap blocking work in `asyncio.to_thread` and cap external calls with `asyncio.wait_for`.
+- **Framework-native primitives still fire underneath.** If a LangGraph tool uses `interrupt()` internally, that still runs after Hexgate's callback returns. The two compose, they do not replace each other.
+- **Parallel tool calls emit parallel approvals.** GPT-5.4, Claude 4.7, and LangGraph's default `ToolNode` all fan out via `asyncio.gather`. Your handler will be called concurrently with different `Decision` objects. Key any state by decision content, never by array index.
 
-- **The callback's simplicity is also a footgun.** `approval_handler=True` bypasses every prompt in one keystroke. Search for it in CI; it's the fastest way to accidentally ship a policy that reads "approval-required" but behaves like "allow".
-- **No cross-process durability at v1.** If the process serving the approval dies (host reboot, container OOM, `hexgate serve` restart) the pending prompt is lost. The framework fails-closed on the tool call — but the human never sees the request.
-- **The handler runs inside the agent turn.** A slow handler stalls the whole turn (streaming tokens included). Wrap everything blocking in `asyncio.to_thread` and cap external calls with `asyncio.wait_for`.
-- **Framework-native primitives still fire underneath.** If you use LangGraph's `interrupt()` inside a tool, our callback fires first, then `interrupt()` fires when the tool actually runs. The primitives compose, they don't replace each other.
-- **Concurrent parallel tool calls emit multiple simultaneous requests.** GPT-5.4, Claude 4.7, and LangGraph's default `ToolNode` all fan out via `asyncio.gather`. Your handler will be invoked concurrently — key state by decision content, not by array position.
+## On the roadmap
 
-## What's on the roadmap
-
-- **`PlatformApprovalHandler`** — Postgres-backed pending-approvals table. Same callback slot; the sink survives process restarts. Unlocks webhook / Slack / mobile / overnight approvers. Ships when a customer asks.
-- **`SlackApprovalHandler`** — post `approval.request` to a channel, treat a reaction as `approval.reply`. First-party implementation on top of the callback.
-- **Per-tool RBAC approvers.** A policy field like `approvers: [role: finance-approver]` so the handler receives the required approver set. Today the callback decides for itself.
-- **Auto-classifier for repeat approvals.** Detect "same tool, same arguments, approved N times → auto-approve the (N+1)th with an audit note". Optional; some regulated tenants explicitly don't want this.
-- **Callback plumbing on non-LangChain adapters.** OpenAI Agents / Pydantic AI / Google ADK adapters have the same slot; each is one small PR to wire.
+- `PlatformApprovalHandler`: Postgres-backed pending queue, same callback slot. Unlocks webhook, Slack, mobile, and overnight approvers.
+- `SlackApprovalHandler`: post an approval request to a channel and treat a reaction as the answer.
+- Per-tool RBAC on approvers, so a policy can require a specific role rather than "any human".
+- Auto-approve rules for repeat identical calls, with an audit note. Opt-in, since some regulated tenants explicitly do not want this.
+- Callback plumbing on the OpenAI Agents, Pydantic AI, and Google ADK adapters.

--- a/docs/concepts/approval-frameworks-compared.mdx
+++ b/docs/concepts/approval-frameworks-compared.mdx
@@ -1,0 +1,74 @@
+---
+title: "Approval — how other frameworks do it"
+description: "An honest comparison of the approval primitive across OpenAI Agents SDK, LangGraph, Pydantic AI, and Claude Code."
+---
+
+Every serious agent framework has an approval story. They differ on what they optimize for — durability, framework-native ergonomics, protocol coupling — and each design has a cost. This page names the tradeoffs we accepted and the ones we didn't.
+
+## TL;DR
+
+| Framework | Primitive | Durable across process restart | State a dev must configure | Concepts to learn |
+|---|---|---|---|---|
+| **Hexgate** | `async fn(decision) -> bool` callback | No (v1) | None — memory-scoped | 1 (the callback) |
+| **OpenAI Agents SDK** | `needs_approval=True` + `RunState.approve()` after `InterruptionEvent` | Yes (serialize `RunState`) | Pick a serialization sink | 4 (needs_approval flag, InterruptionEvent, RunState, approve/reject) |
+| **LangGraph** | `interrupt()` + `Command(resume=...)` | Yes (via checkpointer) | Configure checkpointer (in-memory / SQLite / Postgres) | 4 (interrupt, thread_id, checkpointer, resume) |
+| **Pydantic AI** | Raise `ModelRetry` from the tool | No | None | 2 (ModelRetry exception, retry handling) |
+| **Claude Code** | Terminal prompt in the loop | No | None | 0 (implicit) |
+
+## Why we chose a callback
+
+Every framework except Hexgate ties approval to some in-house state model — `RunState`, checkpointer threads, `ModelRetry` — because they own the agent loop. Hexgate is a policy layer that sits alongside the agent framework you already picked. We can't hand you our `RunState`; we can hand you a callable slot.
+
+The cost: no cross-process durability at v1. If the process that called the tool dies, the pending approval dies with it. In exchange: zero infrastructure to configure, one concept to teach, works identically whether you run in a notebook, a CLI, `hexgate serve`, or an API worker.
+
+Durability lands as a future `PlatformApprovalHandler` — same callback slot, backed by Postgres. Ships when demand shows up.
+
+## Compared to OpenAI Agents SDK
+
+Their model: mark a tool with `needs_approval=True`, run the agent, get an `InterruptionEvent`, call `RunState.approve(tool_call)` or `RunState.reject(tool_call)`, resume with the mutated state. Full docs: [openai.github.io/openai-agents-python — human-in-the-loop](https://openai.github.io/openai-agents-python/human_in_the_loop/).
+
+**Where theirs wins.** `RunState` serializes cleanly. Approve a call from a different process — different host, next day — and resume. That is genuinely nice for overnight human review.
+
+**Where ours wins.** Their model requires the tool decorator to declare approval intent; ours reads it from YAML at bind time, so a policy change doesn't touch tool code. Four concepts (`needs_approval`, `InterruptionEvent`, `RunState`, `approve`) collapse to one (`async fn(decision) -> bool`). And approval is one policy outcome among three (`allow` / `deny` / `approval_required`) — not a separate feature grafted on top.
+
+## Compared to LangGraph
+
+Their model: call `interrupt(payload)` inside a node, LangGraph raises a `GraphInterrupt`, the checkpointer persists graph state under a `thread_id`, resume with `graph.invoke(Command(resume=answer), {"configurable": {"thread_id": ...}})`. Full docs: [langchain-ai.github.io/langgraph — human-in-the-loop](https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/breakpoints/).
+
+**Where theirs wins.** The checkpointer is pluggable — SQLite, Postgres, Redis — and covers the whole graph, not just tool calls. If your app is already LangGraph-native, you'll want `interrupt()`.
+
+**Where ours wins.** No checkpointer to configure and no `thread_id` to manage. LangGraph's out-of-the-box story ships nothing that notifies the approver — you build the Slack post / email / webhook yourself. Our callback IS the notification: the same handler that decides whether to approve also decides how to reach the human.
+
+## Compared to Pydantic AI
+
+Their model: overload `ModelRetry` — raise it from inside the tool and the agent re-prompts the model with the message. Full docs: [ai.pydantic.dev — tools](https://ai.pydantic.dev/tools/).
+
+**Where theirs wins.** Nothing to configure — the exception is the whole feature.
+
+**Where ours wins.** Approval and retry are different domains. `ModelRetry` is grep-invisible when you're auditing "which tools require approval?" — one exception type covers correction, backoff, and human-in-the-loop indistinguishably. Ours emits a distinct `Decision(outcome=NEEDS_APPROVAL)` object into the audit trail; a compliance query for "every approval-required call last quarter" is a straight ClickHouse `SELECT`.
+
+## Compared to Claude Code
+
+Their model: the terminal is the approval sink. Every dangerous tool call prints a prompt; the user hits `y` or `n`. No library API; the loop owns the UI.
+
+**What we stole.** The insight that "no infra" beats "durable" for the developer-loop case. Most approvals happen during dev, in a REPL / CLI / playground; nobody's overnight-approving in a notebook. Optimizing for that path first is right.
+
+**Where ours differs.** Claude Code IS a CLI. Hexgate is a library — we ship the same callback slot to notebook, CLI, `hexgate serve`, FastAPI worker, and (eventually) Postgres-backed background jobs. Same primitive; the sink changes.
+
+We also copied their startup warning: if your policy declares `approval_required` but you passed no handler, `hexgate serve` shouts about it at boot instead of silently auto-approving (which is exactly the bug that motivated the callback in the first place).
+
+## Points of vigilance
+
+- **The callback's simplicity is also a footgun.** `approval_handler=True` bypasses every prompt in one keystroke. Search for it in CI; it's the fastest way to accidentally ship a policy that reads "approval-required" but behaves like "allow".
+- **No cross-process durability at v1.** If the process serving the approval dies (host reboot, container OOM, `hexgate serve` restart) the pending prompt is lost. The framework fails-closed on the tool call — but the human never sees the request.
+- **The handler runs inside the agent turn.** A slow handler stalls the whole turn (streaming tokens included). Wrap everything blocking in `asyncio.to_thread` and cap external calls with `asyncio.wait_for`.
+- **Framework-native primitives still fire underneath.** If you use LangGraph's `interrupt()` inside a tool, our callback fires first, then `interrupt()` fires when the tool actually runs. The primitives compose, they don't replace each other.
+- **Concurrent parallel tool calls emit multiple simultaneous requests.** GPT-5.4, Claude 4.7, and LangGraph's default `ToolNode` all fan out via `asyncio.gather`. Your handler will be invoked concurrently — key state by decision content, not by array position.
+
+## What's on the roadmap
+
+- **`PlatformApprovalHandler`** — Postgres-backed pending-approvals table. Same callback slot; the sink survives process restarts. Unlocks webhook / Slack / mobile / overnight approvers. Ships when a customer asks.
+- **`SlackApprovalHandler`** — post `approval.request` to a channel, treat a reaction as `approval.reply`. First-party implementation on top of the callback.
+- **Per-tool RBAC approvers.** A policy field like `approvers: [role: finance-approver]` so the handler receives the required approver set. Today the callback decides for itself.
+- **Auto-classifier for repeat approvals.** Detect "same tool, same arguments, approved N times → auto-approve the (N+1)th with an audit note". Optional; some regulated tenants explicitly don't want this.
+- **Callback plumbing on non-LangChain adapters.** OpenAI Agents / Pydantic AI / Google ADK adapters have the same slot; each is one small PR to wire.

--- a/docs/concepts/approval-required.mdx
+++ b/docs/concepts/approval-required.mdx
@@ -1,0 +1,89 @@
+---
+title: "Approval-required"
+description: "Ask a human before the tool call runs. One async callback, no infrastructure."
+---
+
+When a policy declares `mode: approval_required` on a tool, Hexgate suspends the tool call and asks a human. The "asking" is a single async callback you supply — `async fn(decision) -> bool`. Return `True` and the tool runs; return `False` (or don't return in time) and the framework sees a `[policy_denied]` marker.
+
+No `RunState`, no checkpointer, no interrupt/resume protocol. The callback shape is the entire primitive; every approver — CLI prompt, playground popup, Slack reaction, webhook poller — is a different implementation of that same callback.
+
+## Quickstart
+
+Declare the tool in your policy:
+
+```yaml
+version: 1
+default_policy: { mode: deny }
+tools:
+  refund_order:
+    mode: approval_required
+    reason: "financial mutation — needs a human"
+```
+
+Wire an approval handler when you bind the policy:
+
+```python
+import asyncio
+from hexgate import create_agent, enforce_policy
+from hexgate.security.decision import Decision
+
+async def ask_terminal(decision: Decision) -> bool:
+    print(f"\n[approval] {decision.agent_name} wants to call "
+          f"{decision.tool_name}({decision.arguments})")
+    print(f"  reason: {decision.reason}")
+    answer = await asyncio.to_thread(input, "  approve? [y/N]: ")
+    return answer.strip().lower() == "y"
+
+agent, handler = create_agent(model="gpt-5.4", tools=[refund_order])
+agent = enforce_policy(agent, "policy.yaml", approval_handler=ask_terminal)
+```
+
+`asyncio.to_thread(input, ...)` matters — a bare `input()` blocks the event loop and stalls every concurrent tool call and every streaming token in the same turn.
+
+## What the callback receives
+
+The `Decision` object carries everything the enforcer knows about the call it's about to make:
+
+| Field | Type | Notes |
+|---|---|---|
+| `tool_name` | `str` | The name the model asked to call (e.g. `refund_order`, `mcp-slack-send_message`). |
+| `arguments` | `dict[str, Any]` | The exact arguments the model produced. Render these to the human — they're what will actually execute. |
+| `reason` | `str` | Human-readable string from the policy engine — usually the failing constraint or the policy's `reason:` field. Show it. |
+| `role` | `str \| None` | The active role (from `User(role=...)`) when the call was made. |
+| `agent_name` | `str` | The agent that issued the call. Useful when several agents share one approval sink. |
+
+Anything you display to the human should come from these fields verbatim — don't paraphrase the arguments and don't invent context that isn't there.
+
+## Four common shapes
+
+**CLI** — the quickstart above.
+
+**Auto-approve for tests.** `bool` is a valid `approval_handler`:
+
+```python
+agent = enforce_policy(agent, "policy.yaml", approval_handler=True)
+```
+
+Never ship this to production; it approves every `approval_required` call unconditionally.
+
+**Playground (built in).** `hexgate serve` binds a `RelayApprovalHandler` automatically. The connected playground tab receives `approval.request` frames and answers with `approval.reply`. See the [Playground](/platform/dashboard#approvals) doc for the wire protocol.
+
+**Webhook / Slack.** Emit an `approval.request` to your own queue, park the callback on an `asyncio.Event`, resolve it from the incoming webhook handler. Same shape as `RelayApprovalHandler` — 40 lines of code, no framework buy-in.
+
+## Points of vigilance
+
+- **Fail-closed on timeout.** If your handler can hang (network, human away), wrap the wait in `asyncio.wait_for` and return `False` on `TimeoutError`. The framework will not do this for you — the tool call sits open until the handler returns.
+- **Blocking calls belong in `asyncio.to_thread`.** `input()`, `requests.post`, `subprocess.run` — anything sync goes through a worker thread or the whole agent turn stalls.
+- **`approval_handler=True` in production is a red flag.** Search for it in CI. It's the fastest way to accidentally ship a policy that reads "approval-required" but behaves like "allow".
+- **Concurrent tool calls fire multiple prompts.** Modern models parallelize tool calls via `asyncio.gather`; your handler will be invoked concurrently with different `Decision` objects. Key any state by `decision.tool_name + repr(decision.arguments)` — never by array index.
+
+## Where to next
+
+- **[Framework comparison](/concepts/approval-frameworks-compared)** — how this callback compares to OpenAI Agents SDK, LangGraph, Pydantic AI, Claude Code.
+- **[Policy decision](/concepts/policy-decision)** — what `Decision` is and where it comes from.
+
+## What Hexgate does NOT do (yet)
+
+- **Cross-process durability.** State lives in the calling process's memory. If it crashes mid-approval, the pending prompt is lost. A durable `PlatformApprovalHandler` (Postgres-backed pending queue, webhook / Slack / mobile approvers) lands when demand shows up.
+- **Per-tool RBAC approvers.** A policy today says "someone must approve" — not "user with role `finance-approver` must approve". Follow-up.
+- **Callback plumbing on non-LangChain adapters.** OpenAI Agents / Pydantic AI / Google ADK adapters currently render `NEEDS_APPROVAL` as denied output without invoking the callback. Same slot exists on their `GuardedTool` — one PR each to wire.

--- a/docs/concepts/approval-required.mdx
+++ b/docs/concepts/approval-required.mdx
@@ -82,8 +82,27 @@ Do not ship this to production. It approves every `approval_required` call witho
 - [Framework comparison](/concepts/approval-frameworks-compared) walks through how other agent frameworks handle approval, and where Hexgate's callback fits in that landscape.
 - [Policy decision](/concepts/policy-decision) covers what `Decision` is and how the enforcer produces one.
 
+## Adapter coverage
+
+The callback is wired through the LangChain, OpenAI Agents, Pydantic AI, and Google ADK adapters. Pass it the same way on each:
+
+```python
+# OpenAI Agents
+from hexgate.adapters.openai import wrap_openai_agent
+wrapped = wrap_openai_agent(agent, enforcer=enforcer, approval_handler=ask_terminal)
+
+# Pydantic AI
+from hexgate.adapters.pydantic_ai import wrap_pydantic_agent
+wrapped = wrap_pydantic_agent(agent=agent, approval_handler=ask_terminal)
+
+# Google ADK
+from hexgate.adapters.google import wrap_google_agent
+wrapped, binding = wrap_google_agent(agent, api_key=..., approval_handler=ask_terminal)
+```
+
+If you use one of the `HexgateRunner` classes, the same argument is available on the constructor and threads through to every run.
+
 ## Known limitations
 
 - **No cross-process durability yet.** State lives in the calling process's memory. A restart drops any pending prompt. A durable, Postgres-backed handler is on the roadmap for when overnight or off-host approvers become a real need.
 - **No per-tool RBAC on approvers.** A policy today says "somebody must approve", not "somebody with role `finance-approver` must approve". Follow-up.
-- **LangChain adapter only.** The OpenAI Agents, Pydantic AI, and Google ADK adapters currently render `approval_required` decisions as denied output instead of invoking the callback. Same slot exists on their `GuardedTool` wrapper, one small PR each to wire.

--- a/docs/concepts/approval-required.mdx
+++ b/docs/concepts/approval-required.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Approval-required"
-description: "Ask a human before the tool call runs. One async callback, no infrastructure."
+description: "Ask a human before a tool call runs, using a single async callback."
 ---
 
-When a policy declares `mode: approval_required` on a tool, Hexgate suspends the tool call and asks a human. The "asking" is a single async callback you supply — `async fn(decision) -> bool`. Return `True` and the tool runs; return `False` (or don't return in time) and the framework sees a `[policy_denied]` marker.
+Some tool calls need a human in the loop. Refunds, sends, deletes, anything that touches money or another user's data. In Hexgate, you mark those tools `approval_required` in the policy and supply an async callback. When the agent tries to call one of them, the callback fires. Return `True` and the call goes through. Return `False` and the framework sees a `[policy_denied]` marker instead of a tool result.
 
-No `RunState`, no checkpointer, no interrupt/resume protocol. The callback shape is the entire primitive; every approver — CLI prompt, playground popup, Slack reaction, webhook poller — is a different implementation of that same callback.
+That callback is the whole feature. You write one function of the shape `async fn(decision) -> bool` and Hexgate calls it every time a tool needs approval. Where the human actually sits (terminal, playground popup, Slack channel, webhook) is up to you.
 
 ## Quickstart
 
@@ -17,10 +17,10 @@ default_policy: { mode: deny }
 tools:
   refund_order:
     mode: approval_required
-    reason: "financial mutation — needs a human"
+    reason: "financial mutation, needs a human"
 ```
 
-Wire an approval handler when you bind the policy:
+Write a handler and pass it when you bind the policy:
 
 ```python
 import asyncio
@@ -38,52 +38,52 @@ agent, handler = create_agent(model="gpt-5.4", tools=[refund_order])
 agent = enforce_policy(agent, "policy.yaml", approval_handler=ask_terminal)
 ```
 
-`asyncio.to_thread(input, ...)` matters — a bare `input()` blocks the event loop and stalls every concurrent tool call and every streaming token in the same turn.
+Notice the `asyncio.to_thread(input, ...)`. Any blocking call inside the handler will stall the whole agent turn if you skip it, including the streaming tokens for the assistant's reply.
 
 ## What the callback receives
 
-The `Decision` object carries everything the enforcer knows about the call it's about to make:
+The `Decision` object holds everything the enforcer knew when it flagged the call.
 
 | Field | Type | Notes |
 |---|---|---|
-| `tool_name` | `str` | The name the model asked to call (e.g. `refund_order`, `mcp-slack-send_message`). |
-| `arguments` | `dict[str, Any]` | The exact arguments the model produced. Render these to the human — they're what will actually execute. |
-| `reason` | `str` | Human-readable string from the policy engine — usually the failing constraint or the policy's `reason:` field. Show it. |
-| `role` | `str \| None` | The active role (from `User(role=...)`) when the call was made. |
-| `agent_name` | `str` | The agent that issued the call. Useful when several agents share one approval sink. |
+| `tool_name` | `str` | Name the model asked to call, e.g. `refund_order`, `mcp-slack-send_message`. |
+| `arguments` | `dict[str, Any]` | Exact arguments the model produced. Show these to the human verbatim, they're what will run. |
+| `reason` | `str` | Human-readable string from the policy engine, usually the failing constraint or the `reason:` field. |
+| `role` | `str \| None` | Active role from `User(role=...)` at the time of the call. |
+| `agent_name` | `str` | Which agent issued the call. Useful when several agents share one approval sink. |
 
-Anything you display to the human should come from these fields verbatim — don't paraphrase the arguments and don't invent context that isn't there.
+If your UI needs more context than this (customer ID, current balance, whatever), thread it into the arguments the model calls the tool with, or attach it via `User` scope. The callback shouldn't be reaching out to fetch its own context.
 
-## Four common shapes
+## Common shapes
 
-**CLI** — the quickstart above.
+**CLI.** The quickstart above.
 
-**Auto-approve for tests.** `bool` is a valid `approval_handler`:
+**Auto-approve during tests.** A plain `bool` is a valid `approval_handler`:
 
 ```python
 agent = enforce_policy(agent, "policy.yaml", approval_handler=True)
 ```
 
-Never ship this to production; it approves every `approval_required` call unconditionally.
+Do not ship this to production. It approves every `approval_required` call without asking, which defeats the point of having the policy in the first place.
 
-**Playground (built in).** `hexgate serve` binds a `RelayApprovalHandler` automatically. The connected playground tab receives `approval.request` frames and answers with `approval.reply`. See the [Playground](/platform/dashboard#approvals) doc for the wire protocol.
+**Playground.** `hexgate serve` binds a `RelayApprovalHandler` for you. Prompts appear inline above the composer in the connected playground tab, and the user's answer flows back over the same WebSocket. Nothing to configure.
 
-**Webhook / Slack.** Emit an `approval.request` to your own queue, park the callback on an `asyncio.Event`, resolve it from the incoming webhook handler. Same shape as `RelayApprovalHandler` — 40 lines of code, no framework buy-in.
+**Webhook or Slack.** Send an `approval.request` to your own queue inside the handler, park on an `asyncio.Event`, and set the event from the webhook handler when the answer arrives. Roughly forty lines of code. `RelayApprovalHandler` in the SDK source is a working reference.
 
-## Points of vigilance
+## Watch out for
 
-- **Fail-closed on timeout.** If your handler can hang (network, human away), wrap the wait in `asyncio.wait_for` and return `False` on `TimeoutError`. The framework will not do this for you — the tool call sits open until the handler returns.
-- **Blocking calls belong in `asyncio.to_thread`.** `input()`, `requests.post`, `subprocess.run` — anything sync goes through a worker thread or the whole agent turn stalls.
-- **`approval_handler=True` in production is a red flag.** Search for it in CI. It's the fastest way to accidentally ship a policy that reads "approval-required" but behaves like "allow".
-- **Concurrent tool calls fire multiple prompts.** Modern models parallelize tool calls via `asyncio.gather`; your handler will be invoked concurrently with different `Decision` objects. Key any state by `decision.tool_name + repr(decision.arguments)` — never by array index.
+- **Timeouts.** If your handler can hang (waiting on a human who went to lunch, a webhook that never fires), wrap the wait in `asyncio.wait_for` and return `False` on `TimeoutError`. Hexgate will not do this for you. The tool call sits open until the handler returns.
+- **Blocking calls.** Anything sync (`input`, `requests.post`, `subprocess.run`) needs `asyncio.to_thread` or the agent turn stops streaming.
+- **`approval_handler=True` in production.** Add a grep to CI. It is the fastest way to accidentally ship a policy that reads "approval required" but behaves like "allow".
+- **Parallel tool calls.** Modern models fan out tool calls via `asyncio.gather`, so your handler will be invoked concurrently with different `Decision` objects. If you keep any state, key it by the decision content, not by array index.
 
 ## Where to next
 
-- **[Framework comparison](/concepts/approval-frameworks-compared)** — how this callback compares to OpenAI Agents SDK, LangGraph, Pydantic AI, Claude Code.
-- **[Policy decision](/concepts/policy-decision)** — what `Decision` is and where it comes from.
+- [Framework comparison](/concepts/approval-frameworks-compared) walks through how other agent frameworks handle approval, and where Hexgate's callback fits in that landscape.
+- [Policy decision](/concepts/policy-decision) covers what `Decision` is and how the enforcer produces one.
 
-## What Hexgate does NOT do (yet)
+## Known limitations
 
-- **Cross-process durability.** State lives in the calling process's memory. If it crashes mid-approval, the pending prompt is lost. A durable `PlatformApprovalHandler` (Postgres-backed pending queue, webhook / Slack / mobile approvers) lands when demand shows up.
-- **Per-tool RBAC approvers.** A policy today says "someone must approve" — not "user with role `finance-approver` must approve". Follow-up.
-- **Callback plumbing on non-LangChain adapters.** OpenAI Agents / Pydantic AI / Google ADK adapters currently render `NEEDS_APPROVAL` as denied output without invoking the callback. Same slot exists on their `GuardedTool` — one PR each to wire.
+- **No cross-process durability yet.** State lives in the calling process's memory. A restart drops any pending prompt. A durable, Postgres-backed handler is on the roadmap for when overnight or off-host approvers become a real need.
+- **No per-tool RBAC on approvers.** A policy today says "somebody must approve", not "somebody with role `finance-approver` must approve". Follow-up.
+- **LangChain adapter only.** The OpenAI Agents, Pydantic AI, and Google ADK adapters currently render `approval_required` decisions as denied output instead of invoking the callback. Same slot exists on their `GuardedTool` wrapper, one small PR each to wire.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,7 +29,9 @@
               "concepts/user-scope",
               "concepts/signed-bundles",
               "concepts/audit-trail",
-              "concepts/mcp"
+              "concepts/mcp",
+              "concepts/approval-required",
+              "concepts/approval-frameworks-compared"
             ]
           },
           {

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -16,6 +16,7 @@ from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
 from hexgate.adapters.google.wrapper import wrap_google_agent
+from hexgate.agents.factory import ApprovalHandler
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import User
 
@@ -30,6 +31,7 @@ class HexgateRunner:
         app_name: str,
         session_service: BaseSessionService,
         api_key: str | None = None,
+        approval_handler: ApprovalHandler | None = None,
         **runner_kwargs: Any,
     ):
         self.api_key = resolve_api_key(api_key)
@@ -41,7 +43,7 @@ class HexgateRunner:
         # Runner is built once — refresh swaps the enforcer's policy
         # without touching it.
         self._wrapped_agent, self._binding = wrap_google_agent(
-            agent, api_key=self.api_key
+            agent, api_key=self.api_key, approval_handler=approval_handler
         )
         self._runner = Runner(
             agent=self._wrapped_agent,

--- a/hexgate/adapters/google/tools.py
+++ b/hexgate/adapters/google/tools.py
@@ -13,29 +13,19 @@ from __future__ import annotations
 import copy
 import functools
 from collections.abc import Callable
-from inspect import isawaitable
 from typing import Any, Union
 
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.tool_context import ToolContext
 
+from hexgate.agents.approvals import resolve_approval_async
 from hexgate.agents.factory import ApprovalHandler
-from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 
 
 ToolEntry = Union[BaseTool, Callable[..., Any]]
-
-
-async def _resolve_approval(handler: ApprovalHandler, decision: Decision) -> bool:
-    """Resolve a NEEDS_APPROVAL decision. ``bool`` handlers short-circuit."""
-    if isinstance(handler, bool):
-        return handler
-    result: Any = handler(decision)
-    if isawaitable(result):
-        result = await result  # type: ignore[assignment]
-    return bool(result)
 
 
 def _normalize(tool: ToolEntry) -> BaseTool:
@@ -71,7 +61,7 @@ def wrap_tool(
         if (
             decision.outcome is DecisionOutcome.NEEDS_APPROVAL
             and approval_handler is not None
-            and await _resolve_approval(approval_handler, decision)
+            and await resolve_approval_async(approval_handler, decision)
         ):
             return await original_run_async(args=args, tool_context=tool_context)
         return decision.as_error_message()

--- a/hexgate/adapters/google/tools.py
+++ b/hexgate/adapters/google/tools.py
@@ -1,6 +1,11 @@
 """Google ADK adapter: wrap ``BaseTool`` so ``run_async`` consults a
 :class:`PolicyEnforcer` first. Non-allow outcomes render as markered
 strings the model sees as tool output.
+
+When a caller supplies ``approval_handler``, a ``NEEDS_APPROVAL``
+decision fires the callback and runs the original tool on truthy return;
+falsy return (or a missing handler) keeps today's behavior of surfacing
+the ``[approval_required]`` marker to the model.
 """
 
 from __future__ import annotations
@@ -8,16 +13,29 @@ from __future__ import annotations
 import copy
 import functools
 from collections.abc import Callable
+from inspect import isawaitable
 from typing import Any, Union
 
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.tool_context import ToolContext
 
+from hexgate.agents.factory import ApprovalHandler
+from hexgate.security.decision import Decision, DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 
 
 ToolEntry = Union[BaseTool, Callable[..., Any]]
+
+
+async def _resolve_approval(handler: ApprovalHandler, decision: Decision) -> bool:
+    """Resolve a NEEDS_APPROVAL decision. ``bool`` handlers short-circuit."""
+    if isinstance(handler, bool):
+        return handler
+    result: Any = handler(decision)
+    if isawaitable(result):
+        result = await result  # type: ignore[assignment]
+    return bool(result)
 
 
 def _normalize(tool: ToolEntry) -> BaseTool:
@@ -32,7 +50,12 @@ def _normalize(tool: ToolEntry) -> BaseTool:
     )
 
 
-def wrap_tool(tool: ToolEntry, enforcer: PolicyEnforcer) -> BaseTool:
+def wrap_tool(
+    tool: ToolEntry,
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> BaseTool:
     """Return a copy of ``tool`` with ``run_async`` gated by ``enforcer``."""
     base = _normalize(tool)
     name = base.name
@@ -45,6 +68,12 @@ def wrap_tool(tool: ToolEntry, enforcer: PolicyEnforcer) -> BaseTool:
         decision = enforcer.decide(name, args or {})
         if decision.allowed:
             return await original_run_async(args=args, tool_context=tool_context)
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and approval_handler is not None
+            and await _resolve_approval(approval_handler, decision)
+        ):
+            return await original_run_async(args=args, tool_context=tool_context)
         return decision.as_error_message()
 
     wrapped = copy.copy(base)
@@ -52,6 +81,11 @@ def wrap_tool(tool: ToolEntry, enforcer: PolicyEnforcer) -> BaseTool:
     return wrapped
 
 
-def wrap_tools(tools: list[ToolEntry], enforcer: PolicyEnforcer) -> list[BaseTool]:
+def wrap_tools(
+    tools: list[ToolEntry],
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> list[BaseTool]:
     """Return a fresh list of policy-gated copies."""
-    return [wrap_tool(t, enforcer) for t in tools]
+    return [wrap_tool(t, enforcer, approval_handler=approval_handler) for t in tools]

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -13,20 +13,27 @@ from __future__ import annotations
 from google.adk.agents import BaseAgent
 
 from hexgate.adapters.google.tools import wrap_tools
+from hexgate.agents.factory import ApprovalHandler
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
 
 
 def wrap_google_agent(
-    agent: BaseAgent, *, api_key: str
+    agent: BaseAgent,
+    *,
+    api_key: str,
+    approval_handler: ApprovalHandler | None = None,
 ) -> tuple[BaseAgent, PolicyBinding]:
     """Return a policy-gated clone of ``agent`` plus its refresh binding.
 
     Caller must open a :class:`User` scope around the run.
-    ``NEEDS_APPROVAL`` outcomes surface as ``[approval_required]``-prefixed
-    strings in tool results; ``[policy_denied]`` for denials. Refresh the
-    returned binding at run boundaries (``HexgateRunner`` does). Fail-loud:
-    an unregistered agent (platform 404) raises — register it first with
+    ``NEEDS_APPROVAL`` outcomes fire ``approval_handler`` (async
+    ``fn(decision) -> bool`` or ``bool`` shorthand); a truthy return
+    runs the tool, falsy or missing handler surfaces the
+    ``[approval_required]``-prefixed string as tool result.
+    ``[policy_denied]`` marks plain denials. Refresh the returned
+    binding at run boundaries (``HexgateRunner`` does). Fail-loud: an
+    unregistered agent (platform 404) raises — register it first with
     ``hexgate register``.
     """
     agent_name = getattr(agent, "name", "default")
@@ -34,7 +41,7 @@ def wrap_google_agent(
 
     resolved = resolve_policy(agent_name, api_key=api_key)
     enforcer = build_enforcer(resolved.engine, agent_name=agent_name, api_key=api_key)
-    guarded_tools = wrap_tools(tools, enforcer)
+    guarded_tools = wrap_tools(tools, enforcer, approval_handler=approval_handler)
     return (
         agent.model_copy(update={"tools": guarded_tools}),
         PolicyBinding(enforcer, resolved.source),

--- a/hexgate/adapters/langchain/tools.py
+++ b/hexgate/adapters/langchain/tools.py
@@ -14,15 +14,20 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Awaitable, Callable
-from inspect import isawaitable
 from typing import Any
 
 from langchain_core.tools import BaseTool
 from langchain_core.tools.structured import StructuredTool
 from pydantic import ConfigDict
 
+from hexgate.agents.approvals import (
+    resolve_approval_async as _resolve_approval_async,
+)
+from hexgate.agents.approvals import (
+    resolve_approval_sync as _resolve_approval_sync,
+)
 from hexgate.agents.factory import ApprovalHandler
-from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.tools.decorators import TOOL_METADATA_ATTR
 
@@ -33,29 +38,6 @@ def _copy_tool_metadata(source: Any, target: Any) -> Any:
     if metadata is not None:
         setattr(target, TOOL_METADATA_ATTR, metadata)
     return target
-
-
-def _resolve_approval_sync(handler: ApprovalHandler, decision: Decision) -> bool:
-    """Resolve a NEEDS_APPROVAL decision in a sync caller (rejects coroutines)."""
-    if isinstance(handler, bool):
-        return handler
-    result = handler(decision)
-    if isawaitable(result):
-        raise RuntimeError(
-            "approval_handler returned a coroutine; sync tool invocation cannot "
-            "await it — use ainvoke/astream/astream_events"
-        )
-    return bool(result)
-
-
-async def _resolve_approval_async(handler: ApprovalHandler, decision: Decision) -> bool:
-    """Resolve a NEEDS_APPROVAL decision in an async caller."""
-    if isinstance(handler, bool):
-        return handler
-    result = handler(decision)
-    if isawaitable(result):
-        result = await result
-    return bool(result)
 
 
 class GuardedTool(BaseTool):

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -25,6 +25,7 @@ from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
 from hexgate.adapters.openai.wrapper import wrap_openai_agent
+from hexgate.agents.factory import ApprovalHandler
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import User
 from hexgate.security.binding import PolicyBinding, resolve_policy
@@ -34,7 +35,12 @@ from hexgate.security.enforcer import build_enforcer
 class HexgateRunner:
     """Runner for OpenAI agents with Hexgate tool policy and observability."""
 
-    def __init__(self, api_key: str | None = None):
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        approval_handler: ApprovalHandler | None = None,
+    ):
         self.api_key = resolve_api_key(api_key)
         if self.api_key is None:
             raise ValueError(
@@ -42,6 +48,7 @@ class HexgateRunner:
             )
         # Cached per agent name — keeps the ETag memory alive across runs.
         self._bindings: dict[str, PolicyBinding] = {}
+        self._approval_handler = approval_handler
 
     def _binding_for(self, agent: Agent) -> PolicyBinding:
         """Get-or-resolve the cached policy binding for ``agent``'s name.
@@ -98,7 +105,11 @@ class HexgateRunner:
         self._setup_observability()
         binding = self._binding_for(agent)
         await binding.refresh_async()  # per-run policy pull; 304 when unchanged
-        wrapped_agent = wrap_openai_agent(agent, enforcer=binding.enforcer)
+        wrapped_agent = wrap_openai_agent(
+            agent,
+            enforcer=binding.enforcer,
+            approval_handler=self._approval_handler,
+        )
         async with user:
             with self._propagate(user, agent.name):
                 return await Runner.run(
@@ -117,7 +128,11 @@ class HexgateRunner:
         self._setup_observability()
         binding = self._binding_for(agent)
         binding.refresh()  # per-run policy pull; 304 when unchanged
-        wrapped_agent = wrap_openai_agent(agent, enforcer=binding.enforcer)
+        wrapped_agent = wrap_openai_agent(
+            agent,
+            enforcer=binding.enforcer,
+            approval_handler=self._approval_handler,
+        )
         with user.sync_scope():
             with self._propagate(user, agent.name):
                 return Runner.run_sync(
@@ -143,7 +158,11 @@ class HexgateRunner:
         self._setup_observability()
         binding = self._binding_for(agent)
         binding.refresh()  # must precede the wrap + setup
-        wrapped_agent = wrap_openai_agent(agent, enforcer=binding.enforcer)
+        wrapped_agent = wrap_openai_agent(
+            agent,
+            enforcer=binding.enforcer,
+            approval_handler=self._approval_handler,
+        )
 
         with user.sync_scope():
             with self._propagate(user, agent.name):

--- a/hexgate/adapters/openai/tools.py
+++ b/hexgate/adapters/openai/tools.py
@@ -13,14 +13,14 @@ from __future__ import annotations
 import copy
 import functools
 import json
-from inspect import isawaitable
 from typing import Any
 
 from agents import FunctionTool
 from agents.tool import ToolContext
 
+from hexgate.agents.approvals import resolve_approval_async
 from hexgate.agents.factory import ApprovalHandler
-from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 
 
@@ -33,16 +33,6 @@ def _parse_args(raw: str) -> dict[str, Any] | None:
     except (TypeError, ValueError):
         return None
     return parsed if isinstance(parsed, dict) else None
-
-
-async def _resolve_approval(handler: ApprovalHandler, decision: Decision) -> bool:
-    """Resolve a NEEDS_APPROVAL decision. ``bool`` handlers short-circuit."""
-    if isinstance(handler, bool):
-        return handler
-    result: Any = handler(decision)
-    if isawaitable(result):
-        result = await result  # type: ignore[assignment]
-    return bool(result)
 
 
 def wrap_tool(
@@ -69,7 +59,7 @@ def wrap_tool(
         if (
             decision.outcome is DecisionOutcome.NEEDS_APPROVAL
             and approval_handler is not None
-            and await _resolve_approval(approval_handler, decision)
+            and await resolve_approval_async(approval_handler, decision)
         ):
             return await original_invoke(ctx, input)
         return decision.as_error_message()

--- a/hexgate/adapters/openai/tools.py
+++ b/hexgate/adapters/openai/tools.py
@@ -1,6 +1,11 @@
 """OpenAI Agents adapter: wrap ``FunctionTool`` so ``on_invoke_tool``
 consults a :class:`PolicyEnforcer` first. Non-allow outcomes render as
 markered strings the model sees as tool output.
+
+When a caller supplies ``approval_handler``, a ``NEEDS_APPROVAL``
+decision fires the callback and runs the original tool on truthy return;
+falsy return (or a missing handler) keeps today's behavior of surfacing
+the ``[approval_required]`` marker to the model.
 """
 
 from __future__ import annotations
@@ -8,11 +13,14 @@ from __future__ import annotations
 import copy
 import functools
 import json
+from inspect import isawaitable
 from typing import Any
 
 from agents import FunctionTool
 from agents.tool import ToolContext
 
+from hexgate.agents.factory import ApprovalHandler
+from hexgate.security.decision import Decision, DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 
 
@@ -27,7 +35,22 @@ def _parse_args(raw: str) -> dict[str, Any] | None:
     return parsed if isinstance(parsed, dict) else None
 
 
-def wrap_tool(tool: FunctionTool, enforcer: PolicyEnforcer) -> FunctionTool:
+async def _resolve_approval(handler: ApprovalHandler, decision: Decision) -> bool:
+    """Resolve a NEEDS_APPROVAL decision. ``bool`` handlers short-circuit."""
+    if isinstance(handler, bool):
+        return handler
+    result: Any = handler(decision)
+    if isawaitable(result):
+        result = await result  # type: ignore[assignment]
+    return bool(result)
+
+
+def wrap_tool(
+    tool: FunctionTool,
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> FunctionTool:
     """Return a copy of ``tool`` with ``on_invoke_tool`` gated by ``enforcer``."""
     if not isinstance(tool, FunctionTool):
         raise TypeError(
@@ -43,6 +66,12 @@ def wrap_tool(tool: FunctionTool, enforcer: PolicyEnforcer) -> FunctionTool:
         decision = enforcer.decide(name, _parse_args(input) or {})
         if decision.allowed:
             return await original_invoke(ctx, input)
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and approval_handler is not None
+            and await _resolve_approval(approval_handler, decision)
+        ):
+            return await original_invoke(ctx, input)
         return decision.as_error_message()
 
     wrapped = copy.copy(tool)
@@ -51,7 +80,13 @@ def wrap_tool(tool: FunctionTool, enforcer: PolicyEnforcer) -> FunctionTool:
 
 
 def wrap_tools(
-    tools: list[FunctionTool], enforcer: PolicyEnforcer
+    tools: list[FunctionTool],
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
 ) -> list[FunctionTool]:
     """Return a fresh list of policy-gated copies."""
-    return [wrap_tool(t, enforcer) for t in tools]
+    return [wrap_tool(t, enforcer, approval_handler=approval_handler) for t in tools]
+
+
+__all__ = ["_parse_args", "wrap_tool", "wrap_tools"]

--- a/hexgate/adapters/openai/wrapper.py
+++ b/hexgate/adapters/openai/wrapper.py
@@ -15,14 +15,23 @@ import dataclasses
 from agents import Agent
 
 from hexgate.adapters.openai.tools import wrap_tools
+from hexgate.agents.factory import ApprovalHandler
 from hexgate.security.enforcer import PolicyEnforcer
 
 
-def wrap_openai_agent(agent: Agent, *, enforcer: PolicyEnforcer) -> Agent:
+def wrap_openai_agent(
+    agent: Agent,
+    *,
+    enforcer: PolicyEnforcer,
+    approval_handler: ApprovalHandler | None = None,
+) -> Agent:
     """Return a clone of ``agent`` whose tools are gated by ``enforcer``.
 
     Mechanics only — resolution/refresh live with the caller. Caller
-    must open a :class:`User` scope around the run.
+    must open a :class:`User` scope around the run. ``approval_handler``
+    (async ``fn(decision) -> bool`` or ``bool`` shorthand) fires when a
+    tool call carries a ``NEEDS_APPROVAL`` outcome; a truthy return runs
+    the tool, falsy surfaces the ``[approval_required]`` marker.
     """
-    guarded_tools = wrap_tools(agent.tools, enforcer)
+    guarded_tools = wrap_tools(agent.tools, enforcer, approval_handler=approval_handler)
     return dataclasses.replace(agent, tools=guarded_tools)

--- a/hexgate/adapters/pydantic_ai/tools.py
+++ b/hexgate/adapters/pydantic_ai/tools.py
@@ -13,26 +13,16 @@ from __future__ import annotations
 
 import copy
 import functools
-from inspect import isawaitable
 from typing import Any
 
 from pydantic_ai import RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import Tool
 
+from hexgate.agents.approvals import resolve_approval_async
 from hexgate.agents.factory import ApprovalHandler
-from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
-
-
-async def _resolve_approval(handler: ApprovalHandler, decision: Decision) -> bool:
-    """Resolve a NEEDS_APPROVAL decision. ``bool`` handlers short-circuit."""
-    if isinstance(handler, bool):
-        return handler
-    result: Any = handler(decision)
-    if isawaitable(result):
-        result = await result  # type: ignore[assignment]
-    return bool(result)
 
 
 def wrap_tool(
@@ -55,7 +45,7 @@ def wrap_tool(
         if (
             decision.outcome is DecisionOutcome.NEEDS_APPROVAL
             and approval_handler is not None
-            and await _resolve_approval(approval_handler, decision)
+            and await resolve_approval_async(approval_handler, decision)
         ):
             return await original_call(args_dict, context)
         raise ModelRetry(decision.as_error_message())

--- a/hexgate/adapters/pydantic_ai/tools.py
+++ b/hexgate/adapters/pydantic_ai/tools.py
@@ -2,22 +2,45 @@
 a :class:`PolicyEnforcer` first. Non-allow outcomes raise
 :class:`ModelRetry` with a rendered :class:`Decision` message (pydantic_ai's
 idiom for feeding a tool failure back to the model).
+
+When a caller supplies ``approval_handler``, a ``NEEDS_APPROVAL``
+decision fires the callback and runs the original tool on truthy return;
+falsy return (or a missing handler) keeps today's behavior of raising
+``ModelRetry`` with the ``[approval_required]`` marker.
 """
 
 from __future__ import annotations
 
 import copy
 import functools
+from inspect import isawaitable
 from typing import Any
 
 from pydantic_ai import RunContext
 from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import Tool
 
+from hexgate.agents.factory import ApprovalHandler
+from hexgate.security.decision import Decision, DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 
 
-def wrap_tool(tool: Tool, enforcer: PolicyEnforcer) -> Tool:
+async def _resolve_approval(handler: ApprovalHandler, decision: Decision) -> bool:
+    """Resolve a NEEDS_APPROVAL decision. ``bool`` handlers short-circuit."""
+    if isinstance(handler, bool):
+        return handler
+    result: Any = handler(decision)
+    if isawaitable(result):
+        result = await result  # type: ignore[assignment]
+    return bool(result)
+
+
+def wrap_tool(
+    tool: Tool,
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> Tool:
     """Return a copy of ``tool`` with ``function_schema.call`` gated by ``enforcer``."""
     name = tool.name
     tool_copy = copy.copy(tool)
@@ -29,12 +52,23 @@ def wrap_tool(tool: Tool, enforcer: PolicyEnforcer) -> Tool:
         decision = enforcer.decide(name, args_dict or {})
         if decision.allowed:
             return await original_call(args_dict, context)
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and approval_handler is not None
+            and await _resolve_approval(approval_handler, decision)
+        ):
+            return await original_call(args_dict, context)
         raise ModelRetry(decision.as_error_message())
 
     tool_copy.function_schema.call = guarded_call
     return tool_copy
 
 
-def wrap_tools(tools: list[Tool], enforcer: PolicyEnforcer) -> list[Tool]:
+def wrap_tools(
+    tools: list[Tool],
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> list[Tool]:
     """Return a fresh list of policy-gated copies."""
-    return [wrap_tool(t, enforcer) for t in tools]
+    return [wrap_tool(t, enforcer, approval_handler=approval_handler) for t in tools]

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -17,6 +17,7 @@ from pydantic_ai.tools import Tool
 
 from hexgate.adapters.pydantic_ai.agent import HexgatePydanticAgent
 from hexgate.adapters.pydantic_ai.tools import wrap_tools
+from hexgate.agents.factory import ApprovalHandler
 from hexgate.config.env import resolve_api_key
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -48,16 +49,19 @@ def wrap_pydantic_agent(
     *,
     agent: Agent,
     api_key: str | None = None,
+    approval_handler: ApprovalHandler | None = None,
 ) -> HexgatePydanticAgent:
     """Wrap a pydantic_ai agent with Hexgate policy + observability.
 
     Returns a :class:`HexgatePydanticAgent` backed by a clone of the
     caller's ``agent``; the original is not mutated. The proxy takes
     ``user`` per call; role resolves at call time from the active
-    :class:`User`. ``NEEDS_APPROVAL`` raises :class:`ModelRetry` with
-    an ``[approval_required]`` marker. ``api_key`` falls back to
-    ``HEXGATE_API_KEY``. The enforced policy is the platform's; unlisted
-    tools are denied.
+    :class:`User`. ``NEEDS_APPROVAL`` fires ``approval_handler`` (async
+    ``fn(decision) -> bool`` or ``bool`` shorthand); a truthy return
+    runs the tool, falsy or missing handler raises :class:`ModelRetry`
+    with an ``[approval_required]`` marker. ``api_key`` falls back to
+    ``HEXGATE_API_KEY``. The enforced policy is the platform's;
+    unlisted tools are denied.
     """
     resolved_key = resolve_api_key(api_key)
     if not resolved_key:
@@ -72,7 +76,9 @@ def wrap_pydantic_agent(
     enforcer = build_enforcer(
         resolved.engine, agent_name=agent_name, api_key=resolved_key
     )
-    cloned_agent = _clone_agent_with_tools(agent, wrap_tools(tools, enforcer))
+    cloned_agent = _clone_agent_with_tools(
+        agent, wrap_tools(tools, enforcer, approval_handler=approval_handler)
+    )
 
     return HexgatePydanticAgent(
         agent=cloned_agent,

--- a/hexgate/agents/approvals.py
+++ b/hexgate/agents/approvals.py
@@ -1,0 +1,53 @@
+"""Shared helpers for resolving an approval_handler return value.
+
+Every adapter (LangChain, OpenAI Agents, Pydantic AI, Google ADK) needs
+the same normalization: accept a `bool` shortcut, accept a sync
+callable, accept an async callable, coerce to bool. Extracted here so
+the three adapter-local copies don't drift — the LangChain version
+already has a guard the others were missing.
+"""
+
+from __future__ import annotations
+
+from inspect import isawaitable
+from typing import Any
+
+from hexgate.agents.factory import ApprovalHandler
+from hexgate.security.decision import Decision
+
+
+def resolve_approval_sync(handler: ApprovalHandler, decision: Decision) -> bool:
+    """Resolve a NEEDS_APPROVAL decision from a sync caller.
+
+    Rejects a coroutine-returning handler: the caller has no event loop
+    to await it in. The right fix in that case is to switch to an async
+    tool invocation path (ainvoke / astream / astream_events on
+    LangChain, `run_async` on Google ADK, etc.).
+    """
+    if isinstance(handler, bool):
+        return handler
+    result: Any = handler(decision)
+    if isawaitable(result):
+        raise RuntimeError(
+            "approval_handler returned a coroutine; sync tool invocation cannot "
+            "await it — use an async entry point (ainvoke / astream / "
+            "astream_events / run_async / etc.) so the handler can be awaited."
+        )
+    return bool(result)
+
+
+async def resolve_approval_async(handler: ApprovalHandler, decision: Decision) -> bool:
+    """Resolve a NEEDS_APPROVAL decision from an async caller.
+
+    Accepts both sync-callable and async-callable handlers uniformly —
+    ``bool`` short-circuits without invocation.
+    """
+    if isinstance(handler, bool):
+        return handler
+    result: Any = handler(decision)
+    if isawaitable(result):
+        result = await result
+    return bool(result)
+
+
+__all__ = ["resolve_approval_async", "resolve_approval_sync"]

--- a/hexgate/cli/serve.py
+++ b/hexgate/cli/serve.py
@@ -366,9 +366,7 @@ async def _serve_loop(context: ServeContext, url: str, console: Console) -> None
                 # Dispatch on a background task so the read loop can
                 # immediately pick up the next frame — critical for
                 # approval.reply arriving mid-chat.
-                task = asyncio.create_task(
-                    _dispatch_message(context, ws, payload)
-                )
+                task = asyncio.create_task(_dispatch_message(context, ws, payload))
                 dispatched.add(task)
                 task.add_done_callback(dispatched.discard)
         except ConnectionClosed:

--- a/hexgate/cli/serve.py
+++ b/hexgate/cli/serve.py
@@ -29,8 +29,10 @@ import json
 import logging
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import quote
+from uuid import uuid4
 
 from pydantic import ValidationError
 from rich.console import Console
@@ -48,8 +50,15 @@ from hexgate.cli._common import (
 from hexgate.cli.state import ChatState
 from hexgate.cloud.client import HexgateConfig, HexgateError
 from hexgate.runtime import User
+from hexgate.security.decision import Decision
 
 logger = logging.getLogger(__name__)
+
+# Default TTL for a single approval request. Long enough for a human to
+# read + click, short enough that the LLM turn's own budget isn't fully
+# consumed on the wait. Configurable per instance if the deployment
+# needs different pacing.
+APPROVAL_TTL_SECONDS = 300
 
 RECONNECT_BASE = 1.0
 RECONNECT_CAP = 15.0
@@ -57,6 +66,135 @@ PING_INTERVAL = 20.0
 # Marker subprotocol the platform echoes back on a successful bearer
 # handshake (matches ``_WS_PROTOCOL_MARKER`` in platform/api/main.py).
 WS_PROTOCOL_MARKER = "hexgate.v1"
+
+
+class RelayApprovalHandler:
+    """``approval_handler`` that routes NEEDS_APPROVAL over the serve WS.
+
+    When the enforcer flags a tool call as ``approval_required``, this
+    handler emits an ``approval.request`` frame on the currently-bound
+    serve WebSocket and awaits a matching ``approval.reply``. The
+    playground dashboard renders the request inline and sends the
+    reply through the same relay.
+
+    Fail-closed by design:
+      * ``__call__`` returns ``False`` if the socket isn't bound (no
+        connected playground → treat as denied rather than hanging the
+        agent turn forever).
+      * ``__call__`` returns ``False`` on TTL timeout — the LLM sees
+        the tool as denied and can recover next turn.
+      * ``unbind_socket`` resolves every in-flight request with
+        ``allowed=False`` on WS disconnect so pending coroutines don't
+        leak past the connection they belonged to.
+
+    Concurrent parallel tool calls (LangGraph's ToolNode fires them via
+    ``asyncio.gather``) are supported: each gets its own decision_id and
+    its own ``asyncio.Event``. WS sends are serialized under a lock
+    because the ``websockets`` library does NOT serialize concurrent
+    ``send()`` calls on one socket — interleaved frames would be a
+    silent bug otherwise.
+    """
+
+    def __init__(self, ttl_seconds: float = APPROVAL_TTL_SECONDS) -> None:
+        self._pending: dict[str, tuple[asyncio.Event, dict[str, Any]]] = {}
+        self._ws: Any = None
+        self._ttl = ttl_seconds
+        # Guards ws.send() from two concurrent __call__ invocations.
+        self._send_lock = asyncio.Lock()
+
+    def bind_socket(self, ws: Any) -> None:
+        """Called by ``_serve_loop`` on each new WS connect."""
+        self._ws = ws
+
+    def unbind_socket(self) -> None:
+        """Called on WS disconnect. Fail-closes every in-flight approval
+        so awaiting handlers unblock immediately (as deny) rather than
+        outliving the connection."""
+        for evt, box in list(self._pending.values()):
+            box["allowed"] = False
+            evt.set()
+        self._pending.clear()
+        self._ws = None
+
+    async def __call__(self, decision: Decision) -> bool:
+        ws = self._ws
+        if ws is None:
+            logger.warning(
+                "approval requested but no playground is connected — denying "
+                "tool_name=%s",
+                decision.tool_name,
+            )
+            return False
+
+        decision_id = f"appr_{uuid4().hex}"
+        evt: asyncio.Event = asyncio.Event()
+        # ``box`` carries the outcome across the coroutine boundary so a
+        # resolve() firing at any point overrides the default (False).
+        box: dict[str, bool] = {"allowed": False}
+        self._pending[decision_id] = (evt, box)
+
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(seconds=self._ttl)
+        ).isoformat()
+        # Use ``type`` on both directions of the approval protocol —
+        # matches every other control frame (hello, reset, session_reset).
+        payload = {
+            "type": "approval.request",
+            "decision_id": decision_id,
+            "tool_name": decision.tool_name,
+            "arguments": decision.arguments or {},
+            "reason": decision.reason,
+            "agent_name": decision.agent_name,
+            "role": decision.role,
+            "expires_at": expires_at,
+        }
+        try:
+            # Narrow except around SEND only — a send failure denies
+            # (fail-closed). Once send succeeds and we're purely awaiting
+            # the Event, an exception here (Timeout is caught below; the
+            # only other path is cancellation) should NOT clobber a
+            # resolve() that already set allowed=True.
+            try:
+                async with self._send_lock:
+                    await ws.send(json.dumps(payload))
+            except Exception:
+                logger.exception(
+                    "approval request %s failed to send — denying", decision_id
+                )
+                return False
+
+            try:
+                await asyncio.wait_for(evt.wait(), timeout=self._ttl)
+            except asyncio.TimeoutError:
+                # Fail-closed on TTL. `box["allowed"]` stays False.
+                logger.info(
+                    "approval request %s timed out after %ss — denying",
+                    decision_id,
+                    self._ttl,
+                )
+        finally:
+            self._pending.pop(decision_id, None)
+        return box["allowed"]
+
+    def resolve(self, decision_id: str, allowed: bool) -> None:
+        """Called by ``_handle_message`` on ``approval.reply``.
+
+        Unknown ``decision_id`` (already timed out, spurious reply,
+        stale from a previous connection) is a no-op — we don't crash
+        the serve loop over untrusted payload keys.
+        """
+        entry = self._pending.get(decision_id)
+        if entry is None:
+            logger.debug(
+                "ignoring approval.reply for unknown decision_id=%r", decision_id
+            )
+            return
+        evt, box = entry
+        # ``allowed`` is validated as a strict bool by the caller
+        # (``_handle_message``) before it lands here — non-bool values
+        # already fail-closed at that layer.
+        box["allowed"] = allowed
+        evt.set()
 
 
 @dataclass
@@ -69,6 +207,11 @@ class ServeContext:
     # Carried on the context so reconnect loops don't need to rebuild
     # the HexgateConfig on every retry.
     api_key: str
+    # The handler wired into enforce_policy(). ``RelayApprovalHandler``
+    # instances need bind/unbind + reply routing; other handler shapes
+    # (auto-approve/deny bool, callable) are simply passed through to
+    # the enforcer without any WS involvement.
+    approval_handler: Any = None
 
 
 def _user_from_payload(attenuation: Any) -> User | None:
@@ -134,6 +277,39 @@ async def _handle_message(
         await ws.send(json.dumps({"type": "session_reset"}))
         return
 
+    if kind == "approval.reply":
+        # Playground answered a NEEDS_APPROVAL prompt. Route to the
+        # relay handler by decision_id. Non-relay handlers (auto-
+        # approve/deny bool, custom callable) can't consume the reply
+        # — log at warning so an operator debugging "why isn't my
+        # approval landing" sees the trail.
+        if not isinstance(context.approval_handler, RelayApprovalHandler):
+            logger.warning(
+                "serve: ignoring approval.reply — active handler is %r, not "
+                "a RelayApprovalHandler; playground approvals only work when "
+                "--approval-mode=ask (the default).",
+                type(context.approval_handler).__name__,
+            )
+            return
+        decision_id = payload.get("decision_id")
+        if not isinstance(decision_id, str):
+            logger.warning("serve: approval.reply missing string decision_id")
+            return
+        allowed = payload.get("allowed")
+        # STRICT bool check — never truthy-coerce. `bool("false")` is
+        # True in Python, so a client sending allowed="false" would
+        # otherwise approve the tool call. Fail-closed contract.
+        if allowed is not True and allowed is not False:
+            logger.warning(
+                "serve: approval.reply for %s has non-bool allowed=%r — "
+                "denying to preserve fail-closed",
+                decision_id,
+                allowed,
+            )
+            allowed = False
+        context.approval_handler.resolve(decision_id, allowed)
+        return
+
     logger.warning("serve: ignoring unknown message type %r", kind)
 
 
@@ -155,6 +331,13 @@ async def _serve_loop(context: ServeContext, url: str, console: Console) -> None
     """
     bearer_value = quote(context.api_key, safe="")
     subprotocols = [f"bearer.{bearer_value}", WS_PROTOCOL_MARKER]
+    # Track dispatched handler tasks so we can cancel them cleanly on
+    # disconnect (and so pending approvals fail-close via unbind, not by
+    # sitting on TTL). Each inbound frame gets its own task — otherwise
+    # a chat frame that triggers an approval prompt would block the
+    # very same coroutine that must read the matching approval.reply
+    # frame off the socket → hard deadlock, every approval TTL-denies.
+    dispatched: set[asyncio.Task[None]] = set()
     async with connect(
         url, ping_interval=PING_INTERVAL, subprotocols=subprotocols
     ) as ws:
@@ -164,37 +347,86 @@ async def _serve_loop(context: ServeContext, url: str, console: Console) -> None
                 "subprotocol — deployment may be running an older API. "
                 "Update the platform or pin to a matching hexgate CLI."
             )
-        console.print(f"[green]connected[/] — relaying through {url}")
-        await ws.send(
-            json.dumps({"type": "hello", "agent": context.runtime.agent_name})
-        )
         try:
+            # Bind AFTER handshake succeeded but INSIDE the try, so the
+            # finally always unbinds — a hello-send failure that bypasses
+            # this block leaves the handler unbound (its default state).
+            if isinstance(context.approval_handler, RelayApprovalHandler):
+                context.approval_handler.bind_socket(ws)
+            console.print(f"[green]connected[/] — relaying through {url}")
+            await ws.send(
+                json.dumps({"type": "hello", "agent": context.runtime.agent_name})
+            )
             async for message in ws:
                 try:
                     payload = json.loads(message)
                 except json.JSONDecodeError:
                     logger.warning("serve: ignoring non-JSON frame")
                     continue
-                try:
-                    await _handle_message(context, ws, payload)
-                except Exception as exc:  # noqa: BLE001
-                    logger.exception("serve: error handling %r", payload.get("type"))
-                    await ws.send(
-                        json.dumps(
-                            {
-                                "event_type": "error",
-                                "message": str(exc),
-                                "run_id": "serve",
-                                "root_run_id": "serve",
-                                "sequence": 0,
-                            }
-                        )
-                    )
+                # Dispatch on a background task so the read loop can
+                # immediately pick up the next frame — critical for
+                # approval.reply arriving mid-chat.
+                task = asyncio.create_task(
+                    _dispatch_message(context, ws, payload)
+                )
+                dispatched.add(task)
+                task.add_done_callback(dispatched.discard)
         except ConnectionClosed:
             console.print("[yellow]disconnected[/]")
+        finally:
+            # Fail-close every in-flight approval FIRST — this lets any
+            # coroutine parked on an approval Event unblock as denied so
+            # the tool call returns to its caller, which then lets the
+            # dispatched task complete naturally. If we cancelled the
+            # tasks first, the enforcer's downstream cleanup would run
+            # under CancelledError and could leak subtasks.
+            if isinstance(context.approval_handler, RelayApprovalHandler):
+                context.approval_handler.unbind_socket()
+            # Give the freshly-denied tool calls a moment to finish
+            # cleanly, then cancel anything still running.
+            if dispatched:
+                _, pending = await asyncio.wait(dispatched, timeout=1.0)
+                for task in pending:
+                    task.cancel()
+                # Reap the cancellations so we don't leak "Task was
+                # destroyed but it is pending!" warnings on shutdown.
+                await asyncio.gather(*pending, return_exceptions=True)
 
 
-async def run_serve(runtime: AgentRuntime) -> None:
+async def _dispatch_message(context: ServeContext, ws: Any, payload: dict) -> None:
+    """Handle one inbound frame, catching + reporting errors as tool events.
+
+    Extracted from ``_serve_loop`` so each frame runs in its own task,
+    which keeps the read loop free to pick up the next frame while a
+    long-running chat call is still streaming. Errors that escape
+    ``_handle_message`` are logged and echoed back to the peer as an
+    ``error`` event so the dashboard sees the failure inline.
+    """
+    try:
+        await _handle_message(context, ws, payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("serve: error handling %r", payload.get("type"))
+        try:
+            await ws.send(
+                json.dumps(
+                    {
+                        "event_type": "error",
+                        "message": str(exc),
+                        "run_id": "serve",
+                        "root_run_id": "serve",
+                        "sequence": 0,
+                    }
+                )
+            )
+        except Exception:  # noqa: BLE001
+            # Socket already gone — nothing to report to.
+            pass
+
+
+async def run_serve(
+    runtime: AgentRuntime,
+    approval_handler: Any = None,
+) -> None:
     """Top-level serve loop with reconnect + graceful shutdown.
 
     Policy hot-reload is handled by the agent's attached :class:`~hexgate.
@@ -202,6 +434,12 @@ async def run_serve(runtime: AgentRuntime) -> None:
     ``agent.refresh_policy()`` at the start of every turn, the source
     sends ``If-None-Match`` to the platform, and a ``304`` short-circuits
     to the cached bundle. No bespoke runtime rebuild needed here.
+
+    ``approval_handler`` is the SAME object the runtime was built with;
+    passed separately so ``_serve_loop`` can bind/unbind it on the WS
+    connect/disconnect boundary when it's a :class:`RelayApprovalHandler`.
+    Non-relay handlers (auto-approve/deny bool, custom callables) are
+    unused here — they take effect inside the enforcer directly.
     """
     console = Console()
     config = HexgateConfig.from_env()
@@ -215,7 +453,12 @@ async def run_serve(runtime: AgentRuntime) -> None:
     # No ``project_id`` in the URL — the bearer subprotocol carries it.
     url = f"{ws_base}/v1/serve"
 
-    context = ServeContext(runtime=runtime, state=ChatState(), api_key=config.api_key)
+    context = ServeContext(
+        runtime=runtime,
+        state=ChatState(),
+        api_key=config.api_key,
+        approval_handler=approval_handler,
+    )
     backoff = RECONNECT_BASE
 
     # ``project_id`` is best-effort display now (Phase 6); show a
@@ -227,6 +470,20 @@ async def run_serve(runtime: AgentRuntime) -> None:
         f"[bold]hexgate-serve[/] agent=[cyan]{runtime.agent_name}[/] "
         f"project=[cyan]{project_display}[/]"
     )
+    # Flag the default-flip loudly for existing operators. Before this
+    # release, `hexgate serve` coerced `ask` → `auto-approve` because
+    # there was no way to prompt during a relay session. Now `ask`
+    # (still the default) uses RelayApprovalHandler — approval_required
+    # tool calls that fire while no playground is connected DENY. This
+    # is the correct security default but a behavior change; scripts
+    # that relied on the old silent auto-approve must opt in explicitly.
+    if isinstance(approval_handler, RelayApprovalHandler):
+        console.print(
+            "[yellow]approval:[/] approval_required tool calls will prompt the "
+            "connected playground; without a connected playground they DENY. "
+            "Use [cyan]--approval-mode auto-approve[/] for headless / CI runs "
+            "if that's what you want."
+        )
     console.print("[dim]Ctrl+C to stop[/]")
 
     while True:
@@ -279,10 +536,10 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         choices=("ask", "auto-approve", "auto-deny"),
         default="ask",
         help=(
-            "How approval-required tool calls are handled. ``ask`` is the "
-            "default and prompts in the terminal; serve coerces it to "
-            "``auto-approve`` since the terminal isn't interactive during "
-            "a WebSocket session."
+            "How approval-required tool calls are handled. ``ask`` (default) "
+            "routes the request to the connected playground for a human to "
+            "decide; ``auto-approve`` / ``auto-deny`` skip the round-trip "
+            "and apply the outcome directly (script / CI mode)."
         ),
     )
     parser.add_argument(
@@ -310,13 +567,15 @@ def main(args: argparse.Namespace) -> int:
 
     agent_obj = load_spec(args.agent_spec)
 
-    # ``ask`` doesn't make sense in serve mode — no TTY prompt during
-    # a relay session. Coerce to auto-approve unless the operator
-    # explicitly picked auto-deny.
-    approval_mode = (
-        args.approval_mode if args.approval_mode == "auto-deny" else "auto-approve"
-    )
-    approval_handler = build_approval_handler(console, approval_mode)
+    # Default (``ask``) routes approvals to the connected playground
+    # via the WS relay. Script/CI callers can still opt into
+    # ``auto-approve`` / ``auto-deny`` to skip the round-trip. The
+    # RelayApprovalHandler needs the socket bound at runtime — that
+    # happens in _serve_loop.
+    if args.approval_mode in ("auto-approve", "auto-deny"):
+        approval_handler = build_approval_handler(console, args.approval_mode)
+    else:
+        approval_handler = RelayApprovalHandler()
 
     try:
         runtime = build_runtime_from_local_agent(
@@ -333,5 +592,5 @@ def main(args: argparse.Namespace) -> int:
         console.print(f"[red]✗[/] {exc}")
         return 1
 
-    asyncio.run(run_serve(runtime))
+    asyncio.run(run_serve(runtime, approval_handler=approval_handler))
     return 0

--- a/hexgate/cli/serve.py
+++ b/hexgate/cli/serve.py
@@ -98,13 +98,20 @@ class RelayApprovalHandler:
     def __init__(self, ttl_seconds: float = APPROVAL_TTL_SECONDS) -> None:
         self._pending: dict[str, tuple[asyncio.Event, dict[str, Any]]] = {}
         self._ws: Any = None
+        self._send_lock: asyncio.Lock | None = None
         self._ttl = ttl_seconds
-        # Guards ws.send() from two concurrent __call__ invocations.
-        self._send_lock = asyncio.Lock()
 
-    def bind_socket(self, ws: Any) -> None:
-        """Called by ``_serve_loop`` on each new WS connect."""
+    def bind_socket(self, ws: Any, send_lock: asyncio.Lock) -> None:
+        """Called by ``_serve_loop`` on each new WS connect.
+
+        Takes the per-connection send lock so approval-request sends
+        serialize with every OTHER send on the same socket (chat
+        stream, reset ack, error echo). One lock across all sends is
+        the only way to keep frames from interleaving — websockets
+        does not serialize concurrent send() calls itself.
+        """
         self._ws = ws
+        self._send_lock = send_lock
 
     def unbind_socket(self) -> None:
         """Called on WS disconnect. Fail-closes every in-flight approval
@@ -115,10 +122,12 @@ class RelayApprovalHandler:
             evt.set()
         self._pending.clear()
         self._ws = None
+        self._send_lock = None
 
     async def __call__(self, decision: Decision) -> bool:
         ws = self._ws
-        if ws is None:
+        send_lock = self._send_lock
+        if ws is None or send_lock is None:
             logger.warning(
                 "approval requested but no playground is connected — denying "
                 "tool_name=%s",
@@ -155,7 +164,7 @@ class RelayApprovalHandler:
             # only other path is cancellation) should NOT clobber a
             # resolve() that already set allowed=True.
             try:
-                async with self._send_lock:
+                async with send_lock:
                     await ws.send(json.dumps(payload))
             except Exception:
                 logger.exception(
@@ -182,8 +191,18 @@ class RelayApprovalHandler:
         Unknown ``decision_id`` (already timed out, spurious reply,
         stale from a previous connection) is a no-op — we don't crash
         the serve loop over untrusted payload keys.
+
+        Atomically pops the entry from ``_pending`` before mutating
+        ``box``: without this, an ``unbind_socket`` firing between
+        ``box["allowed"] = True`` and the parked ``__call__``
+        coroutine waking up would find the still-registered entry and
+        flip ``allowed`` back to False — silently denying a call the
+        user just approved. Popping first means unbind can't see it.
+        The parked ``__call__`` sees ``box["allowed"] == True`` and
+        returns approve; its own ``finally`` ``pop(..., None)`` no-ops
+        because we already removed the entry.
         """
-        entry = self._pending.get(decision_id)
+        entry = self._pending.pop(decision_id, None)
         if entry is None:
             logger.debug(
                 "ignoring approval.reply for unknown decision_id=%r", decision_id
@@ -212,6 +231,43 @@ class ServeContext:
     # (auto-approve/deny bool, callable) are simply passed through to
     # the enforcer without any WS involvement.
     approval_handler: Any = None
+    # Per-connection send lock. Every ``ws.send`` on this connection —
+    # chat stream deltas, reset ack, error echo, approval.request —
+    # must acquire it. Now that ``_serve_loop`` dispatches each inbound
+    # frame as its own asyncio task, two of those sends can fire
+    # concurrently, and the ``websockets`` library does NOT serialize
+    # concurrent ``send()`` calls; interleaved frames would corrupt the
+    # protocol on the peer side. Set at connect time by ``_serve_loop``;
+    # ``None`` outside an active connection.
+    send_lock: asyncio.Lock | None = None
+    # Per-connection chat lock. Serializes the chat branch of
+    # ``_handle_message`` so two concurrent "chat" frames don't both
+    # call ``ChatState.start_turn`` (which unconditionally overwrites
+    # ``self.current_run``) and produce interleaved state mutation.
+    # Approval replies and reset frames still run concurrently with
+    # streaming — only chat-vs-chat is serialized. Set at connect time
+    # by ``_serve_loop``; ``None`` outside an active connection.
+    chat_lock: asyncio.Lock | None = None
+
+
+async def _safe_send(context: "ServeContext", ws: Any, message: str) -> None:
+    """Send ``message`` on ``ws`` under the connection's send lock.
+
+    Every non-approval WS send on the serve path routes through here so
+    concurrent frames don't interleave. The approval-request path
+    inside :class:`RelayApprovalHandler.__call__` acquires the same
+    lock (given to it via ``bind_socket``) — one lock across all send
+    sites is the invariant.
+    """
+    lock = context.send_lock
+    if lock is None:
+        # Not inside an active connection scope — should only happen in
+        # tests that bypass ``_serve_loop``. Fall through to a raw send
+        # so the test isn't forced to invent a lock.
+        await ws.send(message)
+        return
+    async with lock:
+        await ws.send(message)
 
 
 def _user_from_payload(attenuation: Any) -> User | None:
@@ -245,6 +301,32 @@ async def _maybe_user_scope(user: User | None):
             yield
 
 
+async def _run_chat_turn(
+    context: ServeContext, ws: Any, text: str, payload: dict
+) -> None:
+    """Run one chat turn end-to-end: start_turn → stream → apply + send.
+
+    Extracted so the chat branch of ``_handle_message`` can wrap it
+    under ``context.chat_lock`` without a giant indented block. Every
+    outbound event goes through ``_safe_send`` so a mid-turn approval
+    request from the enforcer serializes cleanly with these stream
+    deltas rather than interleaving on the wire.
+    """
+    # Policy refresh is handled inside stream_agent now (Phase 8a) —
+    # the attached PolicySource sends If-None-Match and reuses the
+    # cached bundle on 304. No need for serve to rebuild the runtime.
+    context.state.start_turn(text)
+    user = _user_from_payload(payload.get("user_attenuation"))
+    async with _maybe_user_scope(user):
+        async for event in stream_agent(
+            context.runtime.agent,
+            context.runtime.handler,
+            context.state.build_input(),
+        ):
+            context.state.apply_event(event)
+            await _safe_send(context, ws, event.model_dump_json())
+
+
 async def _handle_message(
     context: ServeContext,
     ws,
@@ -257,24 +339,26 @@ async def _handle_message(
         text = str(payload.get("message", "")).strip()
         if not text:
             return
-        # Policy refresh is handled inside stream_agent now (Phase 8a) —
-        # the attached PolicySource sends If-None-Match and reuses the
-        # cached bundle on 304. No need for serve to rebuild the runtime.
-        context.state.start_turn(text)
-        user = _user_from_payload(payload.get("user_attenuation"))
-        async with _maybe_user_scope(user):
-            async for event in stream_agent(
-                context.runtime.agent,
-                context.runtime.handler,
-                context.state.build_input(),
-            ):
-                context.state.apply_event(event)
-                await ws.send(event.model_dump_json())
+        # Serialize chat turns so two "chat" frames arriving back-to-back
+        # can't both call start_turn() concurrently — start_turn()
+        # unconditionally overwrites ``current_run``, which would leak
+        # the first turn's remaining events into the second turn's
+        # state. Approval replies still race with the streaming chat
+        # (different branch), so the deadlock fix isn't undone.
+        chat_lock = context.chat_lock
+        if chat_lock is None:
+            # No lock provided (test bypass of _serve_loop) — fall
+            # through unserialized; the test is responsible for not
+            # firing overlapping chats.
+            await _run_chat_turn(context, ws, text, payload)
+            return
+        async with chat_lock:
+            await _run_chat_turn(context, ws, text, payload)
         return
 
     if kind == "reset":
         context.state.clear()
-        await ws.send(json.dumps({"type": "session_reset"}))
+        await _safe_send(context, ws, json.dumps({"type": "session_reset"}))
         return
 
     if kind == "approval.reply":
@@ -338,6 +422,11 @@ async def _serve_loop(context: ServeContext, url: str, console: Console) -> None
     # very same coroutine that must read the matching approval.reply
     # frame off the socket → hard deadlock, every approval TTL-denies.
     dispatched: set[asyncio.Task[None]] = set()
+    # Per-connection locks live for the duration of THIS `async with
+    # connect(...)` block. Recreated on every reconnect so a torn-down
+    # connection can't share a lock with the next one — clean lifecycle.
+    context.send_lock = asyncio.Lock()
+    context.chat_lock = asyncio.Lock()
     async with connect(
         url, ping_interval=PING_INTERVAL, subprotocols=subprotocols
     ) as ws:
@@ -352,10 +441,12 @@ async def _serve_loop(context: ServeContext, url: str, console: Console) -> None
             # finally always unbinds — a hello-send failure that bypasses
             # this block leaves the handler unbound (its default state).
             if isinstance(context.approval_handler, RelayApprovalHandler):
-                context.approval_handler.bind_socket(ws)
+                context.approval_handler.bind_socket(ws, context.send_lock)
             console.print(f"[green]connected[/] — relaying through {url}")
-            await ws.send(
-                json.dumps({"type": "hello", "agent": context.runtime.agent_name})
+            await _safe_send(
+                context,
+                ws,
+                json.dumps({"type": "hello", "agent": context.runtime.agent_name}),
             )
             async for message in ws:
                 try:
@@ -389,6 +480,11 @@ async def _serve_loop(context: ServeContext, url: str, console: Console) -> None
                 # Reap the cancellations so we don't leak "Task was
                 # destroyed but it is pending!" warnings on shutdown.
                 await asyncio.gather(*pending, return_exceptions=True)
+            # Drop the per-connection locks so a next-reconnect call to
+            # bind_socket doesn't inherit a stale lock a canceled task
+            # might still be holding.
+            context.send_lock = None
+            context.chat_lock = None
 
 
 async def _dispatch_message(context: ServeContext, ws: Any, payload: dict) -> None:
@@ -405,7 +501,9 @@ async def _dispatch_message(context: ServeContext, ws: Any, payload: dict) -> No
     except Exception as exc:  # noqa: BLE001
         logger.exception("serve: error handling %r", payload.get("type"))
         try:
-            await ws.send(
+            await _safe_send(
+                context,
+                ws,
                 json.dumps(
                     {
                         "event_type": "error",
@@ -414,7 +512,7 @@ async def _dispatch_message(context: ServeContext, ws: Any, payload: dict) -> No
                         "root_run_id": "serve",
                         "sequence": 0,
                     }
-                )
+                ),
             )
         except Exception:  # noqa: BLE001
             # Socket already gone — nothing to report to.

--- a/platform/dashboard/src/lib/playground.test.tsx
+++ b/platform/dashboard/src/lib/playground.test.tsx
@@ -1,0 +1,442 @@
+/**
+ * Tests for ``usePlayground`` — specifically the approval-request flow:
+ * receiving prompts, dispatching replies, TTL sweep, concurrent
+ * approvals resolving out of arrival order.
+ *
+ * We mock the module-level WebSocket. The hook's socket is shared
+ * across React tree unmounts (that's the whole point — chat history
+ * survives navigation), so ``resetPlayground()`` gets called between
+ * tests to wipe the module state cleanly.
+ */
+
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resetPlayground, usePlayground } from "./playground";
+
+/**
+ * Minimal WebSocket mock. Records every payload the hook sends via
+ * ``sent`` and exposes ``receive()`` for the test to shove frames the
+ * other way. The real WebSocket dispatches ``open`` synchronously via
+ * an event; we simulate that by calling the handler immediately.
+ */
+class MockSocket {
+  static instances: MockSocket[] = [];
+  static OPEN = 1;
+
+  readyState = MockSocket.OPEN;
+  sent: string[] = [];
+  url: string;
+  private handlers: Record<string, ((evt: unknown) => void)[]> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    MockSocket.instances.push(this);
+    // Fire open on next tick so the hook's onopen handler runs after
+    // the constructor returns — matches real browser behavior.
+    queueMicrotask(() => this.fire("open", {}));
+  }
+
+  addEventListener(name: string, cb: (evt: unknown) => void): void {
+    (this.handlers[name] ??= []).push(cb);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.fire("close", {});
+  }
+
+  /** Simulate a frame arriving from the server. */
+  receive(frame: unknown): void {
+    this.fire("message", { data: JSON.stringify(frame) });
+  }
+
+  private fire(name: string, evt: unknown): void {
+    (this.handlers[name] ?? []).forEach((cb) => cb(evt));
+  }
+}
+
+beforeEach(() => {
+  MockSocket.instances = [];
+  (globalThis as { WebSocket: unknown }).WebSocket = MockSocket;
+  resetPlayground();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  resetPlayground();
+});
+
+function futureIso(secondsAhead: number): string {
+  return new Date(Date.now() + secondsAhead * 1000).toISOString();
+}
+
+function pastIso(secondsAgo: number): string {
+  return new Date(Date.now() - secondsAgo * 1000).toISOString();
+}
+
+// ---------------------------------------------------------------------
+// Receiving approval requests
+// ---------------------------------------------------------------------
+
+describe("approval requests over the WS", () => {
+  it("renders a received approval.request into pendingApprovals", async () => {
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve(); // let queueMicrotask fire the open handler
+    });
+
+    const ws = MockSocket.instances[0];
+    expect(ws).toBeDefined();
+
+    act(() => {
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_1",
+        tool_name: "send_invoice",
+        arguments: { order_id: "ORD-7", amount: 1250 },
+        reason: "role=contractor + args.amount > 500",
+        agent_name: "billing_bot",
+        role: "contractor",
+        expires_at: futureIso(300),
+      });
+    });
+
+    expect(result.current.state.pendingApprovals).toHaveLength(1);
+    expect(result.current.state.pendingApprovals[0].decision_id).toBe("appr_1");
+    expect(result.current.state.pendingApprovals[0].tool_name).toBe(
+      "send_invoice",
+    );
+  });
+
+  it("dedupes: same decision_id twice → single pending entry", async () => {
+    // Reconnect / replay could deliver the same request twice; the
+    // store's dedupe-by-decision-id keeps the UI honest.
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+
+    const request = {
+      type: "approval.request" as const,
+      decision_id: "appr_dup",
+      tool_name: "x",
+      arguments: {},
+      reason: null,
+      agent_name: "a",
+      role: null,
+      expires_at: futureIso(300),
+    };
+    act(() => {
+      ws.receive(request);
+      ws.receive(request);
+    });
+
+    expect(result.current.state.pendingApprovals).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------
+// Responding — happy path + concurrency
+// ---------------------------------------------------------------------
+
+describe("respondToApproval", () => {
+  it("sends approval.reply with the right decision_id and removes the entry", async () => {
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+
+    act(() => {
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_1",
+        tool_name: "x",
+        arguments: {},
+        reason: null,
+        agent_name: "a",
+        role: null,
+        expires_at: futureIso(300),
+      });
+    });
+
+    act(() => {
+      result.current.respondToApproval("appr_1", true);
+    });
+
+    // Reply frame sent...
+    const replyFrame = ws.sent.find((s) => s.includes("approval.reply"));
+    expect(replyFrame).toBeDefined();
+    const parsed = JSON.parse(replyFrame ?? "{}");
+    expect(parsed).toEqual({
+      type: "approval.reply",
+      decision_id: "appr_1",
+      allowed: true,
+    });
+    // ...and the entry cleared (only on successful send — see #6).
+    expect(result.current.state.pendingApprovals).toHaveLength(0);
+  });
+
+  it("respondToApproval returns false and KEEPS the entry when WS is closed", async () => {
+    // Regression for finding #6: previously, `respondToApproval`
+    // removed the entry from local state EVEN when the WS was closed
+    // and the reply was never sent. User thought they approved; the
+    // SDK denied on disconnect. Silent UI/audit divergence.
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+    act(() => {
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_1",
+        tool_name: "x",
+        arguments: {},
+        reason: null,
+        agent_name: "a",
+        role: null,
+        expires_at: futureIso(300),
+      });
+    });
+
+    // Simulate the socket dropping BEFORE the click. close() fires the
+    // handler which clears pendingApprovals (finding #5), so seed a
+    // fresh one AFTER the close for this test.
+    ws.readyState = 3; // CLOSED
+
+    let ok: boolean | undefined;
+    act(() => {
+      // Re-add manually to test the "socket closed" branch of
+      // respondToApproval in isolation (pendingApprovals was cleared
+      // by the close handler).
+      ok = result.current.respondToApproval("appr_1", true);
+    });
+
+    expect(ok).toBe(false);
+    // No frame sent (WS not open).
+    expect(ws.sent.find((s) => s.includes("approval.reply"))).toBeUndefined();
+  });
+
+  it("resolving one out of many concurrent approvals leaves the others intact", async () => {
+    // Parallel tool calls fire N approval requests simultaneously.
+    // The user might approve #2 first — the others must still render.
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+
+    const req = (id: string) => ({
+      type: "approval.request" as const,
+      decision_id: id,
+      tool_name: "x",
+      arguments: {},
+      reason: null,
+      agent_name: "a",
+      role: null,
+      expires_at: futureIso(300),
+    });
+    act(() => {
+      ws.receive(req("a"));
+      ws.receive(req("b"));
+      ws.receive(req("c"));
+    });
+
+    expect(
+      result.current.state.pendingApprovals.map((p) => p.decision_id),
+    ).toEqual(["a", "b", "c"]);
+
+    act(() => {
+      result.current.respondToApproval("b", true);
+    });
+
+    // "b" removed, order-preserving of the rest.
+    expect(
+      result.current.state.pendingApprovals.map((p) => p.decision_id),
+    ).toEqual(["a", "c"]);
+  });
+
+  it("resolving an unknown decision_id is a no-op", async () => {
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    act(() => {
+      result.current.respondToApproval("appr_ghost", true);
+    });
+
+    expect(result.current.state.pendingApprovals).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------
+// TTL sweep
+// ---------------------------------------------------------------------
+
+describe("TTL sweep", () => {
+  it("drops expired approvals after the 1s sweep tick", async () => {
+    // The serve-side handler already denied on TTL; the UI mustn't
+    // keep a dead prompt visible.
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+
+    act(() => {
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_old",
+        tool_name: "x",
+        arguments: {},
+        reason: null,
+        agent_name: "a",
+        role: null,
+        expires_at: pastIso(1),
+      });
+    });
+
+    expect(result.current.state.pendingApprovals).toHaveLength(1);
+
+    // Advance past the sweep interval.
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+
+    expect(result.current.state.pendingApprovals).toHaveLength(0);
+  });
+
+  it("does NOT drop approvals whose expires_at is still in the future", async () => {
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+
+    act(() => {
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_fresh",
+        tool_name: "x",
+        arguments: {},
+        reason: null,
+        agent_name: "a",
+        role: null,
+        expires_at: futureIso(60),
+      });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(1100);
+      await Promise.resolve();
+    });
+
+    expect(result.current.state.pendingApprovals).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------
+// WS close clears pending list (finding #5)
+// ---------------------------------------------------------------------
+
+describe("WS close", () => {
+  it("clears pendingApprovals when the socket closes", async () => {
+    // Regression for finding #5: the SDK-side unbind_socket() has
+    // already denied every in-flight approval; leaving prompts on
+    // screen lets the user "approve" a decision that already resolved
+    // as denied — silent UI/audit divergence.
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+    act(() => {
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_1",
+        tool_name: "x",
+        arguments: {},
+        reason: null,
+        agent_name: "a",
+        role: null,
+        expires_at: futureIso(300),
+      });
+    });
+    expect(result.current.state.pendingApprovals).toHaveLength(1);
+
+    act(() => {
+      ws.close();
+    });
+    expect(result.current.state.pendingApprovals).toHaveLength(0);
+    expect(result.current.state.connected).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------
+// reset() clears the pending list
+// ---------------------------------------------------------------------
+
+describe("reset()", () => {
+  it("clears pendingApprovals + sends deny-replies for each (finding #8)", async () => {
+    // Regression: reset previously only cleared the local list —
+    // server-side coroutines kept waiting until TTL, then denied
+    // stale calls into the fresh session's audit log.
+    const { result } = renderHook(() => usePlayground({ projectId: "p1" }));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const ws = MockSocket.instances[0];
+
+    act(() => {
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_1",
+        tool_name: "x",
+        arguments: {},
+        reason: null,
+        agent_name: "a",
+        role: null,
+        expires_at: futureIso(300),
+      });
+      ws.receive({
+        type: "approval.request",
+        decision_id: "appr_2",
+        tool_name: "y",
+        arguments: {},
+        reason: null,
+        agent_name: "a",
+        role: null,
+        expires_at: futureIso(300),
+      });
+    });
+    expect(result.current.state.pendingApprovals).toHaveLength(2);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    // Local list cleared.
+    expect(result.current.state.pendingApprovals).toHaveLength(0);
+    // Two deny-replies AND the reset frame sent, in order.
+    const decisions = ws.sent
+      .map((s) => JSON.parse(s))
+      .filter((f) => f.type === "approval.reply");
+    expect(decisions).toHaveLength(2);
+    expect(decisions.map((d) => d.decision_id).sort()).toEqual([
+      "appr_1",
+      "appr_2",
+    ]);
+    expect(decisions.every((d) => d.allowed === false)).toBe(true);
+    expect(ws.sent.some((s) => JSON.parse(s).type === "reset")).toBe(true);
+  });
+});

--- a/platform/dashboard/src/lib/playground.ts
+++ b/platform/dashboard/src/lib/playground.ts
@@ -53,6 +53,29 @@ export interface ErrorEvent {
   message: string;
 }
 
+/**
+ * Approval prompt emitted by ``hexgate serve`` when the enforcer flags
+ * a tool call as ``approval_required``. The serve process blocks on
+ * ``asyncio.Event`` until we send back an ``approval.reply`` with the
+ * matching ``decision_id``. Fail-closed on both ends: TTL expiry or
+ * server disconnect denies the underlying tool call.
+ *
+ * Uses ``type`` (not ``event_type``) — approval is a control frame,
+ * not a streaming event, so it lines up with the other controls
+ * (hello, session_reset, agent_online) rather than the LLM-turn
+ * stream (run_start, block_delta, ...).
+ */
+export interface ApprovalRequestEvent {
+  type: "approval.request";
+  decision_id: string;
+  tool_name: string;
+  arguments: Record<string, unknown>;
+  reason: string | null;
+  agent_name: string;
+  role: string | null;
+  expires_at: string; // ISO
+}
+
 export type StreamEvent =
   | RunStartEvent
   | BlockStartEvent
@@ -109,6 +132,10 @@ export interface PlaygroundState {
   decisions: ToolCall[];
   /** id of the assistant turn currently being streamed into. */
   currentTurnId: string | null;
+  /** Approval prompts awaiting a click. Keyed by decision_id on
+   * removal — NEVER by array index, since concurrent parallel tool
+   * calls can resolve out of arrival order. */
+  pendingApprovals: ApprovalRequestEvent[];
 }
 
 interface Options {
@@ -141,6 +168,7 @@ const INITIAL_STATE: PlaygroundState = {
   messages: [],
   decisions: [],
   currentTurnId: null,
+  pendingApprovals: [],
 };
 
 let cachedState: PlaygroundState = INITIAL_STATE;
@@ -180,6 +208,18 @@ function handleFrame(frame: unknown): void {
     return;
   }
   if (f.type === "session_reset") return;
+  if (f.type === "approval.request") {
+    const req = f as ApprovalRequestEvent;
+    setStore((s) => {
+      // Idempotent — reconnect/replay must not duplicate an already-
+      // pending approval. Match by decision_id.
+      if (s.pendingApprovals.some((a) => a.decision_id === req.decision_id)) {
+        return s;
+      }
+      return { ...s, pendingApprovals: [...s.pendingApprovals, req] };
+    });
+    return;
+  }
   if (f.event_type) setStore((s) => applyEvent(s, f as StreamEvent));
 }
 
@@ -196,7 +236,16 @@ function connectSocket(projectId: string): void {
   });
 
   ws.addEventListener("close", () => {
-    setStore((s) => ({ ...s, connected: false, agentOnline: false }));
+    // Clear pendingApprovals: the SDK-side unbind_socket() has already
+    // denied every in-flight approval, so leaving prompts on screen
+    // would let the user "approve" a decision that already resolved as
+    // denied server-side — silent UI/audit divergence.
+    setStore((s) => ({
+      ...s,
+      connected: false,
+      agentOnline: false,
+      pendingApprovals: [],
+    }));
     if (activeProjectId === projectId) {
       const delay = Math.min(1000 * 2 ** reconnectAttempts, 15000);
       reconnectAttempts += 1;
@@ -274,6 +323,28 @@ export function usePlayground({ projectId }: Options) {
     // happens inside ensureSocketFor on the next mount.
   }, [projectId]);
 
+  // Sweep expired approvals from the pending list every second — only
+  // while there ARE pending approvals. In the common idle case (no
+  // pending) the interval is not installed, so an open Playground tab
+  // contributes zero timer wakeups.
+  const hasPending = state.pendingApprovals.length > 0;
+  useEffect(() => {
+    if (!hasPending) return;
+    const id = setInterval(() => {
+      setStore((s) => {
+        if (s.pendingApprovals.length === 0) return s;
+        const now = Date.now();
+        const kept = s.pendingApprovals.filter(
+          (a) => new Date(a.expires_at).getTime() > now,
+        );
+        return kept.length === s.pendingApprovals.length
+          ? s
+          : { ...s, pendingApprovals: kept };
+      });
+    }, 1000);
+    return () => clearInterval(id);
+  }, [hasPending]);
+
   /**
    * Send a chat message, optionally scoped to a role.
    *
@@ -320,7 +391,21 @@ export function usePlayground({ projectId }: Options) {
 
   function reset() {
     const ws = activeSocket;
-    if (ws && ws.readyState === WebSocket.OPEN) {
+    const isOpen = ws && ws.readyState === WebSocket.OPEN;
+    // Fire an explicit deny for each still-pending approval BEFORE the
+    // reset frame. Without this, the serve-side coroutines keep waiting
+    // up to the full 5min TTL, and denied events from the "old" turn
+    // then land in the middle of the fresh session's audit log.
+    if (isOpen) {
+      for (const req of cachedState.pendingApprovals) {
+        ws.send(
+          JSON.stringify({
+            type: "approval.reply",
+            decision_id: req.decision_id,
+            allowed: false,
+          }),
+        );
+      }
       ws.send(JSON.stringify({ type: "reset" }));
     }
     setStore((s) => ({
@@ -328,10 +413,43 @@ export function usePlayground({ projectId }: Options) {
       currentTurnId: null,
       messages: [],
       decisions: [],
+      pendingApprovals: [],
     }));
   }
 
-  return { state, sendChat, reset };
+  /**
+   * Resolve a pending approval prompt. Sends ``approval.reply`` to the
+   * serve process — its ``asyncio.Event`` unblocks and the tool call
+   * either runs (allowed=true) or returns a policy-denied envelope
+   * (allowed=false). The local removal is gated on a SUCCESSFUL send:
+   * if the WS is closed we keep the entry so the user sees the
+   * disconnected state instead of a phantom "you approved this"
+   * outcome that the SDK never received.
+   */
+  function respondToApproval(decision_id: string, allowed: boolean): boolean {
+    const ws = activeSocket;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return false;
+    try {
+      ws.send(
+        JSON.stringify({
+          type: "approval.reply",
+          decision_id,
+          allowed,
+        }),
+      );
+    } catch {
+      return false;
+    }
+    setStore((s) => ({
+      ...s,
+      pendingApprovals: s.pendingApprovals.filter(
+        (a) => a.decision_id !== decision_id,
+      ),
+    }));
+    return true;
+  }
+
+  return { state, sendChat, reset, respondToApproval };
 }
 
 /**

--- a/platform/dashboard/src/routes/Playground.tsx
+++ b/platform/dashboard/src/routes/Playground.tsx
@@ -20,6 +20,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   usePlayground,
+  type ApprovalRequestEvent,
   type ChatMessage,
   type ToolCall,
 } from "@/lib/playground";
@@ -49,7 +50,9 @@ export function PlaygroundPage() {
 }
 
 function PlaygroundLive({ projectId }: { projectId: string }) {
-  const { state, sendChat, reset } = usePlayground({ projectId });
+  const { state, sendChat, reset, respondToApproval } = usePlayground({
+    projectId,
+  });
   const [composer, setComposer] = useState("");
   const [agent, setAgent] = useState<AgentRead | null>(null);
   const [activeRole, setActiveRole] = useState<string | null>(null);
@@ -268,6 +271,13 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
           )}
         </div>
 
+        {state.pendingApprovals.length > 0 && (
+          <ApprovalPromptStack
+            pending={state.pendingApprovals}
+            onDecide={respondToApproval}
+          />
+        )}
+
         <footer className="border-t border-border p-4">
           <div className="flex items-center gap-2">
             <input
@@ -433,6 +443,137 @@ function DecisionRow({ call }: { call: ToolCall }) {
         <span className="text-muted-foreground text-[10px]">
           {call.endedAt ? `${call.endedAt - call.startedAt}ms` : "…"}
         </span>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------
+// Approval prompts
+// ---------------------------------------------------------------------
+//
+// The prompt renders INLINE above the composer (not as a modal) so the
+// user sees it in the flow of the conversation they were having, not
+// as a context-stealing overlay. When N > 1 concurrent approvals fire
+// (parallel tool calls via asyncio.gather on the serve side), the
+// stack renders each as its own row with its own decide buttons —
+// resolving one doesn't affect the others.
+
+interface ApprovalPromptStackProps {
+  pending: ApprovalRequestEvent[];
+  onDecide: (decision_id: string, allowed: boolean) => boolean;
+}
+
+function ApprovalPromptStack({ pending, onDecide }: ApprovalPromptStackProps) {
+  // One 1 Hz ticker for the whole stack — passed down as ``now`` so
+  // every card renders in lockstep from a single interval. Previously
+  // each card installed its own useCountdown → N cards = N intervals
+  // for the same wall-clock read.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="border-t border-approval/40 bg-approval/5 px-4 py-3 space-y-2 max-h-[45%] overflow-y-auto scrollbar-thin">
+      <div className="flex items-center gap-2 text-xs font-medium text-approval">
+        <ShieldAlert className="size-3.5" />
+        {pending.length === 1
+          ? "1 approval pending"
+          : `${pending.length} approvals pending`}
+      </div>
+      {pending.map((req) => (
+        <ApprovalPromptCard
+          key={req.decision_id}
+          request={req}
+          onDecide={onDecide}
+          now={now}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ApprovalPromptCardProps {
+  request: ApprovalRequestEvent;
+  onDecide: (decision_id: string, allowed: boolean) => boolean;
+  now: number;
+}
+
+function ApprovalPromptCard({
+  request,
+  onDecide,
+  now,
+}: ApprovalPromptCardProps) {
+  const deadline = useMemo(
+    () => new Date(request.expires_at).getTime(),
+    [request.expires_at],
+  );
+  const remaining = Math.max(0, Math.floor((deadline - now) / 1000));
+  const urgency =
+    remaining <= 10
+      ? "text-deny"
+      : remaining <= 30
+        ? "text-approval"
+        : "text-muted-foreground";
+
+  const argsPretty = useMemo(
+    () => JSON.stringify(request.arguments, null, 2),
+    [request.arguments],
+  );
+
+  return (
+    <div className="rounded-md border border-approval/40 bg-background/60 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 text-sm">
+            <Wrench className="size-3.5 text-approval shrink-0" />
+            <span className="font-mono font-medium truncate">
+              {request.tool_name}
+            </span>
+            {request.role && (
+              <Badge
+                variant="outline"
+                className="font-mono text-[10px] shrink-0"
+              >
+                {request.role}
+              </Badge>
+            )}
+          </div>
+          {request.reason && (
+            <p className="mt-1 text-[11px] leading-snug text-muted-foreground">
+              {request.reason}
+            </p>
+          )}
+        </div>
+        <span
+          className={cn("text-[10px] font-mono shrink-0 tabular-nums", urgency)}
+        >
+          {remaining > 0 ? `${remaining}s` : "expired"}
+        </span>
+      </div>
+      <pre className="mt-2 max-h-40 overflow-y-auto rounded bg-muted/60 p-2 text-[11px] font-mono leading-snug scrollbar-thin">
+        {argsPretty}
+      </pre>
+      <div className="mt-2 flex items-center justify-end gap-2">
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-7 gap-1.5 text-xs border-deny/40 hover:bg-deny/10 hover:text-deny"
+          onClick={() => onDecide(request.decision_id, false)}
+        >
+          <X className="size-3" />
+          Deny
+        </Button>
+        <Button
+          size="sm"
+          className="h-7 gap-1.5 text-xs bg-allow hover:bg-allow/90 text-white"
+          onClick={() => onDecide(request.decision_id, true)}
+        >
+          <Check className="size-3" />
+          Approve
+        </Button>
       </div>
     </div>
   );

--- a/tests/adapters/google/test_tools.py
+++ b/tests/adapters/google/test_tools.py
@@ -278,3 +278,101 @@ async def test_wrap_tools_accepts_mixed_callables_and_base_tools() -> None:
     denied = await gated.run_async(args={"text": "x"}, tool_context=None)
     assert allowed == "echo:x"
     assert "policy_denied" in denied
+
+
+# ---------------------------------------------------------------------------
+# approval_handler on NEEDS_APPROVAL decisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_true_runs_original_tool() -> None:
+    """An async handler that returns True lets the tool through."""
+    seen: list[Any] = []
+
+    async def approve(decision: Any) -> bool:
+        seen.append(decision)
+        return True
+
+    wrapped = wrap_tool(
+        _make_function_tool(),
+        _approval_enforcer(),
+        approval_handler=approve,
+    )
+
+    result = await wrapped.run_async(args={"text": "hi"}, tool_context=None)
+
+    assert result == "echo:hi"
+    assert len(seen) == 1
+    assert seen[0].tool_name == "echo"
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_false_returns_marker() -> None:
+    """A handler that returns False falls back to the [approval_required] marker."""
+
+    async def deny(_: Any) -> bool:
+        return False
+
+    wrapped = wrap_tool(
+        _make_function_tool(),
+        _approval_enforcer(),
+        approval_handler=deny,
+    )
+
+    result = await wrapped.run_async(args={"text": "hi"}, tool_context=None)
+
+    assert "approval_required" in result
+
+
+@pytest.mark.asyncio
+async def test_bool_approval_handler_short_circuits() -> None:
+    """approval_handler=True skips the callback and runs the tool."""
+    wrapped = wrap_tool(
+        _make_function_tool(),
+        _approval_enforcer(),
+        approval_handler=True,
+    )
+
+    result = await wrapped.run_async(args={"text": "hi"}, tool_context=None)
+
+    assert result == "echo:hi"
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_not_called_on_plain_deny() -> None:
+    """A plain deny never consults the approval handler."""
+    calls_to_handler: list[Any] = []
+
+    async def approve(decision: Any) -> bool:
+        calls_to_handler.append(decision)
+        return True
+
+    wrapped = wrap_tool(
+        _make_function_tool(),
+        _deny_enforcer(),
+        approval_handler=approve,
+    )
+
+    result = await wrapped.run_async(args={"text": "hi"}, tool_context=None)
+
+    assert "policy_denied" in result
+    assert calls_to_handler == []
+
+
+@pytest.mark.asyncio
+async def test_sync_approval_handler_is_accepted() -> None:
+    """A plain sync callable is a valid handler too."""
+
+    def approve(_: Any) -> bool:
+        return True
+
+    wrapped = wrap_tool(
+        _make_function_tool(),
+        _approval_enforcer(),
+        approval_handler=approve,
+    )
+
+    result = await wrapped.run_async(args={"text": "hi"}, tool_context=None)
+
+    assert result == "echo:hi"

--- a/tests/adapters/openai/test_tools.py
+++ b/tests/adapters/openai/test_tools.py
@@ -246,3 +246,109 @@ async def test_wrap_tools_isolates_policy_decisions_per_tool() -> None:
 
     assert allowed == 'invoked:{"text": "x"}'
     assert "policy_denied" in denied
+
+
+# ---------------------------------------------------------------------------
+# approval_handler on NEEDS_APPROVAL decisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_true_runs_original_tool() -> None:
+    """An async handler that returns True lets the tool through."""
+    calls: list[Any] = []
+    seen_decisions: list[Any] = []
+
+    async def approve(decision: Any) -> bool:
+        seen_decisions.append(decision)
+        return True
+
+    wrapped = wrap_tool(
+        _make_tool(calls=calls),
+        _enforcer(_approval_required_policy_set()),
+        approval_handler=approve,
+    )
+
+    result = await wrapped.on_invoke_tool("ctx", '{"text": "hi"}')
+
+    assert result == 'invoked:{"text": "hi"}'
+    assert len(calls) == 1
+    assert len(seen_decisions) == 1
+    assert seen_decisions[0].tool_name == "echo"
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_false_returns_marker() -> None:
+    """A handler that returns False falls back to the [approval_required] marker."""
+    calls: list[Any] = []
+
+    async def deny(_: Any) -> bool:
+        return False
+
+    wrapped = wrap_tool(
+        _make_tool(calls=calls),
+        _enforcer(_approval_required_policy_set()),
+        approval_handler=deny,
+    )
+
+    result = await wrapped.on_invoke_tool("ctx", '{"text": "hi"}')
+
+    assert "approval_required" in result
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_bool_approval_handler_short_circuits() -> None:
+    """approval_handler=True skips the callback and runs the tool."""
+    calls: list[Any] = []
+    wrapped = wrap_tool(
+        _make_tool(calls=calls),
+        _enforcer(_approval_required_policy_set()),
+        approval_handler=True,
+    )
+
+    result = await wrapped.on_invoke_tool("ctx", '{"text": "hi"}')
+
+    assert result == 'invoked:{"text": "hi"}'
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_not_called_on_plain_deny() -> None:
+    """A plain deny never consults the approval handler."""
+    calls_to_handler: list[Any] = []
+
+    async def approve(decision: Any) -> bool:
+        calls_to_handler.append(decision)
+        return True
+
+    wrapped = wrap_tool(
+        _make_tool(),
+        _enforcer(_deny_policy_set()),
+        approval_handler=approve,
+    )
+
+    result = await wrapped.on_invoke_tool("ctx", '{"text": "hi"}')
+
+    assert "policy_denied" in result
+    assert calls_to_handler == []
+
+
+@pytest.mark.asyncio
+async def test_sync_approval_handler_is_accepted() -> None:
+    """A plain sync callable is a valid handler too."""
+    calls: list[Any] = []
+
+    def approve(_: Any) -> bool:
+        return True
+
+    wrapped = wrap_tool(
+        _make_tool(calls=calls),
+        _enforcer(_approval_required_policy_set()),
+        approval_handler=approve,
+    )
+
+    result = await wrapped.on_invoke_tool("ctx", '{"text": "hi"}')
+
+    assert result == 'invoked:{"text": "hi"}'
+    assert len(calls) == 1

--- a/tests/adapters/pydantic_ai/test_tools.py
+++ b/tests/adapters/pydantic_ai/test_tools.py
@@ -214,3 +214,84 @@ async def test_wrap_tools_isolates_decisions_per_tool() -> None:
 
     with pytest.raises(ModelRetry, match="policy_denied"):
         await tool_b.function_schema.call({"text": "x"}, None)
+
+
+# ---------------------------------------------------------------------------
+# approval_handler on NEEDS_APPROVAL decisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_true_runs_original_tool() -> None:
+    """An async handler that returns True lets the tool through."""
+    seen: list[Any] = []
+
+    async def approve(decision: Any) -> bool:
+        seen.append(decision)
+        return True
+
+    wrapped = wrap_tool(
+        _make_sync_tool(), _approval_enforcer(), approval_handler=approve
+    )
+
+    result = await wrapped.function_schema.call({"text": "hi"}, None)
+
+    assert result == "echo:hi"
+    assert len(seen) == 1
+    assert seen[0].tool_name == "echo"
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_false_raises_approval_marker() -> None:
+    """A handler that returns False raises ModelRetry with the marker."""
+
+    async def deny(_: Any) -> bool:
+        return False
+
+    wrapped = wrap_tool(_make_sync_tool(), _approval_enforcer(), approval_handler=deny)
+
+    with pytest.raises(ModelRetry, match="approval_required"):
+        await wrapped.function_schema.call({"text": "hi"}, None)
+
+
+@pytest.mark.asyncio
+async def test_bool_approval_handler_short_circuits() -> None:
+    """approval_handler=True skips the callback and runs the tool."""
+    wrapped = wrap_tool(_make_sync_tool(), _approval_enforcer(), approval_handler=True)
+
+    result = await wrapped.function_schema.call({"text": "hi"}, None)
+
+    assert result == "echo:hi"
+
+
+@pytest.mark.asyncio
+async def test_approval_handler_not_called_on_plain_deny() -> None:
+    """A plain deny never consults the approval handler."""
+    calls_to_handler: list[Any] = []
+
+    async def approve(decision: Any) -> bool:
+        calls_to_handler.append(decision)
+        return True
+
+    wrapped = wrap_tool(_make_sync_tool(), _deny_enforcer(), approval_handler=approve)
+
+    with pytest.raises(ModelRetry, match="policy_denied"):
+        await wrapped.function_schema.call({"text": "hi"}, None)
+
+    assert calls_to_handler == []
+
+
+@pytest.mark.asyncio
+async def test_sync_approval_handler_is_accepted() -> None:
+    """A plain sync callable is a valid handler too."""
+
+    def approve(_: Any) -> bool:
+        return True
+
+    wrapped = wrap_tool(
+        _make_async_tool(), _approval_enforcer(), approval_handler=approve
+    )
+
+    result = await wrapped.function_schema.call({"text": "hi"}, None)
+
+    assert result == "async:hi"

--- a/tests/cli/test_serve_approval.py
+++ b/tests/cli/test_serve_approval.py
@@ -1,0 +1,491 @@
+"""Tests for :class:`RelayApprovalHandler` — the callback that routes
+NEEDS_APPROVAL decisions over the serve WS to the playground.
+
+We fake the websocket surface (only ``send`` is needed) so the tests
+run in-memory without opening a real socket.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from hexgate.cli.serve import RelayApprovalHandler
+from hexgate.security.decision import Decision, DecisionOutcome
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeWS:
+    """Minimal stand-in for the websockets client WebSocket.
+
+    Records every ``send()`` payload in ``self.sent`` for inspection.
+    Optionally serializes concurrent sends behind an ``asyncio.Lock``
+    that the handler is expected to hold — we assert the ordering
+    invariant separately.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send(self, message: str) -> None:
+        # Yield control so a concurrent send has a chance to interleave
+        # if the handler ISN'T using a lock — this catches the bug the
+        # asyncio.Lock exists to prevent.
+        await asyncio.sleep(0)
+        self.sent.append(json.loads(message))
+
+
+def _decision(tool: str = "send_invoice", **kwargs: Any) -> Decision:
+    return Decision(
+        outcome=DecisionOutcome.NEEDS_APPROVAL,
+        agent_name=kwargs.pop("agent_name", "billing_bot"),
+        tool_name=tool,
+        role=kwargs.pop("role", "default"),
+        reason=kwargs.pop("reason", "test approval"),
+        error_type="approval_required",
+        arguments=kwargs.pop("arguments", {"order_id": "ORD-1"}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path — request emitted, reply unblocks the coroutine
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_emits_approval_request_with_expected_shape() -> None:
+    """``__call__`` must send a well-formed ``approval.request`` frame
+    on the bound socket before it starts waiting for a reply."""
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=1.0)
+    handler.bind_socket(ws)
+
+    async def approve_after_a_tick() -> None:
+        # Give __call__ a chance to send + start awaiting.
+        await asyncio.sleep(0.05)
+        assert len(ws.sent) == 1
+        decision_id = ws.sent[0]["decision_id"]
+        handler.resolve(decision_id, allowed=True)
+
+    task_approve = asyncio.create_task(approve_after_a_tick())
+    result = await handler(_decision())
+    await task_approve
+
+    assert result is True
+    sent = ws.sent[0]
+    # ``type`` (not ``event_type``) — approval is a control frame, same
+    # discriminator as hello / reset / session_reset.
+    assert sent["type"] == "approval.request"
+    assert sent["tool_name"] == "send_invoice"
+    assert sent["arguments"] == {"order_id": "ORD-1"}
+    assert sent["reason"] == "test approval"
+    assert sent["agent_name"] == "billing_bot"
+    assert sent["role"] == "default"
+    assert isinstance(sent["decision_id"], str)
+    assert sent["decision_id"].startswith("appr_")
+    assert isinstance(sent["expires_at"], str)
+
+
+@pytest.mark.asyncio
+async def test_resolve_deny_returns_false() -> None:
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=1.0)
+    handler.bind_socket(ws)
+
+    async def deny_after_a_tick() -> None:
+        await asyncio.sleep(0.05)
+        handler.resolve(ws.sent[0]["decision_id"], allowed=False)
+
+    task = asyncio.create_task(deny_after_a_tick())
+    result = await handler(_decision())
+    await task
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_false_when_no_socket_bound() -> None:
+    """Nothing to send an approval prompt to → deny rather than hang."""
+    handler = RelayApprovalHandler(ttl_seconds=1.0)
+    # Deliberately DON'T bind_socket.
+    result = await handler(_decision())
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_timeout_returns_false() -> None:
+    """No reply within the TTL → deny (fail-closed)."""
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=0.1)
+    handler.bind_socket(ws)
+    result = await handler(_decision())
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_unbind_socket_denies_all_pending() -> None:
+    """Disconnecting mid-approval must fail every waiting handler so
+    coroutines don't outlive the socket they belonged to."""
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=10.0)
+    handler.bind_socket(ws)
+
+    # Fire two approvals in parallel; both will be blocked awaiting
+    # their Events. Unbind should release them both as False.
+    task_a = asyncio.create_task(handler(_decision(tool="a")))
+    task_b = asyncio.create_task(handler(_decision(tool="b")))
+    await asyncio.sleep(0.05)  # let both reach the await
+
+    handler.unbind_socket()
+
+    results = await asyncio.gather(task_a, task_b)
+    assert results == [False, False]
+    # Socket unbound → subsequent __call__ also denies immediately.
+    assert await handler(_decision(tool="c")) is False
+
+
+# ---------------------------------------------------------------------------
+# Concurrency — decision_id keying, no cross-talk, serialized sends
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_get_distinct_decision_ids() -> None:
+    """5 parallel tool calls → 5 unique decision_ids, no key collisions
+    (uuid4 is the source, but pin the invariant so a future rewrite
+    doesn't break it)."""
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=10.0)
+    handler.bind_socket(ws)
+
+    tasks = [asyncio.create_task(handler(_decision(tool=f"t{i}"))) for i in range(5)]
+    # Let all 5 send frames.
+    await asyncio.sleep(0.05)
+    assert len(ws.sent) == 5
+    ids = [frame["decision_id"] for frame in ws.sent]
+    assert len(set(ids)) == 5
+
+    # Resolve each in a scrambled order — verifies the map lookup,
+    # not any FIFO assumption.
+    handler.resolve(ids[2], allowed=True)
+    handler.resolve(ids[0], allowed=False)
+    handler.resolve(ids[4], allowed=True)
+    handler.resolve(ids[1], allowed=True)
+    handler.resolve(ids[3], allowed=False)
+
+    results = await asyncio.gather(*tasks)
+    # Order in results matches task creation order; decisions match
+    # the specific IDs we resolved above.
+    assert results == [False, True, True, False, True]
+
+
+@pytest.mark.asyncio
+async def test_ws_send_is_serialized_across_concurrent_calls() -> None:
+    """The websockets library doesn't serialize concurrent send() calls,
+    so RelayApprovalHandler must hold a lock across the send. Without
+    the lock, two coroutines calling __call__ at the same time could
+    interleave WS frames — silent bug that hides until a big payload
+    exposes it. This test forces the race window and asserts sends
+    landed as complete frames (one after another, not interleaved)."""
+
+    concurrent_in_send = 0
+    peak_concurrency = 0
+
+    class _RaceCapturingWS:
+        def __init__(self) -> None:
+            self.sent: list[dict[str, Any]] = []
+
+        async def send(self, message: str) -> None:
+            nonlocal concurrent_in_send, peak_concurrency
+            concurrent_in_send += 1
+            peak_concurrency = max(peak_concurrency, concurrent_in_send)
+            # Widen the race window so an unprotected send would clearly
+            # observe another concurrent one.
+            await asyncio.sleep(0.01)
+            concurrent_in_send -= 1
+            self.sent.append(json.loads(message))
+
+    ws = _RaceCapturingWS()
+    handler = RelayApprovalHandler(ttl_seconds=10.0)
+    handler.bind_socket(ws)
+
+    tasks = [asyncio.create_task(handler(_decision(tool=f"t{i}"))) for i in range(5)]
+    # Let all sends run (they all get serialized by the lock, then
+    # each awaits its own Event; we don't care about those here).
+    await asyncio.sleep(0.2)
+
+    handler.unbind_socket()
+    await asyncio.gather(*tasks)  # unblocks all as False
+
+    # Peak concurrency inside send() must be 1: no two coroutines can
+    # be mid-send simultaneously if the lock is held correctly.
+    assert peak_concurrency == 1, (
+        f"expected serialized sends, saw {peak_concurrency} concurrent"
+    )
+    assert len(ws.sent) == 5
+
+
+# ---------------------------------------------------------------------------
+# Resolve on unknown decision_id is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_unknown_decision_id_is_noop() -> None:
+    """Spurious ``approval.reply`` payloads (stale from prev connection,
+    typos in a test harness) mustn't crash the handler — they're just
+    dropped silently."""
+    handler = RelayApprovalHandler(ttl_seconds=1.0)
+    # No exception; nothing to observe.
+    handler.resolve("appr_does_not_exist", allowed=True)
+    handler.resolve("appr_does_not_exist_either", allowed=False)
+
+
+# ---------------------------------------------------------------------------
+# Reply routing via ServeContext (integration with _handle_message)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_message_routes_approval_reply(monkeypatch) -> None:
+    """``approval.reply`` frames coming off the WS must reach
+    ``handler.resolve()`` via ``_handle_message`` — the small piece of
+    routing that ties the WS to the handler."""
+    from hexgate.cli.serve import ServeContext, _handle_message
+    from hexgate.cli.state import ChatState
+
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=10.0)
+    handler.bind_socket(ws)
+
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type] — unused for this branch
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=handler,
+    )
+
+    # Start a pending approval so there's something to resolve.
+    task = asyncio.create_task(handler(_decision()))
+    await asyncio.sleep(0.05)
+    decision_id = ws.sent[0]["decision_id"]
+
+    await _handle_message(
+        context,
+        ws,
+        {
+            "type": "approval.reply",
+            "decision_id": decision_id,
+            "allowed": True,
+        },
+    )
+
+    result = await task
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: _apply_approval_handler still routes NEEDS_APPROVAL through
+# the enforcer's callback slot. Pins the full serve→enforcer chain so a
+# future refactor can't silently drop the handler mid-plumbing.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_approval_handler_wires_relay_handler_into_guarded_tools() -> None:
+    """Verify the plumbing that connects ``RelayApprovalHandler`` all the
+    way down to ``GuardedTool.approval_handler`` — the slot the enforcer
+    actually calls on ``NEEDS_APPROVAL``. Without this test, a rename or
+    refactor of ``_apply_approval_handler`` (which we don't own — it
+    lives in ``hexgate/agents/loader.py``) could silently break the
+    Playground approval flow with only the low-level unit tests staying
+    green.
+    """
+    from types import SimpleNamespace
+
+    from hexgate.adapters.langchain.tools import GuardedTool
+    from hexgate.agents.loader import _apply_approval_handler
+    from hexgate.security.enforcer import PolicyEnforcer
+    from hexgate.security.policy_set import load_policy_set_from_dict
+
+    # Minimal Agent-shaped object with one GuardedTool. Real agents get
+    # wrapped by create_agent; we shortcut to just the surface
+    # _apply_approval_handler reads (``.tools``, ``.with_tools``).
+    engine = load_policy_set_from_dict(
+        {
+            "version": 1,
+            "default_policy": {"mode": "deny"},
+            "tools": {"noop": {"mode": "allow"}},
+        }
+    )
+    enforcer = PolicyEnforcer(engine, agent_name="test")
+
+    async def _stub_tool_run(**_: Any) -> str:
+        return "ok"
+
+    from langchain_core.tools import StructuredTool
+
+    inner = StructuredTool.from_function(
+        coroutine=_stub_tool_run,
+        name="noop",
+        description="test tool",
+    )
+    guarded = GuardedTool.wrap(inner, enforcer=enforcer, approval_handler=None)
+
+    class _StubAgent(SimpleNamespace):
+        def with_tools(self, tools):
+            self.tools = list(tools)
+            return self
+
+    agent = _StubAgent(tools=[guarded])
+
+    # This is the exact call serve.py's main() → build_runtime_from_
+    # local_agent → _build_runtime_from_spec makes. If it silently
+    # stops touching guarded.approval_handler, Playground approvals
+    # silently break.
+    relay = RelayApprovalHandler()
+    _apply_approval_handler(agent, relay)
+
+    # Every GuardedTool on the returned agent now carries the relay.
+    assert len(agent.tools) == 1
+    assert isinstance(agent.tools[0], GuardedTool)
+    assert agent.tools[0].approval_handler is relay
+
+
+# ---------------------------------------------------------------------------
+# Strict-bool + protocol contract on `approval.reply`
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_string_allowed_is_treated_as_deny() -> None:
+    """Fail-closed contract: a client that sends ``allowed: "false"``
+    (JSON string, not bool) must be treated as deny, not approved via
+    ``bool("false") == True``. The strict check lives in
+    ``_handle_message``, which is where the reply enters the process."""
+    from hexgate.cli.serve import ServeContext, _handle_message
+    from hexgate.cli.state import ChatState
+
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=10.0)
+    handler.bind_socket(ws)
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=handler,
+    )
+
+    task = asyncio.create_task(handler(_decision()))
+    await asyncio.sleep(0.05)
+    decision_id = ws.sent[0]["decision_id"]
+
+    # String "false" would be truthy under bool() — but must be denied.
+    await _handle_message(
+        context,
+        ws,
+        {"type": "approval.reply", "decision_id": decision_id, "allowed": "false"},
+    )
+    result = await task
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_true_bool_allowed_approves() -> None:
+    """Sanity: the strict check doesn't accidentally reject legit True."""
+    from hexgate.cli.serve import ServeContext, _handle_message
+    from hexgate.cli.state import ChatState
+
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=10.0)
+    handler.bind_socket(ws)
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=handler,
+    )
+
+    task = asyncio.create_task(handler(_decision()))
+    await asyncio.sleep(0.05)
+    decision_id = ws.sent[0]["decision_id"]
+    await _handle_message(
+        context,
+        ws,
+        {"type": "approval.reply", "decision_id": decision_id, "allowed": True},
+    )
+    assert (await task) is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end deadlock regression (finding #1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_serve_loop_does_not_deadlock_on_approval() -> None:
+    """The critical bug the review caught: `_serve_loop` used to await
+    `_handle_message` inline, so a chat frame that triggered an approval
+    prompt would block the very coroutine that must read the matching
+    approval.reply off the socket. Every real approval TTL-denied.
+
+    This test simulates the real read loop's dispatch model (each
+    inbound frame → its own task) and confirms an approval AND its
+    reply can flow through without a stall.
+    """
+    from hexgate.cli.serve import _dispatch_message, ServeContext
+    from hexgate.cli.state import ChatState
+
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=5.0)
+    handler.bind_socket(ws)
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=handler,
+    )
+
+    # Simulate a chat frame arriving that immediately triggers an
+    # approval (bypass stream_agent — we're testing the dispatch model,
+    # not the LLM). Do that by directly calling handler() from a
+    # dispatched task; then dispatch the reply frame from ANOTHER task
+    # to prove the read loop stays free.
+    approval_task = asyncio.create_task(handler(_decision()))
+    await asyncio.sleep(0.05)
+    decision_id = ws.sent[0]["decision_id"]
+
+    # The reply arrives as a separate frame — under the old serial
+    # design, this dispatch would sit behind the still-awaiting
+    # approval_task and deadlock. Under the fixed design (each frame in
+    # its own task), it runs concurrently and resolve() fires the Event.
+    reply_task = asyncio.create_task(
+        _dispatch_message(
+            context,
+            ws,
+            {
+                "type": "approval.reply",
+                "decision_id": decision_id,
+                "allowed": True,
+            },
+        )
+    )
+
+    # Give both tasks time to complete. If deadlocked, we hit the 5s
+    # TTL and get False; asyncio.wait_for with a 2s cap turns the
+    # deadlock into a clear assertion failure rather than a slow test.
+    result = await asyncio.wait_for(approval_task, timeout=2.0)
+    await reply_task
+    assert result is True, (
+        "approval TTL-denied — dispatch model regressed to inline await"
+    )

--- a/tests/cli/test_serve_approval.py
+++ b/tests/cli/test_serve_approval.py
@@ -489,3 +489,116 @@ async def test_serve_loop_does_not_deadlock_on_approval() -> None:
     assert result is True, (
         "approval TTL-denied — dispatch model regressed to inline await"
     )
+
+
+# ---------------------------------------------------------------------------
+# Additional fail-closed branches on _handle_message and __call__
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_failure_denies_and_cleans_pending() -> None:
+    """If ``ws.send`` raises (peer went away between bind and send), the
+    handler must fail-closed and not leak a pending entry."""
+
+    class _BrokenWS:
+        async def send(self, _: str) -> None:
+            raise ConnectionError("peer gone")
+
+    handler = RelayApprovalHandler(ttl_seconds=1.0)
+    handler.bind_socket(_BrokenWS())
+    result = await handler(_decision())
+    assert result is False
+    assert handler._pending == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_message_ignores_approval_reply_when_handler_is_not_relay(
+    caplog,
+) -> None:
+    """A non-relay handler (auto-approve bool, custom callable) can't
+    consume replies — the router must log + drop, not crash."""
+    import logging
+
+    from hexgate.cli.serve import ServeContext, _handle_message
+    from hexgate.cli.state import ChatState
+
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=True,  # auto-approve bool, not a RelayApprovalHandler
+    )
+
+    with caplog.at_level(logging.WARNING, logger="hexgate.cli.serve"):
+        await _handle_message(
+            context,
+            _FakeWS(),
+            {"type": "approval.reply", "decision_id": "appr_x", "allowed": True},
+        )
+    assert any("not a RelayApprovalHandler" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_handle_message_ignores_approval_reply_missing_decision_id(
+    caplog,
+) -> None:
+    """Malformed reply (no string decision_id) must warn and drop, not
+    NPE deep inside ``resolve``."""
+    import logging
+
+    from hexgate.cli.serve import ServeContext, _handle_message
+    from hexgate.cli.state import ChatState
+
+    handler = RelayApprovalHandler(ttl_seconds=1.0)
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=handler,
+    )
+
+    with caplog.at_level(logging.WARNING, logger="hexgate.cli.serve"):
+        await _handle_message(
+            context,
+            _FakeWS(),
+            {"type": "approval.reply", "allowed": True},  # no decision_id
+        )
+    assert any("missing string decision_id" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_message_echoes_error_back_to_peer_on_exception() -> None:
+    """When _handle_message crashes, _dispatch_message must catch, log,
+    and echo an ``error`` event to the peer — the read loop mustn't die."""
+    from hexgate.cli.serve import ServeContext, _dispatch_message
+    from hexgate.cli.state import ChatState
+
+    ws = _FakeWS()
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=None,
+    )
+    # Malformed reset — will crash inside _handle_message because state
+    # isn't fully wired; any exception path works to prove the catch.
+    # We force one by sending an unknown-type frame after monkey-patching
+    # logger to raise. Simpler: send a chat frame — state.start_turn on a
+    # fresh ChatState with runtime=None will trip inside stream_agent.
+    # Cleanest: patch _handle_message directly.
+    import hexgate.cli.serve as serve_mod
+
+    async def _boom(*_, **__):
+        raise RuntimeError("kapow")
+
+    original = serve_mod._handle_message
+    serve_mod._handle_message = _boom
+    try:
+        await _dispatch_message(context, ws, {"type": "chat", "message": "hi"})
+    finally:
+        serve_mod._handle_message = original
+
+    assert len(ws.sent) == 1
+    assert ws.sent[0]["event_type"] == "error"
+    assert "kapow" in ws.sent[0]["message"]

--- a/tests/cli/test_serve_approval.py
+++ b/tests/cli/test_serve_approval.py
@@ -65,7 +65,7 @@ async def test_emits_approval_request_with_expected_shape() -> None:
     on the bound socket before it starts waiting for a reply."""
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=1.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
 
     async def approve_after_a_tick() -> None:
         # Give __call__ a chance to send + start awaiting.
@@ -97,7 +97,7 @@ async def test_emits_approval_request_with_expected_shape() -> None:
 async def test_resolve_deny_returns_false() -> None:
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=1.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
 
     async def deny_after_a_tick() -> None:
         await asyncio.sleep(0.05)
@@ -128,7 +128,7 @@ async def test_timeout_returns_false() -> None:
     """No reply within the TTL → deny (fail-closed)."""
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=0.1)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
     result = await handler(_decision())
     assert result is False
 
@@ -139,7 +139,7 @@ async def test_unbind_socket_denies_all_pending() -> None:
     coroutines don't outlive the socket they belonged to."""
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=10.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
 
     # Fire two approvals in parallel; both will be blocked awaiting
     # their Events. Unbind should release them both as False.
@@ -167,7 +167,7 @@ async def test_concurrent_requests_get_distinct_decision_ids() -> None:
     doesn't break it)."""
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=10.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
 
     tasks = [asyncio.create_task(handler(_decision(tool=f"t{i}"))) for i in range(5)]
     # Let all 5 send frames.
@@ -218,7 +218,7 @@ async def test_ws_send_is_serialized_across_concurrent_calls() -> None:
 
     ws = _RaceCapturingWS()
     handler = RelayApprovalHandler(ttl_seconds=10.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
 
     tasks = [asyncio.create_task(handler(_decision(tool=f"t{i}"))) for i in range(5)]
     # Let all sends run (they all get serialized by the lock, then
@@ -266,7 +266,7 @@ async def test_handle_message_routes_approval_reply(monkeypatch) -> None:
 
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=10.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
 
     context = ServeContext(
         runtime=None,  # type: ignore[arg-type] — unused for this branch
@@ -378,7 +378,7 @@ async def test_string_allowed_is_treated_as_deny() -> None:
 
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=10.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
     context = ServeContext(
         runtime=None,  # type: ignore[arg-type]
         state=ChatState(),
@@ -408,7 +408,7 @@ async def test_true_bool_allowed_approves() -> None:
 
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=10.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
     context = ServeContext(
         runtime=None,  # type: ignore[arg-type]
         state=ChatState(),
@@ -448,7 +448,7 @@ async def test_serve_loop_does_not_deadlock_on_approval() -> None:
 
     ws = _FakeWS()
     handler = RelayApprovalHandler(ttl_seconds=5.0)
-    handler.bind_socket(ws)
+    handler.bind_socket(ws, asyncio.Lock())
     context = ServeContext(
         runtime=None,  # type: ignore[arg-type]
         state=ChatState(),
@@ -506,7 +506,7 @@ async def test_send_failure_denies_and_cleans_pending() -> None:
             raise ConnectionError("peer gone")
 
     handler = RelayApprovalHandler(ttl_seconds=1.0)
-    handler.bind_socket(_BrokenWS())
+    handler.bind_socket(_BrokenWS(), asyncio.Lock())
     result = await handler(_decision())
     assert result is False
     assert handler._pending == {}
@@ -602,3 +602,154 @@ async def test_dispatch_message_echoes_error_back_to_peer_on_exception() -> None
     assert len(ws.sent) == 1
     assert ws.sent[0]["event_type"] == "error"
     assert "kapow" in ws.sent[0]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Post-review fixes (Victor's comments)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_pops_before_setting_so_unbind_cannot_flip_allowed() -> None:
+    """Race regression: if unbind_socket fires between resolve() setting
+    box[allowed]=True and __call__ waking to read it, the pre-fix
+    unbind_socket would find the entry still in _pending and overwrite
+    allowed back to False — silently denying an approved call. Now
+    resolve() pops the entry atomically before mutating box, so unbind
+    can't see it.
+
+    Simulate the race by driving the ordering manually: resolve first
+    (approve), then unbind. The parked __call__ must return True.
+    """
+    ws = _FakeWS()
+    handler = RelayApprovalHandler(ttl_seconds=5.0)
+    handler.bind_socket(ws, asyncio.Lock())
+
+    task = asyncio.create_task(handler(_decision()))
+    await asyncio.sleep(0.05)
+    decision_id = ws.sent[0]["decision_id"]
+
+    # User approves — resolve() should pop the entry atomically.
+    handler.resolve(decision_id, allowed=True)
+    # Immediately after, a disconnect happens. unbind_socket must NOT
+    # find the resolved entry (already popped) and must NOT flip it.
+    handler.unbind_socket()
+
+    result = await task
+    assert result is True, (
+        "approve was silently flipped to deny — resolve() did not pop "
+        "before mutating, or unbind_socket found the stale entry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_serve_context_send_lock_serializes_concurrent_sends() -> None:
+    """Fix #1 regression: every ws.send on the serve socket must go
+    through _safe_send, which acquires context.send_lock. Two
+    concurrent sends must not interleave at the byte-write level.
+    Assert that the lock is actually held by wrapping ws.send with a
+    counter that would spike above 1 if the lock leaked."""
+    from hexgate.cli.serve import ServeContext, _safe_send
+    from hexgate.cli.state import ChatState
+
+    concurrent_in_send = 0
+    max_seen_concurrent = 0
+
+    class _CountingWS:
+        async def send(self, _: str) -> None:
+            nonlocal concurrent_in_send, max_seen_concurrent
+            concurrent_in_send += 1
+            max_seen_concurrent = max(max_seen_concurrent, concurrent_in_send)
+            # Yield control so any second send that isn't lock-guarded
+            # gets the chance to interleave here.
+            await asyncio.sleep(0)
+            concurrent_in_send -= 1
+
+    ws = _CountingWS()
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=None,
+        send_lock=asyncio.Lock(),
+    )
+    await asyncio.gather(*[_safe_send(context, ws, f"m-{i}") for i in range(10)])
+    assert max_seen_concurrent == 1
+
+
+@pytest.mark.asyncio
+async def test_safe_send_falls_back_when_context_has_no_lock() -> None:
+    """When send_lock is None (test bypass of _serve_loop), _safe_send
+    still forwards to ws.send unchanged — otherwise it would hang."""
+    from hexgate.cli.serve import ServeContext, _safe_send
+    from hexgate.cli.state import ChatState
+
+    ws = _FakeWS()
+    context = ServeContext(
+        runtime=None,  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=None,
+        send_lock=None,
+    )
+    await _safe_send(context, ws, json.dumps({"type": "hello"}))
+    assert ws.sent == [{"type": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_chat_lock_serializes_concurrent_chat_turns() -> None:
+    """Fix #2 regression: two 'chat' frames arriving back-to-back must
+    NOT both call ChatState.start_turn concurrently. Under the current
+    dispatch model each frame runs in its own task; the chat_lock on
+    the context is what keeps them serial. Assert by counting overlap
+    inside the chat branch — should stay at 1.
+    """
+    from hexgate.cli.serve import ServeContext, _handle_message
+    from hexgate.cli.state import ChatState
+
+    concurrent_in_chat = 0
+    max_seen_concurrent = 0
+
+    class _NoopWS:
+        async def send(self, _: str) -> None:
+            pass
+
+    async def _fake_stream_agent(agent, handler, inp):  # noqa: ARG001
+        nonlocal concurrent_in_chat, max_seen_concurrent
+        concurrent_in_chat += 1
+        max_seen_concurrent = max(max_seen_concurrent, concurrent_in_chat)
+        # Yield so a lock-free second chat would race in here.
+        await asyncio.sleep(0.01)
+        concurrent_in_chat -= 1
+        if False:  # pragma: no cover — never yields, keeps signature async iter
+            yield None
+
+    class _StubRuntime:
+        agent = object()
+        handler = object()
+
+    context = ServeContext(
+        runtime=_StubRuntime(),  # type: ignore[arg-type]
+        state=ChatState(),
+        api_key="test-key",
+        approval_handler=None,
+        send_lock=asyncio.Lock(),
+        chat_lock=asyncio.Lock(),
+    )
+
+    import hexgate.cli.serve as serve_mod
+
+    original = serve_mod.stream_agent
+    serve_mod.stream_agent = _fake_stream_agent
+    try:
+        ws = _NoopWS()
+        await asyncio.gather(
+            _handle_message(context, ws, {"type": "chat", "message": "first"}),
+            _handle_message(context, ws, {"type": "chat", "message": "second"}),
+        )
+    finally:
+        serve_mod.stream_agent = original
+
+    assert max_seen_concurrent == 1, (
+        "two chat frames overlapped — chat_lock did not serialize them"
+    )


### PR DESCRIPTION
> **Walkthrough deck:** [claude.ai/code/artifact/ba44bb68](https://claude.ai/code/artifact/ba44bb68-92d4-4b9e-8fe0-a10753df2d87). Seven slides covering the primitive, the WS wire flow, adapter coverage, framework comparison, fail-closed guarantees, and quickstart. Skimmable if you don't want to read the whole PR.

## What this fixes

Before this PR, `hexgate serve` silently auto-approved every tool call the policy flagged `approval_required`. The playground never saw those prompts — the user's mode setting made no difference and the whole approval feature was a no-op through the local dev loop.

Now: the SDK asks, the playground pops a prompt inline above the composer, and the user's answer comes back down the same WebSocket the chat is already flowing over. If nobody's connected, if the tab closes mid-prompt, or if the user takes too long — the tool call is denied.

## How it works

```
Playground UI          Platform relay          hexgate serve             SDK enforcer
     │                       │                       │                        │
     │─── chat ─────────────▶│──── relay ──────────▶│─▶ stream_agent ─▶ GuardedTool
     │                       │                       │                    NEEDS_APPROVAL
     │                       │                       │                        │
     │◀── approval.request ──│◀─── forward ─────────│◀─ RelayApprovalHandler(decision)
     │                       │                       │      mint decision_id
     │                       │                       │      await asyncio.Event
User clicks Approve          │                       │
     │                       │                       │
     │─── approval.reply ──▶│──── forward ────────▶│─▶ _handle_message
     │  {decision_id,        │                       │      handler.resolve()
     │   allowed:true}       │                       │      Event.set()
     │                       │                       │                    ▼ tool runs
     │◀── tool.end / delta ─│◀─── stream ──────────│◀───────────────────────┘
```

The relay is untouched — it's still a pure JSON forwarder. All the new behavior lives on the SDK and dashboard sides.

## Design choices worth calling out

- **Simple callback, not serialize-and-resume.** The primitive is `async fn(decision) -> bool`. That's the same shape a CLI dev would use with `input()`, so implementing your own approval sink is a five-line job. No `RunState`, no checkpointer, no cross-process durability at v1 — same tradeoff Claude Code makes.
- **Fail-closed everywhere.** TTL expiry, WebSocket disconnect, no bound socket, unknown decision_id, non-bool `allowed`, send failure — all deny.
- **Session-scoped.** No Postgres, no REST endpoints. If `hexgate serve` restarts mid-approval, the prompt is lost. Durability lands later, when webhook / Slack / mobile approvers become a real need.
- **Inline UI, not a modal.** The prompt renders above the composer so it stays in the flow of the conversation, and multiple parallel tool calls stack instead of fighting over the modal slot.
- **Default flipped from auto-approve to ask.** Headless callers (CI, cron) need to opt back in with `--approval-mode auto-approve`. A loud startup line names the flag.

## Scope

All four framework adapters now carry the `approval_handler` callback: LangChain (via `HexgateAgent` / `hexgate serve`), OpenAI Agents (`wrap_openai_agent` + `HexgateRunner`), Pydantic AI (`wrap_pydantic_agent`), and Google ADK (`wrap_google_agent` + `HexgateRunner`). Same behavior on all four: truthy return runs the tool, falsy return or missing handler renders the existing `[approval_required]` marker to the model (string on OpenAI / Google, `ModelRetry` on Pydantic AI).

The playground path itself (which motivated the PR) stays LangChain-only because `hexgate serve` builds a `HexgateAgent`. What the other adapters unlock is: a developer using them directly can now pass their own callback and have it actually fire.

Explicit non-goals for this PR: durable approvals (Postgres), webhook / Slack integration, per-tool RBAC on approvers, public `TerminalApprovalHandler` helper for CLI devs. All tracked as separate work; the callback slot on each adapter's guarded tool is the extension point.

## Documentation

Two new mintlify pages under `docs/concepts/`, wired into the Concepts nav:

- **`approval-required.mdx`** — quickstart, `Decision` field reference, four common handler shapes (CLI, auto-approve for tests, playground, webhook / Slack), points of vigilance.
- **`approval-frameworks-compared.mdx`** — honest comparison against OpenAI Agents SDK, LangGraph, Pydantic AI, and Claude Code. Names where each framework wins and where our callback trades durability for zero infrastructure.

## Tests

- `tests/cli/test_serve_approval.py` — 17 cases covering the playground WS relay: payload shape, resolve unblocks, TTL denies, disconnect fails all pending, concurrent distinct decision_ids, `asyncio.Lock` serializes concurrent sends, unknown decision_id no-op, `_handle_message` routing (happy + string-allowed + missing-id + non-relay-handler), send-failure denies, `_dispatch_message` error-echo, end-to-end `_apply_approval_handler` plumbing, deadlock regression on `_serve_loop`.
- `tests/adapters/openai/test_tools.py`, `tests/adapters/pydantic_ai/test_tools.py`, `tests/adapters/google/test_tools.py` — 5 cases each on the new callback: async handler true, async handler false, bool shortcut, handler ignored on plain deny, sync handler acceptance.
- `platform/dashboard/src/lib/playground.test.tsx` — 10 cases: receive renders, dedupe, respond sends + optimistic remove on success, resolve one preserves others, unknown decision_id no-op, TTL sweep, WS close clears list, reset sends deny-replies, respond fails when closed.
- **SDK: 954 pass. Dashboard: 71 pass.** Lint, fmt-check, typecheck clean.

## Test plan

- [x] Automated regression suites above
- [ ] After merge: `make demo-notebook` → send a prompt that triggers a role with `approval_required` → confirm the prompt appears in the browser and clicking approve/deny lands the right outcome
- [ ] After merge: fire 5+ parallel tool calls in one turn → confirm each prompt has its own decision_id and resolves independently
