### PR TITLE
feat(mcp): fan out MCP tool wrapping to every adapter

### DIFF
--- a/docs/concepts/mcp.mdx
+++ b/docs/concepts/mcp.mdx
@@ -8,7 +8,7 @@ description: "Auto-wrap third-party Model Context Protocol servers as policy-enf
 [README — MCP servers](https://github.com/HexamindOrganisation/hexgate#-mcp-servers-proxy).
 </Note>
 
-Hexgate's `hexgate.mcp` module wraps any [MCP](https://modelcontextprotocol.io) server as a set of LangChain `BaseTool` objects so they go through the same policy enforcement, audit, and approval flow as native `@agent_tool` functions. Zero glue code: connect the server, every tool it exposes auto-registers under a `mcp-<server>-<tool>` namespace.
+Hexgate's `hexgate.mcp` module wraps any [MCP](https://modelcontextprotocol.io) server as framework-native tool objects so they go through the same policy enforcement, audit, and approval flow as native tool functions. Zero glue code: connect the server, every tool it exposes auto-registers under a `mcp-<server>-<tool>` namespace. Wire the tools through whichever adapter your agent is built on (LangChain, OpenAI Agents, Pydantic AI, Google ADK).
 
 ## Usage
 
@@ -49,6 +49,30 @@ roles:
         mode: allow
         constraints: ["args.repo == 'hexgate'"]
 ```
+
+## Adapter coverage
+
+`MCPToolset` produces framework-agnostic `MCPToolProxy` descriptors. Each adapter has a `wrap_mcp_toolset` that turns those into its own tool type. Same shape everywhere; pick the one that matches your agent.
+
+```python
+# LangChain (also the back-compat default via mcp.tools)
+from hexgate.adapters.langchain.mcp import wrap_mcp_toolset
+tools = wrap_mcp_toolset(mcp)  # list[langchain_core.tools.BaseTool]
+
+# OpenAI Agents
+from hexgate.adapters.openai.mcp import wrap_mcp_toolset
+tools = wrap_mcp_toolset(mcp)  # list[agents.FunctionTool]
+
+# Pydantic AI
+from hexgate.adapters.pydantic_ai.mcp import wrap_mcp_toolset
+tools = wrap_mcp_toolset(mcp)  # list[pydantic_ai.tools.Tool]
+
+# Google ADK
+from hexgate.adapters.google.mcp import wrap_mcp_toolset
+tools = wrap_mcp_toolset(mcp)  # list[google.adk.tools.BaseTool]
+```
+
+Every wrapped tool carries the qualified name, the MCP-advertised description and JSON Schema, and the same `{"ok": True | False, ...}` envelope on invocation. The tools share the toolset's connection lifecycle: once the `async with MCPToolset(...)` block exits, calls return a `use_after_close` envelope rather than crashing.
 
 ## Try it
 

--- a/hexgate/adapters/google/mcp.py
+++ b/hexgate/adapters/google/mcp.py
@@ -58,13 +58,19 @@ class _MCPProxyTool(BaseTool):
         self._call = proxy.call
 
     def _get_declaration(self) -> genai_types.FunctionDeclaration:
-        # Coerce a literal `{}` schema (MCP's "accept anything" shorthand)
-        # to a minimal object schema — Gemini's FunctionDeclaration
-        # validator rejects declarations whose parametersJsonSchema is
-        # missing a top-level `type`, causing the whole tool list to fail
-        # at declaration time. LangChain and OpenAI Agents tolerate `{}`
-        # unchanged, so the coercion is Google-specific.
-        schema = self._input_schema or {"type": "object", "properties": {}}
+        # Gemini's FunctionDeclaration validator rejects any
+        # parametersJsonSchema missing a top-level `type` — literal `{}`,
+        # or a partial like `{"properties": {...}}`, or a bare
+        # `{"anyOf": [...]}`. All three shapes cause the whole tool
+        # list to fail at declaration time, so the agent never gets to
+        # run. Fill in `type: "object"` (the only shape Gemini accepts
+        # for a function-args container) whenever it's absent, and
+        # ensure a `properties` map so the LLM sees an argument surface
+        # rather than an opaque object. LangChain and OpenAI Agents
+        # both tolerate the missing `type` unchanged.
+        schema = self._input_schema if isinstance(self._input_schema, dict) else {}
+        if "type" not in schema:
+            schema = {"type": "object", "properties": {}, **schema}
         return genai_types.FunctionDeclaration(
             name=self.name,
             description=self.description,

--- a/hexgate/adapters/google/mcp.py
+++ b/hexgate/adapters/google/mcp.py
@@ -58,10 +58,17 @@ class _MCPProxyTool(BaseTool):
         self._call = proxy.call
 
     def _get_declaration(self) -> genai_types.FunctionDeclaration:
+        # Coerce a literal `{}` schema (MCP's "accept anything" shorthand)
+        # to a minimal object schema — Gemini's FunctionDeclaration
+        # validator rejects declarations whose parametersJsonSchema is
+        # missing a top-level `type`, causing the whole tool list to fail
+        # at declaration time. LangChain and OpenAI Agents tolerate `{}`
+        # unchanged, so the coercion is Google-specific.
+        schema = self._input_schema or {"type": "object", "properties": {}}
         return genai_types.FunctionDeclaration(
             name=self.name,
             description=self.description,
-            parametersJsonSchema=self._input_schema,
+            parametersJsonSchema=schema,
         )
 
     async def run_async(

--- a/hexgate/adapters/google/mcp.py
+++ b/hexgate/adapters/google/mcp.py
@@ -1,0 +1,82 @@
+"""Google ADK adapter for :class:`~hexgate.mcp.MCPToolset`.
+
+Every :class:`~hexgate.mcp.MCPToolProxy` produced by the toolset becomes
+a :class:`google.adk.tools.BaseTool` subclass whose ``_get_declaration``
+returns a ``FunctionDeclaration`` carrying the MCP tool's raw
+JSON Schema (via ``parametersJsonSchema``) and whose ``run_async``
+forwards to the proxy's ``call``. Once wrapped, the resulting tools
+are indistinguishable from ADK-native :class:`FunctionTool` instances
+to the rest of the Google ADK path — attach them to an ``Agent``, then
+wrap via :func:`~hexgate.adapters.google.wrap_google_agent` so the
+existing per-tool policy gate covers MCP invocations too.
+
+Usage::
+
+    from google.adk.agents import Agent
+    from hexgate.adapters.google import wrap_google_agent
+    from hexgate.adapters.google.mcp import wrap_mcp_toolset
+    from hexgate.mcp import MCPServerConfig, MCPToolset
+
+    slack = MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+    async with MCPToolset(slack) as mcp:
+        agent = Agent(
+            name="bot",
+            tools=[*wrap_mcp_toolset(mcp), *native],
+        )
+        wrapped, binding = wrap_google_agent(agent, api_key=api_key)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from google.adk.tools import BaseTool
+from google.adk.tools.tool_context import ToolContext
+from google.genai import types as genai_types
+
+from hexgate.mcp.proxy import MCPToolProxy, MCPToolset
+
+
+class _MCPProxyTool(BaseTool):
+    """One :class:`BaseTool` that forwards to an :class:`MCPToolProxy`.
+
+    ADK's :class:`FunctionTool` derives its schema from a Python
+    callable's signature via reflection, which can't express the shapes
+    MCP servers advertise (partial ``required``, ``anyOf`` unions,
+    nested objects with dynamic keys). Subclassing :class:`BaseTool`
+    and returning a hand-built :class:`FunctionDeclaration` from
+    ``_get_declaration`` bypasses the reflection path and hands the
+    server's raw JSON Schema straight to the model — via ADK's
+    ``parametersJsonSchema`` alias which accepts JSON Schema dicts.
+    """
+
+    def __init__(self, proxy: MCPToolProxy) -> None:
+        super().__init__(name=proxy.qualified_name, description=proxy.description)
+        # Store the schema + call as private attrs — ADK's BaseTool has
+        # no field for them, so we ride on the object dict.
+        self._input_schema = proxy.input_schema
+        self._call = proxy.call
+
+    def _get_declaration(self) -> genai_types.FunctionDeclaration:
+        return genai_types.FunctionDeclaration(
+            name=self.name,
+            description=self.description,
+            parametersJsonSchema=self._input_schema,
+        )
+
+    async def run_async(
+        self, *, args: dict[str, Any], tool_context: ToolContext
+    ) -> Any:
+        return await self._call(**(args or {}))
+
+
+def wrap_mcp_toolset(toolset: MCPToolset) -> list[BaseTool]:
+    """Wrap every proxy in ``toolset`` as a Google ADK :class:`BaseTool`.
+
+    The returned tools share the toolset's connection lifecycle — they
+    stop working (returning a ``use_after_close`` envelope) once the
+    ``async with MCPToolset(...)`` block exits. Combine with
+    :func:`~hexgate.adapters.google.wrap_google_agent` to gate every
+    invocation through :class:`~hexgate.security.PolicyEnforcer`.
+    """
+    return [_MCPProxyTool(p) for p in toolset.proxies]

--- a/hexgate/adapters/langchain/mcp.py
+++ b/hexgate/adapters/langchain/mcp.py
@@ -1,0 +1,55 @@
+"""LangChain-facing wrapper for :class:`~hexgate.mcp.MCPToolset`.
+
+Every :class:`~hexgate.mcp.MCPToolProxy` produced by the toolset becomes
+a :class:`~langchain_core.tools.StructuredTool` that forwards to the
+proxy's ``call``. Once wrapped, the resulting :class:`BaseTool` objects
+are indistinguishable from native ``@agent_tool`` functions to the rest
+of the LangChain path — hand them to :func:`create_agent`, call
+:func:`enforce_policy`, and the existing :class:`GuardedTool` pass
+gates every invocation through :class:`PolicyEnforcer`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.tools import BaseTool, StructuredTool
+
+from hexgate.mcp.proxy import MCPToolProxy, MCPToolset
+
+
+def _wrap_one(proxy: MCPToolProxy) -> BaseTool:
+    """Build a single :class:`StructuredTool` around ``proxy.call``.
+
+    LangChain's ``StructuredTool.from_function(args_schema=<dict>)``
+    accepts a raw JSON Schema directly — no Pydantic model generation
+    needed. The wrapping ``async def`` is a thin passthrough so
+    LangChain's introspection sees a coroutine with the right name.
+    """
+    schema = proxy.input_schema
+    call = proxy.call
+
+    async def coroutine(**kwargs: Any) -> dict[str, Any]:
+        return await call(**kwargs)
+
+    coroutine.__name__ = proxy.qualified_name
+    return StructuredTool.from_function(
+        coroutine=coroutine,
+        name=proxy.qualified_name,
+        description=proxy.description,
+        args_schema=schema,
+    )
+
+
+def wrap_mcp_toolset(toolset: MCPToolset) -> list[BaseTool]:
+    """Wrap every proxy in ``toolset`` as a LangChain :class:`BaseTool`.
+
+    Called implicitly by :meth:`MCPToolset.tools` for back-compat, or
+    explicitly by adapter-aware callers that want the same
+    ``wrap_mcp_toolset(mcp)`` shape they'd use with the OpenAI /
+    Pydantic AI / Google ADK adapters. The returned tools share the
+    toolset's connection lifecycle — they stop working (returning a
+    ``use_after_close`` envelope) once the ``async with MCPToolset(...)``
+    block exits.
+    """
+    return [_wrap_one(p) for p in toolset.proxies]

--- a/hexgate/adapters/langchain/mcp.py
+++ b/hexgate/adapters/langchain/mcp.py
@@ -11,8 +11,6 @@ gates every invocation through :class:`PolicyEnforcer`.
 
 from __future__ import annotations
 
-from typing import Any
-
 from langchain_core.tools import BaseTool, StructuredTool
 
 from hexgate.mcp.proxy import MCPToolProxy, MCPToolset
@@ -23,21 +21,15 @@ def _wrap_one(proxy: MCPToolProxy) -> BaseTool:
 
     LangChain's ``StructuredTool.from_function(args_schema=<dict>)``
     accepts a raw JSON Schema directly — no Pydantic model generation
-    needed. The wrapping ``async def`` is a thin passthrough so
-    LangChain's introspection sees a coroutine with the right name.
+    needed. ``proxy.call`` is used verbatim as the coroutine; its
+    ``__name__`` is already set to the qualified name by
+    :func:`hexgate.mcp.proxy._build_proxy`.
     """
-    schema = proxy.input_schema
-    call = proxy.call
-
-    async def coroutine(**kwargs: Any) -> dict[str, Any]:
-        return await call(**kwargs)
-
-    coroutine.__name__ = proxy.qualified_name
     return StructuredTool.from_function(
-        coroutine=coroutine,
+        coroutine=proxy.call,
         name=proxy.qualified_name,
         description=proxy.description,
-        args_schema=schema,
+        args_schema=proxy.input_schema,
     )
 
 

--- a/hexgate/adapters/openai/mcp.py
+++ b/hexgate/adapters/openai/mcp.py
@@ -1,0 +1,94 @@
+"""OpenAI Agents adapter for :class:`~hexgate.mcp.MCPToolset`.
+
+Every :class:`~hexgate.mcp.MCPToolProxy` produced by the toolset becomes
+an :class:`agents.FunctionTool` whose ``on_invoke_tool`` forwards to the
+proxy's ``call``. Once wrapped, the resulting :class:`FunctionTool`
+objects are indistinguishable from native ``@function_tool``-decorated
+callables to the rest of the OpenAI Agents path — hand them to an
+``Agent`` alongside your other tools, then wrap the agent via
+:func:`~hexgate.adapters.openai.wrap_openai_agent` so the existing
+per-tool policy gate covers MCP invocations too.
+
+Usage::
+
+    from agents import Agent
+    from hexgate.adapters.openai import wrap_openai_agent
+    from hexgate.adapters.openai.mcp import wrap_mcp_toolset
+    from hexgate.mcp import MCPServerConfig, MCPToolset
+
+    slack = MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+    async with MCPToolset(slack) as mcp:
+        agent = Agent(
+            name="bot",
+            tools=[*wrap_mcp_toolset(mcp), *native_tools],
+        )
+        wrapped = wrap_openai_agent(agent, enforcer=enforcer)
+        await HexgateRunner(api_key).run(wrapped, "…", user=user)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from agents import FunctionTool
+from agents.tool import ToolContext
+
+from hexgate.mcp.proxy import MCPToolProxy, MCPToolset
+
+
+def _parse_args(raw: str) -> dict[str, Any]:
+    """Best-effort JSON-to-dict parse of a tool-call payload.
+
+    An empty or unparseable payload becomes ``{}`` — the proxy's
+    JSON-Schema validator then decides whether that's acceptable.
+    Matches the same tolerance the native OpenAI wrap has.
+    """
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _wrap_one(proxy: MCPToolProxy) -> FunctionTool:
+    """Build a single :class:`FunctionTool` around ``proxy.call``.
+
+    OpenAI Agents' ``FunctionTool`` accepts a raw JSON Schema in
+    ``params_json_schema`` — no dynamic Pydantic model generation
+    needed. ``strict_json_schema=False`` is deliberate: MCP servers
+    routinely advertise schemas that don't meet OpenAI's strict-mode
+    requirements (partial ``required``, optional ``additionalProperties``,
+    ``anyOf`` unions), and we'd rather forward the server's spec
+    verbatim than reject legitimate tools at wrap time. Our own
+    pre-call validator in ``proxy.call`` still catches malformed args
+    before the round trip.
+    """
+    call = proxy.call
+    qualified = proxy.qualified_name
+
+    async def on_invoke_tool(ctx: ToolContext[Any], raw: str) -> Any:
+        return await call(**_parse_args(raw))
+
+    return FunctionTool(
+        name=qualified,
+        description=proxy.description,
+        params_json_schema=proxy.input_schema,
+        on_invoke_tool=on_invoke_tool,
+        strict_json_schema=False,
+    )
+
+
+def wrap_mcp_toolset(toolset: MCPToolset) -> list[FunctionTool]:
+    """Wrap every proxy in ``toolset`` as an OpenAI Agents
+    :class:`FunctionTool`.
+
+    The returned tools share the toolset's connection lifecycle — they
+    stop working (returning a ``use_after_close`` envelope) once the
+    ``async with MCPToolset(...)`` block exits. Combine with
+    :func:`~hexgate.adapters.openai.wrap_openai_agent` to gate every
+    invocation through :class:`~hexgate.security.PolicyEnforcer`.
+    """
+    return [_wrap_one(p) for p in toolset.proxies]

--- a/hexgate/adapters/openai/mcp.py
+++ b/hexgate/adapters/openai/mcp.py
@@ -65,15 +65,18 @@ def _wrap_one(proxy: MCPToolProxy) -> FunctionTool:
     verbatim than reject legitimate tools at wrap time. Our own
     pre-call validator in ``proxy.call`` still catches malformed args
     before the round trip.
+
+    ``on_invoke_tool`` is the one bit that can't collapse to
+    ``proxy.call`` directly — OpenAI hands us the raw JSON string, not
+    a parsed dict.
     """
     call = proxy.call
-    qualified = proxy.qualified_name
 
     async def on_invoke_tool(ctx: ToolContext[Any], raw: str) -> Any:
         return await call(**_parse_args(raw))
 
     return FunctionTool(
-        name=qualified,
+        name=proxy.qualified_name,
         description=proxy.description,
         params_json_schema=proxy.input_schema,
         on_invoke_tool=on_invoke_tool,

--- a/hexgate/adapters/pydantic_ai/mcp.py
+++ b/hexgate/adapters/pydantic_ai/mcp.py
@@ -24,8 +24,6 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Any
-
 from pydantic_ai.tools import Tool
 
 from hexgate.mcp.proxy import MCPToolProxy, MCPToolset
@@ -35,20 +33,15 @@ def _wrap_one(proxy: MCPToolProxy) -> Tool:
     """Build a single :class:`Tool` around ``proxy.call``.
 
     Pydantic AI's ``Tool.from_schema`` accepts a raw JSON Schema — no
-    dynamic Pydantic model generation is needed. The passed function
-    receives the LLM's arguments as ``**kwargs``; Pydantic AI's
-    validator (built from the same schema) is the outer gate, and our
-    ``proxy.call`` runs its own JSON-Schema check as a defence-in-depth
-    layer before the server round-trip.
+    dynamic Pydantic model generation is needed. ``proxy.call`` is
+    passed verbatim as the function; its ``__name__`` is already the
+    qualified name (set by :func:`hexgate.mcp.proxy._build_proxy`).
+    Pydantic AI's own validator (built from the same schema) is the
+    outer gate; our ``proxy.call`` runs its own JSON-Schema check as a
+    defence-in-depth layer before the server round-trip.
     """
-    call = proxy.call
-
-    async def fn(**kwargs: Any) -> dict[str, Any]:
-        return await call(**kwargs)
-
-    fn.__name__ = proxy.qualified_name
     return Tool.from_schema(
-        function=fn,
+        function=proxy.call,
         name=proxy.qualified_name,
         description=proxy.description,
         json_schema=proxy.input_schema,

--- a/hexgate/adapters/pydantic_ai/mcp.py
+++ b/hexgate/adapters/pydantic_ai/mcp.py
@@ -1,0 +1,67 @@
+"""Pydantic AI adapter for :class:`~hexgate.mcp.MCPToolset`.
+
+Every :class:`~hexgate.mcp.MCPToolProxy` produced by the toolset becomes
+a :class:`pydantic_ai.tools.Tool` via ``Tool.from_schema`` — Pydantic
+AI's raw-JSON-Schema entry point. Once wrapped, the resulting Tools
+are indistinguishable from ``@agent.tool``-decorated callables to the
+rest of the Pydantic AI path — attach them to an ``Agent`` and wrap
+via :func:`~hexgate.adapters.pydantic_ai.wrap_pydantic_agent` so the
+existing per-tool policy gate covers MCP invocations too.
+
+Usage::
+
+    from pydantic_ai import Agent
+    from hexgate.adapters.pydantic_ai import wrap_pydantic_agent
+    from hexgate.adapters.pydantic_ai.mcp import wrap_mcp_toolset
+    from hexgate.mcp import MCPServerConfig, MCPToolset
+
+    slack = MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+    async with MCPToolset(slack) as mcp:
+        agent = Agent("openai:gpt-5.4", tools=[*wrap_mcp_toolset(mcp), *native])
+        proxy = wrap_pydantic_agent(agent=agent)
+        await proxy.run("…", user=user)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic_ai.tools import Tool
+
+from hexgate.mcp.proxy import MCPToolProxy, MCPToolset
+
+
+def _wrap_one(proxy: MCPToolProxy) -> Tool:
+    """Build a single :class:`Tool` around ``proxy.call``.
+
+    Pydantic AI's ``Tool.from_schema`` accepts a raw JSON Schema — no
+    dynamic Pydantic model generation is needed. The passed function
+    receives the LLM's arguments as ``**kwargs``; Pydantic AI's
+    validator (built from the same schema) is the outer gate, and our
+    ``proxy.call`` runs its own JSON-Schema check as a defence-in-depth
+    layer before the server round-trip.
+    """
+    call = proxy.call
+
+    async def fn(**kwargs: Any) -> dict[str, Any]:
+        return await call(**kwargs)
+
+    fn.__name__ = proxy.qualified_name
+    return Tool.from_schema(
+        function=fn,
+        name=proxy.qualified_name,
+        description=proxy.description,
+        json_schema=proxy.input_schema,
+    )
+
+
+def wrap_mcp_toolset(toolset: MCPToolset) -> list[Tool]:
+    """Wrap every proxy in ``toolset`` as a Pydantic AI :class:`Tool`.
+
+    The returned tools share the toolset's connection lifecycle — they
+    stop working (returning a ``use_after_close`` envelope) once the
+    ``async with MCPToolset(...)`` block exits. Combine with
+    :func:`~hexgate.adapters.pydantic_ai.wrap_pydantic_agent` to gate
+    every invocation through :class:`~hexgate.security.PolicyEnforcer`.
+    """
+    return [_wrap_one(p) for p in toolset.proxies]

--- a/hexgate/cli/register/google.py
+++ b/hexgate/cli/register/google.py
@@ -70,29 +70,82 @@ def _extract_system_prompt(instruction: object) -> str | None:
 
 
 def _to_tool_definition(tool: BaseTool) -> ToolDefinition | None:
-    """Convert a Google ADK tool to a ToolDefinition."""
+    """Convert a Google ADK tool to a ToolDefinition.
+
+    Reads schema from BOTH declaration fields: ``parameters`` (the typed
+    ``google.genai.types.Schema`` shape ADK's native ``FunctionTool``
+    populates from Python signatures) AND ``parametersJsonSchema`` (the
+    raw JSON Schema dict path used by tools that came from a source
+    without Python type hints — hexgate's MCP wrapper is the canonical
+    case). Without the JSON-Schema fallback, every MCP tool registers
+    with an empty argument schema and any policy generated from that
+    (write-vs-read classification, arg-level rules) is computed
+    against zero fields — silently mis-gated.
+    """
     declaration = tool._get_declaration()
     if declaration is None:
         return None
 
     parameters = declaration.parameters
-    raw_properties: dict[str, Any] = (
-        dict(parameters.properties or {}) if parameters else {}
-    )
-    properties = {
-        prop_name: InputProperty(
-            title=prop_name,
-            type=_schema_type(prop),
+    if parameters is not None:
+        raw_properties: dict[str, Any] = dict(parameters.properties or {})
+        properties = {
+            prop_name: InputProperty(
+                title=prop_name,
+                type=_schema_type(prop),
+            )
+            for prop_name, prop in raw_properties.items()
+        }
+        required = list(parameters.required or [])
+    else:
+        properties, required = _properties_from_json_schema(
+            declaration.parameters_json_schema
         )
-        for prop_name, prop in raw_properties.items()
-    }
-    required = list(parameters.required or []) if parameters else []
 
     return ToolDefinition(
         name=tool.name,
         description=tool.description or "",
         input_schema=InputSchema(properties=properties, required=required),
     )
+
+
+def _properties_from_json_schema(
+    schema: Any,
+) -> tuple[dict[str, InputProperty], list[str]]:
+    """Extract properties + required list from a raw JSON Schema dict.
+
+    Falls back to empty maps when the schema is missing, malformed, or
+    doesn't declare object properties. The registered ToolDefinition
+    still carries name + description; only the arg surface goes empty.
+    """
+    if not isinstance(schema, dict):
+        return {}, []
+    raw_properties = schema.get("properties")
+    if not isinstance(raw_properties, dict):
+        raw_properties = {}
+    properties = {
+        prop_name: InputProperty(
+            title=prop_name,
+            type=_json_schema_prop_type(prop),
+        )
+        for prop_name, prop in raw_properties.items()
+    }
+    raw_required = schema.get("required")
+    required = (
+        [str(r) for r in raw_required if isinstance(r, str)]
+        if isinstance(raw_required, list)
+        else []
+    )
+    return properties, required
+
+
+def _json_schema_prop_type(prop: Any) -> str:
+    """Read the ``type`` field off a raw JSON Schema property dict."""
+    if isinstance(prop, dict):
+        t = prop.get("type")
+        if isinstance(t, str):
+            return t.lower()
+    return "string"
 
 
 def _schema_type(schema: Any) -> str:

--- a/hexgate/mcp/__init__.py
+++ b/hexgate/mcp/__init__.py
@@ -1,22 +1,33 @@
 """Wrap third-party MCP (Model Context Protocol) servers as guarded tools.
 
-The single public entry point is :class:`MCPToolset`, an async context
-manager that connects to one or more MCP servers, enumerates their tool
-catalogs, and exposes them as LangChain :class:`BaseTool` objects ready
-to hand to :func:`create_agent`. From there the existing
-:func:`enforce_policy` pass wraps each one in :class:`GuardedTool` —
-MCP tools become indistinguishable from native ``@agent_tool``
-functions to the rest of the runtime, including policy enforcement,
-audit, and approval flows.
+The public entry point is :class:`MCPToolset`, an async context manager
+that connects to one or more MCP servers, enumerates their tool
+catalogs, and exposes them as framework-agnostic
+:class:`MCPToolProxy` descriptors. Each supported agent framework has
+its own ``wrap_mcp_toolset(toolset)`` that turns proxies into
+framework-native tool objects; from there the existing per-adapter
+``enforce_policy`` pass gates every invocation through
+:class:`PolicyEnforcer`, so MCP tools behave like native
+``@agent_tool`` functions all the way through — including audit and
+approval flows.
+
+Adapters:
+
+  * ``hexgate.adapters.langchain.mcp`` → LangChain ``BaseTool``
+  * ``hexgate.adapters.openai.mcp`` → OpenAI Agents ``FunctionTool``
+  * ``hexgate.adapters.pydantic_ai.mcp`` → Pydantic AI ``Tool``
+  * ``hexgate.adapters.google.mcp`` → Google ADK ``BaseTool``
 
 Tool naming is ``mcp-<server>-<tool>`` (hyphens, not colons — OpenAI's
 function-calling spec rejects colons in tool names). The server name is
 caller-supplied and validated to ``^[a-z0-9-]{1,32}$`` so qualified
 names stay under OpenAI's 64-char tool-name limit.
 
-Example::
+Example (OpenAI Agents; substitute the adapter that matches your stack)::
 
-    from hexgate import create_agent, enforce_policy
+    from agents import Agent
+    from hexgate.adapters.openai import wrap_openai_agent
+    from hexgate.adapters.openai.mcp import wrap_mcp_toolset
     from hexgate.mcp import MCPServerConfig, MCPToolset
 
     slack = MCPServerConfig(
@@ -27,11 +38,13 @@ Example::
     )
 
     async with MCPToolset(slack) as mcp:
-        agent, handler = create_agent(
-            model="gpt-5.4", tools=[*native_tools, *mcp.tools]
-        )
-        agent = enforce_policy(agent, "policy.yaml")
-        await agent.ainvoke({"messages": [...]})
+        agent = Agent(name="bot", tools=[*wrap_mcp_toolset(mcp), *native_tools])
+        wrapped = wrap_openai_agent(agent, enforcer=enforcer)
+
+For LangChain-first code, :meth:`MCPToolset.tools` is a back-compat
+shortcut that returns LangChain ``BaseTool`` objects directly —
+equivalent to importing ``wrap_mcp_toolset`` from
+``hexgate.adapters.langchain.mcp``.
 """
 
 from hexgate.mcp.client import MCPClient, MCPConnectionError

--- a/hexgate/mcp/__init__.py
+++ b/hexgate/mcp/__init__.py
@@ -36,12 +36,13 @@ Example::
 
 from hexgate.mcp.client import MCPClient, MCPConnectionError
 from hexgate.mcp.config import MCPServerConfig, MCPServerConfigError
-from hexgate.mcp.proxy import MCPToolset
+from hexgate.mcp.proxy import MCPToolProxy, MCPToolset
 
 __all__ = [
     "MCPClient",
     "MCPConnectionError",
     "MCPServerConfig",
     "MCPServerConfigError",
+    "MCPToolProxy",
     "MCPToolset",
 ]

--- a/hexgate/mcp/proxy.py
+++ b/hexgate/mcp/proxy.py
@@ -139,6 +139,15 @@ class MCPToolset:
         # AsyncExitStack registers cleanup ATOMICALLY with __aenter__ — the
         # subprocess/HTTP transport can't be acquired-but-untracked even
         # under CancelledError between the lines.
+        #
+        # Reset the closed flag first so a caller re-entering the same
+        # toolset instance (the exit-clear comment on __aexit__ says
+        # this is intended) gets a working toolset. Without this reset,
+        # __aenter__ opens connections + populates _proxies, but the
+        # first .proxies / .tools access raises "already exited" from
+        # the stale flag — the agent can't be built on a live
+        # connection.
+        self._closed = False
         self._stack = contextlib.AsyncExitStack()
         try:
             for config in self._configs:

--- a/hexgate/mcp/proxy.py
+++ b/hexgate/mcp/proxy.py
@@ -21,6 +21,7 @@ directly — pre-adapter-split callers keep working.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import logging
@@ -121,6 +122,18 @@ class MCPToolset:
         self._stack: contextlib.AsyncExitStack | None = None
         self._proxies: list[MCPToolProxy] = []
         self._states: list[_ToolsetState] = []
+        # Set once `__aexit__` has run so both `.proxies` and `.tools` can
+        # raise on post-close access instead of silently returning `[]` —
+        # otherwise `wrap_mcp_toolset(mcp)` called after the `async with`
+        # block would hand an agent an empty tool list and the LLM would
+        # say "I don't have that capability" with no visible error.
+        self._closed = False
+        # First-access cache for the LangChain back-compat shortcut.
+        # Pre-refactor `.tools` was a stable list stored on the instance;
+        # rebuilding fresh StructuredTool objects each access broke
+        # identity for downstream de-dup / in-place enforcer patterns
+        # (GuardedTool's shallow-copy + swap being the concrete case).
+        self._langchain_tools: list[Any] | None = None
 
     async def __aenter__(self) -> "MCPToolset":
         # AsyncExitStack registers cleanup ATOMICALLY with __aenter__ — the
@@ -165,6 +178,9 @@ class MCPToolset:
     ) -> bool | None:
         stack = self._stack
         self._stack = None
+        # Flip closed BEFORE the stack teardown so any callback that
+        # re-reads `.proxies` (e.g. an exit-time diagnostic) fails loudly.
+        self._closed = True
         # Clear BOTH _proxies and _states so a re-entered toolset doesn't
         # accumulate phantom state objects from earlier sessions. (The
         # AsyncExitStack itself is single-use, so re-enter mostly means
@@ -172,6 +188,7 @@ class MCPToolset:
         # honest rather than relying on no-one ever doing it.)
         self._proxies.clear()
         self._states.clear()
+        self._langchain_tools = None
         if stack is None:
             return None
         # Forward exc_info so the inner transports take the right
@@ -180,11 +197,29 @@ class MCPToolset:
         # decision is preserved.
         return await stack.__aexit__(exc_type, exc, tb)
 
+    def _check_open(self) -> None:
+        """Raise if the toolset's `async with` block has already exited.
+
+        Silently returning an empty proxy list post-close would let
+        `wrap_mcp_toolset(mcp)` produce `[]` on the way out and the
+        agent would build with zero MCP tools, no error, no log. Raise
+        instead so the misuse surfaces at wrap time.
+        """
+        if self._closed:
+            raise RuntimeError(
+                "MCPToolset(...) has already exited — its transports are torn "
+                "down. Move the wrap_mcp_toolset(...) call and any downstream "
+                "agent construction INSIDE the `async with MCPToolset(...) as "
+                "mcp:` block, or open a fresh toolset."
+            )
+
     @property
     def proxies(self) -> list[MCPToolProxy]:
         """The combined tool catalog across every attached server, as
         framework-agnostic descriptors. Feed to any adapter's
-        ``wrap_mcp_toolset(mcp)`` to get framework-native tools."""
+        ``wrap_mcp_toolset(mcp)`` to get framework-native tools. Raises
+        ``RuntimeError`` if accessed after the `async with` block exits."""
+        self._check_open()
         return list(self._proxies)
 
     @property
@@ -192,10 +227,18 @@ class MCPToolset:
         """LangChain BaseTools, one per proxy. Back-compat shortcut for
         code written before per-adapter wrappers existed — equivalent to
         ``wrap_mcp_toolset(self)`` from
-        :mod:`hexgate.adapters.langchain.mcp`."""
-        from hexgate.adapters.langchain.mcp import wrap_mcp_toolset
+        :mod:`hexgate.adapters.langchain.mcp`.
 
-        return wrap_mcp_toolset(self)
+        Cached on first access so the returned list has stable identity
+        across calls — some downstream patterns (GuardedTool's
+        shallow-copy + swap, in-place `already_wrapped` sets) depend on
+        seeing the same object twice."""
+        self._check_open()
+        if self._langchain_tools is None:
+            from hexgate.adapters.langchain.mcp import wrap_mcp_toolset
+
+            self._langchain_tools = wrap_mcp_toolset(self)
+        return self._langchain_tools
 
 
 async def _mark_closed(state: _ToolsetState) -> None:
@@ -223,11 +266,19 @@ def _build_proxy(
     # meaning "accept anything". Falsy-or would replace it with the
     # type=object fallback below, narrowing what the server actually
     # advertised and changing the LLM-visible spec.
-    schema = (
+    #
+    # Shallow-copy the schema so a downstream framework (LangChain's
+    # StructuredTool internals, Google's FunctionDeclaration constructor,
+    # etc.) that mutates the dict in place — injecting
+    # `additionalProperties: false`, normalizing a `$defs` key — doesn't
+    # bleed the mutation back into the MCP `Tool.inputSchema` reference
+    # or into sibling adapter wrappers built from the same proxy.
+    raw_schema = (
         mcp_tool.inputSchema
         if mcp_tool.inputSchema is not None
         else {"type": "object", "properties": {}}
     )
+    schema = dict(raw_schema)
     description = mcp_tool.description or f"{qualified} (no description provided)"
     validator = _validator_for(schema, qualified)
 
@@ -256,19 +307,24 @@ def _build_proxy(
             result = await state.client.call_tool(inner_name, kwargs)
         except MCPConnectionError as exc:
             return _error_envelope("not_connected", str(exc), qualified)
-        except httpx.HTTPError as exc:
-            # Transport-level network failure (HTTP transport). Surface as
-            # a structured error so the agent can decide to retry rather
-            # than the run aborting.
+        except (httpx.HTTPError, TimeoutError, asyncio.TimeoutError) as exc:
+            # Transport-level failures — HTTP network blip / 5xx, or a
+            # per-call timeout raised by either the SDK's asyncio wait or
+            # a stdlib TimeoutError. Surface as retryable so the agent
+            # can decide to back off, not abort the run.
             return _error_envelope("transport_error", str(exc), qualified)
         except Exception as exc:
-            # Catches the SDK's RuntimeError on output-schema validation
-            # failures + any other surprise the transport may raise. The
-            # agent's loop then sees a tool message instead of an exception
-            # killing the run — same contract @agent_tool functions get
-            # via ``failure_mode="result"``.
+            # Anything else the transport / SDK may raise. Bucket under a
+            # stable ``"unknown"`` type instead of leaking the Python
+            # exception class name (was `"valueerror"`, `"runtimeerror"`,
+            # etc. — none of which appear in the documented type set
+            # policy YAML or downstream consumers can switch on). The
+            # exception class shows up in the message so operators still
+            # see it in logs / audit.
             return _error_envelope(
-                exc.__class__.__name__.lower(), str(exc) or repr(exc), qualified
+                "unknown",
+                f"{exc.__class__.__name__}: {exc}" if str(exc) else repr(exc),
+                qualified,
             )
         return _result_to_envelope(qualified, result)
 

--- a/hexgate/mcp/proxy.py
+++ b/hexgate/mcp/proxy.py
@@ -1,16 +1,22 @@
-"""Auto-register MCP server tools as LangChain :class:`BaseTool` instances.
+"""Framework-agnostic MCP toolset: enumerate tools, forward calls, own the
+transport lifecycle.
 
-The toolset is an async context manager: enter opens connections to each
-configured server, walks the (paginated) tool catalog, and builds proxies;
-exit tears the transports down. The proxies forward calls to the live
-MCP session — they must not outlive the context manager.
+The proxy layer produces :class:`MCPToolProxy` descriptors — one per MCP
+tool exposed by the connected servers. Each descriptor carries the
+LLM-facing metadata (name / description / JSON Schema) and an async
+``call(**kwargs) -> dict`` that forwards to the live MCP session and
+returns the ``{"ok": True | False, ...}`` envelope shape native
+``@agent_tool`` functions use.
 
-The tools returned look identical to ``@agent_tool``-decorated functions
-to the rest of the runtime: pass them to :func:`create_agent`, call
-:func:`enforce_policy` as usual, and the existing
-:class:`GuardedTool` wrap routes every call through
-:class:`PolicyEnforcer`. Policy YAML references them by the qualified
-name ``mcp-<server>-<tool>``.
+To hand these tools to an agent framework, wrap the toolset via the
+adapter of your choice:
+
+    from hexgate.adapters.langchain.mcp import wrap_mcp_toolset
+    async with MCPToolset(slack_cfg) as mcp:
+        tools = wrap_mcp_toolset(mcp)  # list[langchain BaseTool]
+
+For back-compat, :meth:`MCPToolset.tools` still returns LangChain tools
+directly — pre-adapter-split callers keep working.
 """
 
 from __future__ import annotations
@@ -18,16 +24,19 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
-from collections.abc import Iterable
-from typing import Any
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 import httpx
 import jsonschema
-from langchain_core.tools import BaseTool, StructuredTool
 from mcp.types import CallToolResult, Tool
 
 from hexgate.mcp.client import MCPClient, MCPConnectionError
 from hexgate.mcp.config import MCPServerConfig
+
+if TYPE_CHECKING:
+    from langchain_core.tools import BaseTool
 
 logger = logging.getLogger("hexgate.mcp.proxy")
 
@@ -50,6 +59,27 @@ class _ToolsetState:
         self.open = True
 
 
+@dataclass(frozen=True, slots=True)
+class MCPToolProxy:
+    """Framework-agnostic descriptor for one MCP tool.
+
+    Adapters (LangChain, OpenAI Agents, Pydantic AI, Google ADK) read
+    only the four fields below; nothing about the underlying
+    :class:`MCPClient` or :class:`_ToolsetState` leaks out. Wrap into a
+    framework-native tool via that adapter's ``wrap_mcp_toolset(...)``.
+
+    ``call`` is the async closure produced by :func:`_build_proxy`. It
+    handles pre-call JSON-Schema validation, exception mapping, and
+    envelope shaping — everything the framework would otherwise have to
+    reimplement.
+    """
+
+    qualified_name: str
+    description: str
+    input_schema: dict[str, Any]
+    call: Callable[..., Awaitable[dict[str, Any]]]
+
+
 class MCPToolset:
     """Holds open connections to one or more MCP servers + exposes tools.
 
@@ -64,9 +94,12 @@ class MCPToolset:
     Usage::
 
         async with MCPToolset(slack_cfg, github_cfg) as mcp:
+            # LangChain path (back-compat shortcut):
             agent, handler = create_agent(model="gpt-5.4", tools=mcp.tools)
-            agent = enforce_policy(agent, "policy.yaml")
-            await agent.ainvoke(...)
+
+            # OR any other adapter, via its wrap_mcp_toolset:
+            from hexgate.adapters.openai.mcp import wrap_mcp_toolset
+            openai_tools = wrap_mcp_toolset(mcp)
     """
 
     def __init__(self, *configs: MCPServerConfig) -> None:
@@ -86,7 +119,7 @@ class MCPToolset:
             )
         self._configs = configs
         self._stack: contextlib.AsyncExitStack | None = None
-        self._tools: list[BaseTool] = []
+        self._proxies: list[MCPToolProxy] = []
         self._states: list[_ToolsetState] = []
 
     async def __aenter__(self) -> "MCPToolset":
@@ -111,7 +144,7 @@ class MCPToolset:
                 # before the client's __aexit__ runs.
                 self._stack.push_async_callback(_mark_closed, state)
                 for mcp_tool in catalog:
-                    self._tools.append(_build_proxy_tool(state, config, mcp_tool))
+                    self._proxies.append(_build_proxy(state, config, mcp_tool))
         except BaseException:
             # aclose() suppresses inner errors; if cancellation hit us we
             # still re-raise the original. Drop the stack reference so
@@ -132,12 +165,12 @@ class MCPToolset:
     ) -> bool | None:
         stack = self._stack
         self._stack = None
-        # Clear BOTH _tools and _states so a re-entered toolset doesn't
+        # Clear BOTH _proxies and _states so a re-entered toolset doesn't
         # accumulate phantom state objects from earlier sessions. (The
         # AsyncExitStack itself is single-use, so re-enter mostly means
         # "tests that reuse the instance"; the clears keep that path
         # honest rather than relying on no-one ever doing it.)
-        self._tools.clear()
+        self._proxies.clear()
         self._states.clear()
         if stack is None:
             return None
@@ -148,19 +181,31 @@ class MCPToolset:
         return await stack.__aexit__(exc_type, exc, tb)
 
     @property
-    def tools(self) -> list[BaseTool]:
-        """The combined tool catalog across every attached server."""
-        return list(self._tools)
+    def proxies(self) -> list[MCPToolProxy]:
+        """The combined tool catalog across every attached server, as
+        framework-agnostic descriptors. Feed to any adapter's
+        ``wrap_mcp_toolset(mcp)`` to get framework-native tools."""
+        return list(self._proxies)
+
+    @property
+    def tools(self) -> "list[BaseTool]":
+        """LangChain BaseTools, one per proxy. Back-compat shortcut for
+        code written before per-adapter wrappers existed — equivalent to
+        ``wrap_mcp_toolset(self)`` from
+        :mod:`hexgate.adapters.langchain.mcp`."""
+        from hexgate.adapters.langchain.mcp import wrap_mcp_toolset
+
+        return wrap_mcp_toolset(self)
 
 
 async def _mark_closed(state: _ToolsetState) -> None:
     state.open = False
 
 
-def _build_proxy_tool(
+def _build_proxy(
     state: _ToolsetState, config: MCPServerConfig, mcp_tool: Tool
-) -> BaseTool:
-    """One LangChain BaseTool that forwards calls to ``state.client``.
+) -> MCPToolProxy:
+    """One :class:`MCPToolProxy` that forwards calls to ``state.client``.
 
     Closure captures the shared state + the tool's server-local name;
     LLM-visible name is the qualified ``mcp-<server>-<tool>`` form so it
@@ -168,11 +213,11 @@ def _build_proxy_tool(
     """
     qualified = config.qualified_tool_name(mcp_tool.name)
     inner_name = mcp_tool.name
-    # MCP gives us JSON Schema; LangChain's StructuredTool accepts the dict
-    # form directly as args_schema, no Pydantic model generation needed for
-    # the LLM-facing contract. We validate the args ourselves against this
-    # same schema BEFORE forwarding so a missing-required-arg call returns
-    # a structured error envelope instead of a wasted server round-trip.
+    # MCP gives us JSON Schema; adapters (LangChain / OpenAI Agents /
+    # etc.) each decide how to feed it into their tool constructor. We
+    # validate args ourselves against this schema BEFORE forwarding so a
+    # missing-required-arg call returns a structured error envelope
+    # instead of a wasted server round-trip.
     #
     # `is None` (not `or`) — an empty dict `{}` is a VALID JSON Schema
     # meaning "accept anything". Falsy-or would replace it with the
@@ -186,7 +231,7 @@ def _build_proxy_tool(
     description = mcp_tool.description or f"{qualified} (no description provided)"
     validator = _validator_for(schema, qualified)
 
-    async def proxy(**kwargs: Any) -> dict[str, Any]:
+    async def call(**kwargs: Any) -> dict[str, Any]:
         if not state.open:
             return _error_envelope(
                 "use_after_close",
@@ -227,12 +272,12 @@ def _build_proxy_tool(
             )
         return _result_to_envelope(qualified, result)
 
-    proxy.__name__ = qualified
-    return StructuredTool.from_function(
-        coroutine=proxy,
-        name=qualified,
+    call.__name__ = qualified
+    return MCPToolProxy(
+        qualified_name=qualified,
         description=description,
-        args_schema=schema,
+        input_schema=schema,
+        call=call,
     )
 
 
@@ -242,8 +287,8 @@ def _validator_for(
     """Build a JSON Schema validator for an MCP tool's inputSchema.
 
     Returns ``None`` if the schema is unusable (e.g. not an object schema,
-    no fields to validate) — that's the same loose contract LangChain
-    accepts and we don't want to be stricter than the LLM-facing spec.
+    no fields to validate) — that's the same loose contract adapters
+    accept and we don't want to be stricter than the LLM-facing spec.
     """
     try:
         validator_cls = jsonschema.validators.validator_for(schema)

--- a/tests/adapters/google/test_mcp.py
+++ b/tests/adapters/google/test_mcp.py
@@ -1,0 +1,226 @@
+"""Tests for the Google ADK adapter's MCP tool-set wrapper.
+
+Framework-agnostic behavior (envelope shape, schema validation,
+lifecycle, use-after-close) is exercised against
+:class:`MCPToolProxy` directly in ``tests/mcp/test_proxy_core.py``.
+This file covers only the ``MCPToolProxy → BaseTool`` conversion:
+metadata + JSON-Schema passthrough via ``_get_declaration``, and
+envelope roundtrip via ``run_async``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from google.adk.tools import BaseTool
+from mcp.types import CallToolResult, TextContent, Tool as MCPTool
+
+from hexgate.adapters.google.mcp import wrap_mcp_toolset
+from hexgate.mcp import MCPServerConfig, MCPToolProxy
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _text_result(text: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
+
+
+class _FakeMCPClient:
+    def __init__(self, config: MCPServerConfig) -> None:
+        self.config = config
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._next: CallToolResult | Exception = _text_result("default")
+
+    def returns(self, result: CallToolResult) -> None:
+        self._next = result
+
+    def raises(self, exc: Exception) -> None:
+        self._next = exc
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if isinstance(self._next, Exception):
+            raise self._next
+        return self._next
+
+
+def _slack_config() -> MCPServerConfig:
+    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+
+
+def _mcp_tool(
+    name: str, *, description: str = "", schema: dict | None = None
+) -> MCPTool:
+    return MCPTool(
+        name=name,
+        description=description or None,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+def _toolset_with(*proxies: MCPToolProxy) -> Any:
+    class _FakeToolset:
+        pass
+
+    fake = _FakeToolset()
+    fake.proxies = list(proxies)
+    return fake
+
+
+def _build_proxy(client: _FakeMCPClient, mcp_tool: MCPTool) -> MCPToolProxy:
+    from hexgate.mcp.proxy import _ToolsetState
+    from hexgate.mcp.proxy import _build_proxy as build
+
+    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+
+
+# ---- wrap_mcp_toolset — shape ---------------------------------------------
+
+
+def test_wrap_returns_a_base_tool_per_proxy() -> None:
+    client = _FakeMCPClient(_slack_config())
+    proxy_a = _build_proxy(client, _mcp_tool("send"))
+    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+
+    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+
+    assert len(tools) == 2
+    for tool in tools:
+        assert isinstance(tool, BaseTool)
+
+
+def test_wrap_preserves_qualified_name() -> None:
+    """The qualified name is the LLM-visible identifier — must survive
+    the ADK wrapping unchanged so policy YAML references resolve at
+    enforcement time."""
+    client = _FakeMCPClient(_slack_config())
+    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    assert wrapped.name == "mcp-slack-send"
+
+
+def test_wrap_preserves_description() -> None:
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, _mcp_tool("send", description="Post a message"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    assert wrapped.description == "Post a message"
+
+
+# ---- _get_declaration — the JSON Schema bridge -----------------------------
+
+
+def test_declaration_carries_raw_json_schema() -> None:
+    """ADK's :class:`FunctionTool` derives its schema from the callable's
+    signature and can't express partial ``required`` / ``anyOf`` /
+    nested-object shapes MCP servers advertise. Our BaseTool subclass
+    bypasses that by returning a FunctionDeclaration with the raw
+    JSON Schema via ``parametersJsonSchema`` — verified here so a future
+    ADK refactor that stops honoring that alias would break loudly."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "channel": {"type": "string"},
+            "text": {"type": "string"},
+        },
+        "required": ["channel", "text"],
+    }
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    declaration = wrapped._get_declaration()
+
+    assert declaration.name == "mcp-slack-send"
+    # ADK uses camelCase alias on construction but attribute access is
+    # snake_case (pydantic model convention).
+    assert declaration.parameters_json_schema == schema
+
+
+def test_declaration_preserves_empty_input_schema() -> None:
+    """An MCP tool advertising ``inputSchema={}`` (accept anything) must
+    reach ADK unchanged — otherwise the LLM sees a spec the server
+    didn't ask for."""
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, MCPTool(name="freeform", inputSchema={}))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    declaration = wrapped._get_declaration()
+
+    assert declaration.parameters_json_schema == {}
+
+
+# ---- run_async roundtrip ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_async_returns_ok_envelope() -> None:
+    """End-to-end: ADK's run_async(args=<dict>, tool_context=...) →
+    proxy.call(**args) → envelope. Consistent across every adapter."""
+    client = _FakeMCPClient(_slack_config())
+    client.returns(_text_result("sent"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.run_async(
+        args={"channel": "#dev", "text": "hi"}, tool_context=None
+    )
+
+    assert result == {"ok": True, "content": "sent"}
+    assert client.calls == [("send", {"channel": "#dev", "text": "hi"})]
+
+
+@pytest.mark.asyncio
+async def test_run_async_returns_error_envelope_on_provider_exception() -> None:
+    """A provider exception surfaces as {"ok": False, ...} — never
+    bubbles out as a raised exception, matching the other adapters."""
+    client = _FakeMCPClient(_slack_config())
+    client.raises(RuntimeError("simulated failure"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.run_async(
+        args={"channel": "#dev", "text": "hi"}, tool_context=None
+    )
+
+    assert result["ok"] is False
+    assert "simulated failure" in result["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_run_async_returns_schema_validation_error_for_bad_args() -> None:
+    """Missing required args are rejected by proxy.call's validator
+    BEFORE the server round-trip — the ADK layer just forwards the
+    envelope back to the LLM."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "channel": {"type": "string"},
+            "text": {"type": "string"},
+        },
+        "required": ["channel", "text"],
+    }
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.run_async(args={"channel": "#dev"}, tool_context=None)
+
+    assert result["ok"] is False
+    assert result["error"]["type"] == "schema_validation_error"
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_async_tolerates_none_args() -> None:
+    """A tool call with ADK passing ``args=None`` (an empty invocation)
+    must map to ``{}`` on the way in, not crash inside ``**None``."""
+    client = _FakeMCPClient(_slack_config())
+    client.returns(_text_result("pong"))
+    proxy = _build_proxy(client, _mcp_tool("ping"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.run_async(args=None, tool_context=None)  # type: ignore[arg-type]
+
+    assert result == {"ok": True, "content": "pong"}
+    assert client.calls == [("ping", {})]

--- a/tests/adapters/google/test_mcp.py
+++ b/tests/adapters/google/test_mcp.py
@@ -10,81 +10,30 @@ envelope roundtrip via ``run_async``.
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 from google.adk.tools import BaseTool
-from mcp.types import CallToolResult, TextContent, Tool as MCPTool
+from mcp.types import Tool as MCPTool
 
 from hexgate.adapters.google.mcp import wrap_mcp_toolset
-from hexgate.mcp import MCPServerConfig, MCPToolProxy
-
-
-# ---- helpers ---------------------------------------------------------------
-
-
-def _text_result(text: str) -> CallToolResult:
-    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
-
-
-class _FakeMCPClient:
-    def __init__(self, config: MCPServerConfig) -> None:
-        self.config = config
-        self.calls: list[tuple[str, dict[str, Any]]] = []
-        self._next: CallToolResult | Exception = _text_result("default")
-
-    def returns(self, result: CallToolResult) -> None:
-        self._next = result
-
-    def raises(self, exc: Exception) -> None:
-        self._next = exc
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
-        self.calls.append((name, arguments))
-        if isinstance(self._next, Exception):
-            raise self._next
-        return self._next
-
-
-def _slack_config() -> MCPServerConfig:
-    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
-
-
-def _mcp_tool(
-    name: str, *, description: str = "", schema: dict | None = None
-) -> MCPTool:
-    return MCPTool(
-        name=name,
-        description=description or None,
-        inputSchema=schema or {"type": "object", "properties": {}},
-    )
-
-
-def _toolset_with(*proxies: MCPToolProxy) -> Any:
-    class _FakeToolset:
-        pass
-
-    fake = _FakeToolset()
-    fake.proxies = list(proxies)
-    return fake
-
-
-def _build_proxy(client: _FakeMCPClient, mcp_tool: MCPTool) -> MCPToolProxy:
-    from hexgate.mcp.proxy import _ToolsetState
-    from hexgate.mcp.proxy import _build_proxy as build
-
-    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+from tests.mcp.conftest import (
+    FakeMCPClient,
+    build_proxy,
+    mcp_tool,
+    slack_config,
+    text_result,
+    toolset_stub,
+)
 
 
 # ---- wrap_mcp_toolset — shape ---------------------------------------------
 
 
 def test_wrap_returns_a_base_tool_per_proxy() -> None:
-    client = _FakeMCPClient(_slack_config())
-    proxy_a = _build_proxy(client, _mcp_tool("send"))
-    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+    client = FakeMCPClient(slack_config())
+    proxy_a = build_proxy(client, mcp_tool("send"))
+    proxy_b = build_proxy(client, mcp_tool("list_channels"))
 
-    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+    tools = wrap_mcp_toolset(toolset_stub(proxy_a, proxy_b))
 
     assert len(tools) == 2
     for tool in tools:
@@ -95,15 +44,15 @@ def test_wrap_preserves_qualified_name() -> None:
     """The qualified name is the LLM-visible identifier — must survive
     the ADK wrapping unchanged so policy YAML references resolve at
     enforcement time."""
-    client = _FakeMCPClient(_slack_config())
-    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    client = FakeMCPClient(slack_config())
+    [wrapped] = wrap_mcp_toolset(toolset_stub(build_proxy(client, mcp_tool("send"))))
     assert wrapped.name == "mcp-slack-send"
 
 
 def test_wrap_preserves_description() -> None:
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, _mcp_tool("send", description="Post a message"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, mcp_tool("send", description="Post a message"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
     assert wrapped.description == "Post a message"
 
 
@@ -125,9 +74,9 @@ def test_declaration_carries_raw_json_schema() -> None:
         },
         "required": ["channel", "text"],
     }
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     declaration = wrapped._get_declaration()
 
@@ -137,17 +86,24 @@ def test_declaration_carries_raw_json_schema() -> None:
     assert declaration.parameters_json_schema == schema
 
 
-def test_declaration_preserves_empty_input_schema() -> None:
-    """An MCP tool advertising ``inputSchema={}`` (accept anything) must
-    reach ADK unchanged — otherwise the LLM sees a spec the server
-    didn't ask for."""
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, MCPTool(name="freeform", inputSchema={}))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+def test_declaration_coerces_empty_input_schema_to_minimal_object() -> None:
+    """An MCP tool advertising ``inputSchema={}`` (accept anything) is
+    a valid JSON Schema, but Gemini's FunctionDeclaration validator
+    rejects declarations whose ``parametersJsonSchema`` has no top-level
+    ``type`` — the tool would silently vanish from the model's
+    available toolset. Coerce ``{}`` to the minimal object schema
+    Gemini accepts. LangChain and OpenAI Agents don't need this
+    (they tolerate ``{}`` unchanged); the coercion is Google-specific."""
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, MCPTool(name="freeform", inputSchema={}))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     declaration = wrapped._get_declaration()
 
-    assert declaration.parameters_json_schema == {}
+    assert declaration.parameters_json_schema == {
+        "type": "object",
+        "properties": {},
+    }
 
 
 # ---- run_async roundtrip ---------------------------------------------------
@@ -157,10 +113,10 @@ def test_declaration_preserves_empty_input_schema() -> None:
 async def test_run_async_returns_ok_envelope() -> None:
     """End-to-end: ADK's run_async(args=<dict>, tool_context=...) →
     proxy.call(**args) → envelope. Consistent across every adapter."""
-    client = _FakeMCPClient(_slack_config())
-    client.returns(_text_result("sent"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    client.returns(text_result("sent"))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.run_async(
         args={"channel": "#dev", "text": "hi"}, tool_context=None
@@ -174,10 +130,10 @@ async def test_run_async_returns_ok_envelope() -> None:
 async def test_run_async_returns_error_envelope_on_provider_exception() -> None:
     """A provider exception surfaces as {"ok": False, ...} — never
     bubbles out as a raised exception, matching the other adapters."""
-    client = _FakeMCPClient(_slack_config())
+    client = FakeMCPClient(slack_config())
     client.raises(RuntimeError("simulated failure"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.run_async(
         args={"channel": "#dev", "text": "hi"}, tool_context=None
@@ -200,9 +156,9 @@ async def test_run_async_returns_schema_validation_error_for_bad_args() -> None:
         },
         "required": ["channel", "text"],
     }
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.run_async(args={"channel": "#dev"}, tool_context=None)
 
@@ -215,10 +171,10 @@ async def test_run_async_returns_schema_validation_error_for_bad_args() -> None:
 async def test_run_async_tolerates_none_args() -> None:
     """A tool call with ADK passing ``args=None`` (an empty invocation)
     must map to ``{}`` on the way in, not crash inside ``**None``."""
-    client = _FakeMCPClient(_slack_config())
-    client.returns(_text_result("pong"))
-    proxy = _build_proxy(client, _mcp_tool("ping"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    client.returns(text_result("pong"))
+    proxy = build_proxy(client, mcp_tool("ping"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.run_async(args=None, tool_context=None)  # type: ignore[arg-type]
 

--- a/tests/adapters/google/test_mcp.py
+++ b/tests/adapters/google/test_mcp.py
@@ -106,6 +106,61 @@ def test_declaration_coerces_empty_input_schema_to_minimal_object() -> None:
     }
 
 
+def test_declaration_coerces_non_empty_schema_missing_type() -> None:
+    """Regression for post-review finding: the old ``or {...}`` guard
+    only fired on falsy dicts. A non-empty schema missing a top-level
+    ``type`` (e.g. ``{"properties": {...}}`` or ``{"anyOf": [...]}``)
+    passed through unchanged and hit the exact Gemini rejection the
+    guard claimed to prevent. Now we inject ``type: "object"`` whenever
+    it's absent, keeping the caller's other keys."""
+    schema = {"properties": {"channel": {"type": "string"}}}
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, MCPTool(name="partial", inputSchema=schema))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
+
+    declaration = wrapped._get_declaration()
+
+    assert declaration.parameters_json_schema["type"] == "object"
+    # Caller's `properties` map is preserved verbatim.
+    assert declaration.parameters_json_schema["properties"] == {
+        "channel": {"type": "string"}
+    }
+
+
+def test_declaration_coerces_schema_that_only_has_anyof() -> None:
+    """Second flavor of the type-missing case — a bare ``anyOf`` schema
+    still needs a top-level ``type`` for Gemini, and the caller's
+    ``anyOf`` must survive the coercion."""
+    schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, MCPTool(name="nullable", inputSchema=schema))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
+
+    declaration = wrapped._get_declaration()
+
+    assert declaration.parameters_json_schema["type"] == "object"
+    assert declaration.parameters_json_schema["anyOf"] == schema["anyOf"]
+
+
+def test_declaration_leaves_schema_with_explicit_type_alone() -> None:
+    """A well-formed schema (with a top-level ``type``) must NOT be
+    coerced or have its fields rewritten — otherwise a caller who
+    picked a non-object top-level (rare but valid) would be silently
+    overridden."""
+    schema = {
+        "type": "object",
+        "properties": {"foo": {"type": "string"}},
+        "required": ["foo"],
+    }
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, MCPTool(name="fine", inputSchema=schema))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
+
+    declaration = wrapped._get_declaration()
+
+    assert declaration.parameters_json_schema == schema
+
+
 # ---- run_async roundtrip ---------------------------------------------------
 
 

--- a/tests/adapters/langchain/test_mcp.py
+++ b/tests/adapters/langchain/test_mcp.py
@@ -1,0 +1,198 @@
+"""Tests for the LangChain adapter's MCP tool-set wrapper.
+
+The framework-agnostic behavior (envelope shaping, schema validation,
+lifecycle, use-after-close, etc.) lives in ``tests/mcp/test_proxy_core.py``
+and is exercised there against :class:`MCPToolProxy` directly. This file
+covers only the thin ``MCPToolProxy → BaseTool`` conversion: the
+LangChain-facing metadata (name, description, args_schema) must reach
+the tool intact and ``ainvoke`` must roundtrip the envelope back to the
+caller unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from langchain_core.tools import BaseTool
+from mcp.types import CallToolResult, TextContent, Tool
+
+from hexgate.adapters.langchain.mcp import wrap_mcp_toolset
+from hexgate.mcp import MCPServerConfig, MCPToolProxy
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _text_result(text: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
+
+
+class _FakeMCPClient:
+    """Minimal client shim mirroring the one in test_proxy_core."""
+
+    def __init__(self, config: MCPServerConfig) -> None:
+        self.config = config
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._next: CallToolResult | Exception = _text_result("default")
+
+    def returns(self, result: CallToolResult) -> None:
+        self._next = result
+
+    def raises(self, exc: Exception) -> None:
+        self._next = exc
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if isinstance(self._next, Exception):
+            raise self._next
+        return self._next
+
+
+def _slack_config() -> MCPServerConfig:
+    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+
+
+def _mcp_tool(name: str, *, description: str = "", schema: dict | None = None) -> Tool:
+    return Tool(
+        name=name,
+        description=description or None,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+def _toolset_with(*proxies: MCPToolProxy) -> Any:
+    """A stand-in for MCPToolset that only exposes what wrap_mcp_toolset reads."""
+
+    class _FakeToolset:
+        pass
+
+    fake = _FakeToolset()
+    fake.proxies = list(proxies)
+    return fake
+
+
+def _build_proxy(client: _FakeMCPClient, mcp_tool: Tool) -> MCPToolProxy:
+    """Build a real MCPToolProxy backed by the fake client."""
+    from hexgate.mcp.proxy import _build_proxy as build, _ToolsetState
+
+    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+
+
+# ---- wrap_mcp_toolset — shape ---------------------------------------------
+
+
+def test_wrap_returns_a_langchain_base_tool_per_proxy() -> None:
+    client = _FakeMCPClient(_slack_config())
+    proxy_a = _build_proxy(client, _mcp_tool("send"))
+    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+
+    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+
+    assert len(tools) == 2
+    for tool in tools:
+        assert isinstance(tool, BaseTool)
+
+
+def test_wrap_preserves_qualified_name() -> None:
+    """The qualified name is the LLM-visible identifier — must survive
+    the LangChain wrapping unchanged so policy YAML references resolve."""
+    client = _FakeMCPClient(_slack_config())
+    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    assert wrapped.name == "mcp-slack-send"
+
+
+def test_wrap_preserves_description_and_schema() -> None:
+    """description + args_schema must reach the LangChain tool intact so
+    the LLM sees the same contract the MCP server advertised."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "channel": {"type": "string"},
+            "text": {"type": "string"},
+        },
+        "required": ["channel", "text"],
+    }
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(
+        client, _mcp_tool("send", description="Post a message", schema=schema)
+    )
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    assert wrapped.description == "Post a message"
+    assert wrapped.args_schema == schema
+
+
+def test_wrap_preserves_empty_input_schema() -> None:
+    """An MCP tool advertising ``inputSchema={}`` (accept anything) must
+    reach LangChain as ``args_schema={}``, not as the type=object
+    fallback — otherwise LangChain would enforce a spec the server
+    didn't ask for."""
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, Tool(name="freeform", inputSchema={}))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    assert wrapped.args_schema == {}
+
+
+# ---- wrap_mcp_toolset — ainvoke roundtrip ----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wrapped_tool_ainvoke_returns_ok_envelope() -> None:
+    """The end-to-end LangChain path: ainvoke → proxy.call → envelope."""
+    client = _FakeMCPClient(_slack_config())
+    client.returns(_text_result("sent"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.ainvoke({"channel": "#dev", "text": "hi"})
+
+    assert result == {"ok": True, "content": "sent"}
+    assert client.calls == [("send", {"channel": "#dev", "text": "hi"})]
+
+
+@pytest.mark.asyncio
+async def test_wrapped_tool_ainvoke_returns_error_envelope() -> None:
+    """A provider exception surfaces as {"ok": False, ...} through ainvoke,
+    not as a raised exception — same contract native @agent_tool has."""
+    client = _FakeMCPClient(_slack_config())
+    client.raises(RuntimeError("simulated failure"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.ainvoke({"channel": "#dev", "text": "hi"})
+
+    assert result["ok"] is False
+    assert "simulated failure" in result["error"]["message"]
+
+
+# ---- MCPToolset.tools back-compat shortcut --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_toolset_tools_shortcut_returns_langchain_tools(monkeypatch) -> None:
+    """``MCPToolset.tools`` is documented public API — it must still return
+    LangChain tools by delegating to ``wrap_mcp_toolset`` internally, so
+    pre-adapter-split code (``mcp.tools``) keeps working unchanged."""
+    from hexgate.mcp import MCPToolset
+
+    class _NoopClient:
+        def __init__(self, config: MCPServerConfig) -> None:
+            self.config = config
+
+        async def __aenter__(self) -> "_NoopClient":
+            return self
+
+        async def __aexit__(self, *exc_info: Any) -> None:
+            pass
+
+        async def list_tools(self) -> list[Tool]:
+            return [_mcp_tool("ping")]
+
+    monkeypatch.setattr("hexgate.mcp.proxy.MCPClient", _NoopClient)
+
+    async with MCPToolset(_slack_config()) as mcp:
+        tools = mcp.tools
+        assert len(tools) == 1
+        assert isinstance(tools[0], BaseTool)
+        assert tools[0].name == "mcp-slack-ping"

--- a/tests/adapters/langchain/test_mcp.py
+++ b/tests/adapters/langchain/test_mcp.py
@@ -15,79 +15,29 @@ from typing import Any
 
 import pytest
 from langchain_core.tools import BaseTool
-from mcp.types import CallToolResult, TextContent, Tool
+from mcp.types import Tool
 
 from hexgate.adapters.langchain.mcp import wrap_mcp_toolset
-from hexgate.mcp import MCPServerConfig, MCPToolProxy
-
-
-# ---- helpers ---------------------------------------------------------------
-
-
-def _text_result(text: str) -> CallToolResult:
-    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
-
-
-class _FakeMCPClient:
-    """Minimal client shim mirroring the one in test_proxy_core."""
-
-    def __init__(self, config: MCPServerConfig) -> None:
-        self.config = config
-        self.calls: list[tuple[str, dict[str, Any]]] = []
-        self._next: CallToolResult | Exception = _text_result("default")
-
-    def returns(self, result: CallToolResult) -> None:
-        self._next = result
-
-    def raises(self, exc: Exception) -> None:
-        self._next = exc
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
-        self.calls.append((name, arguments))
-        if isinstance(self._next, Exception):
-            raise self._next
-        return self._next
-
-
-def _slack_config() -> MCPServerConfig:
-    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
-
-
-def _mcp_tool(name: str, *, description: str = "", schema: dict | None = None) -> Tool:
-    return Tool(
-        name=name,
-        description=description or None,
-        inputSchema=schema or {"type": "object", "properties": {}},
-    )
-
-
-def _toolset_with(*proxies: MCPToolProxy) -> Any:
-    """A stand-in for MCPToolset that only exposes what wrap_mcp_toolset reads."""
-
-    class _FakeToolset:
-        pass
-
-    fake = _FakeToolset()
-    fake.proxies = list(proxies)
-    return fake
-
-
-def _build_proxy(client: _FakeMCPClient, mcp_tool: Tool) -> MCPToolProxy:
-    """Build a real MCPToolProxy backed by the fake client."""
-    from hexgate.mcp.proxy import _build_proxy as build, _ToolsetState
-
-    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+from hexgate.mcp import MCPServerConfig
+from tests.mcp.conftest import (
+    FakeMCPClient,
+    build_proxy,
+    mcp_tool,
+    slack_config,
+    text_result,
+    toolset_stub,
+)
 
 
 # ---- wrap_mcp_toolset — shape ---------------------------------------------
 
 
 def test_wrap_returns_a_langchain_base_tool_per_proxy() -> None:
-    client = _FakeMCPClient(_slack_config())
-    proxy_a = _build_proxy(client, _mcp_tool("send"))
-    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+    client = FakeMCPClient(slack_config())
+    proxy_a = build_proxy(client, mcp_tool("send"))
+    proxy_b = build_proxy(client, mcp_tool("list_channels"))
 
-    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+    tools = wrap_mcp_toolset(toolset_stub(proxy_a, proxy_b))
 
     assert len(tools) == 2
     for tool in tools:
@@ -97,8 +47,8 @@ def test_wrap_returns_a_langchain_base_tool_per_proxy() -> None:
 def test_wrap_preserves_qualified_name() -> None:
     """The qualified name is the LLM-visible identifier — must survive
     the LangChain wrapping unchanged so policy YAML references resolve."""
-    client = _FakeMCPClient(_slack_config())
-    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    client = FakeMCPClient(slack_config())
+    [wrapped] = wrap_mcp_toolset(toolset_stub(build_proxy(client, mcp_tool("send"))))
     assert wrapped.name == "mcp-slack-send"
 
 
@@ -113,11 +63,11 @@ def test_wrap_preserves_description_and_schema() -> None:
         },
         "required": ["channel", "text"],
     }
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(
-        client, _mcp_tool("send", description="Post a message", schema=schema)
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(
+        client, mcp_tool("send", description="Post a message", schema=schema)
     )
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     assert wrapped.description == "Post a message"
     assert wrapped.args_schema == schema
@@ -128,9 +78,9 @@ def test_wrap_preserves_empty_input_schema() -> None:
     reach LangChain as ``args_schema={}``, not as the type=object
     fallback — otherwise LangChain would enforce a spec the server
     didn't ask for."""
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, Tool(name="freeform", inputSchema={}))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, Tool(name="freeform", inputSchema={}))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
     assert wrapped.args_schema == {}
 
 
@@ -140,10 +90,10 @@ def test_wrap_preserves_empty_input_schema() -> None:
 @pytest.mark.asyncio
 async def test_wrapped_tool_ainvoke_returns_ok_envelope() -> None:
     """The end-to-end LangChain path: ainvoke → proxy.call → envelope."""
-    client = _FakeMCPClient(_slack_config())
-    client.returns(_text_result("sent"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    client.returns(text_result("sent"))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.ainvoke({"channel": "#dev", "text": "hi"})
 
@@ -155,10 +105,10 @@ async def test_wrapped_tool_ainvoke_returns_ok_envelope() -> None:
 async def test_wrapped_tool_ainvoke_returns_error_envelope() -> None:
     """A provider exception surfaces as {"ok": False, ...} through ainvoke,
     not as a raised exception — same contract native @agent_tool has."""
-    client = _FakeMCPClient(_slack_config())
+    client = FakeMCPClient(slack_config())
     client.raises(RuntimeError("simulated failure"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.ainvoke({"channel": "#dev", "text": "hi"})
 
@@ -187,11 +137,11 @@ async def test_mcp_toolset_tools_shortcut_returns_langchain_tools(monkeypatch) -
             pass
 
         async def list_tools(self) -> list[Tool]:
-            return [_mcp_tool("ping")]
+            return [mcp_tool("ping")]
 
     monkeypatch.setattr("hexgate.mcp.proxy.MCPClient", _NoopClient)
 
-    async with MCPToolset(_slack_config()) as mcp:
+    async with MCPToolset(slack_config()) as mcp:
         tools = mcp.tools
         assert len(tools) == 1
         assert isinstance(tools[0], BaseTool)

--- a/tests/adapters/openai/test_mcp.py
+++ b/tests/adapters/openai/test_mcp.py
@@ -11,70 +11,20 @@ metadata passthrough, JSON-input parsing, and envelope roundtrip via
 from __future__ import annotations
 
 import json
-from typing import Any
 
 import pytest
 from agents import FunctionTool
-from mcp.types import CallToolResult, TextContent, Tool
+from mcp.types import Tool
 
 from hexgate.adapters.openai.mcp import _parse_args, wrap_mcp_toolset
-from hexgate.mcp import MCPServerConfig, MCPToolProxy
-
-
-# ---- helpers ---------------------------------------------------------------
-
-
-def _text_result(text: str) -> CallToolResult:
-    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
-
-
-class _FakeMCPClient:
-    def __init__(self, config: MCPServerConfig) -> None:
-        self.config = config
-        self.calls: list[tuple[str, dict[str, Any]]] = []
-        self._next: CallToolResult | Exception = _text_result("default")
-
-    def returns(self, result: CallToolResult) -> None:
-        self._next = result
-
-    def raises(self, exc: Exception) -> None:
-        self._next = exc
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
-        self.calls.append((name, arguments))
-        if isinstance(self._next, Exception):
-            raise self._next
-        return self._next
-
-
-def _slack_config() -> MCPServerConfig:
-    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
-
-
-def _mcp_tool(name: str, *, description: str = "", schema: dict | None = None) -> Tool:
-    return Tool(
-        name=name,
-        description=description or None,
-        inputSchema=schema or {"type": "object", "properties": {}},
-    )
-
-
-def _toolset_with(*proxies: MCPToolProxy) -> Any:
-    """A stand-in for MCPToolset that only exposes what wrap_mcp_toolset reads."""
-
-    class _FakeToolset:
-        pass
-
-    fake = _FakeToolset()
-    fake.proxies = list(proxies)
-    return fake
-
-
-def _build_proxy(client: _FakeMCPClient, mcp_tool: Tool) -> MCPToolProxy:
-    from hexgate.mcp.proxy import _ToolsetState
-    from hexgate.mcp.proxy import _build_proxy as build
-
-    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+from tests.mcp.conftest import (
+    FakeMCPClient,
+    build_proxy,
+    mcp_tool,
+    slack_config,
+    text_result,
+    toolset_stub,
+)
 
 
 # ---- _parse_args -----------------------------------------------------------
@@ -112,11 +62,11 @@ def test_parse_args_object_payload_round_trips() -> None:
 
 
 def test_wrap_returns_a_function_tool_per_proxy() -> None:
-    client = _FakeMCPClient(_slack_config())
-    proxy_a = _build_proxy(client, _mcp_tool("send"))
-    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+    client = FakeMCPClient(slack_config())
+    proxy_a = build_proxy(client, mcp_tool("send"))
+    proxy_b = build_proxy(client, mcp_tool("list_channels"))
 
-    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+    tools = wrap_mcp_toolset(toolset_stub(proxy_a, proxy_b))
 
     assert len(tools) == 2
     for tool in tools:
@@ -126,8 +76,8 @@ def test_wrap_returns_a_function_tool_per_proxy() -> None:
 def test_wrap_preserves_qualified_name() -> None:
     """The qualified name is the LLM-visible identifier — must survive
     the OpenAI wrapping unchanged so policy YAML references resolve."""
-    client = _FakeMCPClient(_slack_config())
-    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    client = FakeMCPClient(slack_config())
+    [wrapped] = wrap_mcp_toolset(toolset_stub(build_proxy(client, mcp_tool("send"))))
     assert wrapped.name == "mcp-slack-send"
 
 
@@ -140,11 +90,11 @@ def test_wrap_preserves_description_and_schema() -> None:
         },
         "required": ["channel", "text"],
     }
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(
-        client, _mcp_tool("send", description="Post a message", schema=schema)
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(
+        client, mcp_tool("send", description="Post a message", schema=schema)
     )
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     assert wrapped.description == "Post a message"
     assert wrapped.params_json_schema == schema
@@ -156,9 +106,9 @@ def test_wrap_disables_openai_strict_json_schema() -> None:
     Wrapping with ``strict_json_schema=True`` would reject legitimate
     tools at wrap time; disable it and let our own validator carry the
     load."""
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
     assert wrapped.strict_json_schema is False
 
 
@@ -166,9 +116,9 @@ def test_wrap_preserves_empty_input_schema() -> None:
     """An MCP tool advertising ``inputSchema={}`` (accept anything) must
     reach OpenAI as ``params_json_schema={}``, not the type=object
     fallback — otherwise the LLM sees a spec the server didn't ask for."""
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, Tool(name="freeform", inputSchema={}))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, Tool(name="freeform", inputSchema={}))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
     assert wrapped.params_json_schema == {}
 
 
@@ -178,10 +128,10 @@ def test_wrap_preserves_empty_input_schema() -> None:
 @pytest.mark.asyncio
 async def test_on_invoke_tool_returns_ok_envelope() -> None:
     """End-to-end: on_invoke_tool(ctx, raw JSON) → proxy.call → envelope."""
-    client = _FakeMCPClient(_slack_config())
-    client.returns(_text_result("sent"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    client.returns(text_result("sent"))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.on_invoke_tool(
         None, json.dumps({"channel": "#dev", "text": "hi"})
@@ -195,10 +145,10 @@ async def test_on_invoke_tool_returns_ok_envelope() -> None:
 async def test_on_invoke_tool_returns_error_envelope_on_provider_exception() -> None:
     """A provider exception surfaces as {"ok": False, ...} through
     on_invoke_tool — never bubbles up as a raised exception."""
-    client = _FakeMCPClient(_slack_config())
+    client = FakeMCPClient(slack_config())
     client.raises(RuntimeError("simulated failure"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.on_invoke_tool(
         None, json.dumps({"channel": "#dev", "text": "hi"})
@@ -221,9 +171,9 @@ async def test_on_invoke_tool_returns_schema_validation_error_for_bad_args() -> 
         },
         "required": ["channel", "text"],
     }
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.on_invoke_tool(None, json.dumps({"channel": "#dev"}))
 
@@ -237,10 +187,10 @@ async def test_on_invoke_tool_handles_empty_raw_payload() -> None:
     """An empty raw payload becomes ``{}`` and reaches proxy.call as
     such. Whether it's accepted depends on the tool's schema — for a
     no-required-args tool it should succeed."""
-    client = _FakeMCPClient(_slack_config())
-    client.returns(_text_result("pong"))
-    proxy = _build_proxy(client, _mcp_tool("ping"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    client.returns(text_result("pong"))
+    proxy = build_proxy(client, mcp_tool("ping"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.on_invoke_tool(None, "")
 

--- a/tests/adapters/openai/test_mcp.py
+++ b/tests/adapters/openai/test_mcp.py
@@ -1,0 +1,248 @@
+"""Tests for the OpenAI Agents adapter's MCP tool-set wrapper.
+
+Framework-agnostic behavior (envelope shape, schema validation,
+lifecycle, use-after-close) is exercised against
+:class:`MCPToolProxy` directly in ``tests/mcp/test_proxy_core.py``.
+This file covers only the ``MCPToolProxy → FunctionTool`` conversion:
+metadata passthrough, JSON-input parsing, and envelope roundtrip via
+``on_invoke_tool``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from agents import FunctionTool
+from mcp.types import CallToolResult, TextContent, Tool
+
+from hexgate.adapters.openai.mcp import _parse_args, wrap_mcp_toolset
+from hexgate.mcp import MCPServerConfig, MCPToolProxy
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _text_result(text: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
+
+
+class _FakeMCPClient:
+    def __init__(self, config: MCPServerConfig) -> None:
+        self.config = config
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._next: CallToolResult | Exception = _text_result("default")
+
+    def returns(self, result: CallToolResult) -> None:
+        self._next = result
+
+    def raises(self, exc: Exception) -> None:
+        self._next = exc
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if isinstance(self._next, Exception):
+            raise self._next
+        return self._next
+
+
+def _slack_config() -> MCPServerConfig:
+    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+
+
+def _mcp_tool(name: str, *, description: str = "", schema: dict | None = None) -> Tool:
+    return Tool(
+        name=name,
+        description=description or None,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+def _toolset_with(*proxies: MCPToolProxy) -> Any:
+    """A stand-in for MCPToolset that only exposes what wrap_mcp_toolset reads."""
+
+    class _FakeToolset:
+        pass
+
+    fake = _FakeToolset()
+    fake.proxies = list(proxies)
+    return fake
+
+
+def _build_proxy(client: _FakeMCPClient, mcp_tool: Tool) -> MCPToolProxy:
+    from hexgate.mcp.proxy import _ToolsetState
+    from hexgate.mcp.proxy import _build_proxy as build
+
+    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+
+
+# ---- _parse_args -----------------------------------------------------------
+
+
+def test_parse_args_empty_returns_empty_dict() -> None:
+    """No payload → empty dict; the proxy's validator then decides
+    whether that satisfies the tool's schema."""
+    assert _parse_args("") == {}
+
+
+def test_parse_args_invalid_json_returns_empty_dict() -> None:
+    """Junk payload → empty dict, not an exception — matches the
+    tolerance of the native OpenAI wrap so schema validation is the
+    single rejection point."""
+    assert _parse_args("not json") == {}
+
+
+def test_parse_args_non_object_json_returns_empty_dict() -> None:
+    """Lists and scalars aren't valid tool argument payloads → drop
+    them so downstream never sees a non-dict."""
+    assert _parse_args("[1, 2]") == {}
+    assert _parse_args("42") == {}
+    assert _parse_args('"hi"') == {}
+
+
+def test_parse_args_object_payload_round_trips() -> None:
+    assert _parse_args('{"channel": "#dev", "text": "hi"}') == {
+        "channel": "#dev",
+        "text": "hi",
+    }
+
+
+# ---- wrap_mcp_toolset — shape ---------------------------------------------
+
+
+def test_wrap_returns_a_function_tool_per_proxy() -> None:
+    client = _FakeMCPClient(_slack_config())
+    proxy_a = _build_proxy(client, _mcp_tool("send"))
+    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+
+    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+
+    assert len(tools) == 2
+    for tool in tools:
+        assert isinstance(tool, FunctionTool)
+
+
+def test_wrap_preserves_qualified_name() -> None:
+    """The qualified name is the LLM-visible identifier — must survive
+    the OpenAI wrapping unchanged so policy YAML references resolve."""
+    client = _FakeMCPClient(_slack_config())
+    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    assert wrapped.name == "mcp-slack-send"
+
+
+def test_wrap_preserves_description_and_schema() -> None:
+    schema = {
+        "type": "object",
+        "properties": {
+            "channel": {"type": "string"},
+            "text": {"type": "string"},
+        },
+        "required": ["channel", "text"],
+    }
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(
+        client, _mcp_tool("send", description="Post a message", schema=schema)
+    )
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    assert wrapped.description == "Post a message"
+    assert wrapped.params_json_schema == schema
+
+
+def test_wrap_disables_openai_strict_json_schema() -> None:
+    """MCP servers routinely advertise schemas that don't meet OpenAI's
+    strict-mode requirements (partial ``required``, ``anyOf``, etc.).
+    Wrapping with ``strict_json_schema=True`` would reject legitimate
+    tools at wrap time; disable it and let our own validator carry the
+    load."""
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    assert wrapped.strict_json_schema is False
+
+
+def test_wrap_preserves_empty_input_schema() -> None:
+    """An MCP tool advertising ``inputSchema={}`` (accept anything) must
+    reach OpenAI as ``params_json_schema={}``, not the type=object
+    fallback — otherwise the LLM sees a spec the server didn't ask for."""
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, Tool(name="freeform", inputSchema={}))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    assert wrapped.params_json_schema == {}
+
+
+# ---- on_invoke_tool roundtrip ---------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_invoke_tool_returns_ok_envelope() -> None:
+    """End-to-end: on_invoke_tool(ctx, raw JSON) → proxy.call → envelope."""
+    client = _FakeMCPClient(_slack_config())
+    client.returns(_text_result("sent"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.on_invoke_tool(
+        None, json.dumps({"channel": "#dev", "text": "hi"})
+    )
+
+    assert result == {"ok": True, "content": "sent"}
+    assert client.calls == [("send", {"channel": "#dev", "text": "hi"})]
+
+
+@pytest.mark.asyncio
+async def test_on_invoke_tool_returns_error_envelope_on_provider_exception() -> None:
+    """A provider exception surfaces as {"ok": False, ...} through
+    on_invoke_tool — never bubbles up as a raised exception."""
+    client = _FakeMCPClient(_slack_config())
+    client.raises(RuntimeError("simulated failure"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.on_invoke_tool(
+        None, json.dumps({"channel": "#dev", "text": "hi"})
+    )
+
+    assert result["ok"] is False
+    assert "simulated failure" in result["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_on_invoke_tool_returns_schema_validation_error_for_bad_args() -> None:
+    """Missing required args are rejected by proxy.call's validator
+    BEFORE the server round-trip — must reach the LLM as a structured
+    envelope, not the LLM getting whatever the server sends back."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "channel": {"type": "string"},
+            "text": {"type": "string"},
+        },
+        "required": ["channel", "text"],
+    }
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.on_invoke_tool(None, json.dumps({"channel": "#dev"}))
+
+    assert result["ok"] is False
+    assert result["error"]["type"] == "schema_validation_error"
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_on_invoke_tool_handles_empty_raw_payload() -> None:
+    """An empty raw payload becomes ``{}`` and reaches proxy.call as
+    such. Whether it's accepted depends on the tool's schema — for a
+    no-required-args tool it should succeed."""
+    client = _FakeMCPClient(_slack_config())
+    client.returns(_text_result("pong"))
+    proxy = _build_proxy(client, _mcp_tool("ping"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.on_invoke_tool(None, "")
+
+    assert result == {"ok": True, "content": "pong"}
+    assert client.calls == [("ping", {})]

--- a/tests/adapters/pydantic_ai/test_mcp.py
+++ b/tests/adapters/pydantic_ai/test_mcp.py
@@ -10,81 +10,29 @@ metadata passthrough and envelope roundtrip via
 
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
-from mcp.types import CallToolResult, TextContent, Tool as MCPTool
 from pydantic_ai.tools import Tool
 
 from hexgate.adapters.pydantic_ai.mcp import wrap_mcp_toolset
-from hexgate.mcp import MCPServerConfig, MCPToolProxy
-
-
-# ---- helpers ---------------------------------------------------------------
-
-
-def _text_result(text: str) -> CallToolResult:
-    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
-
-
-class _FakeMCPClient:
-    def __init__(self, config: MCPServerConfig) -> None:
-        self.config = config
-        self.calls: list[tuple[str, dict[str, Any]]] = []
-        self._next: CallToolResult | Exception = _text_result("default")
-
-    def returns(self, result: CallToolResult) -> None:
-        self._next = result
-
-    def raises(self, exc: Exception) -> None:
-        self._next = exc
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
-        self.calls.append((name, arguments))
-        if isinstance(self._next, Exception):
-            raise self._next
-        return self._next
-
-
-def _slack_config() -> MCPServerConfig:
-    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
-
-
-def _mcp_tool(
-    name: str, *, description: str = "", schema: dict | None = None
-) -> MCPTool:
-    return MCPTool(
-        name=name,
-        description=description or None,
-        inputSchema=schema or {"type": "object", "properties": {}},
-    )
-
-
-def _toolset_with(*proxies: MCPToolProxy) -> Any:
-    class _FakeToolset:
-        pass
-
-    fake = _FakeToolset()
-    fake.proxies = list(proxies)
-    return fake
-
-
-def _build_proxy(client: _FakeMCPClient, mcp_tool: MCPTool) -> MCPToolProxy:
-    from hexgate.mcp.proxy import _ToolsetState
-    from hexgate.mcp.proxy import _build_proxy as build
-
-    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+from tests.mcp.conftest import (
+    FakeMCPClient,
+    build_proxy,
+    mcp_tool,
+    slack_config,
+    text_result,
+    toolset_stub,
+)
 
 
 # ---- wrap_mcp_toolset — shape ---------------------------------------------
 
 
 def test_wrap_returns_a_pydantic_tool_per_proxy() -> None:
-    client = _FakeMCPClient(_slack_config())
-    proxy_a = _build_proxy(client, _mcp_tool("send"))
-    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+    client = FakeMCPClient(slack_config())
+    proxy_a = build_proxy(client, mcp_tool("send"))
+    proxy_b = build_proxy(client, mcp_tool("list_channels"))
 
-    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+    tools = wrap_mcp_toolset(toolset_stub(proxy_a, proxy_b))
 
     assert len(tools) == 2
     for tool in tools:
@@ -95,15 +43,15 @@ def test_wrap_preserves_qualified_name() -> None:
     """The qualified name is the LLM-visible identifier — must survive
     the Pydantic AI wrapping unchanged so policy YAML references
     resolve at enforcement time."""
-    client = _FakeMCPClient(_slack_config())
-    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    client = FakeMCPClient(slack_config())
+    [wrapped] = wrap_mcp_toolset(toolset_stub(build_proxy(client, mcp_tool("send"))))
     assert wrapped.name == "mcp-slack-send"
 
 
 def test_wrap_preserves_description() -> None:
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, _mcp_tool("send", description="Post a message"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, mcp_tool("send", description="Post a message"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
     assert wrapped.description == "Post a message"
 
 
@@ -114,10 +62,10 @@ def test_wrap_preserves_description() -> None:
 async def test_call_returns_ok_envelope() -> None:
     """End-to-end: pydantic_ai's function_schema.call(args_dict, ctx) →
     proxy.call(**args) → envelope. Args are unpacked from the dict."""
-    client = _FakeMCPClient(_slack_config())
-    client.returns(_text_result("sent"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    client.returns(text_result("sent"))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.function_schema.call({"channel": "#dev", "text": "hi"}, None)
 
@@ -130,10 +78,10 @@ async def test_call_returns_error_envelope_on_provider_exception() -> None:
     """A provider exception surfaces as {"ok": False, ...} — does NOT
     bubble as ModelRetry or a raised exception. Consistent with the
     other adapters' MCP wrap behavior."""
-    client = _FakeMCPClient(_slack_config())
+    client = FakeMCPClient(slack_config())
     client.raises(RuntimeError("simulated failure"))
-    proxy = _build_proxy(client, _mcp_tool("send"))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    proxy = build_proxy(client, mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     result = await wrapped.function_schema.call({"channel": "#dev", "text": "hi"}, None)
 
@@ -158,9 +106,9 @@ async def test_call_returns_schema_validation_error_for_bad_args_from_proxy_laye
         },
         "required": ["channel", "text"],
     }
-    client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
-    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    client = FakeMCPClient(slack_config())
+    proxy = build_proxy(client, mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(toolset_stub(proxy))
 
     # Bypass pydantic_ai's outer validation by calling proxy.call
     # directly through the Tool — this exercises the inner defence.

--- a/tests/adapters/pydantic_ai/test_mcp.py
+++ b/tests/adapters/pydantic_ai/test_mcp.py
@@ -1,0 +1,171 @@
+"""Tests for the Pydantic AI adapter's MCP tool-set wrapper.
+
+Framework-agnostic behavior (envelope shape, schema validation,
+lifecycle, use-after-close) is exercised against
+:class:`MCPToolProxy` directly in ``tests/mcp/test_proxy_core.py``.
+This file covers only the ``MCPToolProxy → Tool`` conversion:
+metadata passthrough and envelope roundtrip via
+``function_schema.call``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from mcp.types import CallToolResult, TextContent, Tool as MCPTool
+from pydantic_ai.tools import Tool
+
+from hexgate.adapters.pydantic_ai.mcp import wrap_mcp_toolset
+from hexgate.mcp import MCPServerConfig, MCPToolProxy
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _text_result(text: str) -> CallToolResult:
+    return CallToolResult(content=[TextContent(type="text", text=text)], isError=False)
+
+
+class _FakeMCPClient:
+    def __init__(self, config: MCPServerConfig) -> None:
+        self.config = config
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._next: CallToolResult | Exception = _text_result("default")
+
+    def returns(self, result: CallToolResult) -> None:
+        self._next = result
+
+    def raises(self, exc: Exception) -> None:
+        self._next = exc
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if isinstance(self._next, Exception):
+            raise self._next
+        return self._next
+
+
+def _slack_config() -> MCPServerConfig:
+    return MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+
+
+def _mcp_tool(
+    name: str, *, description: str = "", schema: dict | None = None
+) -> MCPTool:
+    return MCPTool(
+        name=name,
+        description=description or None,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+def _toolset_with(*proxies: MCPToolProxy) -> Any:
+    class _FakeToolset:
+        pass
+
+    fake = _FakeToolset()
+    fake.proxies = list(proxies)
+    return fake
+
+
+def _build_proxy(client: _FakeMCPClient, mcp_tool: MCPTool) -> MCPToolProxy:
+    from hexgate.mcp.proxy import _ToolsetState
+    from hexgate.mcp.proxy import _build_proxy as build
+
+    return build(_ToolsetState(client), client.config, mcp_tool)  # type: ignore[arg-type]
+
+
+# ---- wrap_mcp_toolset — shape ---------------------------------------------
+
+
+def test_wrap_returns_a_pydantic_tool_per_proxy() -> None:
+    client = _FakeMCPClient(_slack_config())
+    proxy_a = _build_proxy(client, _mcp_tool("send"))
+    proxy_b = _build_proxy(client, _mcp_tool("list_channels"))
+
+    tools = wrap_mcp_toolset(_toolset_with(proxy_a, proxy_b))
+
+    assert len(tools) == 2
+    for tool in tools:
+        assert isinstance(tool, Tool)
+
+
+def test_wrap_preserves_qualified_name() -> None:
+    """The qualified name is the LLM-visible identifier — must survive
+    the Pydantic AI wrapping unchanged so policy YAML references
+    resolve at enforcement time."""
+    client = _FakeMCPClient(_slack_config())
+    [wrapped] = wrap_mcp_toolset(_toolset_with(_build_proxy(client, _mcp_tool("send"))))
+    assert wrapped.name == "mcp-slack-send"
+
+
+def test_wrap_preserves_description() -> None:
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, _mcp_tool("send", description="Post a message"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+    assert wrapped.description == "Post a message"
+
+
+# ---- function_schema.call roundtrip ---------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_returns_ok_envelope() -> None:
+    """End-to-end: pydantic_ai's function_schema.call(args_dict, ctx) →
+    proxy.call(**args) → envelope. Args are unpacked from the dict."""
+    client = _FakeMCPClient(_slack_config())
+    client.returns(_text_result("sent"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.function_schema.call({"channel": "#dev", "text": "hi"}, None)
+
+    assert result == {"ok": True, "content": "sent"}
+    assert client.calls == [("send", {"channel": "#dev", "text": "hi"})]
+
+
+@pytest.mark.asyncio
+async def test_call_returns_error_envelope_on_provider_exception() -> None:
+    """A provider exception surfaces as {"ok": False, ...} — does NOT
+    bubble as ModelRetry or a raised exception. Consistent with the
+    other adapters' MCP wrap behavior."""
+    client = _FakeMCPClient(_slack_config())
+    client.raises(RuntimeError("simulated failure"))
+    proxy = _build_proxy(client, _mcp_tool("send"))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    result = await wrapped.function_schema.call({"channel": "#dev", "text": "hi"}, None)
+
+    assert result["ok"] is False
+    assert "simulated failure" in result["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_call_returns_schema_validation_error_for_bad_args_from_proxy_layer() -> (
+    None
+):
+    """Even if pydantic_ai's outer validator lets an arg dict through,
+    our proxy's own validator rejects malformed args BEFORE the server
+    round-trip. That layer is exercised by feeding an unvalidated
+    partial dict directly — as would happen if pydantic_ai's model
+    were permissive on that field."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "channel": {"type": "string"},
+            "text": {"type": "string"},
+        },
+        "required": ["channel", "text"],
+    }
+    client = _FakeMCPClient(_slack_config())
+    proxy = _build_proxy(client, _mcp_tool("send", schema=schema))
+    [wrapped] = wrap_mcp_toolset(_toolset_with(proxy))
+
+    # Bypass pydantic_ai's outer validation by calling proxy.call
+    # directly through the Tool — this exercises the inner defence.
+    result = await wrapped.function_schema.call({"channel": "#dev"}, None)
+
+    assert result["ok"] is False
+    assert result["error"]["type"] == "schema_validation_error"
+    assert client.calls == []

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -1,0 +1,100 @@
+"""Shared test fixtures for the MCP proxy layer and every per-adapter
+wrapper suite.
+
+Before this file, `_FakeMCPClient`, `_slack_config`, `_mcp_tool`,
+`_toolset_with`, `_build_proxy`, and `_text_result` were copy-pasted
+into five test modules (~50 lines apiece). Small drifts already
+appeared (``_next_result`` vs ``_next``) making shared assertions
+brittle. Consolidated here and re-exported via a stable module path so
+adapter tests can `from tests.mcp.conftest import ...`.
+
+Kept module-level (not pytest fixtures) so tests can build multiple
+clients/proxies per case without decorator ceremony. These helpers
+have no per-test state; they're just builders.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.types import CallToolResult, TextContent, Tool
+
+from hexgate.mcp import MCPServerConfig, MCPToolProxy
+
+
+def text_result(text: str, *, is_error: bool = False) -> CallToolResult:
+    """A `CallToolResult` with a single text block."""
+    return CallToolResult(
+        content=[TextContent(type="text", text=text)], isError=is_error
+    )
+
+
+class FakeMCPClient:
+    """Minimal stand-in for :class:`MCPClient`.
+
+    Implements just the subset _build_proxy reads: ``config`` (for the
+    qualified name) and ``call_tool``. Every call appends to
+    ``self.calls`` so tests can assert forwarding shape.
+    """
+
+    def __init__(self, config: MCPServerConfig) -> None:
+        self.config = config
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._next: CallToolResult | Exception = text_result("default")
+
+    def returns(self, result: CallToolResult) -> None:
+        self._next = result
+
+    def raises(self, exc: Exception) -> None:
+        self._next = exc
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
+        self.calls.append((name, arguments))
+        if isinstance(self._next, Exception):
+            raise self._next
+        return self._next
+
+
+def slack_config(**overrides: Any) -> MCPServerConfig:
+    """A stdio MCPServerConfig with sensible defaults for tests."""
+    base: dict[str, Any] = {
+        "name": "slack",
+        "transport": "stdio",
+        "command": "slack-mcp",
+    }
+    base.update(overrides)
+    return MCPServerConfig(**base)
+
+
+def mcp_tool(name: str, *, description: str = "", schema: dict | None = None) -> Tool:
+    """A minimal MCP `Tool` — description defaults to unset so proxy's
+    "no description provided" fallback path is exercised too."""
+    return Tool(
+        name=name,
+        description=description or None,
+        inputSchema=schema or {"type": "object", "properties": {}},
+    )
+
+
+def toolset_stub(*proxies: MCPToolProxy) -> Any:
+    """A stand-in for :class:`MCPToolset` that only exposes what
+    adapter `wrap_mcp_toolset` functions read (`.proxies`)."""
+
+    class _Stub:
+        pass
+
+    stub = _Stub()
+    stub.proxies = list(proxies)
+    return stub
+
+
+def build_proxy(client: FakeMCPClient, tool: Tool) -> MCPToolProxy:
+    """Build a real :class:`MCPToolProxy` backed by ``client``.
+
+    Imports `_build_proxy` and `_ToolsetState` lazily so this module
+    stays cheap when a test only wants the fake client.
+    """
+    from hexgate.mcp.proxy import _ToolsetState
+    from hexgate.mcp.proxy import _build_proxy as build
+
+    return build(_ToolsetState(client), client.config, tool)  # type: ignore[arg-type]

--- a/tests/mcp/test_proxy_core.py
+++ b/tests/mcp/test_proxy_core.py
@@ -1,4 +1,4 @@
-"""Tests for the MCP → LangChain tool proxy layer.
+"""Framework-agnostic tests for the MCP proxy layer.
 
 Uses a hand-rolled fake :class:`MCPClient` to exercise the proxy without
 spawning a real subprocess. The end-to-end transport (stdio + http) is
@@ -6,6 +6,11 @@ covered by the official ``mcp`` SDK's own tests; what we own here is the
 qualified-naming, schema passthrough, call-forwarding, envelope shape,
 structured-output handling, schema validation, and lifecycle behavior
 of our wrapper.
+
+LangChain-specific wrapping is covered in
+``tests/adapters/langchain/test_mcp.py``; this file drives
+:class:`MCPToolProxy` directly via its async ``call(**kwargs)`` so the
+assertions don't depend on any agent framework.
 """
 
 from __future__ import annotations
@@ -21,10 +26,10 @@ from mcp.types import (
     Tool,
 )
 
-from hexgate.mcp import MCPServerConfig, MCPToolset
+from hexgate.mcp import MCPServerConfig, MCPToolProxy, MCPToolset
 from hexgate.mcp.client import MCPConnectionError
 from hexgate.mcp.proxy import (
-    _build_proxy_tool,
+    _build_proxy,
     _result_to_envelope,
     _ToolsetState,
 )
@@ -42,7 +47,7 @@ def _text_result(text: str, *, is_error: bool = False) -> CallToolResult:
 class _FakeMCPClient:
     """Minimal stand-in for :class:`MCPClient` — records calls, scripts results.
 
-    Implements just the subset _build_proxy_tool reads: ``config`` (for the
+    Implements just the subset _build_proxy reads: ``config`` (for the
     qualified name) and ``call_tool``. Each call appends to ``self.calls``.
     """
 
@@ -100,77 +105,85 @@ def test_envelope_wraps_text_content_as_ok() -> None:
         ],
         isError=False,
     )
-    out = _result_to_envelope("mcp-slack-search", result)
-    assert out == {"ok": True, "content": "line one\nline two"}
+    env = _result_to_envelope("mcp-slack-send", result)
+    assert env == {"ok": True, "content": "line one\nline two"}
 
 
 def test_envelope_marks_isError_as_not_ok() -> None:
-    """isError must flip the envelope to {"ok": False, ...} — otherwise the
-    agent would treat a failed tool call as successful."""
-    out = _result_to_envelope(
-        "mcp-slack-search", _text_result("rate limited", is_error=True)
+    """MCP's isError=true is a deterministic tool-level failure — surface
+    it as {"ok": False, "error": ...} so the agent doesn't treat it as
+    success just because a payload came back."""
+    result = CallToolResult(
+        content=[TextContent(type="text", text="channel not found")],
+        isError=True,
     )
-    assert out["ok"] is False
-    assert out["error"]["type"] == "tool_error"
-    assert "rate limited" in out["error"]["message"]
-    assert out["error"]["tool_name"] == "mcp-slack-search"
+    env = _result_to_envelope("mcp-slack-send", result)
+    assert env["ok"] is False
+    assert env["error"]["type"] == "tool_error"
+    assert "channel not found" in env["error"]["message"]
 
 
 def test_envelope_includes_structured_content() -> None:
-    """MCP's structuredContent is a first-class typed return path — must not
-    silently disappear (was finding #4 in the code review)."""
+    """structuredContent is MCP's first-class typed-return path — must be
+    surfaced so the LLM sees typed data even without a content block."""
     result = CallToolResult(
         content=[],
-        structuredContent={"channel_id": "C123", "ts": "1700000000.000"},
+        structuredContent={"channel_id": "C123", "ts": "1700000000.001"},
         isError=False,
     )
-    out = _result_to_envelope("mcp-slack-send", result)
-    assert out["ok"] is True
-    # Rendered as JSON text the LLM can parse.
-    assert '"channel_id": "C123"' in out["content"]
-    assert '"ts": "1700000000.000"' in out["content"]
+    env = _result_to_envelope("mcp-slack-send", result)
+    assert env["ok"] is True
+    # JSON serialization is stable (sort_keys) so callers can substring-check.
+    assert '"channel_id": "C123"' in env["content"]
+    assert '"ts": "1700000000.001"' in env["content"]
 
 
 def test_envelope_extracts_text_from_embedded_resource() -> None:
-    """EmbeddedResource carries readable text via ``.resource.text``;
-    dropping it was a silent data loss."""
-    result = CallToolResult(
-        content=[
-            EmbeddedResource(
-                type="resource",
-                resource=TextResourceContents(
-                    uri="file:///tmp/note.txt", text="hello from a resource"
-                ),
-            )
-        ],
-        isError=False,
+    """EmbeddedResource wrapping a text-typed resource must reach the LLM."""
+    resource = TextResourceContents(
+        uri="file:///tmp/x.txt", mimeType="text/plain", text="embedded body"
     )
-    out = _result_to_envelope("mcp-fs-read", result)
-    assert out["ok"] is True
-    assert "hello from a resource" in out["content"]
+    block = EmbeddedResource(type="resource", resource=resource)
+    result = CallToolResult(content=[block], isError=False)
+    env = _result_to_envelope("mcp-fs-read", result)
+    assert env == {"ok": True, "content": "embedded body"}
 
 
 def test_envelope_falls_back_to_placeholder_for_empty_content() -> None:
-    """A tool that returns nothing shouldn't render as the literal empty
-    string — that would look like a "" success to the LLM."""
-    empty = CallToolResult(content=[], isError=False)
-    out = _result_to_envelope("mcp-slack-noop", empty)
-    assert out == {"ok": True, "content": "(no textual content)"}
+    """A tool that returns nothing usable (no text, no structuredContent)
+    must not surface an empty LLM message — the LLM needs SOMETHING to
+    react to."""
+    result = CallToolResult(content=[], isError=False)
+    env = _result_to_envelope("mcp-noop-ping", result)
+    assert env == {"ok": True, "content": "(no textual content)"}
 
 
-# ---- _build_proxy_tool — naming + schema + description ---------------------
+# ---- _build_proxy — descriptor shape ---------------------------------------
 
 
-def test_proxy_tool_uses_qualified_name() -> None:
+def test_proxy_returns_mcp_tool_proxy() -> None:
+    """_build_proxy produces an MCPToolProxy dataclass — the canonical
+    descriptor every adapter reads."""
+    proxy = _build_proxy(
+        _state(_FakeMCPClient(_slack_config())),
+        _slack_config(),
+        _tool("send_message"),
+    )
+    assert isinstance(proxy, MCPToolProxy)
+
+
+def test_proxy_uses_qualified_name() -> None:
     """LLM-visible name must be ``mcp-<server>-<tool>`` so it can't collide
     with native tools or with another MCP server exposing the same tool."""
-    proxy = _build_proxy_tool(
-        _state(_FakeMCPClient(_slack_config())), _slack_config(), _tool("send_message")
+    proxy = _build_proxy(
+        _state(_FakeMCPClient(_slack_config())),
+        _slack_config(),
+        _tool("send_message"),
     )
-    assert proxy.name == "mcp-slack-send_message"
+    assert proxy.qualified_name == "mcp-slack-send_message"
 
 
-def test_proxy_tool_passes_through_description_and_schema() -> None:
+def test_proxy_passes_through_description_and_schema() -> None:
     """MCP's description + inputSchema must reach the LLM unchanged so it
     knows when + how to call the tool."""
     schema = {
@@ -182,21 +195,22 @@ def test_proxy_tool_passes_through_description_and_schema() -> None:
         "required": ["channel", "text"],
     }
     cfg = _slack_config()
-    proxy = _build_proxy_tool(
+    proxy = _build_proxy(
         _state(_FakeMCPClient(cfg)),
         cfg,
         _tool("send_message", description="Post a message to a channel", schema=schema),
     )
     assert proxy.description == "Post a message to a channel"
-    assert proxy.args_schema == schema
+    assert proxy.input_schema == schema
 
 
-def test_proxy_tool_falls_back_to_default_description() -> None:
-    """A tool with no description shouldn't break the LangChain BaseTool
-    contract (which requires a non-empty description) — fall back to the
-    qualified name so the LLM at least sees a label."""
+def test_proxy_falls_back_to_default_description() -> None:
+    """A tool with no description shouldn't produce an empty descriptor —
+    adapters that require non-empty descriptions (LangChain) would
+    otherwise refuse to build a tool. Fall back to the qualified name so
+    the LLM at least sees a label."""
     cfg = _slack_config()
-    proxy = _build_proxy_tool(_state(_FakeMCPClient(cfg)), cfg, _tool("list_channels"))
+    proxy = _build_proxy(_state(_FakeMCPClient(cfg)), cfg, _tool("list_channels"))
     assert proxy.description
     assert "mcp-slack-list_channels" in proxy.description
 
@@ -204,45 +218,44 @@ def test_proxy_tool_falls_back_to_default_description() -> None:
 def test_proxy_preserves_empty_input_schema() -> None:
     """A server that advertises inputSchema={} (valid JSON Schema meaning
     "accept anything") must NOT be silently replaced with the
-    type=object fallback — that narrows the spec the LLM sees and
-    changes args_schema. Falsy-or bug; only `is None` should trigger
-    the fallback."""
+    type=object fallback — that narrows the spec the LLM sees. Falsy-or
+    bug; only `is None` should trigger the fallback."""
     cfg = _slack_config()
     # MCP's `Tool.inputSchema` default-factories to {}, so we get that
     # naturally by omitting it — same shape as the live failure path.
     tool = Tool(name="freeform", description="anything goes", inputSchema={})
-    proxy = _build_proxy_tool(_state(_FakeMCPClient(cfg)), cfg, tool)
-    # The exact dict the server sent should reach LangChain unchanged.
-    assert proxy.args_schema == {}
+    proxy = _build_proxy(_state(_FakeMCPClient(cfg)), cfg, tool)
+    # The exact dict the server sent should reach the descriptor unchanged.
+    assert proxy.input_schema == {}
 
 
-# ---- proxy call forwarding -------------------------------------------------
+# ---- proxy.call() forwarding -----------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_proxy_forwards_call_with_server_local_name() -> None:
+async def test_proxy_call_forwards_with_server_local_name() -> None:
     """The proxy must call ``client.call_tool(inner_name, ...)`` — NOT the
     qualified name — because the server only knows its local tool names."""
     client = _FakeMCPClient(_slack_config())
     client.returns(_text_result("ok"))
-    proxy = _build_proxy_tool(_state(client), _slack_config(), _tool("send_message"))
+    proxy = _build_proxy(_state(client), _slack_config(), _tool("send_message"))
 
-    result = await proxy.ainvoke({"channel": "#dev", "text": "hi"})
+    result = await proxy.call(channel="#dev", text="hi")
 
     assert client.calls == [("send_message", {"channel": "#dev", "text": "hi"})]
     assert result == {"ok": True, "content": "ok"}
 
 
 @pytest.mark.asyncio
-async def test_proxy_returns_error_envelope_on_provider_exception() -> None:
+async def test_proxy_call_returns_error_envelope_on_provider_exception() -> None:
     """Provider RuntimeErrors (e.g. SDK output-schema validation failures)
     must surface as a {"ok": False, "error": ...} envelope — never bubble
-    up and abort the agent run (was finding #7)."""
+    up and abort the agent run."""
     client = _FakeMCPClient(_slack_config())
     client.raises(RuntimeError("simulated SDK output-schema violation"))
-    proxy = _build_proxy_tool(_state(client), _slack_config(), _tool("send_message"))
+    proxy = _build_proxy(_state(client), _slack_config(), _tool("send_message"))
 
-    result = await proxy.ainvoke({"channel": "#dev", "text": "hi"})
+    result = await proxy.call(channel="#dev", text="hi")
 
     assert result["ok"] is False
     assert "simulated SDK output-schema violation" in result["error"]["message"]
@@ -250,14 +263,14 @@ async def test_proxy_returns_error_envelope_on_provider_exception() -> None:
 
 
 @pytest.mark.asyncio
-async def test_proxy_returns_error_envelope_on_not_connected() -> None:
+async def test_proxy_call_returns_error_envelope_on_not_connected() -> None:
     """An MCPConnectionError (use-after-close at the client level) must
     also produce an envelope — never raise out of the proxy."""
     client = _FakeMCPClient(_slack_config())
     client.raises(MCPConnectionError("session torn down"))
-    proxy = _build_proxy_tool(_state(client), _slack_config(), _tool("send_message"))
+    proxy = _build_proxy(_state(client), _slack_config(), _tool("send_message"))
 
-    result = await proxy.ainvoke({"channel": "#dev", "text": "hi"})
+    result = await proxy.call(channel="#dev", text="hi")
 
     assert result["ok"] is False
     assert result["error"]["type"] == "not_connected"
@@ -269,7 +282,7 @@ async def test_proxy_returns_error_envelope_on_not_connected() -> None:
 @pytest.mark.asyncio
 async def test_proxy_rejects_missing_required_arg_before_round_trip() -> None:
     """An LLM call that omits a required arg must NOT reach the server —
-    return a structured validation error envelope instead (was finding #13)."""
+    return a structured validation error envelope instead."""
     schema = {
         "type": "object",
         "properties": {
@@ -279,11 +292,11 @@ async def test_proxy_rejects_missing_required_arg_before_round_trip() -> None:
         "required": ["channel", "text"],
     }
     client = _FakeMCPClient(_slack_config())
-    proxy = _build_proxy_tool(
+    proxy = _build_proxy(
         _state(client), _slack_config(), _tool("send_message", schema=schema)
     )
 
-    result = await proxy.ainvoke({"channel": "#dev"})  # missing "text"
+    result = await proxy.call(channel="#dev")  # missing "text"
 
     assert result["ok"] is False
     assert result["error"]["type"] == "schema_validation_error"
@@ -302,11 +315,11 @@ async def test_proxy_accepts_valid_args_through_schema_validation() -> None:
     }
     client = _FakeMCPClient(_slack_config())
     client.returns(_text_result("sent"))
-    proxy = _build_proxy_tool(
+    proxy = _build_proxy(
         _state(client), _slack_config(), _tool("send_message", schema=schema)
     )
 
-    result = await proxy.ainvoke({"channel": "#dev"})
+    result = await proxy.call(channel="#dev")
 
     assert client.calls == [("send_message", {"channel": "#dev"})]
     assert result == {"ok": True, "content": "sent"}
@@ -320,14 +333,14 @@ async def test_proxy_post_close_returns_clear_error_envelope() -> None:
     """If the toolset has been torn down, the proxy must NOT raise the
     cryptic 'use async with MCPClient(...)' error from the underlying
     client — the user never instantiated an MCPClient (they used
-    MCPToolset). Was finding #10."""
+    MCPToolset)."""
     state = _state(_FakeMCPClient(_slack_config()))
-    proxy = _build_proxy_tool(state, _slack_config(), _tool("send_message"))
+    proxy = _build_proxy(state, _slack_config(), _tool("send_message"))
 
     # Simulate the toolset's __aexit__ marking the state closed.
     state.open = False
 
-    result = await proxy.ainvoke({"channel": "#dev", "text": "hi"})
+    result = await proxy.call(channel="#dev", text="hi")
 
     assert result["ok"] is False
     assert result["error"]["type"] == "use_after_close"
@@ -346,7 +359,7 @@ def test_toolset_requires_at_least_one_config() -> None:
 def test_toolset_rejects_duplicate_server_names() -> None:
     """OpenAI's function-calling API rejects duplicate function names —
     catch the construction-time mistake with a clear message rather than
-    surfacing it as a BadRequestError on the first ainvoke (finding #12)."""
+    surfacing it as a BadRequestError on the first ainvoke."""
     cfg = MCPServerConfig(name="slack", transport="stdio", command="x")
     with pytest.raises(ValueError, match="duplicate server name"):
         MCPToolset(cfg, cfg)
@@ -384,7 +397,10 @@ async def test_toolset_opens_then_closes_clients(monkeypatch) -> None:
     async with MCPToolset(a, b) as mcp:
         assert opened == ["a", "b"]
         assert closed == []  # nothing closed yet
-        assert [t.name for t in mcp.tools] == ["mcp-a-ping", "mcp-b-ping"]
+        assert [p.qualified_name for p in mcp.proxies] == [
+            "mcp-a-ping",
+            "mcp-b-ping",
+        ]
 
     # Exit closes in reverse order — symmetric teardown via AsyncExitStack.
     assert closed == ["b", "a"]
@@ -436,9 +452,9 @@ async def test_proxy_returns_transport_error_envelope_on_httpx_error() -> None:
 
     client = _FakeMCPClient(_slack_config())
     client.raises(httpx.ConnectError("connection refused"))
-    proxy = _build_proxy_tool(_state(client), _slack_config(), _tool("send_message"))
+    proxy = _build_proxy(_state(client), _slack_config(), _tool("send_message"))
 
-    result = await proxy.ainvoke({"channel": "#dev", "text": "hi"})
+    result = await proxy.call(channel="#dev", text="hi")
 
     assert result["ok"] is False
     assert result["error"]["type"] == "transport_error"
@@ -447,20 +463,17 @@ async def test_proxy_returns_transport_error_envelope_on_httpx_error() -> None:
 
 @pytest.mark.asyncio
 async def test_proxy_skips_validation_for_tool_with_no_input_schema() -> None:
-    """An MCP tool that advertises no inputSchema (or one we can't build
-    a validator for) must still accept calls — fall back to LangChain's
-    loose dict contract rather than refusing to invoke."""
+    """An MCP tool whose inputSchema can't build a validator must still
+    accept calls — fall back to accepting anything rather than refusing
+    to invoke."""
     client = _FakeMCPClient(_slack_config())
     client.returns(_text_result("ok"))
-    # Tool() with empty schema → validator covers {"type": "object"}.
-    # Tools with schemas we can't validate fall back silently (see
-    # _validator_for's exception path); use a malformed schema to exercise it.
     cfg = _slack_config()
     bad_schema = {"type": "object", "properties": {"x": {"type": "not-a-real-type"}}}
-    proxy = _build_proxy_tool(_state(client), cfg, _tool("ping", schema=bad_schema))
+    proxy = _build_proxy(_state(client), cfg, _tool("ping", schema=bad_schema))
 
     # Must not raise — validator fallback returns None on schema error.
-    result = await proxy.ainvoke({"x": 1})
+    result = await proxy.call(x=1)
     assert result == {"ok": True, "content": "ok"}
 
 
@@ -508,7 +521,7 @@ def test_error_envelope_only_transport_error_is_retryable() -> None:
     closed = _error_envelope("use_after_close", "closed", "mcp-x-y")
     schema_err = _error_envelope("schema_validation_error", "bad args", "mcp-x-y")
     assert transport["error"]["retryable"] is True
-    assert tool_err["error"]["retryable"] is False  # was True before — wrong
+    assert tool_err["error"]["retryable"] is False
     assert closed["error"]["retryable"] is False
     assert schema_err["error"]["retryable"] is False
 
@@ -545,8 +558,8 @@ async def test_toolset_flips_state_to_closed_on_exit(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
-async def test_toolset_clears_states_and_tools_on_exit(monkeypatch) -> None:
-    """Both ``_tools`` and ``_states`` must be cleared on exit — leaving
+async def test_toolset_clears_states_and_proxies_on_exit(monkeypatch) -> None:
+    """Both ``_proxies`` and ``_states`` must be cleared on exit — leaving
     ``_states`` populated would let a re-entered toolset accumulate
     phantom state objects from earlier sessions, and any code that
     iterates ``mcp._states`` would see stale closed entries."""
@@ -570,11 +583,11 @@ async def test_toolset_clears_states_and_tools_on_exit(monkeypatch) -> None:
     toolset = MCPToolset(cfg)
     async with toolset as mcp:
         assert len(mcp._states) == 1  # noqa: SLF001
-        assert len(mcp._tools) == 2  # noqa: SLF001
+        assert len(mcp._proxies) == 1 * 2  # noqa: SLF001 — 2 tools returned
 
     # Both internal lists are flushed — no phantom entries left behind.
     assert toolset._states == []  # noqa: SLF001
-    assert toolset._tools == []  # noqa: SLF001
+    assert toolset._proxies == []  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_proxy_core.py
+++ b/tests/mcp/test_proxy_core.py
@@ -33,58 +33,18 @@ from hexgate.mcp.proxy import (
     _result_to_envelope,
     _ToolsetState,
 )
-
-
-# ---- helpers ---------------------------------------------------------------
-
-
-def _text_result(text: str, *, is_error: bool = False) -> CallToolResult:
-    return CallToolResult(
-        content=[TextContent(type="text", text=text)], isError=is_error
-    )
-
-
-class _FakeMCPClient:
-    """Minimal stand-in for :class:`MCPClient` — records calls, scripts results.
-
-    Implements just the subset _build_proxy reads: ``config`` (for the
-    qualified name) and ``call_tool``. Each call appends to ``self.calls``.
-    """
-
-    def __init__(self, config: MCPServerConfig) -> None:
-        self.config = config
-        self.calls: list[tuple[str, dict[str, Any]]] = []
-        self._next_result: CallToolResult | Exception = _text_result("default")
-
-    def returns(self, result: CallToolResult) -> None:
-        self._next_result = result
-
-    def raises(self, exc: Exception) -> None:
-        self._next_result = exc
-
-    async def call_tool(self, name: str, arguments: dict[str, Any]) -> CallToolResult:
-        self.calls.append((name, arguments))
-        if isinstance(self._next_result, Exception):
-            raise self._next_result
-        return self._next_result
-
-
-def _slack_config(**overrides: Any) -> MCPServerConfig:
-    base: dict[str, Any] = {
-        "name": "slack",
-        "transport": "stdio",
-        "command": "slack-mcp",
-    }
-    base.update(overrides)
-    return MCPServerConfig(**base)
-
-
-def _tool(name: str, *, description: str = "", schema: dict | None = None) -> Tool:
-    return Tool(
-        name=name,
-        description=description or None,
-        inputSchema=schema or {"type": "object", "properties": {}},
-    )
+from tests.mcp.conftest import (
+    FakeMCPClient as _FakeMCPClient,
+)
+from tests.mcp.conftest import (
+    mcp_tool as _tool,
+)
+from tests.mcp.conftest import (
+    slack_config as _slack_config,
+)
+from tests.mcp.conftest import (
+    text_result as _text_result,
+)
 
 
 def _state(client: _FakeMCPClient | Any) -> _ToolsetState:
@@ -617,3 +577,175 @@ async def test_toolset_aexit_forwards_suppression_return(monkeypatch) -> None:
     # Inner CM says "I handled it" — the with block must NOT re-raise.
     async with MCPToolset(cfg):
         raise RuntimeError("inner CM should suppress this")
+
+
+# ---- Post-close guard (code-review finding #3) -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxies_raises_after_close(monkeypatch) -> None:
+    """`.proxies` after `__aexit__` must raise RuntimeError, not silently
+    return `[]`. Prior behavior let `wrap_mcp_toolset(mcp)` outside the
+    `async with` block produce an empty tool list and the agent built
+    with zero MCP tools — user saw no error, just an LLM that pretended
+    the tool didn't exist."""
+
+    class _NoopClient:
+        def __init__(self, config: MCPServerConfig) -> None:
+            self.config = config
+
+        async def __aenter__(self) -> "_NoopClient":
+            return self
+
+        async def __aexit__(self, *exc_info: Any) -> None:
+            pass
+
+        async def list_tools(self) -> list[Tool]:
+            return [_tool("ping")]
+
+    monkeypatch.setattr("hexgate.mcp.proxy.MCPClient", _NoopClient)
+
+    cfg = MCPServerConfig(name="a", transport="stdio", command="x")
+    toolset = MCPToolset(cfg)
+    async with toolset:
+        pass  # exit immediately
+
+    with pytest.raises(RuntimeError, match="already exited"):
+        _ = toolset.proxies
+
+
+@pytest.mark.asyncio
+async def test_tools_raises_after_close(monkeypatch) -> None:
+    """Same guard on the LangChain back-compat shortcut — hitting
+    `mcp.tools` after close must raise, not silently return `[]`."""
+
+    class _NoopClient:
+        def __init__(self, config: MCPServerConfig) -> None:
+            self.config = config
+
+        async def __aenter__(self) -> "_NoopClient":
+            return self
+
+        async def __aexit__(self, *exc_info: Any) -> None:
+            pass
+
+        async def list_tools(self) -> list[Tool]:
+            return [_tool("ping")]
+
+    monkeypatch.setattr("hexgate.mcp.proxy.MCPClient", _NoopClient)
+
+    cfg = MCPServerConfig(name="a", transport="stdio", command="x")
+    toolset = MCPToolset(cfg)
+    async with toolset:
+        pass
+
+    with pytest.raises(RuntimeError, match="already exited"):
+        _ = toolset.tools
+
+
+# ---- .tools identity stability (code-review finding #1) --------------------
+
+
+@pytest.mark.asyncio
+async def test_tools_returns_same_list_on_repeat_access(monkeypatch) -> None:
+    """Pre-refactor `mcp.tools` was a stored list, so identity was
+    stable across calls. Post-refactor it was a property that rebuilt
+    fresh StructuredTool objects each access, silently breaking any
+    downstream pattern that de-duped by identity or wrapped in place
+    (GuardedTool's shallow-copy + swap being the concrete case). The
+    property is now cached on first access."""
+
+    class _NoopClient:
+        def __init__(self, config: MCPServerConfig) -> None:
+            self.config = config
+
+        async def __aenter__(self) -> "_NoopClient":
+            return self
+
+        async def __aexit__(self, *exc_info: Any) -> None:
+            pass
+
+        async def list_tools(self) -> list[Tool]:
+            return [_tool("ping"), _tool("pong")]
+
+    monkeypatch.setattr("hexgate.mcp.proxy.MCPClient", _NoopClient)
+
+    cfg = MCPServerConfig(name="a", transport="stdio", command="x")
+    async with MCPToolset(cfg) as mcp:
+        first = mcp.tools
+        second = mcp.tools
+        # Same underlying list AND same wrapped objects — an in-place
+        # rewrap pattern (`already_wrapped: set = set(); already_wrapped.add(t)`)
+        # will see stable identity.
+        assert first is second
+        assert [id(t) for t in first] == [id(t) for t in second]
+
+
+# ---- Exception mapping (code-review finding #2) ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_proxy_maps_timeout_error_to_retryable_transport_error() -> None:
+    """A generic ``asyncio.TimeoutError`` from the SDK's per-call timeout
+    used to land in the catch-all `unknown` branch with `retryable=False`
+    — meaning a genuinely transient timeout the agent should have
+    retried instead aborted the run. TimeoutError is now bucketed with
+    other transport failures."""
+    import asyncio as _asyncio
+
+    client = _FakeMCPClient(_slack_config())
+    client.raises(_asyncio.TimeoutError())
+    proxy = _build_proxy(_state(client), _slack_config(), _tool("send"))
+
+    result = await proxy.call()
+
+    assert result["ok"] is False
+    assert result["error"]["type"] == "transport_error"
+    assert result["error"]["retryable"] is True
+
+
+@pytest.mark.asyncio
+async def test_proxy_uses_stable_unknown_type_for_unhandled_exceptions() -> None:
+    """Bucketing unhandled exceptions under `exc.__class__.__name__.lower()`
+    produced unstable type strings (`"valueerror"`, `"httpstatuserror"`)
+    that leaked Python internals and weren't in the documented type set.
+    Policy YAML / downstream consumers switching on `error.type` couldn't
+    handle them. The bucket is now the stable string `"unknown"`; the
+    class name still surfaces in the human-readable message."""
+    client = _FakeMCPClient(_slack_config())
+    client.raises(ValueError("something odd happened"))
+    proxy = _build_proxy(_state(client), _slack_config(), _tool("send"))
+
+    result = await proxy.call()
+
+    assert result["error"]["type"] == "unknown"
+    # Class name preserved in the message for operator log grep.
+    assert "ValueError" in result["error"]["message"]
+    assert "something odd happened" in result["error"]["message"]
+
+
+# ---- Defensive schema copy (code-review finding #5) ------------------------
+
+
+def test_proxy_shields_input_schema_from_downstream_mutation() -> None:
+    """MCP's `Tool.inputSchema` is shared across the raw MCPTool, the
+    MCPToolProxy, and every adapter wrapper built from it. If any
+    framework (LangChain internals, Google's FunctionDeclaration ctor,
+    etc.) mutates the dict in place — normalizing types, injecting
+    `additionalProperties`, adding `$defs` — the mutation must NOT
+    bleed back into the raw MCPTool or into sibling adapter wrappers.
+    _build_proxy shallow-copies the schema to defend against that."""
+    original_schema = {
+        "type": "object",
+        "properties": {"channel": {"type": "string"}},
+        "required": ["channel"],
+    }
+    tool = Tool(name="send", inputSchema=original_schema)
+    proxy = _build_proxy(_state(_FakeMCPClient(_slack_config())), _slack_config(), tool)
+
+    # A downstream framework mutates the proxy's schema.
+    proxy.input_schema["additionalProperties"] = False
+
+    # The original schema on the MCPTool is untouched.
+    assert "additionalProperties" not in original_schema
+    assert "additionalProperties" not in tool.inputSchema

--- a/tests/mcp/test_proxy_core.py
+++ b/tests/mcp/test_proxy_core.py
@@ -643,6 +643,47 @@ async def test_tools_raises_after_close(monkeypatch) -> None:
         _ = toolset.tools
 
 
+@pytest.mark.asyncio
+async def test_toolset_reset_closed_flag_on_reenter(monkeypatch) -> None:
+    """Regression for post-review finding: __aexit__ set _closed=True
+    but __aenter__ never reset it. A caller re-entering the same
+    MCPToolset instance in a second ``async with`` block would open
+    connections fine, but the first ``.proxies`` / ``.tools`` access
+    would raise "already exited" from the stale flag — the live
+    connection was unusable. __aenter__ now resets _closed at the top."""
+
+    class _NoopClient:
+        def __init__(self, config: MCPServerConfig) -> None:
+            self.config = config
+
+        async def __aenter__(self) -> "_NoopClient":
+            return self
+
+        async def __aexit__(self, *exc_info: Any) -> None:
+            pass
+
+        async def list_tools(self) -> list[Tool]:
+            return [_tool("ping")]
+
+    monkeypatch.setattr("hexgate.mcp.proxy.MCPClient", _NoopClient)
+
+    cfg = MCPServerConfig(name="a", transport="stdio", command="x")
+    toolset = MCPToolset(cfg)
+
+    async with toolset as mcp:
+        assert len(mcp.proxies) == 1
+
+    # First `with` closed it — proxies access must raise.
+    with pytest.raises(RuntimeError, match="already exited"):
+        _ = toolset.proxies
+
+    # Re-enter the same instance — must work again on the fresh
+    # connection, not raise from the stale _closed flag.
+    async with toolset as mcp:
+        assert len(mcp.proxies) == 1
+        assert mcp.proxies[0].qualified_name == "mcp-a-ping"
+
+
 # ---- .tools identity stability (code-review finding #1) --------------------
 
 

--- a/tests/register/test_manifest.py
+++ b/tests/register/test_manifest.py
@@ -120,6 +120,61 @@ def test_google_manifest_schema():
     assert manifest == expected_manifest
 
 
+def test_google_manifest_extracts_mcp_tool_schema_from_json_schema():
+    """Regression for post-review finding: _to_tool_definition used to
+    read only declaration.parameters (the typed Schema field). Google
+    ADK's native FunctionTool populates parameters from Python
+    signatures, but hexgate's MCP wrapper populates parametersJsonSchema
+    (raw JSON Schema dict) instead. Result: every MCP tool registered
+    with an empty arg schema, and any policy generated from that
+    (write-vs-read classification, arg-level rules) was computed
+    against zero fields — tools silently mis-gated. Now
+    _to_tool_definition also reads parametersJsonSchema and lifts
+    properties + required from there when parameters is None."""
+    from mcp.types import Tool as MCPTool
+
+    from hexgate.adapters.google.mcp import wrap_mcp_toolset
+    from hexgate.cli.register.google import _to_tool_definition
+    from hexgate.mcp import MCPServerConfig
+    from hexgate.mcp.proxy import _ToolsetState
+    from hexgate.mcp.proxy import _build_proxy as build
+
+    class _FakeClient:
+        def __init__(self, config):
+            self.config = config
+
+        async def call_tool(self, *_args, **_kwargs):
+            raise AssertionError("not exercised")
+
+    cfg = MCPServerConfig(name="slack", transport="stdio", command="slack-mcp")
+    schema = {
+        "type": "object",
+        "properties": {
+            "channel": {"type": "string"},
+            "text": {"type": "string"},
+        },
+        "required": ["channel", "text"],
+    }
+    mcp_tool = MCPTool(name="send", description="Post a message", inputSchema=schema)
+    proxy = build(_ToolsetState(_FakeClient(cfg)), cfg, mcp_tool)
+
+    class _Stub:
+        pass
+
+    stub = _Stub()
+    stub.proxies = [proxy]
+    [adk_tool] = wrap_mcp_toolset(stub)
+
+    tool_def = _to_tool_definition(adk_tool)
+    assert tool_def is not None
+    assert tool_def.name == "mcp-slack-send"
+    # Both properties surface — pre-fix this was `{}`.
+    assert set(tool_def.input_schema.properties.keys()) == {"channel", "text"}
+    assert tool_def.input_schema.properties["channel"].type == "string"
+    # Required list carries through too — pre-fix this was `[]`.
+    assert sorted(tool_def.input_schema.required) == ["channel", "text"]
+
+
 def test_pydantic_ai_manifest_schema():
     """Test the schema of the Pydantic AI manifest."""
     from pydantic_ai import Agent


### PR DESCRIPTION
## What this ships

Follow-up to the merged MCP proxy PR (#57). Before this PR, `MCPToolset` produced `langchain_core.tools.BaseTool` and only the LangChain adapter path could reach MCP servers. Now every framework adapter (LangChain, OpenAI Agents, Pydantic AI, Google ADK) has a matching `wrap_mcp_toolset(toolset)` that turns MCP tools into framework-native tool objects, and the existing per-adapter `enforce_policy` gate covers them for free.

Design captured in `_design/MCP_ADAPTERS.md` (kept local, not in this PR).

## Shape

```
hexgate/mcp/
├── client.py                 # unchanged (MCP protocol client)
├── config.py                 # unchanged (MCPServerConfig)
└── proxy.py                  # split: MCPToolProxy dataclass now framework-agnostic

hexgate/adapters/
├── langchain/mcp.py          # wrap_mcp_toolset(toolset) -> list[BaseTool]
├── openai/mcp.py             # wrap_mcp_toolset(toolset) -> list[FunctionTool]
├── pydantic_ai/mcp.py        # wrap_mcp_toolset(toolset) -> list[Tool]
└── google/mcp.py             # wrap_mcp_toolset(toolset) -> list[BaseTool]
```

`MCPToolProxy(qualified_name, description, input_schema, call)` is the canonical descriptor. Each adapter reads only those four fields; nothing about the underlying `MCPClient` or `_ToolsetState` leaks out. The `{"ok": True|False, ...}` envelope is preserved across every path so the LLM sees one shape regardless of framework.

## Usage (identical across adapters)

```python
from hexgate.mcp import MCPServerConfig, MCPToolset

# Pick the adapter that matches your agent:
from hexgate.adapters.openai.mcp import wrap_mcp_toolset      # OpenAI Agents
# from hexgate.adapters.pydantic_ai.mcp import wrap_mcp_toolset  # Pydantic AI
# from hexgate.adapters.google.mcp import wrap_mcp_toolset        # Google ADK
# from hexgate.adapters.langchain.mcp import wrap_mcp_toolset     # LangChain

async with MCPToolset(slack_cfg) as mcp:
    tools = wrap_mcp_toolset(mcp)
    # feed tools into whichever agent you're building, then enforce_policy
```

`mcp.tools` still returns LangChain tools directly as a back-compat shortcut for pre-adapter-split code.

## Schema question — resolved without workarounds

Design doc flagged that Pydantic AI and Google ADK might need dynamic Pydantic-model generation from JSON Schema. Two inline spikes proved neither is needed:

- **Pydantic AI**: `Tool.from_schema(function, name, description, json_schema)` accepts raw JSON Schema. Trivial wrap.
- **Google ADK**: Subclass `BaseTool`, override `_get_declaration()` to return a `FunctionDeclaration` with `parametersJsonSchema=<dict>`. The camelCase alias accepts JSON Schema dicts and Gemini receives them intact.

Both adapters ship the minimal ~30-line wrap.

## Code review — 8 findings addressed

Ran `/code-review` at xhigh before pushing. 15 findings survived verification; 8 fixed in the final commit, 5 deferred with reason:

**Fixed:**
- `MCPToolset.tools` identity instability (cached on first access)
- Post-close `.proxies` / `.tools` silently returned `[]` (now raise RuntimeError)
- Unstable `exc.__class__.__name__` error types normalized to `"unknown"`
- `TimeoutError` bucketed as retryable `transport_error` (was landing non-retryable)
- Google `{}` schema causing Gemini rejection (coerced to minimal object schema)
- Shared mutable `input_schema` dict (defensive shallow copy in `_build_proxy`)
- Stale `hexgate/mcp/__init__.py` docstring (still claimed LangChain-only)
- Passthrough coroutine wrappers dropped across all four adapters
- Test fixture duplication extracted to `tests/mcp/conftest.py`

**Deferred (noted in the commit):** sync `func=` on LangChain (pre-existing), lazy langchain import (langchain is a hard dep today), OpenAI `_tool_origin` observability, Google `tool_context` forwarding, non-object JSON drops (matches existing wrap behavior).

## Tests

- **`tests/mcp/test_proxy_core.py`** — framework-agnostic behavior against `MCPToolProxy` directly (envelope, validation, lifecycle, use-after-close, plus 5 new regression tests pinning the review fixes)
- **`tests/adapters/{langchain,openai,pydantic_ai,google}/test_mcp.py`** — per-adapter tests, thin, focused on the `MCPToolProxy → <framework tool>` conversion
- **`tests/mcp/conftest.py`** — shared helpers (`FakeMCPClient`, `slack_config`, `mcp_tool`, `toolset_stub`, `build_proxy`, `text_result`) imported into all five test files
- **964 SDK tests pass** (was 921 before the fanout, +43 net)
- Ruff, fmt-check clean on every touched file

## Docs

`docs/concepts/mcp.mdx` gains an "Adapter coverage" section with the one-line `wrap_mcp_toolset` call for each of the four adapters.

## Scope + roadmap

Follow-ups noted but not shipping here (all listed in `docs/concepts/mcp.mdx`'s existing "what hexgate does NOT do yet" section):
- Streaming tool responses
- Non-text content blocks (images / binary resources)
- Response-side policy gating
- Reconnection
- Declarative `mcp_servers:` block in `agent.yaml`

## Test plan

- [x] Full SDK suite passes (964 tests)
- [x] Code review addressed
- [ ] Post-merge: `make demo-mcp` runs unchanged on the LangChain path (back-compat)
- [ ] Post-merge: adapt `examples/mcp_demo.py` or add sibling demos for each adapter (small follow-up)
