### PR TITLE
refactor(sdk): Generalize audit api keys registry

### DIFF
--- a/docs/internals/audit-pipeline.md
+++ b/docs/internals/audit-pipeline.md
@@ -1,6 +1,6 @@
 # Audit Pipeline Specification
 
-> Status: living — kept in sync with the audit code. Last reviewed 2026-06.
+> Status: living — kept in sync with the audit code. Last reviewed 2026-07.
 
 Scope: the end-to-end path that records every policy decision a Hexgate-wrapped
 agent makes, from the SDK enforcement point to durable storage in ClickHouse and
@@ -145,7 +145,9 @@ The sender is **injected per enforcer**, not looked up globally — see §3.4.
 
 ### 3.2 `AuditSender` — fire-and-forget POST
 
-`hexgate/audit.py`. `emit()` is synchronous and non-blocking; it schedules a
+`hexgate/tracing/_senders.py` — shared by `hexgate.audit` (policy decisions)
+and `hexgate.tracing.usage` (LLM token usage); neither module owns it. `emit()`
+is synchronous and non-blocking; it schedules a
 background `asyncio.Task` that performs the POST. Key behaviours:
 
 - **Bounded concurrency.** An `asyncio.Semaphore(max_in_flight=32)` caps
@@ -176,17 +178,24 @@ synchronous.
 
 ### 3.4 Configuration & lifecycle
 
-`configure(api_key=None, base_url=None) -> AuditSender | None`:
+`hexgate.audit.configure(api_key=None, base_url=None) -> AuditSender | None`
+is a thin, decisions-specific wrapper around the shared
+`hexgate.tracing._senders.get_or_create_sender()`:
 
 - Resolves `api_key` from the argument or `HEXGATE_API_KEY`; returns `None` (audit
   inert) when no key is resolvable.
 - Resolves `base_url` from the argument or `HEXGATE_API_URL`, defaulting to
   Hexgate Cloud (`https://app.hexgate.ai`); set `http://localhost:8000` when
   self-hosting. The endpoint is `<base_url>/v1/audit/decisions`.
-- **Keyed by api_key.** Senders live in a registry `dict[str, AuditSender]`.
-  Calling `configure()` again with the **same** key returns the existing sender
-  (idempotent); a **different** key gets its own sender with its own bearer
-  token. This is what lets one process audit several tenants/keys correctly.
+- **Keyed by `(api_key, path)`.** Senders live in a shared registry
+  `dict[tuple[str, str], AuditSender]` in `hexgate/tracing/_senders.py`, reused
+  by every event type that goes through it (currently policy decisions and LLM
+  usage — see `hexgate.tracing.usage`). Calling `configure()` again with the
+  **same** key returns the existing decisions sender (idempotent); a
+  **different** key gets its own sender with its own bearer token. Keying on
+  the pair rather than `api_key` alone is what lets one process audit several
+  tenants/keys *and* emit more than one event type per key without a usage
+  sender silently reusing (and POSTing to) the decisions endpoint.
 
 Each adapter wrapper (`wrap_langchain_agent`, `wrap_openai_agent`,
 `wrap_google_agent`, `wrap_pydantic_agent`) and `factory.enforce_policy` call
@@ -196,7 +205,9 @@ local runs work without an explicit key.
 
 #### Local mode (`HEXGATE_LOCAL_MODE`)
 
-Setting `HEXGATE_LOCAL_MODE=1` makes `configure()` return `None` even when
+The gate lives in `hexgate/tracing/_senders.py` and applies to every event
+type sharing the registry, not just decisions. Setting `HEXGATE_LOCAL_MODE=1`
+makes `configure()` (and `configure_usage_sender()`) return `None` even when
 `HEXGATE_API_KEY` is present in env. `bootstrap(local_only=True)` sets the var
 *before* the first `configure()` call, and `hexgate chat` passes
 `local_only=True` — so the inner-loop REPL never posts audit events even if
@@ -213,10 +224,12 @@ There are now two clean operating modes, not three:
 | **Local** | (irrelevant) | `1`, or unset with no key | YAML / disk / builtin | suppressed |
 | **Platform-managed** | set | unset | platform fetch | emitted |
 
-A single INFO line (`audit suppressed: HEXGATE_LOCAL_MODE=1 (...)`) is logged
-the first time `configure()` is called with both a key and local mode active
-— exactly the case where the suppression would be surprising. The "no key
-anywhere" case stays quiet.
+A single INFO line (`sender suppressed for <path>: HEXGATE_LOCAL_MODE=1
+(...)`) is logged the first time a given path (e.g. `/v1/audit/decisions`)
+is configured with both a key and local mode active — exactly the case where
+the suppression would be surprising. The gate is logged **per path**, not
+once per process, since decisions and LLM usage each warrant their own
+first-suppression notice. The "no key anywhere" case stays quiet.
 
 A separate WARNING fires from `bootstrap()` itself when both `HEXGATE_API_KEY`
 and `HEXGATE_LOCAL_POLICY` are set — that combination is almost always a
@@ -227,17 +240,26 @@ saves a later debugging detour.
 > — chat vs. serve, inner loop vs. team loop — see the
 > ["Which path do I pick?"](/two-paths) page.
 
-`async shutdown()` drains in-flight tasks and closes every sender's HTTP client.
-It is safe to call multiple times and is the recommended teardown hook. Absent
-it, background sends still pending when the event loop tears down are
-**cancelled, not finished** — events emitted shortly before process exit are
-lost. GC closing the httpx client does not flush anything.
+`async shutdown()` drains in-flight tasks and closes every sender's HTTP client
+**across the whole shared registry** — decisions and LLM usage alike. It is
+safe to call multiple times and is the recommended teardown hook; either
+`hexgate.audit.shutdown()` or `hexgate.tracing.usage.shutdown()` drains
+everything, since both delegate to the same
+`hexgate.tracing._senders.shutdown()`. Absent it, background sends still
+pending when the event loop tears down are **cancelled, not finished** —
+events emitted shortly before process exit are lost. GC closing the httpx
+client does not flush anything.
 
 | Function | Purpose |
 |----------|---------|
-| `configure(key, url)` | Get-or-create the sender for `key`. Idempotent per key. |
-| `get_sender(key)` | Registry lookup by key (diagnostics). Prefer the injected sender. |
-| `shutdown()` | Drain + close all senders. |
+| `hexgate.tracing._senders.get_or_create_sender(path, key, url)` | Get-or-create the sender for `(key, path)`. Idempotent per pair. |
+| `hexgate.tracing._senders.get_sender(path, key)` | Registry lookup by `(key, path)` (diagnostics). Prefer the injected sender. |
+| `hexgate.tracing._senders.shutdown()` | Drain + close every sender for every path. |
+| `hexgate.audit.configure(key, url)` | Decisions-specific: `get_or_create_sender("/v1/audit/decisions", key, url)`. |
+| `hexgate.audit.get_sender(key)` | Decisions-specific: `get_sender("/v1/audit/decisions", key)`. |
+| `hexgate.tracing.usage.configure_usage_sender(key, url)` | LLM-usage-specific: `get_or_create_sender("/v1/audit/llm-invocations", key, url)`. |
+| `hexgate.tracing.usage.get_usage_sender(key)` | LLM-usage-specific: `get_sender("/v1/audit/llm-invocations", key)`. |
+| `hexgate.audit.shutdown()` / `hexgate.tracing.usage.shutdown()` | Both call the shared `shutdown()`; either drains all event types. |
 
 ---
 

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -661,9 +661,9 @@ def _should_bind_policy(bind_policy: bool | None, name: str | None) -> bool:
     # opted into local mode, the auto-detect must not surprise-bind to the
     # platform — that would defeat the whole point of the gate. ``bind_policy=True``
     # is honored above so a deliberate caller can still opt in.
-    from hexgate import audit
+    from hexgate.tracing._senders import _local_mode_active
 
-    if audit._local_mode_active():
+    if _local_mode_active():
         return False
     if os.environ.get("HEXGATE_LOCAL_POLICY"):
         return True

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -6,20 +6,16 @@ Lifecycle: configure() per api_key, await shutdown() at process exit.
 
 from __future__ import annotations
 
-import asyncio
 import json
-import logging
-import os
-import random
 import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
-import httpx
-
-from hexgate.config.env import resolve_api_key, resolve_api_url
+from hexgate.tracing._senders import AuditSender, get_or_create_sender
+from hexgate.tracing._senders import get_sender as _get_sender
+from hexgate.tracing._senders import shutdown as _shutdown_all
 
 if TYPE_CHECKING:
     # Annotation-only: Decision is used solely as a type hint below, so it stays
@@ -29,8 +25,6 @@ if TYPE_CHECKING:
     # avoided (binding.py keeps its enforcer import under TYPE_CHECKING too), so
     # this is correctness-by-design, not a workaround — keep it here.
     from hexgate.security.decision import Decision
-
-_log = logging.getLogger(__name__)
 
 # Mirrors the platform's MAX_ARGS_BYTES (platform/api/audit.py). The platform
 # rejects (413) rather than truncates, so an over-cap event would be lost
@@ -128,187 +122,15 @@ class AuditEvent:
         }
 
 
-class AuditSender:
-    """Per-decision fire-and-forget POST. Bounded by an asyncio.Semaphore.
-
-    emit() is sync and non-blocking — schedules a background task. Drops with
-    a periodic log when the semaphore is saturated (platform slow/unreachable).
-    """
-
-    def __init__(
-        self,
-        endpoint: str,
-        api_key: str,
-        *,
-        max_in_flight: int = 32,
-        http_timeout: float = 5.0,
-    ) -> None:
-        self._endpoint = endpoint
-        self._api_key = api_key
-        self._max_in_flight = max_in_flight
-        self._http_timeout = http_timeout
-        # The semaphore and httpx client are loop-bound: asyncio primitives
-        # latch onto the first loop that drives them and reject any other
-        # (e.g. a second asyncio.run()). Build them eagerly so configure()
-        # stays sync, but track the loop and rebuild if it rotates.
-        #
-        # Capture the build-time loop so emit() can reach it from an executor
-        # thread (a sync tool under run_in_executor has no loop of its own).
-        try:
-            self._loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
-        except RuntimeError:
-            self._loop = None
-        self._semaphore = asyncio.Semaphore(max_in_flight)
-        self._client: httpx.AsyncClient | None = self._new_client()
-        self._tasks: set[asyncio.Task[None]] = set()
-        self._closing = False
-        self._dropped = 0
-        self._warned_no_loop = False
-
-    def _new_client(self) -> httpx.AsyncClient:
-        return httpx.AsyncClient(
-            timeout=self._http_timeout,
-            headers={"Authorization": f"Bearer {self._api_key}"},
-        )
-
-    def _ensure_loop_state(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Adopt the running loop on first use; rebuild on loop rotation.
-
-        The previous client/semaphore are bound to a now-defunct loop, so
-        drop them (GC closes the old client) and rebuild on ``loop``."""
-        if self._loop is loop:
-            return
-        if self._loop is not None:
-            self._semaphore = asyncio.Semaphore(self._max_in_flight)
-            self._client = self._new_client()
-            self._dropped = 0
-        self._loop = loop
-
-    def emit(self, event: AuditEvent) -> None:
-        if self._closing or self._client is None:
-            return
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            # Called off-loop (sync tool on a run_in_executor thread): route
-            # to the build-time loop instead of dropping the event.
-            loop = self._loop
-            if loop is None or loop.is_closed():
-                if not self._warned_no_loop:
-                    _log.warning(
-                        "audit emit called with no running loop and no live "
-                        "bound loop; skipping"
-                    )
-                    self._warned_no_loop = True
-                return
-            try:
-                loop.call_soon_threadsafe(self._spawn_send, event)
-            except RuntimeError:
-                pass  # loop torn down between the is_closed() check and the call
-            return
-        self._ensure_loop_state(loop)
-        self._spawn_send(event)
-
-    def _spawn_send(self, event: AuditEvent) -> None:
-        """Create the send task. MUST run on the bound loop's thread —
-        ``create_task`` and the loop-bound semaphore require the running loop.
-        Reached on-loop from :meth:`emit`, or via ``call_soon_threadsafe``."""
-        if self._closing or self._client is None:
-            return
-        if self._semaphore.locked():
-            self._dropped += 1
-            if self._dropped % 100 == 1:
-                _log.warning(
-                    "audit sender saturated; %d events dropped (platform slow?)",
-                    self._dropped,
-                )
-            return
-        task = asyncio.create_task(self._send(event), name="hexgate-audit-send")
-        self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
-
-    async def _send(self, event: AuditEvent) -> None:
-        if self._client is None:
-            # Invariant: _send is only reached after start() initialised
-            # the client. Raise so `python -O` can't strip the check.
-            raise RuntimeError("audit sender _send called before start()")
-        async with self._semaphore:
-            payload = event.as_payload()
-            try:
-                response = await self._client.post(self._endpoint, json=payload)
-                if response.status_code == 503:
-                    # Equal jitter: a fleet of SDKs hitting the same platform
-                    # 503 must not retry in lockstep.
-                    delay = min(self._http_timeout, 2.0)
-                    await asyncio.sleep(random.uniform(delay / 2, delay))
-                    response = await self._client.post(self._endpoint, json=payload)
-                if response.status_code >= 400:
-                    _log.error(
-                        "audit ingest failed: %s %s",
-                        response.status_code,
-                        response.text[:200],
-                    )
-            except httpx.RequestError as exc:
-                _log.warning("audit ingest network error: %s", exc)
-
-    async def close(self, drain_timeout: float = 5.0) -> None:
-        """Stop accepting new emits; drain in-flight tasks; close the HTTP client."""
-        self._closing = True
-        if self._tasks:
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*self._tasks, return_exceptions=True),
-                    timeout=drain_timeout,
-                )
-            except asyncio.TimeoutError:
-                _log.warning(
-                    "audit close: drain timed out with %d tasks pending",
-                    len(self._tasks),
-                )
-        if self._client is not None:
-            await self._client.aclose()
-
-
 # --- Per-key sender registry --------------------------------------------------
+#
+# The registry mechanics (dict + get-or-create + shutdown), the
+# HEXGATE_LOCAL_MODE gate, and AuditSender itself now live in the neutral
+# hexgate.tracing._senders module, shared with hexgate.tracing.usage. The
+# functions below are thin, decisions-specific wrappers around it.
 
 
 _AUDIT_PATH = "/v1/audit/decisions"
-
-# Setting this env var to a truthy value (``1``/``true``/``yes``/``on``,
-# case-insensitive) makes ``configure()`` a no-op even when ``HEXGATE_API_KEY``
-# is present. ``bootstrap(local_only=True)`` sets it; ``hexgate chat``
-# passes ``local_only=True``. The check happens on every ``configure()``
-# call (not cached) so an adapter wrapper that re-``configure``s after
-# bootstrap still respects the gate.
-_LOCAL_MODE_ENV = "HEXGATE_LOCAL_MODE"
-
-# One-shot log gate so the "audit suppressed: local mode" message lands
-# the first time it'd matter (a key WAS set but local mode preempted)
-# and stays quiet thereafter.
-_logged_local_mode_suppressed = False
-# One sender per resolved api_key. A single process may wrap agents for
-# several tenants/keys, and each must emit with its own bearer token — so
-# senders are keyed by api_key rather than kept as a first-wins singleton.
-# The registry is unbounded and assumes a small, fixed key set per process;
-# a key-per-request pattern would leak one sender + httpx pool per unique
-# key. Such callers must evict explicitly (await sender.close(), then drop
-# the dict entry) or use shutdown().
-_senders: dict[str, AuditSender] = {}
-
-
-def _local_mode_active() -> bool:
-    """True if ``HEXGATE_LOCAL_MODE`` is set to a truthy value.
-
-    Accepts ``1``/``true``/``yes``/``on`` (case-insensitive). Everything
-    else — including unset — evaluates false. Mirrors the truthy-value
-    parser the platform's ``HEXGATE_COOKIE_SECURE`` knob uses, so the
-    behavior is consistent across the codebase's env flags."""
-    return os.environ.get(_LOCAL_MODE_ENV, "").strip().lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
 
 
 def configure(
@@ -327,32 +149,7 @@ def configure(
     iterating locally and don't want cloud writes" path
     (``hexgate chat`` opts in via ``bootstrap(local_only=True)``).
     """
-    global _logged_local_mode_suppressed
-    if _local_mode_active():
-        # Only log when a key was actually present — otherwise the
-        # message is just noise during a no-key local run.
-        resolved = resolve_api_key(api_key)
-        if resolved and not _logged_local_mode_suppressed:
-            _log.info(
-                "audit suppressed: %s=1 (a key is configured but local "
-                "mode is on, so events stay on this machine)",
-                _LOCAL_MODE_ENV,
-            )
-            _logged_local_mode_suppressed = True
-        return None
-    resolved_key = resolve_api_key(api_key)
-    if not resolved_key:
-        return None
-    existing = _senders.get(resolved_key)
-    if existing is not None:
-        return existing
-    resolved_url = resolve_api_url(base_url)
-    sender = AuditSender(
-        endpoint=f"{resolved_url}{_AUDIT_PATH}",
-        api_key=resolved_key,
-    )
-    _senders[resolved_key] = sender
-    return sender
+    return get_or_create_sender(_AUDIT_PATH, api_key, base_url)
 
 
 def get_sender(api_key: str | None = None) -> AuditSender | None:
@@ -362,14 +159,10 @@ def get_sender(api_key: str | None = None) -> AuditSender | None:
     :class:`~hexgate.security.enforcer.PolicyEnforcer`; this lookup exists for
     diagnostics and is unambiguous only when scoped to a key.
     """
-    resolved_key = resolve_api_key(api_key)
-    if not resolved_key:
-        return None
-    return _senders.get(resolved_key)
+    return _get_sender(_AUDIT_PATH, api_key)
 
 
 async def shutdown() -> None:
-    """Drain in-flight emits and close every sender. Safe to call multiple times."""
-    senders = list(_senders.values())
-    _senders.clear()
-    await asyncio.gather(*(s.close() for s in senders), return_exceptions=True)
+    """Drain in-flight emits and close every sender in the shared registry
+    (decisions and LLM usage alike). Safe to call multiple times."""
+    await _shutdown_all()

--- a/hexgate/bootstrap.py
+++ b/hexgate/bootstrap.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 from hexgate import audit
 from hexgate.config.env import resolve_api_key
 from hexgate.config.settings import Settings
+from hexgate.tracing._senders import _LOCAL_MODE_ENV
 
 _log = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
     load_dotenv(env_path, override=False)
     if local_only:
         # Set BEFORE audit.configure() so the first call sees the gate.
-        os.environ[audit._LOCAL_MODE_ENV] = "1"
+        os.environ[_LOCAL_MODE_ENV] = "1"
     if resolve_api_key() and os.environ.get("HEXGATE_LOCAL_POLICY"):
         _log.warning(
             "HEXGATE_API_KEY and HEXGATE_LOCAL_POLICY are both set; the local "

--- a/hexgate/security/enforcer.py
+++ b/hexgate/security/enforcer.py
@@ -13,9 +13,10 @@ import logging
 from collections.abc import Callable, Mapping
 from typing import Any
 
-from hexgate.audit import AuditEvent, AuditSender, configure
+from hexgate.audit import AuditEvent, configure
 from hexgate.runtime.context import get_current_user
 from hexgate.security.decision import Decision, PolicyEngine
+from hexgate.tracing._senders import AuditSender
 
 _log = logging.getLogger(__name__)
 

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -1,0 +1,283 @@
+"""Shared sender registry — generic get-or-create/shutdown machinery reused
+by ``hexgate.audit`` (policy decisions) and ``hexgate.tracing.usage`` (LLM
+token usage). Neither of those modules owns this one; both import from it.
+
+Also owns the ``HEXGATE_LOCAL_MODE`` gate: a single kill switch that
+suppresses every event type sharing this registry, not just decisions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import random
+from typing import Any, Protocol
+
+import httpx
+
+from hexgate.config.env import resolve_api_key, resolve_api_url
+
+_log = logging.getLogger(__name__)
+
+
+class _PayloadEvent(Protocol):
+    """Structural type for anything ``AuditSender`` can emit — a frozen
+    event dataclass exposing a flat-dict wire payload. Both ``AuditEvent``
+    and ``LlmUsageEvent`` satisfy this without either being imported here."""
+
+    def as_payload(self) -> dict[str, Any]: ...
+
+
+class AuditSender:
+    """Fire-and-forget POST for a single ``(api_key, path)`` pair. Bounded
+    by an asyncio.Semaphore.
+
+    emit() is sync and non-blocking — schedules a background task. Drops with
+    a periodic log when the semaphore is saturated (platform slow/unreachable).
+    Named for its original use (policy decisions); reused unmodified for any
+    event type whose payload is a flat JSON dict via ``as_payload()``.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        api_key: str,
+        *,
+        max_in_flight: int = 32,
+        http_timeout: float = 5.0,
+    ) -> None:
+        self._endpoint = endpoint
+        self._api_key = api_key
+        self._max_in_flight = max_in_flight
+        self._http_timeout = http_timeout
+        # The semaphore and httpx client are loop-bound: asyncio primitives
+        # latch onto the first loop that drives them and reject any other
+        # (e.g. a second asyncio.run()). Build them eagerly so configure()
+        # stays sync, but track the loop and rebuild if it rotates.
+        #
+        # Capture the build-time loop so emit() can reach it from an executor
+        # thread (a sync tool under run_in_executor has no loop of its own).
+        try:
+            self._loop: asyncio.AbstractEventLoop | None = asyncio.get_running_loop()
+        except RuntimeError:
+            self._loop = None
+        self._semaphore = asyncio.Semaphore(max_in_flight)
+        self._client: httpx.AsyncClient | None = self._new_client()
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._closing = False
+        self._dropped = 0
+        self._warned_no_loop = False
+
+    def _new_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            timeout=self._http_timeout,
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+
+    def _ensure_loop_state(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Adopt the running loop on first use; rebuild on loop rotation.
+
+        The previous client/semaphore are bound to a now-defunct loop, so
+        drop them (GC closes the old client) and rebuild on ``loop``."""
+        if self._loop is loop:
+            return
+        if self._loop is not None:
+            self._semaphore = asyncio.Semaphore(self._max_in_flight)
+            self._client = self._new_client()
+            self._dropped = 0
+        self._loop = loop
+
+    def emit(self, event: _PayloadEvent) -> None:
+        if self._closing or self._client is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            # Called off-loop (sync tool on a run_in_executor thread): route
+            # to the build-time loop instead of dropping the event.
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                if not self._warned_no_loop:
+                    _log.warning(
+                        "audit emit called with no running loop and no live "
+                        "bound loop; skipping"
+                    )
+                    self._warned_no_loop = True
+                return
+            try:
+                loop.call_soon_threadsafe(self._spawn_send, event)
+            except RuntimeError:
+                pass  # loop torn down between the is_closed() check and the call
+            return
+        self._ensure_loop_state(loop)
+        self._spawn_send(event)
+
+    def _spawn_send(self, event: _PayloadEvent) -> None:
+        """Create the send task. MUST run on the bound loop's thread —
+        ``create_task`` and the loop-bound semaphore require the running loop.
+        Reached on-loop from :meth:`emit`, or via ``call_soon_threadsafe``."""
+        if self._closing or self._client is None:
+            return
+        if self._semaphore.locked():
+            self._dropped += 1
+            if self._dropped % 100 == 1:
+                _log.warning(
+                    "audit sender saturated; %d events dropped (platform slow?)",
+                    self._dropped,
+                )
+            return
+        task = asyncio.create_task(self._send(event), name="hexgate-audit-send")
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _send(self, event: _PayloadEvent) -> None:
+        if self._client is None:
+            # Invariant: _send is only reached after start() initialised
+            # the client. Raise so `python -O` can't strip the check.
+            raise RuntimeError("audit sender _send called before start()")
+        async with self._semaphore:
+            payload = event.as_payload()
+            try:
+                response = await self._client.post(self._endpoint, json=payload)
+                if response.status_code == 503:
+                    # Equal jitter: a fleet of SDKs hitting the same platform
+                    # 503 must not retry in lockstep.
+                    delay = min(self._http_timeout, 2.0)
+                    await asyncio.sleep(random.uniform(delay / 2, delay))
+                    response = await self._client.post(self._endpoint, json=payload)
+                if response.status_code >= 400:
+                    _log.error(
+                        "audit ingest failed: %s %s",
+                        response.status_code,
+                        response.text[:200],
+                    )
+            except httpx.RequestError as exc:
+                _log.warning("audit ingest network error: %s", exc)
+
+    async def close(self, drain_timeout: float = 5.0) -> None:
+        """Stop accepting new emits; drain in-flight tasks; close the HTTP client."""
+        self._closing = True
+        if self._tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*self._tasks, return_exceptions=True),
+                    timeout=drain_timeout,
+                )
+            except asyncio.TimeoutError:
+                _log.warning(
+                    "audit close: drain timed out with %d tasks pending",
+                    len(self._tasks),
+                )
+        if self._client is not None:
+            await self._client.aclose()
+
+
+# --- Shared (api_key, path) registry ----------------------------------------
+
+# Setting this env var to a truthy value (``1``/``true``/``yes``/``on``,
+# case-insensitive) makes ``get_or_create_sender()`` a no-op for every event
+# type sharing this registry, even when ``HEXGATE_API_KEY`` is present.
+# ``bootstrap(local_only=True)`` sets it; ``hexgate chat`` passes
+# ``local_only=True``. The check happens on every call (not cached) so an
+# adapter wrapper that re-configures after bootstrap still respects the gate.
+_LOCAL_MODE_ENV = "HEXGATE_LOCAL_MODE"
+
+# One-shot log gate per path, so the "sender suppressed" message lands the
+# first time it'd matter for that event type (a key WAS set but local mode
+# preempted it) and stays quiet thereafter. Per-path rather than a single
+# global flag, since decisions and usage each warrant their own
+# first-suppression notice.
+_logged_local_mode_suppressed: set[str] = set()
+
+# One sender per (api_key, path) pair. A single process may wrap agents for
+# several tenants/keys and emit more than one event type, and each pair must
+# emit with its own bearer token to its own endpoint — so senders are keyed
+# by the pair rather than kept as a first-wins singleton or keyed by api_key
+# alone (which would make a usage sender for an already-configured decisions
+# key silently reuse the decisions sender and POST to the wrong endpoint).
+# The registry is unbounded and assumes a small, fixed key set per process;
+# a key-per-request pattern would leak one sender + httpx pool per unique
+# pair. Such callers must evict explicitly (await sender.close(), then drop
+# the dict entry) or use shutdown().
+_senders: dict[tuple[str, str], AuditSender] = {}
+
+
+def _local_mode_active() -> bool:
+    """True if ``HEXGATE_LOCAL_MODE`` is set to a truthy value.
+
+    Accepts ``1``/``true``/``yes``/``on`` (case-insensitive). Everything
+    else — including unset — evaluates false. Mirrors the truthy-value
+    parser the platform's ``HEXGATE_COOKIE_SECURE`` knob uses, so the
+    behavior is consistent across the codebase's env flags."""
+    return os.environ.get(_LOCAL_MODE_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def get_or_create_sender(
+    path: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> AuditSender | None:
+    """Get-or-create the sender for ``(api_key, path)``. Idempotent per pair.
+
+    Both ``api_key``/``base_url`` fall back to ``HEXGATE_API_KEY`` /
+    ``HEXGATE_API_URL`` env vars. Reuses the existing sender when the same
+    pair was already configured; distinct pairs get distinct senders.
+    Returns ``None`` when no api_key is resolvable — the caller's event type
+    stays inert.
+
+    Also returns ``None`` when ``HEXGATE_LOCAL_MODE`` is set in env, even if
+    a key was resolvable — that's the "I have a key in .env but I'm
+    iterating locally and don't want cloud writes" path (``hexgate chat``
+    opts in via ``bootstrap(local_only=True)``), shared by every event type
+    that goes through this registry.
+    """
+    if _local_mode_active():
+        # Only log when a key was actually present — otherwise the
+        # message is just noise during a no-key local run.
+        resolved = resolve_api_key(api_key)
+        if resolved and path not in _logged_local_mode_suppressed:
+            _log.info(
+                "sender suppressed for %s: %s=1 (a key is configured but "
+                "local mode is on, so events stay on this machine)",
+                path,
+                _LOCAL_MODE_ENV,
+            )
+            _logged_local_mode_suppressed.add(path)
+        return None
+    resolved_key = resolve_api_key(api_key)
+    if not resolved_key:
+        return None
+    cache_key = (resolved_key, path)
+    existing = _senders.get(cache_key)
+    if existing is not None:
+        return existing
+    resolved_url = resolve_api_url(base_url)
+    sender = AuditSender(endpoint=f"{resolved_url}{path}", api_key=resolved_key)
+    _senders[cache_key] = sender
+    return sender
+
+
+def get_sender(path: str, api_key: str | None = None) -> AuditSender | None:
+    """Return the sender for ``(api_key, path)`` (api_key falling back to
+    ``HEXGATE_API_KEY``), if configured. Never creates one."""
+    resolved_key = resolve_api_key(api_key)
+    if not resolved_key:
+        return None
+    return _senders.get((resolved_key, path))
+
+
+async def shutdown() -> None:
+    """Drain in-flight emits and close every sender for every path.
+
+    Safe to call multiple times. Drains the whole shared registry — calling
+    this from either ``hexgate.audit`` or ``hexgate.tracing.usage`` closes
+    both event types' senders in one shot."""
+    senders = list(_senders.values())
+    _senders.clear()
+    await asyncio.gather(*(s.close() for s in senders), return_exceptions=True)

--- a/hexgate/tracing/usage.py
+++ b/hexgate/tracing/usage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from hexgate.tracing._senders import AuditSender, get_or_create_sender
+from hexgate.tracing._senders import get_sender as _get_sender
+from hexgate.tracing._senders import shutdown as _shutdown_all
+
+_LLM_USAGE_PATH = "/v1/audit/llm-invocations"
+
+
+@dataclass(frozen=True, slots=True)
+class LlmUsageEvent:
+    agent_name: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    latency_ms: int
+    status: str  # e.g., "success", "error"
+    session_id: str = ""
+    user_id: str = ""
+    error_code: str | None = None  # optional error code if status is "error"
+    event_id: UUID = field(default_factory=uuid4)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "event_id": str(self.event_id),
+            "occurred_at": self.occurred_at.isoformat(),
+            "agent_name": self.agent_name,
+            "session_id": self.session_id,
+            "user_id": self.user_id,
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "latency_ms": self.latency_ms,
+            "status": self.status,
+            "error_code": self.error_code or "",
+        }
+
+
+def configure_usage_sender(
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> AuditSender | None:
+    """Get-or-create the LLM-usage sender for ``api_key``. Idempotent per key.
+
+    Shares the registry (and the ``HEXGATE_LOCAL_MODE`` gate) with
+    :func:`hexgate.audit.configure` via ``hexgate.tracing._senders`` — the
+    same api_key configured for decisions gets its own sender here, keyed
+    separately by endpoint path so the two event types never collide.
+    """
+    return get_or_create_sender(_LLM_USAGE_PATH, api_key, base_url)
+
+
+def get_usage_sender(api_key: str | None = None) -> AuditSender | None:
+    """Return the LLM-usage sender for ``api_key`` (or ``HEXGATE_API_KEY``),
+    if configured. Never creates one."""
+    return _get_sender(_LLM_USAGE_PATH, api_key)
+
+
+async def shutdown() -> None:
+    """Drain in-flight emits and close every sender in the shared registry
+    (decisions and LLM usage alike). Safe to call multiple times;
+    equivalent to :func:`hexgate.audit.shutdown` — either name drains the
+    whole shared registry."""
+    await _shutdown_all()

--- a/tests/agents/test_create_agent_binding.py
+++ b/tests/agents/test_create_agent_binding.py
@@ -155,11 +155,11 @@ def test_auto_mode_respects_hexgate_local_mode(
     create_agent under local mode stays bare — the user explicitly asked
     for no platform IO from this process."""
     import hexgate.cloud.client as client_mod
-    from hexgate import audit
+    from hexgate.tracing._senders import _LOCAL_MODE_ENV
 
     monkeypatch.setenv("HEXGATE_API_KEY", "fty_test_demo_dummybiscuit")
     monkeypatch.setenv("HEXGATE_BIND_AGENTS", "1")
-    monkeypatch.setenv(audit._LOCAL_MODE_ENV, "1")
+    monkeypatch.setenv(_LOCAL_MODE_ENV, "1")
     # The platform must never be contacted — fail hard if a client is built.
     monkeypatch.setattr(
         client_mod,
@@ -182,9 +182,9 @@ def test_bind_policy_true_overrides_hexgate_local_mode(
 ) -> None:
     """``bind_policy=True`` is the explicit-caller form — local mode shouldn't
     silently veto it. The kill switch only short-circuits the auto-detect path."""
-    from hexgate import audit
+    from hexgate.tracing._senders import _LOCAL_MODE_ENV
 
-    monkeypatch.setenv(audit._LOCAL_MODE_ENV, "1")
+    monkeypatch.setenv(_LOCAL_MODE_ENV, "1")
     monkeypatch.setattr(
         factory,
         "_bind_policy",

--- a/tests/audit/test_configure.py
+++ b/tests/audit/test_configure.py
@@ -1,26 +1,32 @@
-"""audit.configure() — env fallback, explicit args, idempotency."""
+"""audit.configure() — thin wiring onto the shared sender registry.
+
+Generic registry mechanics (idempotency, distinct-key/path isolation,
+HEXGATE_LOCAL_MODE suppression) live in tests/tracing/test_senders.py under
+Design C — this file only checks that audit.py wires the shared registry to
+the right endpoint (/v1/audit/decisions).
+"""
 
 from __future__ import annotations
 
-import logging
 from collections.abc import Iterator
 
 import pytest
 
 import hexgate.audit as audit_mod
+from hexgate.tracing import _senders
 
 
 @pytest.fixture(autouse=True)
 def _isolate_audit_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Reset the sender registry + clear HEXGATE_* env between tests."""
-    audit_mod._senders.clear()
-    audit_mod._logged_local_mode_suppressed = False
+    """Reset the shared sender registry + clear HEXGATE_* env between tests."""
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed.clear()
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
     monkeypatch.delenv("HEXGATE_API_URL", raising=False)
-    monkeypatch.delenv(audit_mod._LOCAL_MODE_ENV, raising=False)
+    monkeypatch.delenv(_senders._LOCAL_MODE_ENV, raising=False)
     yield
-    audit_mod._senders.clear()
-    audit_mod._logged_local_mode_suppressed = False
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed.clear()
 
 
 def test_returns_none_when_no_key_anywhere() -> None:
@@ -61,90 +67,26 @@ def test_explicit_base_url_wins_over_env(monkeypatch: pytest.MonkeyPatch) -> Non
     assert sender._endpoint == "https://explicit.example.com/v1/audit/decisions"
 
 
-def test_idempotent_per_key_returns_same_sender() -> None:
-    first = audit_mod.configure("k1")
-    second = audit_mod.configure("k1")  # same key → reuse
-    assert first is second
-
-
-def test_distinct_keys_get_distinct_senders() -> None:
-    sender_a = audit_mod.configure("k1")
-    sender_b = audit_mod.configure("k2")
-    assert sender_a is not sender_b
-    assert sender_a._client.headers["Authorization"] == "Bearer k1"
-    assert sender_b._client.headers["Authorization"] == "Bearer k2"
-
-
 def test_get_sender_scoped_by_key() -> None:
     sender = audit_mod.configure("k1")
     assert audit_mod.get_sender("k1") is sender
     assert audit_mod.get_sender("k2") is None
 
 
-# ---------------------------------------------------------------------------
-# HEXGATE_LOCAL_MODE gate
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "yes", "on"])
-def test_local_mode_env_suppresses_configure(
-    monkeypatch: pytest.MonkeyPatch, truthy: str
-) -> None:
-    """Any truthy value of HEXGATE_LOCAL_MODE makes configure() return None
-    even when an api_key is in env. The gate is the whole point of local
-    mode: a key in .env (left over from a platform session) must not cause
-    cloud writes the next time the dev runs `hexgate chat`."""
+def test_local_mode_suppresses_configure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Full HEXGATE_LOCAL_MODE truth-table coverage lives in
+    tests/tracing/test_senders.py; this just confirms audit.configure()
+    actually reaches the shared gate."""
     monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
-    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, truthy)
+    monkeypatch.setenv(_senders._LOCAL_MODE_ENV, "1")
     assert audit_mod.configure() is None
     assert audit_mod.get_sender("real_key") is None
 
 
-@pytest.mark.parametrize("falsy", ["0", "false", "no", "off", ""])
-def test_local_mode_falsy_does_not_suppress(
-    monkeypatch: pytest.MonkeyPatch, falsy: str
-) -> None:
-    """Explicit falsy values behave as if unset — symmetry with the
-    truthy parametrize prevents a future refactor from accidentally
-    making `HEXGATE_LOCAL_MODE=0` count as 'on'."""
-    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
-    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, falsy)
-    sender = audit_mod.configure()
-    assert sender is not None
-
-
-def test_local_mode_explicit_key_arg_still_suppressed(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The gate fires even when a caller passes an explicit api_key —
-    adapter wrappers that do `audit.configure(api_key=...)` post-bootstrap
-    must respect local mode too."""
-    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
-    assert audit_mod.configure("explicit_key") is None
-
-
-def test_local_mode_logs_suppression_once(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """A single INFO line at the first suppression; further configure()
-    calls stay silent so a busy startup doesn't repeat itself."""
-    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
-    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
-    with caplog.at_level(logging.INFO, logger="hexgate.audit"):
-        audit_mod.configure()
-        audit_mod.configure()
-        audit_mod.configure()
-    suppressed = [r for r in caplog.records if "audit suppressed" in r.message]
-    assert len(suppressed) == 1
-
-
-def test_local_mode_silent_when_no_key_present(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
-) -> None:
-    """No key + local mode is the OSS "I never set a key" case — no log
-    line, because there's no surprise to disambiguate."""
-    monkeypatch.setenv(audit_mod._LOCAL_MODE_ENV, "1")
-    with caplog.at_level(logging.INFO, logger="hexgate.audit"):
-        audit_mod.configure()
-    suppressed = [r for r in caplog.records if "audit suppressed" in r.message]
-    assert suppressed == []
+async def test_shutdown_delegates_to_shared_registry() -> None:
+    """audit.shutdown() drains the shared registry, not a private copy —
+    covered end-to-end (with the usage.py side too) in
+    tests/tracing/test_usage_configure.py."""
+    audit_mod.configure("k1")
+    await audit_mod.shutdown()
+    assert _senders._senders == {}

--- a/tests/audit/test_integration.py
+++ b/tests/audit/test_integration.py
@@ -17,6 +17,7 @@ import pytest
 import hexgate.audit as audit_mod
 from hexgate.audit import AuditEvent
 from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.tracing import _senders
 
 pytestmark = pytest.mark.integration
 
@@ -57,7 +58,7 @@ async def test_wire_format_accepted_by_platform() -> None:
 async def test_sender_emits_end_to_end_without_errors() -> None:
     """Drives the full SDK path: configure → emit → drain. Confirms no raised exceptions."""
     _need_token()
-    audit_mod._senders.clear()  # reset for a clean configure
+    _senders._senders.clear()  # reset for a clean configure
     sender = audit_mod.configure(TOKEN, PLATFORM_URL)
     try:
         sender.emit(_event())

--- a/tests/security/test_enforcer_audit.py
+++ b/tests/security/test_enforcer_audit.py
@@ -7,8 +7,8 @@ from typing import Any
 
 import pytest
 
-import hexgate.audit as audit_mod
 from hexgate.audit import AuditEvent
+from hexgate.tracing import _senders
 from hexgate.runtime.context import User
 from hexgate.security.decision import DecisionOutcome, Verdict
 from hexgate.security.enforcer import PolicyEnforcer
@@ -33,9 +33,9 @@ class _CapturingSender:
 
 @pytest.fixture(autouse=True)
 def _reset_audit_senders() -> None:
-    audit_mod._senders.clear()
+    _senders._senders.clear()
     yield
-    audit_mod._senders.clear()
+    _senders._senders.clear()
 
 
 def test_no_sender_means_no_emit() -> None:

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pytest
 
 from hexgate import audit, bootstrap
+from hexgate.tracing import _senders
 
 
 def _stub_dotenv_with_required_keys(
@@ -40,15 +41,15 @@ def _stub_dotenv_with_required_keys(
 @pytest.fixture(autouse=True)
 def _isolate_audit_and_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Reset audit + the env vars bootstrap touches between tests."""
-    audit._senders.clear()
-    audit._logged_local_mode_suppressed = False
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed.clear()
     monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
     monkeypatch.delenv("HEXGATE_API_URL", raising=False)
     monkeypatch.delenv("HEXGATE_LOCAL_POLICY", raising=False)
-    monkeypatch.delenv(audit._LOCAL_MODE_ENV, raising=False)
+    monkeypatch.delenv(_senders._LOCAL_MODE_ENV, raising=False)
     yield
-    audit._senders.clear()
-    audit._logged_local_mode_suppressed = False
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed.clear()
 
 
 def test_bootstrap_loads_requested_env_file(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -80,7 +81,7 @@ def test_local_only_sets_env_var_before_audit_configure(
     real_configure = audit.configure
 
     def spy_configure(*args, **kwargs):
-        observed_env["HEXGATE_LOCAL_MODE"] = os.environ.get(audit._LOCAL_MODE_ENV)
+        observed_env["HEXGATE_LOCAL_MODE"] = os.environ.get(_senders._LOCAL_MODE_ENV)
         return real_configure(*args, **kwargs)
 
     monkeypatch.setattr(audit, "configure", spy_configure)
@@ -89,7 +90,7 @@ def test_local_only_sets_env_var_before_audit_configure(
     assert observed_env["HEXGATE_LOCAL_MODE"] == "1"
     # Sanity: with the gate on, configure returned None even though a key
     # was in env — registry is empty.
-    assert audit._senders == {}
+    assert _senders._senders == {}
 
 
 def test_local_only_false_leaves_env_var_unset(
@@ -99,7 +100,7 @@ def test_local_only_false_leaves_env_var_unset(
     ``hexgate serve`` and any other platform-bound caller rely on this."""
     _stub_dotenv_with_required_keys(monkeypatch)
     bootstrap.bootstrap("test.env")  # default
-    assert os.environ.get(audit._LOCAL_MODE_ENV) is None
+    assert os.environ.get(_senders._LOCAL_MODE_ENV) is None
 
 
 def test_bootstrap_warns_when_key_and_local_policy_both_set(

--- a/tests/tracing/test_sender.py
+++ b/tests/tracing/test_sender.py
@@ -1,4 +1,11 @@
-"""AuditSender behavior. Mocks the httpx.AsyncClient on the sender instance."""
+"""AuditSender behavior. Mocks the httpx.AsyncClient on the sender instance.
+
+Moved here from tests/audit/ under Design C: AuditSender is a fully generic
+sender (it only depends on ``event.as_payload()``), now living in
+hexgate.tracing._senders and shared by hexgate.audit and
+hexgate.tracing.usage — its own tests belong next to it, not under
+tests/audit/.
+"""
 
 from __future__ import annotations
 
@@ -7,9 +14,13 @@ import logging
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
+import pytest
 
-from hexgate.audit import AuditEvent, AuditSender
+from hexgate.audit import AuditEvent
 from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.tracing._senders import AuditSender
+
+_LOGGER_NAME = "hexgate.tracing._senders"
 
 
 def _event() -> AuditEvent:
@@ -57,7 +68,7 @@ async def test_semaphore_saturation_drops_events(
     sender = AuditSender("http://x/y", "k", max_in_flight=1)
     await sender._semaphore.acquire()
     try:
-        with caplog.at_level(logging.WARNING, logger="hexgate.audit"):
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
             for _ in range(5):
                 sender.emit(_event())
         assert sender._dropped == 5
@@ -107,7 +118,7 @@ async def test_network_error_logged_not_raised(
     sender._client = MagicMock()
     sender._client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
     sender._client.aclose = AsyncMock()
-    with caplog.at_level(logging.WARNING, logger="hexgate.audit"):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
         sender.emit(_event())
         await asyncio.gather(*sender._tasks)
     assert any("network error" in r.message for r in caplog.records)
@@ -118,7 +129,7 @@ def test_no_running_loop_skips_silently(caplog: "logging.LogCaptureFixture") -> 
     no-ops with a one-time warning."""
     sender = AuditSender("http://x/y", "k")
     assert sender._loop is None
-    with caplog.at_level(logging.WARNING, logger="hexgate.audit"):
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
         sender.emit(_event())
         sender.emit(_event())  # second call: silent
     assert len(sender._tasks) == 0
@@ -147,6 +158,67 @@ async def test_emit_from_executor_thread_routes_to_bound_loop() -> None:
     assert sender._warned_no_loop is False  # routed, not dropped
     await asyncio.gather(*sender._tasks)
     sender._client.post.assert_called_once()
+
+
+def test_emit_when_call_soon_threadsafe_raises_then_error_is_swallowed() -> None:
+    """Loop torn down between the is_closed() check and call_soon_threadsafe:
+    the race is swallowed, not raised."""
+    sender = AuditSender("http://x/y", "k")
+    assert sender._loop is None  # built outside any running loop
+    fake_loop = MagicMock()
+    fake_loop.is_closed.return_value = False
+    fake_loop.call_soon_threadsafe.side_effect = RuntimeError("loop closed mid-call")
+    sender._loop = fake_loop
+    sender.emit(_event())  # must not raise
+    assert len(sender._tasks) == 0
+
+
+def test_spawn_send_when_closing_then_no_task_is_created() -> None:
+    sender = AuditSender("http://x/y", "k")
+    sender._closing = True
+    sender._spawn_send(_event())
+    assert len(sender._tasks) == 0
+
+
+async def test_send_when_client_is_none_then_runtimeerror_is_raised() -> None:
+    sender = AuditSender("http://x/y", "k")
+    sender._client = None
+    with pytest.raises(RuntimeError, match="before start"):
+        await sender._send(_event())
+
+
+async def test_send_when_response_status_is_4xx_then_failure_is_logged(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    sender = AuditSender("http://x/y", "k")
+    sender._client = MagicMock()
+    sender._client.post = AsyncMock(
+        return_value=MagicMock(status_code=404, text="not found")
+    )
+    sender._client.aclose = AsyncMock()
+    with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
+        sender.emit(_event())
+        await asyncio.gather(*sender._tasks)
+    assert any("ingest failed" in r.message for r in caplog.records)
+
+
+async def test_close_when_drain_times_out_then_warning_is_logged(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    sender = AuditSender("http://x/y", "k")
+    sender._client = _stub_client()
+    task = asyncio.create_task(asyncio.sleep(10))
+    sender._tasks.add(task)
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        await sender.close(drain_timeout=0.01)
+    assert any("drain timed out" in r.message for r in caplog.records)
+    assert task.cancelled()
+
+
+async def test_close_when_client_is_none_then_no_error_is_raised() -> None:
+    sender = AuditSender("http://x/y", "k")
+    sender._client = None
+    await sender.close()  # must not raise
 
 
 def test_rebuilds_loop_bound_state_across_event_loops() -> None:

--- a/tests/tracing/test_senders.py
+++ b/tests/tracing/test_senders.py
@@ -1,0 +1,188 @@
+"""hexgate.tracing._senders — the shared (api_key, path) registry and the
+HEXGATE_LOCAL_MODE gate, tested directly against the neutral module rather
+than through hexgate.audit or hexgate.tracing.usage.
+
+Moved here from tests/audit/test_configure.py under Design C: this is the
+generic registry machinery both audit.py and usage.py import, not
+decisions-specific behavior — see Specs/token_counts.md for the full
+writeup.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+
+import pytest
+
+import hexgate.tracing._senders as senders_mod
+
+_DECISIONS_PATH = "/v1/audit/decisions"
+_USAGE_PATH = "/v1/audit/llm-invocations"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sender_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset the sender registry + clear HEXGATE_* env between tests."""
+    senders_mod._senders.clear()
+    senders_mod._logged_local_mode_suppressed.clear()
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_URL", raising=False)
+    monkeypatch.delenv(senders_mod._LOCAL_MODE_ENV, raising=False)
+    yield
+    senders_mod._senders.clear()
+    senders_mod._logged_local_mode_suppressed.clear()
+
+
+# ---------------------------------------------------------------------------
+# get_or_create_sender() / get_sender() — generic registry mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_returns_none_when_no_key_anywhere() -> None:
+    assert senders_mod.get_or_create_sender(_DECISIONS_PATH) is None
+    assert senders_mod.get_sender(_DECISIONS_PATH) is None
+
+
+def test_idempotent_per_key_and_path_returns_same_sender() -> None:
+    first = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k1")
+    second = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k1")  # reuse
+    assert first is second
+
+
+def test_distinct_keys_get_distinct_senders() -> None:
+    sender_a = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k1")
+    sender_b = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k2")
+    assert sender_a is not sender_b
+    assert sender_a._client.headers["Authorization"] == "Bearer k1"
+    assert sender_b._client.headers["Authorization"] == "Bearer k2"
+
+
+def test_same_key_distinct_paths_get_distinct_senders() -> None:
+    """The whole point of the (api_key, path) composite key: one
+    HEXGATE_API_KEY covers both decisions and LLM usage for the same
+    project, but each event type needs its own live connection to its own
+    endpoint — see Specs/token_counts.md."""
+    decisions_sender = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k1")
+    usage_sender = senders_mod.get_or_create_sender(_USAGE_PATH, "k1")
+    assert decisions_sender is not usage_sender
+    assert decisions_sender._endpoint.endswith(_DECISIONS_PATH)
+    assert usage_sender._endpoint.endswith(_USAGE_PATH)
+    # Same bearer token, different connections.
+    assert (
+        decisions_sender._client.headers["Authorization"]
+        == usage_sender._client.headers["Authorization"]
+        == "Bearer k1"
+    )
+
+
+def test_get_sender_scoped_by_key_and_path() -> None:
+    sender = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k1")
+    assert senders_mod.get_sender(_DECISIONS_PATH, "k1") is sender
+    assert senders_mod.get_sender(_DECISIONS_PATH, "k2") is None
+    assert senders_mod.get_sender(_USAGE_PATH, "k1") is None  # different path
+
+
+def test_env_api_key_and_url_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_KEY", "env_key")
+    monkeypatch.setenv("HEXGATE_API_URL", "https://prod.example.com/")
+    sender = senders_mod.get_or_create_sender(_DECISIONS_PATH)
+    assert sender is not None
+    assert sender._endpoint == f"https://prod.example.com{_DECISIONS_PATH}"
+
+
+def test_explicit_args_win_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HEXGATE_API_KEY", "env_key")
+    monkeypatch.setenv("HEXGATE_API_URL", "https://env.example.com")
+    sender = senders_mod.get_or_create_sender(
+        _DECISIONS_PATH, "explicit_key", "https://explicit.example.com"
+    )
+    assert sender._client.headers["Authorization"] == "Bearer explicit_key"
+    assert sender._endpoint == f"https://explicit.example.com{_DECISIONS_PATH}"
+
+
+# ---------------------------------------------------------------------------
+# HEXGATE_LOCAL_MODE gate — shared by every path through this registry
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("truthy", ["1", "true", "TRUE", "yes", "on"])
+def test_local_mode_env_suppresses_every_path(
+    monkeypatch: pytest.MonkeyPatch, truthy: str
+) -> None:
+    """Any truthy value of HEXGATE_LOCAL_MODE makes get_or_create_sender()
+    return None even when an api_key is in env — for every path sharing
+    this registry, not just decisions."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
+    monkeypatch.setenv(senders_mod._LOCAL_MODE_ENV, truthy)
+    assert senders_mod.get_or_create_sender(_DECISIONS_PATH) is None
+    assert senders_mod.get_or_create_sender(_USAGE_PATH) is None
+    assert senders_mod.get_sender(_DECISIONS_PATH, "real_key") is None
+
+
+@pytest.mark.parametrize("falsy", ["0", "false", "no", "off", ""])
+def test_local_mode_falsy_does_not_suppress(
+    monkeypatch: pytest.MonkeyPatch, falsy: str
+) -> None:
+    """Explicit falsy values behave as if unset — symmetry with the
+    truthy parametrize prevents a future refactor from accidentally
+    making `HEXGATE_LOCAL_MODE=0` count as 'on'."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
+    monkeypatch.setenv(senders_mod._LOCAL_MODE_ENV, falsy)
+    sender = senders_mod.get_or_create_sender(_DECISIONS_PATH)
+    assert sender is not None
+
+
+def test_local_mode_explicit_key_arg_still_suppressed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate fires even when a caller passes an explicit api_key —
+    adapter wrappers that do `configure(api_key=...)` post-bootstrap
+    must respect local mode too."""
+    monkeypatch.setenv(senders_mod._LOCAL_MODE_ENV, "1")
+    assert senders_mod.get_or_create_sender(_DECISIONS_PATH, "explicit_key") is None
+
+
+def test_local_mode_logs_suppression_once_per_path(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A single INFO line at the first suppression per path; further calls
+    for the same path stay silent so a busy startup doesn't repeat itself.
+    A different path (decisions vs. usage) gets its own first notice."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
+    monkeypatch.setenv(senders_mod._LOCAL_MODE_ENV, "1")
+    with caplog.at_level(logging.INFO, logger="hexgate.tracing._senders"):
+        senders_mod.get_or_create_sender(_DECISIONS_PATH)
+        senders_mod.get_or_create_sender(_DECISIONS_PATH)
+        senders_mod.get_or_create_sender(_DECISIONS_PATH)
+        senders_mod.get_or_create_sender(_USAGE_PATH)
+    suppressed = [r for r in caplog.records if "suppressed" in r.message]
+    assert len(suppressed) == 2  # one for decisions, one for usage
+    assert any(_DECISIONS_PATH in r.message for r in suppressed)
+    assert any(_USAGE_PATH in r.message for r in suppressed)
+
+
+def test_local_mode_silent_when_no_key_present(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """No key + local mode is the OSS "I never set a key" case — no log
+    line, because there's no surprise to disambiguate."""
+    monkeypatch.setenv(senders_mod._LOCAL_MODE_ENV, "1")
+    with caplog.at_level(logging.INFO, logger="hexgate.tracing._senders"):
+        senders_mod.get_or_create_sender(_DECISIONS_PATH)
+    suppressed = [r for r in caplog.records if "suppressed" in r.message]
+    assert suppressed == []
+
+
+# ---------------------------------------------------------------------------
+# shutdown() — drains every path in one call
+# ---------------------------------------------------------------------------
+
+
+async def test_shutdown_drains_every_path_for_a_key() -> None:
+    decisions_sender = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k1")
+    usage_sender = senders_mod.get_or_create_sender(_USAGE_PATH, "k1")
+    await senders_mod.shutdown()
+    assert senders_mod._senders == {}
+    assert decisions_sender._closing is True
+    assert usage_sender._closing is True

--- a/tests/tracing/test_usage_configure.py
+++ b/tests/tracing/test_usage_configure.py
@@ -1,0 +1,78 @@
+"""usage.configure_usage_sender() — thin wiring onto the shared sender
+registry, mirroring tests/audit/test_configure.py.
+
+Generic registry mechanics live in tests/tracing/test_senders.py — this file
+only checks that usage.py wires the shared registry to the right endpoint
+(/v1/audit/llm-invocations), and that it truly shares the registry (and the
+HEXGATE_LOCAL_MODE gate) with hexgate.audit rather than duplicating it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+import hexgate.audit as audit_mod
+import hexgate.tracing.usage as usage_mod
+from hexgate.tracing import _senders
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sender_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset the shared sender registry + clear HEXGATE_* env between tests."""
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed.clear()
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_URL", raising=False)
+    monkeypatch.delenv(_senders._LOCAL_MODE_ENV, raising=False)
+    yield
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed.clear()
+
+
+def test_returns_none_when_no_key_anywhere() -> None:
+    assert usage_mod.configure_usage_sender() is None
+    assert usage_mod.get_usage_sender() is None
+
+
+def test_wires_to_llm_invocations_endpoint() -> None:
+    sender = usage_mod.configure_usage_sender("k")
+    assert sender is not None
+    assert sender._endpoint == "https://app.hexgate.ai/v1/audit/llm-invocations"
+
+
+def test_get_usage_sender_scoped_by_key() -> None:
+    sender = usage_mod.configure_usage_sender("k1")
+    assert usage_mod.get_usage_sender("k1") is sender
+    assert usage_mod.get_usage_sender("k2") is None
+
+
+def test_same_key_gets_distinct_sender_from_audit() -> None:
+    """The one HEXGATE_API_KEY that covers a project's decisions also
+    covers its LLM usage, but each event type gets its own live sender —
+    see Specs/token_counts.md."""
+    decisions_sender = audit_mod.configure("k1")
+    usage_sender = usage_mod.configure_usage_sender("k1")
+    assert decisions_sender is not usage_sender
+    assert decisions_sender._endpoint.endswith("/v1/audit/decisions")
+    assert usage_sender._endpoint.endswith("/v1/audit/llm-invocations")
+
+
+def test_local_mode_suppresses_usage_sender_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """usage.py shares audit.py's HEXGATE_LOCAL_MODE gate via the shared
+    registry — no separate copy of the check."""
+    monkeypatch.setenv("HEXGATE_API_KEY", "real_key")
+    monkeypatch.setenv(_senders._LOCAL_MODE_ENV, "1")
+    assert usage_mod.configure_usage_sender() is None
+
+
+async def test_either_modules_shutdown_drains_both() -> None:
+    """A single shutdown() call — from either module — drains both event
+    types' senders, per the Design C decision."""
+    audit_mod.configure("k1")
+    usage_mod.configure_usage_sender("k1")
+    await usage_mod.shutdown()
+    assert _senders._senders == {}

--- a/tests/tracing/test_usage_event.py
+++ b/tests/tracing/test_usage_event.py
@@ -1,0 +1,73 @@
+"""LlmUsageEvent.as_payload() field mapping for the platform's llm-invocations endpoint."""
+
+from __future__ import annotations
+
+from hexgate.tracing.usage import LlmUsageEvent
+
+
+def _event(**overrides) -> LlmUsageEvent:
+    base = dict(
+        agent_name="example_agent",
+        model="gpt-4o",
+        input_tokens=100,
+        output_tokens=50,
+        latency_ms=250,
+        status="success",
+    )
+    return LlmUsageEvent(**{**base, **overrides})
+
+
+def test_as_payload_happy_path() -> None:
+    ev = _event(session_id="sess_1", user_id="alice", error_code=None)
+    wire = ev.as_payload()
+
+    assert wire["event_id"] == str(ev.event_id)
+    assert wire["occurred_at"] == ev.occurred_at.isoformat()
+    assert wire["agent_name"] == "example_agent"
+    assert wire["session_id"] == "sess_1"
+    assert wire["user_id"] == "alice"
+    assert wire["model"] == "gpt-4o"
+    assert wire["input_tokens"] == 100
+    assert wire["output_tokens"] == 50
+    assert wire["latency_ms"] == 250
+    assert wire["status"] == "success"
+    assert wire["error_code"] == ""
+    # project_id, agent_version_id, received_at are server-resolved and must
+    # never be sent on the wire — see AuditEnvelope on the platform side.
+    assert "project_id" not in wire
+    assert "agent_version_id" not in wire
+    assert "received_at" not in wire
+
+
+def test_as_payload_when_optional_fields_omitted_then_defaults_are_used() -> None:
+    wire = _event().as_payload()  # session_id/user_id/error_code left at defaults
+    assert wire["session_id"] == ""
+    assert wire["user_id"] == ""
+    assert wire["error_code"] == ""
+
+
+def test_as_payload_when_error_code_is_none_then_it_is_stringified_to_empty() -> None:
+    """The platform's error_code column is a plain str (default ""), not
+    Optional — None must never reach the wire or ingest 422s."""
+    wire = _event(error_code=None).as_payload()
+    assert wire["error_code"] == ""
+
+
+def test_as_payload_when_status_is_error_then_error_code_is_included() -> None:
+    wire = _event(status="error", error_code="rate_limited").as_payload()
+    assert wire["status"] == "error"
+    assert wire["error_code"] == "rate_limited"
+
+
+def test_event_id_defaults_to_a_stringified_uuid_and_is_unique_per_event() -> None:
+    """event_id defaults via uuid4 (mirrors AuditEvent) rather than requiring
+    the caller to generate one; as_payload() stringifies it for the wire."""
+    ev1, ev2 = _event(), _event()
+
+    assert ev1.event_id != ev2.event_id
+    assert ev1.as_payload()["event_id"] == str(ev1.event_id)
+
+
+def test_as_payload_when_occurred_at_defaults_then_occurred_at_has_utc_offset() -> None:
+    wire = _event().as_payload()
+    assert "+00:00" in wire["occurred_at"]


### PR DESCRIPTION
## What is changing? 

The **AuditSender** class from hexgate/audit.py is moved to a new [hexgate/tracing/_senders.py](https://github.com/HexamindOrganisation/hexgate/compare/vl/refactor/generalize_audit_api_keys_registry?expand=1#diff-e16676d060a29f26683fab89d814a31b5b67b3c6839a35b7b39e623330b264a0) file. The class is nearly identical, except for **event** type parameter in **emit()**, **_spawn_send()**, **_send()**, which is changed from **AuditEvent** to a generalised **_PayloadEvent**.

## Why is this change necessary?
To send the llm invocation reports, we need a class nearly identical to **AuditSender**, so it is generalised to be used to send both llm invocations and audits. This class includes an API registry which maps from **(api_key, path)** pairs to sender instances — the same **HEXGATE_API_KEY** covers both event types for a project, but each needs its own live connection to its own endpoint (`/v1/audit/decisions` vs. `/v1/audit/llm-invocations`). Keying by `api_key` alone would make configuring the second event type silently reuse the first one's sender and POST to the wrong endpoint.

The **HEXGATE_LOCAL_MODE** gate (suppresses sends during local iteration, e.g. `hexgate chat`) moves with it, so both event types share the same kill switch instead of duplicating the check.

`audit.py` keeps `AuditEvent` and the decision-specific redaction/truncation logic, and becomes a thin wrapper around the shared registry — `configure()` / `get_sender()` / `shutdown()` are unchanged from the caller's perspective. `usage.py` gains the equivalent `configure_usage_sender()` / `get_usage_sender()` / `shutdown()` as the first real consumer proving the registry generalises.

## Design choices
- Registry keyed by `(api_key, path)`, not `api_key` alone — see "Decision — sender registry for LLM-usage events: Design C" on [Notion](https://app.notion.com/p/Count-tokens-per-LLM-395fb45dbae2809abda5e148373b3096) for the alternatives considered (fully separate registry per event type vs. merging into audit.py).
- First of two PRs for LLM token usage capture — per-adapter hooks (`emit_llm_usage()`, LangChain/OpenAI/Google/Pydantic AI wiring) land separately.

## Tests
- make check
- pytest -m integration