### PR TITLE
refactor(sdk): split approval + tracing types so adapters skip LangChain

### DIFF
--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -16,7 +16,7 @@ from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
 from hexgate.adapters.google.wrapper import wrap_google_agent
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import User
 

--- a/hexgate/adapters/google/tools.py
+++ b/hexgate/adapters/google/tools.py
@@ -20,7 +20,7 @@ from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.tool_context import ToolContext
 
 from hexgate.agents.approvals import resolve_approval_async
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from google.adk.agents import BaseAgent
 
 from hexgate.adapters.google.tools import wrap_tools
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
 

--- a/hexgate/adapters/langchain/tools.py
+++ b/hexgate/adapters/langchain/tools.py
@@ -26,7 +26,7 @@ from hexgate.agents.approvals import (
 from hexgate.agents.approvals import (
     resolve_approval_sync as _resolve_approval_sync,
 )
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.tools.decorators import TOOL_METADATA_ATTR

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -25,7 +25,7 @@ from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
 from hexgate.adapters.openai.wrapper import wrap_openai_agent
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import User
 from hexgate.security.binding import PolicyBinding, resolve_policy

--- a/hexgate/adapters/openai/tools.py
+++ b/hexgate/adapters/openai/tools.py
@@ -19,7 +19,7 @@ from agents import FunctionTool
 from agents.tool import ToolContext
 
 from hexgate.agents.approvals import resolve_approval_async
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 

--- a/hexgate/adapters/openai/wrapper.py
+++ b/hexgate/adapters/openai/wrapper.py
@@ -15,7 +15,7 @@ import dataclasses
 from agents import Agent
 
 from hexgate.adapters.openai.tools import wrap_tools
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.security.enforcer import PolicyEnforcer
 
 

--- a/hexgate/adapters/pydantic_ai/tools.py
+++ b/hexgate/adapters/pydantic_ai/tools.py
@@ -20,7 +20,7 @@ from pydantic_ai.exceptions import ModelRetry
 from pydantic_ai.tools import Tool
 
 from hexgate.agents.approvals import resolve_approval_async
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -17,7 +17,7 @@ from pydantic_ai.tools import Tool
 
 from hexgate.adapters.pydantic_ai.agent import HexgatePydanticAgent
 from hexgate.adapters.pydantic_ai.tools import wrap_tools
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.config.env import resolve_api_key
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer

--- a/hexgate/agents/approvals.py
+++ b/hexgate/agents/approvals.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from inspect import isawaitable
 from typing import Any
 
-from hexgate.agents.factory import ApprovalHandler
+from hexgate.approvals import ApprovalHandler
 from hexgate.security.decision import Decision
 
 

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Self, TypeAlias
 
@@ -32,6 +32,8 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.store.base import BaseStore
 from pydantic import BaseModel
 
+# BC re-export — canonical home is hexgate.approvals (framework-agnostic).
+from hexgate.approvals import ApprovalHandler  # noqa: F401 — re-export
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import (
     LocalWorkspace,
@@ -40,7 +42,6 @@ from hexgate.runtime import (
     reset_current_tool_use_context,
     set_current_tool_use_context,
 )
-from hexgate.security.decision import Decision
 from hexgate.streaming import StreamEvent, new_root_run_id, normalize_langchain_events
 from hexgate.tracing.langfuse import (
     CallbackHandler,
@@ -53,7 +54,6 @@ LangChainAgentGraph: TypeAlias = CompiledStateGraph
 ToolSpec: TypeAlias = BaseTool | Callable[..., Any] | dict[str, Any]
 AgentState: TypeAlias = dict[str, Any]
 AgentInput: TypeAlias = str | Sequence[object] | Mapping[str, object] | BaseModel
-ApprovalHandler: TypeAlias = bool | Callable[[Decision], bool | Awaitable[bool]]
 DEFAULT_SYSTEM_PROMPT = (
     "You are a helpful assistant built on a tool-using agent runtime.\n\n"
     "Your job is to answer clearly and directly, using the tools available to "

--- a/hexgate/approvals.py
+++ b/hexgate/approvals.py
@@ -1,0 +1,24 @@
+"""Framework-agnostic approval-handler type alias.
+
+Extracted from :mod:`hexgate.agents.factory` so adapter code paths
+(``hexgate.adapters.openai``, ``hexgate.adapters.pydantic_ai``,
+``hexgate.adapters.google``) can reference the type without transitively
+loading LangChain and LangGraph via ``factory.py``'s module-top imports.
+
+The alias itself has no framework dependencies — it composes a plain
+``bool`` shortcut with a ``Callable`` over :class:`Decision`, both
+stdlib. Everything an adapter needs to talk about approvals lives here;
+:mod:`hexgate.agents.approvals` (the ``resolve_approval_*`` helpers)
+imports from this module so it stays framework-agnostic too.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeAlias
+
+from hexgate.security.decision import Decision
+
+ApprovalHandler: TypeAlias = bool | Callable[[Decision], bool | Awaitable[bool]]
+
+__all__ = ["ApprovalHandler"]

--- a/hexgate/cli/chat.py
+++ b/hexgate/cli/chat.py
@@ -30,7 +30,7 @@ from hexgate.cli.state import ChatState, LiveRunState, ToolActivity
 from hexgate.security.decision import Decision, DecisionOutcome
 from hexgate.streaming import ToolCallState
 from hexgate.tools.decorators import format_tool_call_label
-from hexgate.tracing.langfuse import maybe_get_trace_url
+from hexgate.tracing.langfuse_core import maybe_get_trace_url
 
 MAX_LIVE_RESPONSE_LINES = 12
 MAX_LIVE_RESPONSE_CHARS = 2_400

--- a/hexgate/tools/__init__.py
+++ b/hexgate/tools/__init__.py
@@ -1,23 +1,42 @@
-"""Tool definitions."""
+"""Tool definitions.
 
-from hexgate.tools.bash import bash
-from hexgate.tools.decorators import agent_tool
-from hexgate.tools.files import edit_file, glob, grep, read_file, write_file
+Attributes load lazily via ``__getattr__`` — scaffolding for the follow-up
+PR that also lazifies ``hexgate/__init__.py``. Until then the top-level
+package still eager-imports every name here, so the savings don't land
+yet; the split is in place so the second PR only has to touch one file.
+"""
 
-__all__ = [
-    "agent_tool",
-    "bash",
-    "edit_file",
-    "glob",
-    "grep",
-    "read_file",
-    "write_file",
-]
+from importlib import import_module as _import_module
+from typing import Any as _Any
+
+_LAZY_ATTRS: dict[str, str] = {
+    "agent_tool": "hexgate.tools.decorators",
+    "bash": "hexgate.tools.bash",
+    "edit_file": "hexgate.tools.files",
+    "glob": "hexgate.tools.files",
+    "grep": "hexgate.tools.files",
+    "read_file": "hexgate.tools.files",
+    "write_file": "hexgate.tools.files",
+}
+
+__all__ = list(_LAZY_ATTRS)
 
 
-def __getattr__(name: str) -> object:
+def __getattr__(name: str) -> _Any:
+    """Resolve a public attribute lazily."""
+    module_path = _LAZY_ATTRS.get(name)
+    if module_path is not None:
+        value = getattr(_import_module(module_path), name)
+        globals()[name] = value
+        return value
+
     from hexgate.tools._relocated import RELOCATED_TOOLS, relocated_import_error
 
     if name in RELOCATED_TOOLS:
         raise relocated_import_error(name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Public names in ``dir(hexgate.tools)``."""
+    return sorted(_LAZY_ATTRS)

--- a/hexgate/tools/decorators.py
+++ b/hexgate/tools/decorators.py
@@ -7,10 +7,9 @@ import inspect
 from typing import Any, Literal
 
 import httpx
-from langchain_core.tools import tool
 
 from hexgate.runtime import get_current_tool_use_context
-from hexgate.tracing.langfuse import observe
+from hexgate.tracing.langfuse_core import observe
 from hexgate.utils.retry import async_retry, is_retryable_error
 
 TOOL_METADATA_ATTR = "__tool_metadata__"
@@ -144,7 +143,15 @@ def agent_tool(
         wrapped.__doc__ = func.__doc__
         wrapped.__annotations__ = _exposed_annotations(func)
         wrapped.__signature__ = exposed_signature
-        registered_tool = tool(wrapped)
+        # Lazy LC import: the @agent_tool decorator produces a
+        # ``langchain_core.tools.BaseTool``, but we don't want the
+        # import at module load time — that would drag LC into every
+        # adapter-only user's install just by having decorators.py on
+        # the import graph. Paid once at decoration time (which only
+        # happens when the caller actually uses the decorator).
+        from langchain_core.tools import tool as _lc_tool
+
+        registered_tool = _lc_tool(wrapped)
         setattr(
             registered_tool,
             TOOL_METADATA_ATTR,

--- a/hexgate/tracing/langfuse.py
+++ b/hexgate/tracing/langfuse.py
@@ -1,25 +1,29 @@
-"""Langfuse integration helpers."""
+"""LangChain-tied Langfuse integration.
+
+The framework-agnostic bits (``get_client``, ``propagate_attributes``,
+``observe``, ``maybe_get_trace_url``, the ``LangfuseHandler`` Protocol)
+live in :mod:`hexgate.tracing.langfuse_core` and are re-exported here so
+pre-refactor imports of the form ``from hexgate.tracing.langfuse import
+observe`` keep working. Code that DOESN'T need the LangChain callback
+handler should import from ``_core`` directly to skip the
+``langfuse.langchain`` + ``langchain_core.runnables`` load.
+"""
 
 from __future__ import annotations
 
 from inspect import signature
-from typing import Any, Protocol
 
-from langfuse import get_client, observe as langfuse_observe
-from langfuse.langchain import CallbackHandler
 from langchain_core.runnables import RunnableConfig
+from langfuse.langchain import CallbackHandler
 
-
-class LangfuseHandler(Protocol):
-    """Protocol for the Langfuse callback handler used by hexgate."""
-
-    last_trace_id: str | None
-    langfuse_metadata: dict[str, Any]
-
-
-def observe(*args, **kwargs):
-    """Apply the Langfuse observe decorator."""
-    return langfuse_observe(*args, **kwargs)
+# Re-exports for back-compat with pre-split callers.
+from hexgate.tracing.langfuse_core import (  # noqa: F401 — re-export
+    LangfuseHandler,
+    get_client,
+    maybe_get_trace_url,
+    observe,
+    propagate_attributes,
+)
 
 
 def get_langfuse_handler(
@@ -56,13 +60,3 @@ def get_langfuse_runnable_config(handler: CallbackHandler) -> RunnableConfig:
         config["metadata"] = {k: v for k, v in metadata.items() if v is not None}
 
     return config
-
-
-def maybe_get_trace_url(handler: CallbackHandler | None = None) -> str | None:
-    """Return the current trace URL if Langfuse is active."""
-    client = get_client()
-    trace_id = getattr(handler, "last_trace_id", None) if handler is not None else None
-    try:
-        return client.get_trace_url(trace_id=trace_id)
-    except Exception:
-        return None

--- a/hexgate/tracing/langfuse_core.py
+++ b/hexgate/tracing/langfuse_core.py
@@ -1,0 +1,44 @@
+"""Framework-agnostic Langfuse helpers.
+
+Split from :mod:`hexgate.tracing.langfuse` so consumers that only need
+the Langfuse client + observe decorator + trace-URL helper (adapter
+runners, ``@agent_tool``-decorated built-ins, the CLI trace hint) can
+avoid the LangChain-tied ``CallbackHandler`` path.
+
+The LC-flavored helpers (``get_langfuse_handler``,
+``get_langfuse_runnable_config``, the ``CallbackHandler`` re-export)
+stay in :mod:`hexgate.tracing.langfuse`; they eagerly import
+``langfuse.langchain`` and ``langchain_core.runnables``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from langfuse import get_client, observe, propagate_attributes
+
+
+class LangfuseHandler(Protocol):
+    """Structural type for the Langfuse callback handler used by hexgate."""
+
+    last_trace_id: str | None
+    langfuse_metadata: dict[str, Any]
+
+
+def maybe_get_trace_url(handler: LangfuseHandler | None = None) -> str | None:
+    """Return the current trace URL if Langfuse is active."""
+    client = get_client()
+    trace_id = getattr(handler, "last_trace_id", None) if handler is not None else None
+    try:
+        return client.get_trace_url(trace_id=trace_id)
+    except Exception:
+        return None
+
+
+__all__ = [
+    "LangfuseHandler",
+    "get_client",
+    "maybe_get_trace_url",
+    "observe",
+    "propagate_attributes",
+]

--- a/tests/tracing/test_tracing.py
+++ b/tests/tracing/test_tracing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from hexgate.tracing import langfuse as lf
+from hexgate.tracing import langfuse_core as lf_core
 
 
 class LegacyCallbackHandler:
@@ -109,7 +110,11 @@ def test_maybe_get_trace_url_uses_handler_trace_id(
 ) -> None:
     """Resolve the trace URL for the last streamed trace id."""
     client = DummyClient()
-    monkeypatch.setattr(lf, "get_client", lambda: client)
+    # ``maybe_get_trace_url`` moved from ``langfuse`` to ``langfuse_core`` in
+    # the SDK-slimming refactor; the ``langfuse`` module re-exports it for BC.
+    # Patch the callee's home so the closure over ``get_client`` picks up the
+    # dummy client.
+    monkeypatch.setattr(lf_core, "get_client", lambda: client)
 
     class Handler:
         """Provide a last trace id for lookup."""
@@ -126,6 +131,6 @@ def test_maybe_get_trace_url_returns_none_on_client_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Return none when the Langfuse client cannot resolve the trace URL."""
-    monkeypatch.setattr(lf, "get_client", lambda: DummyClient(should_fail=True))
+    monkeypatch.setattr(lf_core, "get_client", lambda: DummyClient(should_fail=True))
 
     assert lf.maybe_get_trace_url() is None


### PR DESCRIPTION
## Why

Right now `pip install hexgate` pulls the world: LangChain, LangGraph, Langfuse, LiteLLM, the OpenAI Agents SDK, Pydantic AI, Google ADK. Anyone building on one framework still pays for all of them at install time and at import time. The plan is to make each framework SDK an opt-in extra (`pip install hexgate[langchain]`, `[openai]`, `[google]`, `[pydantic-ai]`, `[all]`), so people only get what they use.

Before we can do that, a few bits of the core need to stop dragging LangChain into places that have nothing to do with it. This PR is that prep work.

## What changed

Three shared pieces used to force a LangChain load on anyone who touched them:

1. `ApprovalHandler` lived in `hexgate.agents.factory`, which imports half of LangGraph. Adapter code only needed the type alias, not the factory.
2. The Langfuse tracing module bundled the framework-agnostic helpers (`observe`, `get_client`, `maybe_get_trace_url`) with the LangChain callback handler, so a caller that just wanted a trace URL still paid for `langfuse.langchain` + `langchain_core.runnables`.
3. `@agent_tool` imported LangChain's `@tool` at module load, so every module that decorates a built-in tool triggered LangChain even when the user was on a different framework.

Fixed by extracting `hexgate.approvals` (framework-agnostic type alias), splitting the tracing module into `langfuse_core` (framework-agnostic) and `langfuse` (LangChain-tied), and making the `@tool` import lazy inside `@agent_tool`. All old import paths keep working via re-exports, so no downstream code breaks.

Nothing about install or runtime behavior changes yet. That comes in PR 2 (pyproject extras + lazy `hexgate/__init__.py` + CI matrix).

## Files worth a look

- `hexgate/approvals.py` (new): the framework-agnostic type alias
- `hexgate/tracing/langfuse_core.py` (new): observe, get_client, maybe_get_trace_url, LangfuseHandler protocol
- `hexgate/tracing/langfuse.py`: shrunk to the LangChain callback handler bits, re-exports the core names for BC
- `hexgate/agents/factory.py`: `ApprovalHandler` re-exported for BC, no other change
- `hexgate/tools/decorators.py`: `@agent_tool` now imports LangChain's `@tool` lazily at decoration time
- `hexgate/tools/__init__.py`: lazy `__getattr__` scaffolding for PR 2 (savings don't land yet)
- `hexgate/cli/chat.py`: migrated to `langfuse_core` so `hexgate chat` no longer drags LangChain just to resolve a trace URL
- `hexgate/adapters/**`: 9 files, mechanical `ApprovalHandler` import swap

## Verified

- 1484 tests pass
- ruff clean, fmt clean, 87.1% branch coverage
- confirmed `import hexgate.adapters.openai.tools` adds zero LangChain modules on top of `hexgate.approvals`

## Note for reviewers who write tests against the SDK

`maybe_get_trace_url` now reads `get_client` from `hexgate.tracing.langfuse_core`. If you were monkeypatching `hexgate.tracing.langfuse.get_client` in a test, the patch will succeed (the name still exists via re-export) but no longer intercepts the callee. Patch `hexgate.tracing.langfuse_core.get_client` instead.