### PR TITLE
fix(dashboard): Graph reads registered manifest as source of tools

### DIFF
--- a/platform/dashboard/src/lib/graph.test.ts
+++ b/platform/dashboard/src/lib/graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildOverviewGraph } from "./graph";
 import type { AgentManifestView, AgentRead } from "./api";
 
@@ -123,5 +123,49 @@ describe("buildOverviewGraph — manifest-fed tools unblock code-registered agen
     expect(graph.edges.filter((e) => e.source === "agent:skeleton")).toEqual(
       [],
     );
+  });
+
+  it("renders an agent whose envelope has manifest=null (registered, no version yet)", () => {
+    // Post-review regression: pre-fix `?.manifest ?? null` collapsed
+    // "no envelope" and "envelope with null manifest" into the same
+    // fallback. The latter is a real state per AgentManifestView docs
+    // (agent row exists, no persisted AgentVersion.manifest yet). We
+    // now render a bare agent node in that case so the operator sees
+    // the agent exists — dropping it silently would reproduce the
+    // exact "No agents yet" bug this PR set out to fix.
+    const envelope = {
+      name: "half_registered",
+      manifest: null,
+      version: null,
+      content_hash: null,
+      updated_at: "2026-07-03T00:00:00Z",
+    } as unknown as AgentManifestView;
+
+    const graph = buildOverviewGraph(
+      [agent("half_registered", "")],
+      [envelope],
+    );
+    expect(graph.agentViews).toHaveLength(1);
+    expect(graph.agentViews[0].name).toBe("half_registered");
+    expect(graph.agentViews[0].tools).toEqual([]);
+  });
+
+  it("warns and keeps the first envelope on duplicate manifest names", () => {
+    // Two envelopes for the same agent name would silently overwrite
+    // each other under a naive Map.set loop, hiding a real backend
+    // bug (join fan-out, stale envelope during rename). Log once and
+    // keep the first so devtools surfaces the problem.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const first = manifestFor("dupe", ["first_tool"]);
+      const second = manifestFor("dupe", ["second_tool"]);
+      const graph = buildOverviewGraph([agent("dupe", "")], [first, second]);
+      expect(graph.agentViews).toHaveLength(1);
+      expect(graph.agentViews[0].tools).toEqual(["first_tool"]);
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toMatch(/duplicate manifest envelope/);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/platform/dashboard/src/lib/graph.test.ts
+++ b/platform/dashboard/src/lib/graph.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { buildOverviewGraph } from "./graph";
+import type { AgentManifestView, AgentRead } from "./api";
+
+/**
+ * Focused regressions for the overview-graph builder. Semantic parsing
+ * (mergedTools, effectiveMode, inherits) is covered in policy.test.ts;
+ * this file only pins the manifest-vs-agent_yaml source resolution that
+ * unblocks the Graph tab for code-registered agents.
+ */
+
+const FLAT_POLICY = `
+version: 1
+default_policy: { mode: deny }
+tools:
+  web_search: { mode: allow }
+  fetch: { mode: allow }
+`;
+
+function agent(name: string, agentYaml: string): AgentRead {
+  return {
+    name,
+    agent_yaml: agentYaml,
+    policy_yaml: FLAT_POLICY,
+  } as unknown as AgentRead;
+}
+
+function manifestFor(
+  name: string,
+  tools: string[],
+  model: string | null = "gpt-5.4",
+): AgentManifestView {
+  return {
+    name,
+    manifest: {
+      name,
+      description: null,
+      framework: "langchain",
+      model,
+      system_prompt: null,
+      tools: tools.map((t) => ({
+        name: t,
+        description: null,
+        input_schema: { properties: {}, required: [] },
+      })),
+    },
+    version: 1,
+    content_hash: "hash",
+    updated_at: "2026-07-03T00:00:00Z",
+  } as unknown as AgentManifestView;
+}
+
+describe("buildOverviewGraph — manifest-fed tools unblock code-registered agents", () => {
+  it("renders an agent whose agent_yaml is empty when the manifest is provided", () => {
+    // Reproduces the reported bug: code-registered agents leave
+    // agent_yaml as "". Without the manifest path, buildAgentView
+    // returns null → agentViews.length === 0 → the Graph shows
+    // "No agents yet." even though /agents and /policies show it fine.
+    const graph = buildOverviewGraph(
+      [agent("code_bot", "")],
+      [manifestFor("code_bot", ["web_search", "fetch"])],
+    );
+
+    expect(graph.agentViews).toHaveLength(1);
+    expect(graph.agentViews[0].tools).toEqual(["web_search", "fetch"]);
+    // Agent node + everyone node + 2 tool nodes = 4.
+    const nodeKinds = graph.nodes.map((n) => n.type);
+    expect(nodeKinds.filter((t) => t === "agent")).toHaveLength(1);
+    expect(nodeKinds.filter((t) => t === "tool")).toHaveLength(2);
+  });
+
+  it("falls back to agent_yaml parsing when no manifests are provided", () => {
+    // Legacy YAML-edited agents (no registered manifest) still work
+    // the way they used to.
+    const graph = buildOverviewGraph([
+      agent("legacy_bot", "name: legacy_bot\nmodel: gpt-4\ntools:\n  - fetch"),
+    ]);
+
+    expect(graph.agentViews).toHaveLength(1);
+    expect(graph.agentViews[0].tools).toEqual(["fetch"]);
+  });
+
+  it("mixes manifest-fed and yaml-fed agents in the same project", () => {
+    // One code-registered (manifest present) + one legacy YAML-edited
+    // (no manifest entry). Both must appear on the graph.
+    const graph = buildOverviewGraph(
+      [
+        agent("code_bot", ""),
+        agent(
+          "legacy_bot",
+          "name: legacy_bot\nmodel: gpt-4\ntools:\n  - fetch",
+        ),
+      ],
+      [manifestFor("code_bot", ["web_search"])],
+    );
+
+    expect(graph.agentViews).toHaveLength(2);
+    const byName = Object.fromEntries(
+      graph.agentViews.map((v) => [v.name, v.tools]),
+    );
+    expect(byName["code_bot"]).toEqual(["web_search"]);
+    expect(byName["legacy_bot"]).toEqual(["fetch"]);
+  });
+
+  it("skips a code-registered agent whose manifest is not yet available", () => {
+    // Timing edge case: agents.data landed before manifests.data. The
+    // agent with empty agent_yaml and no matching manifest can't be
+    // rendered — drop it rather than crash. Once the manifests query
+    // finishes, the useMemo re-runs and the agent appears.
+    const graph = buildOverviewGraph([agent("code_bot", "")], []);
+    expect(graph.agentViews).toHaveLength(0);
+  });
+
+  it("empty manifest tool list is respected (agent shown with no tool edges)", () => {
+    // A registered agent with zero tools should render as a node with
+    // no outgoing edges, not vanish from the graph.
+    const graph = buildOverviewGraph(
+      [agent("skeleton", "")],
+      [manifestFor("skeleton", [])],
+    );
+    expect(graph.agentViews).toHaveLength(1);
+    expect(graph.agentViews[0].tools).toEqual([]);
+    expect(graph.edges.filter((e) => e.source === "agent:skeleton")).toEqual(
+      [],
+    );
+  });
+});

--- a/platform/dashboard/src/lib/graph.test.ts
+++ b/platform/dashboard/src/lib/graph.test.ts
@@ -168,4 +168,71 @@ describe("buildOverviewGraph — manifest-fed tools unblock code-registered agen
       warnSpy.mockRestore();
     }
   });
+
+  it("skips tool edges when the agent's policy_yaml won't parse", () => {
+    // Post-review regression: rendering a parse-failed agent against
+    // the fail-closed empty policy caused every tool edge to draw in
+    // deny styling, telling the operator their real policy was
+    // rejecting everything when the real problem was a YAML parse
+    // error. Graph now skips the tool-edge loop for parse-failed
+    // agents; the agent node still appears (carrying the
+    // policyParseFailed flag) so the operator can spot + fix it in
+    // the Policies editor.
+    const broken = {
+      name: "broken_bot",
+      agent_yaml: "",
+      policy_yaml: ":::garbage yaml",
+    } as unknown as AgentRead;
+    const graph = buildOverviewGraph(
+      [broken],
+      [manifestFor("broken_bot", ["web_search", "fetch"])],
+    );
+
+    expect(graph.agentViews).toHaveLength(1);
+    expect(graph.agentViews[0].policyParseFailed).toBe(true);
+    // Agent node exists, carries the flag for the UI to render a warning.
+    const agentNode = graph.nodes.find((n) => n.id === "agent:broken_bot");
+    expect(agentNode).toBeDefined();
+    expect(
+      (agentNode!.data as { policyParseFailed?: boolean }).policyParseFailed,
+    ).toBe(true);
+    // No tool edges emitted from this agent — misleading deny paint
+    // suppressed at the source.
+    expect(graph.edges.filter((e) => e.source === "agent:broken_bot")).toEqual(
+      [],
+    );
+  });
+
+  it("excludes parse-failed agents from the tool-node worst-case aggregate", () => {
+    // The tool-node's left strip encodes worst-case mode across every
+    // agent that references it. If we let a parse-failed agent's
+    // fail-closed empty policy contribute, every shared tool would
+    // display deny — poisoning the aggregate for well-formed agents
+    // that also reference the same tool. Filter the parse-failed ones
+    // out of the aggregate.
+    const ok = {
+      name: "ok_bot",
+      agent_yaml: "",
+      policy_yaml: FLAT_POLICY,
+    } as unknown as AgentRead;
+    const broken = {
+      name: "broken_bot",
+      agent_yaml: "",
+      policy_yaml: ":::garbage",
+    } as unknown as AgentRead;
+    const graph = buildOverviewGraph(
+      [ok, broken],
+      [
+        manifestFor("ok_bot", ["web_search"]),
+        manifestFor("broken_bot", ["web_search"]),
+      ],
+    );
+
+    const toolNode = graph.nodes.find((n) => n.id === "tool:web_search");
+    expect(toolNode).toBeDefined();
+    // FLAT_POLICY has web_search: allow, so the well-formed agent's
+    // vote should win — the parse-failed one's fail-closed deny would
+    // overpower it if it weren't filtered.
+    expect((toolNode!.data as { mode: string }).mode).toBe("allow");
+  });
 });

--- a/platform/dashboard/src/lib/graph.ts
+++ b/platform/dashboard/src/lib/graph.ts
@@ -99,6 +99,10 @@ export function buildOverviewGraph(
         name: view.name,
         model: view.model,
         toolCount: view.tools.length,
+        // Broken-policy signal — the AgentNode component can surface
+        // this as a warning marker instead of the caller thinking the
+        // fail-closed empty policy is the operator's real one.
+        policyParseFailed: view.policyParseFailed,
       },
       draggable: false,
     });
@@ -115,7 +119,11 @@ export function buildOverviewGraph(
       },
     });
 
-    // agent → tools
+    // agent → tools. Skip when policy_yaml couldn't parse — otherwise
+    // every edge would draw deny (from the fail-closed empty policy)
+    // and tell an operator with a transient YAML typo that their real
+    // policy is broken.
+    if (view.policyParseFailed) return;
     for (const toolName of view.tools) {
       const mode = effectiveMode(view, toolName);
       edges.push({
@@ -134,9 +142,11 @@ export function buildOverviewGraph(
     // Determine the "worst" mode for the left strip on the tool node.
     // Shares MODE_STRENGTH ordering with parsePolicy's cross-role merge
     // via the exported worstMode helper — one source of truth for
-    // "which mode wins when they disagree."
+    // "which mode wins when they disagree." Skip agents whose policy
+    // failed to parse — their fail-closed empty policy would return
+    // deny for every tool and poison the aggregate.
     const modesForTool: Mode[] = agentViews
-      .filter((v) => v.tools.includes(toolName))
+      .filter((v) => !v.policyParseFailed && v.tools.includes(toolName))
       .map((v) => effectiveMode(v, toolName));
     const mode = worstMode(modesForTool) ?? "default";
     nodes.push({

--- a/platform/dashboard/src/lib/graph.ts
+++ b/platform/dashboard/src/lib/graph.ts
@@ -1,5 +1,5 @@
 import type { Edge, Node } from "@xyflow/react";
-import type { AgentRead } from "./api";
+import type { AgentManifestView, AgentRead } from "./api";
 import {
   buildAgentView,
   effectiveMode,
@@ -24,10 +24,24 @@ export interface OverviewGraph {
   agentViews: AgentView[];
 }
 
-/** Build the full project overview: everyone → all agents → all tools. */
-export function buildOverviewGraph(agents: AgentRead[]): OverviewGraph {
+/**
+ * Build the full project overview: everyone → all agents → all tools.
+ *
+ * ``manifests`` (indexed by agent name) is optional but should be
+ * provided in production — it's the source of truth for tools of
+ * code-registered agents whose ``agent_yaml`` column is empty. Legacy
+ * YAML-edited agents (no manifest entry) fall back to parsing
+ * ``agent_yaml`` as before.
+ */
+export function buildOverviewGraph(
+  agents: AgentRead[],
+  manifests?: AgentManifestView[],
+): OverviewGraph {
+  const manifestByName = new Map<string, AgentManifestView>(
+    (manifests ?? []).map((m) => [m.name, m]),
+  );
   const agentViews = agents
-    .map(buildAgentView)
+    .map((a) => buildAgentView(a, manifestByName.get(a.name)?.manifest ?? null))
     .filter((a): a is AgentView => a !== null);
 
   const uniqueTools = new Set<string>();

--- a/platform/dashboard/src/lib/graph.ts
+++ b/platform/dashboard/src/lib/graph.ts
@@ -32,16 +32,42 @@ export interface OverviewGraph {
  * code-registered agents whose ``agent_yaml`` column is empty. Legacy
  * YAML-edited agents (no manifest entry) fall back to parsing
  * ``agent_yaml`` as before.
+ *
+ * The map preserves the three-way distinction ``buildAgentView`` needs:
+ * a missing envelope means "fall back to yaml", an envelope with a null
+ * manifest field means "render the agent as registered-but-no-tools",
+ * and a full manifest means "read tools + model from it". Collapsing
+ * those into one nullable path silently drops half-registered agents.
  */
 export function buildOverviewGraph(
   agents: AgentRead[],
   manifests?: AgentManifestView[],
 ): OverviewGraph {
-  const manifestByName = new Map<string, AgentManifestView>(
-    (manifests ?? []).map((m) => [m.name, m]),
-  );
+  const envelopeByName = new Map<string, AgentManifestView>();
+  for (const envelope of manifests ?? []) {
+    if (envelopeByName.has(envelope.name)) {
+      // Two envelopes with the same name would silently overwrite each
+      // other — the last-wins Map default hides a real data problem
+      // (join fan-out on the server, or a stale envelope from a
+      // pending rename). Log once so a broken response is visible in
+      // devtools rather than showing up as a wrong tool list.
+      console.warn(
+        `buildOverviewGraph: duplicate manifest envelope for agent ${envelope.name}; keeping the first, ignoring later entries`,
+      );
+      continue;
+    }
+    envelopeByName.set(envelope.name, envelope);
+  }
   const agentViews = agents
-    .map((a) => buildAgentView(a, manifestByName.get(a.name)?.manifest ?? null))
+    .map((a) => {
+      const envelope = envelopeByName.get(a.name);
+      // Preserve undefined (no envelope → yaml fallback) vs null
+      // (envelope with null manifest → render bare) — collapsing both
+      // to null was the bug the review flagged.
+      const manifestInfo =
+        envelope === undefined ? undefined : envelope.manifest;
+      return buildAgentView(a, manifestInfo);
+    })
     .filter((a): a is AgentView => a !== null);
 
   const uniqueTools = new Set<string>();

--- a/platform/dashboard/src/lib/policy.test.ts
+++ b/platform/dashboard/src/lib/policy.test.ts
@@ -699,4 +699,47 @@ describe("buildAgentView — manifest as source of truth", () => {
       buildAgentView(agent({ yaml: "name: x", policy: ":::garbage" })),
     ).toBeNull();
   });
+
+  it("marks policyParseFailed and suppresses missingInPolicy on parse failure", () => {
+    // Post-post-review regression: the first fix rendered a
+    // parse-failed agent against the fail-closed empty policy, which
+    // then landed every tool in `missingInPolicy` and painted every
+    // edge deny — misleading the operator into rewriting a policy
+    // that was actually just mid-typing. AgentView now carries
+    // `policyParseFailed` so graph consumers can render a distinct
+    // broken-policy state, and `missingInPolicy` is empty so no false
+    // "your policy doesn't cover these tools" story is told.
+    const view = buildAgentView(
+      agent({ yaml: "", policy: ":::garbage yaml" }),
+      { model: "gpt-5.4", tools: [{ name: "web_search" }, { name: "fetch" }] },
+    );
+    expect(view).not.toBeNull();
+    expect(view!.policyParseFailed).toBe(true);
+    // Suppressed — otherwise both tools would be flagged as unpoliced
+    // when the real problem is a YAML parse error.
+    expect(view!.missingInPolicy).toEqual([]);
+  });
+
+  it("policyParseFailed is false for a well-formed policy", () => {
+    // Sanity: normal agents don't accidentally get flagged as broken.
+    const view = buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }), {
+      model: "gpt-5.4",
+      tools: [{ name: "web_search" }],
+    });
+    expect(view!.policyParseFailed).toBe(false);
+  });
+
+  it("degrades gracefully when manifest.tools is not an array", () => {
+    // Post-post-review regression: a manifest whose `.tools` field
+    // arrives null or non-array (backend serialization bug, partial
+    // record) used to throw TypeError from .map inside the useMemo,
+    // tearing down the entire Graph page. Now the Array.isArray guard
+    // degrades to an empty tool list — the agent still renders.
+    const view = buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }), {
+      model: "gpt-5.4",
+      tools: null as unknown as { name: string }[],
+    });
+    expect(view).not.toBeNull();
+    expect(view!.tools).toEqual([]);
+  });
 });

--- a/platform/dashboard/src/lib/policy.test.ts
+++ b/platform/dashboard/src/lib/policy.test.ts
@@ -572,3 +572,86 @@ describe("buildAgentView — malformed input", () => {
     expect(view!.name).toBe("test");
   });
 });
+
+describe("buildAgentView — manifest as source of truth", () => {
+  const agent = (opts: { yaml: string; policy: string }): AgentRead =>
+    ({
+      name: "graph_smoke",
+      agent_yaml: opts.yaml,
+      policy_yaml: opts.policy,
+    }) as unknown as AgentRead;
+
+  it("reads tools + model from the manifest when provided, ignoring agent_yaml", () => {
+    // Code-registered agents leave agent_yaml empty; the manifest is
+    // the source of truth for their tool list. Passing the manifest
+    // must produce a usable AgentView even when agent_yaml is "".
+    const view = buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }), {
+      model: "gpt-5.4",
+      tools: [{ name: "web_search" }, { name: "fetch" }],
+    });
+    expect(view).not.toBeNull();
+    expect(view!.name).toBe("graph_smoke");
+    expect(view!.model).toBe("gpt-5.4");
+    expect(view!.tools).toEqual(["web_search", "fetch"]);
+  });
+
+  it("prefers manifest tools over agent_yaml tools even when both are present", () => {
+    // Manifest wins because it's the fresher source (updated on every
+    // register). agent_yaml can be a stale hand-edited fixture.
+    const view = buildAgentView(
+      agent({
+        yaml: "name: x\nmodel: legacy\ntools:\n  - stale_tool",
+        policy: FLAT_POLICY,
+      }),
+      { model: "gpt-5.4", tools: [{ name: "fresh_tool" }] },
+    );
+    expect(view!.tools).toEqual(["fresh_tool"]);
+    expect(view!.model).toBe("gpt-5.4");
+  });
+
+  it("handles manifest.model === null by returning an empty model string", () => {
+    // AgentManifest.model is `string | null`. AgentView.model is
+    // non-null string, so coerce null → "" rather than propagating.
+    const view = buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }), {
+      model: null,
+      tools: [{ name: "ping" }],
+    });
+    expect(view!.model).toBe("");
+  });
+
+  it("falls back to agent_yaml parsing when manifest is not provided", () => {
+    // Legacy YAML-edited agents have no registered manifest but do have
+    // agent_yaml. buildAgentView(agent, undefined) exercises the fallback.
+    const view = buildAgentView(
+      agent({
+        yaml: "name: legacy\nmodel: gpt-4\ntools:\n  - fetch",
+        policy: FLAT_POLICY,
+      }),
+    );
+    expect(view!.tools).toEqual(["fetch"]);
+    expect(view!.model).toBe("gpt-4");
+  });
+
+  it("falls back to agent_yaml parsing when manifest is explicit null", () => {
+    // manifests[agentName]?.manifest can be null (registered agent
+    // whose latest AgentVersion has manifest=null via legacy path).
+    // Same fallback as undefined.
+    const view = buildAgentView(
+      agent({
+        yaml: "name: x\ntools: []",
+        policy: FLAT_POLICY,
+      }),
+      null,
+    );
+    expect(view).not.toBeNull();
+  });
+
+  it("previously-broken code-registered agent (empty agent_yaml, no manifest) returns null gracefully", () => {
+    // The exact fingerprint of the pre-fix bug: agent_yaml === "" AND
+    // no manifest info. buildAgentView returns null — the Graph filters
+    // it out, showing "No agents yet." The manifest path fixes real
+    // registered agents; a truly manifest-less agent with empty YAML
+    // has nothing to render and shouldn't crash the graph.
+    expect(buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }))).toBeNull();
+  });
+});

--- a/platform/dashboard/src/lib/policy.test.ts
+++ b/platform/dashboard/src/lib/policy.test.ts
@@ -632,26 +632,71 @@ describe("buildAgentView — manifest as source of truth", () => {
     expect(view!.model).toBe("gpt-4");
   });
 
-  it("falls back to agent_yaml parsing when manifest is explicit null", () => {
-    // manifests[agentName]?.manifest can be null (registered agent
-    // whose latest AgentVersion has manifest=null via legacy path).
-    // Same fallback as undefined.
-    const view = buildAgentView(
-      agent({
-        yaml: "name: x\ntools: []",
-        policy: FLAT_POLICY,
-      }),
-      null,
-    );
+  it("renders a bare agent when the envelope exists but its manifest is null", () => {
+    // Post-review regression: `AgentManifestView.manifest` is nullable
+    // (agent row exists, no persisted AgentVersion.manifest yet). The
+    // pre-fix collapse `?.manifest ?? null` sent this state through the
+    // agent_yaml fallback, which then dropped the agent because its
+    // agent_yaml was empty. Now we distinguish `null` (envelope
+    // present, manifest not yet registered) from `undefined` (no
+    // envelope, legacy agent) and render a bare node in the former
+    // case — the operator sees the agent exists and can register it.
+    const view = buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }), null);
     expect(view).not.toBeNull();
+    expect(view!.name).toBe("graph_smoke");
+    expect(view!.tools).toEqual([]);
+    expect(view!.model).toBe("");
   });
 
-  it("previously-broken code-registered agent (empty agent_yaml, no manifest) returns null gracefully", () => {
-    // The exact fingerprint of the pre-fix bug: agent_yaml === "" AND
-    // no manifest info. buildAgentView returns null — the Graph filters
-    // it out, showing "No agents yet." The manifest path fixes real
-    // registered agents; a truly manifest-less agent with empty YAML
-    // has nothing to render and shouldn't crash the graph.
+  it("still returns null for an empty agent_yaml when no envelope was queried", () => {
+    // The truly-legacy path: no manifest lookup happened for this
+    // agent at all (either the caller has no manifests query wired,
+    // or the agent predates the manifest flow entirely). Empty
+    // agent_yaml means no signal that the agent is actually registered,
+    // so dropping it is the honest choice.
     expect(buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }))).toBeNull();
+  });
+
+  it("stringifies non-string tool.name values defensively", () => {
+    // Post-review regression: pre-fix parseAgent applied
+    // agent.tools.map(String) to guard against non-string entries.
+    // The manifest branch has to preserve that defense — a stray
+    // ToolDefinition whose `.name` is a number or object would
+    // otherwise flow unstringified into ReactFlow node/edge ids.
+    const view = buildAgentView(agent({ yaml: "", policy: FLAT_POLICY }), {
+      model: "gpt-5.4",
+      tools: [
+        { name: "web_search" },
+        { name: 42 as unknown as string },
+        { name: undefined as unknown as string },
+      ],
+    });
+    expect(view!.tools).toEqual(["web_search", "42", ""]);
+  });
+
+  it("renders a manifest agent even when its policy_yaml won't parse", () => {
+    // Post-review regression: buildAgentView used to return null on
+    // any parsePolicy failure, dropping otherwise-valid manifest
+    // agents from the graph. With manifest info, we fall back to a
+    // fail-closed default policy so the agent stays visible; the
+    // operator sees the node and can fix the broken policy_yaml in
+    // the editor instead of the agent silently vanishing.
+    const view = buildAgentView(
+      agent({ yaml: "", policy: ":::garbage yaml" }),
+      { model: "gpt-5.4", tools: [{ name: "web_search" }] },
+    );
+    expect(view).not.toBeNull();
+    expect(view!.tools).toEqual(["web_search"]);
+    // Fail-closed: default_policy.mode defaults to deny.
+    expect(view!.policy.default_policy.mode).toBe("deny");
+  });
+
+  it("still returns null when policy_yaml won't parse AND there's no manifest envelope", () => {
+    // Symmetry with the "empty agent_yaml, no envelope" case: without
+    // any manifest signal, a broken policy on a legacy agent is
+    // ambiguous enough that dropping is honest.
+    expect(
+      buildAgentView(agent({ yaml: "name: x", policy: ":::garbage" })),
+    ).toBeNull();
   });
 });

--- a/platform/dashboard/src/lib/policy.ts
+++ b/platform/dashboard/src/lib/policy.ts
@@ -317,45 +317,63 @@ export function mergedTools(policy: ParsedPolicy): Record<string, ToolPolicy> {
 
 /**
  * Build an :class:`AgentView` from an :class:`AgentRead` and, optionally,
- * that agent's registered manifest.
+ * that agent's registered-manifest envelope.
  *
  * ``agent_yaml`` is a legacy column from the pre-manifest dashboard flow
  * where users hand-edited YAML. Code-registered agents (``hexgate
  * register``) leave it empty — the source of truth for their tool list
- * lives on the AgentVersion.manifest instead. When ``manifest`` is
- * provided, its ``.tools`` and ``.model`` are used verbatim; the
- * ``agent_yaml`` fallback only applies to legacy agents.
+ * lives on the AgentVersion.manifest instead.
  *
- * Policy always parses from ``agent.policy_yaml`` — that's the operator's
- * editable policy document regardless of registration path.
+ * The ``manifestInfo`` argument is deliberately three-valued so the
+ * builder can distinguish three real cases that used to collapse into
+ * one "silently drop the agent" failure:
+ *
+ *   * ``undefined`` — caller has no manifest envelope for this agent
+ *     (either legacy dashboard hasn't queried manifests, or the agent
+ *     genuinely predates the manifest flow). Fall back to parsing
+ *     ``agent_yaml``.
+ *   * ``null`` — envelope exists on the manifests endpoint but its
+ *     ``.manifest`` field is null (agent row present, no persisted
+ *     ``AgentVersion.manifest`` yet — a real state per
+ *     ``AgentManifestView`` docs). Render the agent with the DB name
+ *     and no tools rather than falling to the empty-``agent_yaml``
+ *     path that would drop it entirely.
+ *   * object — normal case, read tools + model from the manifest.
+ *
+ * Policy parses from ``agent.policy_yaml``. If it can't parse but the
+ * caller had manifest info, we still render the agent with a fail-closed
+ * default policy — the operator can see the agent exists and fix the
+ * broken YAML in the Policies editor, instead of the agent silently
+ * vanishing from the graph.
  */
 export function buildAgentView(
   agent: AgentRead,
-  manifest?: {
+  manifestInfo?: {
     model: string | null;
     tools: readonly { name: string }[];
   } | null,
 ): AgentView | null {
   const parsedPolicy = parsePolicy(agent.policy_yaml);
-  if (!parsedPolicy) return null;
 
   let name: string;
   let model: string;
   let tools: string[];
+  const hasEnvelope = manifestInfo !== undefined;
 
-  if (manifest) {
-    // Prefer the registered manifest — it's the source of truth for
-    // code-defined agents. ``manifest.name`` isn't carried on the
-    // envelope (the enclosing view already has it), so fall back to
-    // AgentRead.name.
+  if (manifestInfo) {
+    // Registered agent with a persisted manifest — the common case.
     name = agent.name;
-    model = manifest.model ?? "";
-    tools = manifest.tools.map((t) => t.name);
+    model = manifestInfo.model ?? "";
+    tools = manifestInfo.tools.map((t) => String(t?.name ?? ""));
+  } else if (manifestInfo === null) {
+    // Registered agent whose latest AgentVersion has no manifest yet.
+    // Render as a bare node so the operator sees the agent exists —
+    // the tool list will appear once they run ``hexgate register``.
+    name = agent.name;
+    model = "";
+    tools = [];
   } else {
-    // No manifest → this is a legacy YAML-edited agent. Parse
-    // agent_yaml. Returns null if the YAML is unparseable or empty
-    // (empty is the pre-manifest register bug's fingerprint — Graph
-    // now avoids that path by preferring the manifest above).
+    // No envelope at all → legacy YAML-edited agent. Parse agent_yaml.
     const parsedAgent = parseAgent(agent.agent_yaml, agent.policy_yaml);
     if (!parsedAgent) return null;
     name = parsedAgent.name || agent.name;
@@ -363,14 +381,32 @@ export function buildAgentView(
     tools = [...parsedAgent.tools];
   }
 
+  // Fail-closed default policy when parse failed but the caller
+  // confirmed the agent is real (manifest envelope present). Legacy
+  // agents with unparseable policy_yaml continue to drop — they have
+  // no other signal that the agent is genuinely registered.
+  const effectivePolicy: ParsedPolicy = parsedPolicy ?? {
+    version: 1,
+    default_policy: { mode: "deny" },
+    tools: {},
+    roles: {},
+  };
+  if (!parsedPolicy && !hasEnvelope) return null;
+
   // Display tool list = manifest declaration OR agent.yaml declaration.
   // Role-only policy entries do NOT create callable tools — the runtime
   // registers tools from agent.tools (the SDK-decorated functions);
   // policy just gates them. Including role-only tools here would draw
   // phantom capability edges on the graph.
-  const merged = mergedTools(parsedPolicy);
+  const merged = mergedTools(effectivePolicy);
   const missingInPolicy = tools.filter((t) => !(t in merged));
-  return { name, model, tools, policy: parsedPolicy, missingInPolicy };
+  return {
+    name,
+    model,
+    tools,
+    policy: effectivePolicy,
+    missingInPolicy,
+  };
 }
 
 /**

--- a/platform/dashboard/src/lib/policy.ts
+++ b/platform/dashboard/src/lib/policy.ts
@@ -55,6 +55,14 @@ export interface AgentView {
   /** Tools that appear in agent.yaml but have no policy entry (neither
    *  at flat top level nor in any role) → default_policy applies. */
   missingInPolicy: string[];
+  /** True when ``policy_yaml`` couldn't be parsed. The ``policy`` field
+   *  above is then a fail-closed placeholder (default_policy=deny, no
+   *  tools, no roles) — do NOT render it as if it were the operator's
+   *  policy: every tool would appear as denied + missing-in-policy,
+   *  which is a strictly wrong story to tell about a transient YAML
+   *  parse error. Graph consumers should render the agent node with a
+   *  broken-policy marker and skip tool edges. */
+  policyParseFailed: boolean;
 }
 
 function isMode(x: unknown): x is Mode {
@@ -364,7 +372,15 @@ export function buildAgentView(
     // Registered agent with a persisted manifest — the common case.
     name = agent.name;
     model = manifestInfo.model ?? "";
-    tools = manifestInfo.tools.map((t) => String(t?.name ?? ""));
+    // ``Array.isArray`` guard: a manifest whose ``tools`` field arrives
+    // null or non-array (backend serialization bug, partial record,
+    // schema drift) used to blow up ``.map`` inside the ``useMemo`` and
+    // tear down the whole Graph page. Degrade to an empty tool list
+    // instead — the agent still renders and the operator can see it
+    // exists.
+    tools = Array.isArray(manifestInfo.tools)
+      ? manifestInfo.tools.map((t) => String(t?.name ?? ""))
+      : [];
   } else if (manifestInfo === null) {
     // Registered agent whose latest AgentVersion has no manifest yet.
     // Render as a bare node so the operator sees the agent exists —
@@ -398,14 +414,22 @@ export function buildAgentView(
   // registers tools from agent.tools (the SDK-decorated functions);
   // policy just gates them. Including role-only tools here would draw
   // phantom capability edges on the graph.
+  const policyParseFailed = parsedPolicy === null;
   const merged = mergedTools(effectivePolicy);
-  const missingInPolicy = tools.filter((t) => !(t in merged));
+  // Suppress the "missing in policy" list when the policy itself failed
+  // to parse — otherwise every manifest tool would land in there and
+  // paint the graph as fully-denied, misleading the operator into
+  // rewriting a policy that was actually fine (mid-typing YAML, etc.).
+  const missingInPolicy = policyParseFailed
+    ? []
+    : tools.filter((t) => !(t in merged));
   return {
     name,
     model,
     tools,
     policy: effectivePolicy,
     missingInPolicy,
+    policyParseFailed,
   };
 }
 

--- a/platform/dashboard/src/lib/policy.ts
+++ b/platform/dashboard/src/lib/policy.ts
@@ -315,25 +315,62 @@ export function mergedTools(policy: ParsedPolicy): Record<string, ToolPolicy> {
   return merged;
 }
 
-export function buildAgentView(agent: AgentRead): AgentView | null {
-  const parsedAgent = parseAgent(agent.agent_yaml, agent.policy_yaml);
+/**
+ * Build an :class:`AgentView` from an :class:`AgentRead` and, optionally,
+ * that agent's registered manifest.
+ *
+ * ``agent_yaml`` is a legacy column from the pre-manifest dashboard flow
+ * where users hand-edited YAML. Code-registered agents (``hexgate
+ * register``) leave it empty — the source of truth for their tool list
+ * lives on the AgentVersion.manifest instead. When ``manifest`` is
+ * provided, its ``.tools`` and ``.model`` are used verbatim; the
+ * ``agent_yaml`` fallback only applies to legacy agents.
+ *
+ * Policy always parses from ``agent.policy_yaml`` — that's the operator's
+ * editable policy document regardless of registration path.
+ */
+export function buildAgentView(
+  agent: AgentRead,
+  manifest?: {
+    model: string | null;
+    tools: readonly { name: string }[];
+  } | null,
+): AgentView | null {
   const parsedPolicy = parsePolicy(agent.policy_yaml);
-  if (!parsedAgent || !parsedPolicy) return null;
-  // Display tool list = agent.yaml declaration ONLY. Role-only tool
-  // entries in policy don't create callable tools — the runtime
+  if (!parsedPolicy) return null;
+
+  let name: string;
+  let model: string;
+  let tools: string[];
+
+  if (manifest) {
+    // Prefer the registered manifest — it's the source of truth for
+    // code-defined agents. ``manifest.name`` isn't carried on the
+    // envelope (the enclosing view already has it), so fall back to
+    // AgentRead.name.
+    name = agent.name;
+    model = manifest.model ?? "";
+    tools = manifest.tools.map((t) => t.name);
+  } else {
+    // No manifest → this is a legacy YAML-edited agent. Parse
+    // agent_yaml. Returns null if the YAML is unparseable or empty
+    // (empty is the pre-manifest register bug's fingerprint — Graph
+    // now avoids that path by preferring the manifest above).
+    const parsedAgent = parseAgent(agent.agent_yaml, agent.policy_yaml);
+    if (!parsedAgent) return null;
+    name = parsedAgent.name || agent.name;
+    model = parsedAgent.model;
+    tools = [...parsedAgent.tools];
+  }
+
+  // Display tool list = manifest declaration OR agent.yaml declaration.
+  // Role-only policy entries do NOT create callable tools — the runtime
   // registers tools from agent.tools (the SDK-decorated functions);
   // policy just gates them. Including role-only tools here would draw
   // phantom capability edges on the graph.
-  const tools = [...parsedAgent.tools];
   const merged = mergedTools(parsedPolicy);
   const missingInPolicy = tools.filter((t) => !(t in merged));
-  return {
-    name: parsedAgent.name || agent.name,
-    model: parsedAgent.model,
-    tools,
-    policy: parsedPolicy,
-    missingInPolicy,
-  };
+  return { name, model, tools, policy: parsedPolicy, missingInPolicy };
 }
 
 /**

--- a/platform/dashboard/src/routes/Graph.tsx
+++ b/platform/dashboard/src/routes/Graph.tsx
@@ -33,17 +33,24 @@ export function GraphPage() {
     enabled: !!scope.projectId,
   });
 
-  // Wait for the manifests query to settle (success OR error) before
-  // building — otherwise a background refetch (post-register invalidate,
-  // window-focus refetch) would run the memo with the OLD manifests.data
-  // paired with the NEW agents.data. A code-registered agent freshly
+  // Wait for the manifests query to settle before building — otherwise
+  // a background refetch (post-register invalidate, window-focus
+  // refetch) would run the memo with the OLD manifests.data paired
+  // with the NEW agents.data, and a code-registered agent freshly
   // added in the invalidate cycle would flicker as missing from the
-  // graph until the manifests query catches up. On the isError branch we
-  // build with manifests.data === undefined intentionally — legacy
-  // agents still render and the banner below surfaces the failure so
-  // the user isn't left staring at an empty graph with no explanation.
+  // graph until manifests catches up.
+  //
+  // The `dataUpdatedAt` timestamps are what catches the refetch race —
+  // an earlier version gated on `manifests.data === undefined`, which
+  // is only true on the FIRST fetch, so a background refetch with a
+  // stale cached array slipped past the guard. Comparing the two
+  // update timestamps holds the memo whenever agents is "newer" than
+  // manifests and manifests is trying to catch up.
   const graphBuildBlocked =
-    manifests.isFetching && !manifests.isError && manifests.data === undefined;
+    manifests.isFetching &&
+    !manifests.isError &&
+    (manifests.data === undefined ||
+      manifests.dataUpdatedAt < agents.dataUpdatedAt);
 
   const { nodes, edges, agentViews } = useMemo(() => {
     if (!agents.data) return { nodes: [], edges: [], agentViews: [] };
@@ -54,6 +61,20 @@ export function GraphPage() {
   if (scope.status === "no-project") {
     return <NoProjectEmptyState resource="graph" />;
   }
+
+  // Only surface the manifest-load banner when there is genuinely no
+  // cached data to fall back to. React Query keeps the last-good array
+  // on refetch failure, so a good load followed by a background 500
+  // still renders a complete graph — showing the red banner in that
+  // case would be a false alarm that erodes trust.
+  const showManifestError = manifests.isError && manifests.data === undefined;
+  // Distinguish "no agents in this project" from "agents exist but
+  // couldn't render because manifests failed to load and every agent
+  // is code-registered (empty agent_yaml)." Two contradictory messages
+  // ("No agents yet" + error banner) confused the user; this splits
+  // them into one honest empty-state per case.
+  const agentsExistButBlocked =
+    showManifestError && (agents.data?.length ?? 0) > 0;
 
   return (
     <div className="-mx-8 -my-6 h-[calc(100vh-56px)] flex flex-col">
@@ -74,11 +95,7 @@ export function GraphPage() {
         </div>
       </div>
 
-      {/* Surface manifest-query failure explicitly. Without this, a 500
-          on listAgentManifests would silently drop every code-registered
-          agent and the user would see "No agents yet" with no error — the
-          exact bug this PR aimed to fix. */}
-      {manifests.isError && (
+      {showManifestError && (
         <div className="flex items-center gap-2 px-8 py-2 text-xs bg-deny/5 border-b border-deny/30 text-deny">
           <AlertTriangle className="size-3.5 shrink-0" />
           <span>
@@ -94,8 +111,10 @@ export function GraphPage() {
             Loading…
           </div>
         ) : agentViews.length === 0 ? (
-          <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground">
-            No agents yet.
+          <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground text-center px-8">
+            {agentsExistButBlocked
+              ? "Agents exist in this project, but the manifests endpoint failed so they can't be drawn. Refresh to retry."
+              : "No agents yet."}
           </div>
         ) : (
           <ReactFlow

--- a/platform/dashboard/src/routes/Graph.tsx
+++ b/platform/dashboard/src/routes/Graph.tsx
@@ -7,6 +7,7 @@ import {
   MiniMap,
   BackgroundVariant,
 } from "@xyflow/react";
+import { AlertTriangle } from "lucide-react";
 import { api } from "@/lib/api";
 import { useProjectScoped } from "@/lib/active";
 import { buildOverviewGraph } from "@/lib/graph";
@@ -32,10 +33,23 @@ export function GraphPage() {
     enabled: !!scope.projectId,
   });
 
+  // Wait for the manifests query to settle (success OR error) before
+  // building — otherwise a background refetch (post-register invalidate,
+  // window-focus refetch) would run the memo with the OLD manifests.data
+  // paired with the NEW agents.data. A code-registered agent freshly
+  // added in the invalidate cycle would flicker as missing from the
+  // graph until the manifests query catches up. On the isError branch we
+  // build with manifests.data === undefined intentionally — legacy
+  // agents still render and the banner below surfaces the failure so
+  // the user isn't left staring at an empty graph with no explanation.
+  const graphBuildBlocked =
+    manifests.isFetching && !manifests.isError && manifests.data === undefined;
+
   const { nodes, edges, agentViews } = useMemo(() => {
     if (!agents.data) return { nodes: [], edges: [], agentViews: [] };
+    if (graphBuildBlocked) return { nodes: [], edges: [], agentViews: [] };
     return buildOverviewGraph(agents.data, manifests.data);
-  }, [agents.data, manifests.data]);
+  }, [agents.data, manifests.data, graphBuildBlocked]);
 
   if (scope.status === "no-project") {
     return <NoProjectEmptyState resource="graph" />;
@@ -60,8 +74,22 @@ export function GraphPage() {
         </div>
       </div>
 
+      {/* Surface manifest-query failure explicitly. Without this, a 500
+          on listAgentManifests would silently drop every code-registered
+          agent and the user would see "No agents yet" with no error — the
+          exact bug this PR aimed to fix. */}
+      {manifests.isError && (
+        <div className="flex items-center gap-2 px-8 py-2 text-xs bg-deny/5 border-b border-deny/30 text-deny">
+          <AlertTriangle className="size-3.5 shrink-0" />
+          <span>
+            Couldn't load registered manifests. Code-registered agents may be
+            missing from the graph. Refresh to retry.
+          </span>
+        </div>
+      )}
+
       <div className="flex-1 relative">
-        {agents.isLoading || manifests.isLoading ? (
+        {agents.isLoading || (manifests.isLoading && !manifests.isError) ? (
           <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground">
             Loading…
           </div>

--- a/platform/dashboard/src/routes/Graph.tsx
+++ b/platform/dashboard/src/routes/Graph.tsx
@@ -21,11 +21,21 @@ export function GraphPage() {
     queryFn: () => api.listAgents(scope.projectId as string),
     enabled: !!scope.projectId,
   });
+  // Manifests are the source of truth for tools on code-registered
+  // agents (hexgate register), whose Agent.agent_yaml is empty. Legacy
+  // YAML-edited agents just don't have a manifest entry and fall back
+  // to agent_yaml parsing. Both queries hit the same project so the
+  // pair reload together on a project switch.
+  const manifests = useQuery({
+    queryKey: ["agent-manifests", scope.projectId],
+    queryFn: () => api.listAgentManifests(scope.projectId as string),
+    enabled: !!scope.projectId,
+  });
 
   const { nodes, edges, agentViews } = useMemo(() => {
     if (!agents.data) return { nodes: [], edges: [], agentViews: [] };
-    return buildOverviewGraph(agents.data);
-  }, [agents.data]);
+    return buildOverviewGraph(agents.data, manifests.data);
+  }, [agents.data, manifests.data]);
 
   if (scope.status === "no-project") {
     return <NoProjectEmptyState resource="graph" />;
@@ -51,7 +61,7 @@ export function GraphPage() {
       </div>
 
       <div className="flex-1 relative">
-        {agents.isLoading ? (
+        {agents.isLoading || manifests.isLoading ? (
           <div className="absolute inset-0 grid place-items-center text-sm text-muted-foreground">
             Loading…
           </div>


### PR DESCRIPTION
## The bug

Fresh `hexgate serve`, agents show up on **/agents**, policies fill in on **/policies**, but **/graph** is empty - "No agents yet."

## Root cause

`hexgate register` creates Agent rows with `agent_yaml=""` and populates the manifest instead. The three dashboard pages diverge on which source they read:

| Page | Reads | Behavior |
|---|---|---|
| /agents | `listAgentManifests` → AgentVersion.manifest | ✓ shows agent |
| /policies | `listAgents.policy_yaml` | ✓ shows editor |
| /graph | `listAgents.agent_yaml` | ✗ `yaml.load("")` → undefined → `parseAgent` null → `buildAgentView` null → agent silently dropped |

## Fix (client-side)

Graph now reads the manifest as the source of truth for tools + model on code-registered agents. `agent_yaml` parsing is the fallback path for legacy YAML-edited agents that predate the manifest flow.

- `buildAgentView(agent, manifest?)` — prefers manifest's `.tools[].name` + `.model` when provided; falls back to `agent_yaml` when the caller didn't have a manifest for this agent.
- `buildOverviewGraph(agents, manifests?)` — takes both lists, indexes manifests by name, threads the match into each `buildAgentView`.
- `Graph.tsx` — fetches both `listAgents` and `listAgentManifests` (same project, both required); waits for both before rendering.

## Migration

None needed. Existing broken agents just work after this ships — they had a manifest all along, the client just wasn't looking at it.

## Tests

11 new tests across `policy.test.ts` (extended `buildAgentView` semantics) and a new `graph.test.ts` (overview builder). Key regressions:

- `buildAgentView` prefers manifest tools + model over `agent_yaml`
- `buildAgentView` coerces `manifest.model=null` to `""`
- Falls back to `agent_yaml` when manifest is undefined
- Returns null for empty `agent_yaml` + no manifest (the exact fingerprint of the pre-fix bug — graceful, doesn't crash)
- `buildOverviewGraph` renders manifest-fed agents whose `agent_yaml` is `""`
- Mixes manifest-fed and yaml-fed agents in one project
- Skips a code-registered agent whose manifest isn't loaded yet (query timing race, resolves on re-render)
- Empty manifest tool list → agent node with no outgoing edges

**Full dashboard suite: 139 passed. Lint + typecheck + prettier clean.**

## Test plan

- [x] Automated regression tests above
- [ ] Post-merge: `hexgate serve` → register an agent → /graph shows it immediately (no re-register needed)
- [ ] Post-merge: legacy agent with hand-edited `agent_yaml` still renders correctly
