### PR TITLE
fix(platform-api): patch clickhouse_ping at its actual import site in readiness test

### DIFF
--- a/platform/api/tests/features/audit/test_audit.py
+++ b/platform/api/tests/features/audit/test_audit.py
@@ -727,7 +727,7 @@ def test_liveness_does_not_ping_clickhouse(
 def test_readiness_reports_clickhouse(
     monkeypatch: pytest.MonkeyPatch, path: str
 ) -> None:
-    monkeypatch.setattr("hexgate_api.main.clickhouse_ping", lambda: False)
+    monkeypatch.setattr("hexgate_api.health.clickhouse_ping", lambda: False)
     r = TestClient(app).get(path)
     assert r.status_code == 503
     assert r.json()["clickhouse"] == "unreachable"


### PR DESCRIPTION
## Summary
- `test_readiness_reports_clickhouse` monkeypatched `hexgate_api.main.clickhouse_ping`, but the `#64` refactor (carve flat modules into core/deps/domains packages) moved `_readiness()` into `hexgate_api/health.py`, which resolves `clickhouse_ping` from its own module-level import — so the patch never took effect and the test silently exercised the real (healthy) ClickHouse instead of the unreachable case it's meant to cover.
- Repointed the patch to `hexgate_api.health.clickhouse_ping`, matching where `_readiness()` actually looks up the name.

## Test plan
- [x] `make platform-api-check`
- [x] `make check-all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)