### PR TITLE
Add the gates demo: marimo narrative, policy, and one-box launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,10 @@ policy-test-wasm: ## Smoke a wasm-engine decision on the example policy
 demo-mcp: ## Run the MCP-proxy demo (self-contained, no external services or LLM key)
 	$(UV) python examples/mcp_demo.py
 
+.PHONY: demo-gates
+demo-gates: ## Open the gates showcase notebook (agent + MCP + policy; no LLM key). Local only — does NOT touch the Daytona snapshot.
+	$(UV) --with marimo marimo edit deploy/gates-demo/notebook.py
+
 .PHONY: demo-override
 demo-override: ## Build a deny-everything bundle + chat with HEXGATE_LOCAL_POLICY set
 	@echo "→ Writing a deny-everything override policy…"

--- a/deploy/boot.py
+++ b/deploy/boot.py
@@ -102,28 +102,28 @@ def start_services(dash_url: str | None = None) -> dict[str, str]:
     if hexkit_url:
         HEXKIT_URL_FILE.write_text(hexkit_url)
 
-    # --- Seed + mint the serve token BEFORE starting the API ------------
-    # provision talks to the shared SQLite + keystore directly (it doesn't
-    # need the API up), and it seeds docs_agent. Doing it first means the API's
-    # startup backfill_bundles compiles docs_agent's policy bundle — do it after
-    # the API boots and backfill has already run, and docs_agent is left
-    # bundle-less (usable only via the pydantic fallback, and unsignable).
-    sys.path.insert(0, str(DEPLOY_DIR))
-    sys.path.insert(0, str(API_DIR))
-    from provision import provision_serve_token  # noqa: E402  (path set above)
-
-    SERVE_KEY_FILE.write_text(provision_serve_token())
-    print("[boot] seeded demo agents + minted HEXGATE_API_KEY", flush=True)
-
     # --- Platform API (background) --------------------------------------
-    # Its lifespan re-runs the (idempotent) seed and compiles any missing
-    # bundles — including docs_agent's, now that it exists.
     _spawn(
         ["uvicorn", "hexgate_api.main:app", "--host", "0.0.0.0", "--port", str(API_PORT)],
         cwd=API_DIR,
         env=env,
     )
     _wait_healthy(f"{api_base}/v1/.well-known/keys")
+
+    # --- Mint the serve token + seed AFTER the API is healthy -----------
+    # Must come after _wait_healthy: run-integrated.sh treats SERVE_KEY_FILE
+    # appearing as "platform ready" and immediately binds the hexkit backend to
+    # the API, so the key must not exist before uvicorn answers. docs_agent is
+    # seeded without a compiled bundle — the SDK binds it via the pydantic
+    # policy_yaml fallback, which is fine here (the demo never requires signed
+    # bundles). The seed is best-effort (see provision) so a bad policy.yaml
+    # can't take down the BYOK notebook path.
+    sys.path.insert(0, str(DEPLOY_DIR))
+    sys.path.insert(0, str(API_DIR))
+    from provision import provision_serve_token  # noqa: E402  (path set above)
+
+    SERVE_KEY_FILE.write_text(provision_serve_token())
+    print("[boot] seeded demo agents + minted HEXGATE_API_KEY", flush=True)
     # serve itself runs in the notebook kernel (serve_manager), bound to the
     # live agent object. boot only hands it the key (file) + HEXGATE_API_URL (env).
     return env

--- a/deploy/boot.py
+++ b/deploy/boot.py
@@ -32,11 +32,16 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent          # repo root
 API_DIR = REPO_ROOT / "platform" / "api"
 DEPLOY_DIR = Path(__file__).resolve().parent
-NOTEBOOK = DEPLOY_DIR / "demo_notebook.py"
+# Which notebook marimo serves. Defaults to the BYOK "define your own agent"
+# demo; the gates demo sets HEXGATE_NOTEBOOK=deploy/gates-demo/notebook.py.
+NOTEBOOK = Path(os.environ.get("HEXGATE_NOTEBOOK", str(DEPLOY_DIR / "demo_notebook.py")))
 
 API_PORT = int(os.environ.get("HEXGATE_API_PORT", "8000"))
 MARIMO_PORT = int(os.environ.get("HEXGATE_MARIMO_PORT", "2718"))
 DASH_URL_FILE = Path(os.environ.get("HEXGATE_DASH_URL_FILE", "/tmp/hexgate_dash_url"))
+# The public hexkit URL, when the integrated (gates) demo runs hexkit alongside.
+# The notebook's "run it in a different app" section links to it if present.
+HEXKIT_URL_FILE = Path(os.environ.get("HEXGATE_HEXKIT_URL_FILE", "/tmp/hexkit_url"))
 SERVE_KEY_FILE = Path(os.environ.get("HEXGATE_SERVE_KEY_FILE", "/tmp/hexgate_serve_key"))
 
 _procs: list[subprocess.Popen] = []
@@ -90,21 +95,35 @@ def start_services(dash_url: str | None = None) -> dict[str, str]:
     # local API origin when not running behind a tunnel (local testing).
     DASH_URL_FILE.write_text((dash_url or api_base).strip())
 
+    # Publish the public hexkit URL too, when the integrated demo passes one
+    # (HEXGATE_HEXKIT_URL). The gates notebook links to it; absent = the
+    # notebook shows its "running locally" note instead.
+    hexkit_url = os.environ.get("HEXGATE_HEXKIT_URL", "").strip()
+    if hexkit_url:
+        HEXKIT_URL_FILE.write_text(hexkit_url)
+
+    # --- Seed + mint the serve token BEFORE starting the API ------------
+    # provision talks to the shared SQLite + keystore directly (it doesn't
+    # need the API up), and it seeds docs_agent. Doing it first means the API's
+    # startup backfill_bundles compiles docs_agent's policy bundle — do it after
+    # the API boots and backfill has already run, and docs_agent is left
+    # bundle-less (usable only via the pydantic fallback, and unsignable).
+    sys.path.insert(0, str(DEPLOY_DIR))
+    sys.path.insert(0, str(API_DIR))
+    from provision import provision_serve_token  # noqa: E402  (path set above)
+
+    SERVE_KEY_FILE.write_text(provision_serve_token())
+    print("[boot] seeded demo agents + minted HEXGATE_API_KEY", flush=True)
+
     # --- Platform API (background) --------------------------------------
+    # Its lifespan re-runs the (idempotent) seed and compiles any missing
+    # bundles — including docs_agent's, now that it exists.
     _spawn(
         ["uvicorn", "hexgate_api.main:app", "--host", "0.0.0.0", "--port", str(API_PORT)],
         cwd=API_DIR,
         env=env,
     )
     _wait_healthy(f"{api_base}/v1/.well-known/keys")
-
-    # --- Mint the serve token (shares the now-seeded SQLite + keystore) ---
-    sys.path.insert(0, str(DEPLOY_DIR))
-    sys.path.insert(0, str(API_DIR))
-    from provision import provision_serve_token  # noqa: E402  (path set above)
-
-    SERVE_KEY_FILE.write_text(provision_serve_token())
-    print("[boot] minted HEXGATE_API_KEY for seeded project", flush=True)
     # serve itself runs in the notebook kernel (serve_manager), bound to the
     # live agent object. boot only hands it the key (file) + HEXGATE_API_URL (env).
     return env

--- a/deploy/daytona_full_snapshot.py
+++ b/deploy/daytona_full_snapshot.py
@@ -34,10 +34,11 @@ from daytona import (
 SNAPSHOT = "hexgate-hexkit-demo"
 HEXGATE_REPO = "https://github.com/HexamindOrganisation/hexgate"
 HEXKIT_REPO = "https://github.com/HexamindOrganisation/hexkit"
-# Branches to bake. Both default to main. Until the gates PR (#81) lands, run
-# with HEXGATE_REF=feat/gates-demo (hexkit's gdocs-agent #16 is already on main).
-# Override either with HEXGATE_REF / HEXKIT_REF.
-HEXGATE_REF = os.environ.get("HEXGATE_REF", "main")
+# Branches to bake. hexkit is on main (gdocs-agent #16 merged). hexgate is
+# pinned to the gates branch INTERIM so the demo builds with no override — the
+# gates code isn't on main yet. FLIP TO "main" WHEN #81 MERGES (tracked as the
+# productionization follow-up). Override either with HEXGATE_REF / HEXKIT_REF.
+HEXGATE_REF = os.environ.get("HEXGATE_REF", "feat/gates-demo")
 HEXKIT_REF = os.environ.get("HEXKIT_REF", "main")
 
 

--- a/deploy/daytona_full_snapshot.py
+++ b/deploy/daytona_full_snapshot.py
@@ -34,11 +34,11 @@ from daytona import (
 SNAPSHOT = "hexgate-hexkit-demo"
 HEXGATE_REPO = "https://github.com/HexamindOrganisation/hexgate"
 HEXKIT_REPO = "https://github.com/HexamindOrganisation/hexkit"
-# Branches to bake. hexkit is on main (gdocs-agent #16 merged). hexgate is
-# pinned to the gates branch INTERIM so the demo builds with no override — the
-# gates code isn't on main yet. FLIP TO "main" WHEN #81 MERGES (tracked as the
-# productionization follow-up). Override either with HEXGATE_REF / HEXKIT_REF.
-HEXGATE_REF = os.environ.get("HEXGATE_REF", "feat/gates-demo")
+# Branches to bake. Both default to main (so this is safe to merge). Until the
+# gates PR (#81) lands, the gates code isn't on main — pass
+# HEXGATE_REF=feat/gates-demo to build the full demo in the meantime. Override
+# either with HEXGATE_REF / HEXKIT_REF.
+HEXGATE_REF = os.environ.get("HEXGATE_REF", "main")
 HEXKIT_REF = os.environ.get("HEXKIT_REF", "main")
 
 

--- a/deploy/daytona_full_snapshot.py
+++ b/deploy/daytona_full_snapshot.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Build the COMBINED snapshot for the end-to-end gates demo:
+hexgate (platform + marimo) + hexkit (the "any app" agent UI), baked together.
+
+Clones BOTH repos and runs their own setup so a single Daytona sandbox can host
+the whole stack (platform + marimo + hexkit's tiers + the gdocs backend). The
+manual end-to-end launcher — spawn it with deploy/daytona_full_spawn.py. (The
+committed single-repo path is deploy/daytona_snapshot.py + the daytona-snapshot
+workflow; wiring this combined build into CI is the post-#81 follow-up.)
+
+    export DAYTONA_API_KEY=dtn_...
+    uv run --with daytona python deploy/daytona_full_snapshot.py          # reuse if exists
+    uv run --with daytona python deploy/daytona_full_snapshot.py --force  # delete + rebuild
+
+Then: uv run --with daytona python deploy/daytona_full_spawn.py
+
+Heavy build (two repos, two Node builds) — expect a few minutes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+from daytona import (
+    CreateSnapshotParams,
+    Daytona,
+    DaytonaConfig,
+    Image,
+    Resources,
+)
+
+SNAPSHOT = "hexgate-hexkit-demo"
+HEXGATE_REPO = "https://github.com/HexamindOrganisation/hexgate"
+HEXKIT_REPO = "https://github.com/HexamindOrganisation/hexkit"
+# Branches to bake. Both default to main. Until the gates PR (#81) lands, run
+# with HEXGATE_REF=feat/gates-demo (hexkit's gdocs-agent #16 is already on main).
+# Override either with HEXGATE_REF / HEXKIT_REF.
+HEXGATE_REF = os.environ.get("HEXGATE_REF", "main")
+HEXKIT_REF = os.environ.get("HEXKIT_REF", "main")
+
+
+def _delete_snapshot(daytona: Daytona) -> None:
+    daytona.snapshot.delete(daytona.snapshot.get(SNAPSHOT))
+
+
+def main() -> None:
+    daytona = Daytona(DaytonaConfig(api_key=os.environ["DAYTONA_API_KEY"]))
+
+    image = (
+        Image.base("python:3.13-slim-bookworm")
+        .run_commands(
+            "apt-get update && apt-get install -y --no-install-recommends "
+            "git curl ca-certificates gnupg make psmisc",  # make + fuser (run-backends.sh)
+            "curl -fsSL https://deb.nodesource.com/setup_20.x | bash - "
+            "&& apt-get install -y nodejs",
+            "npm install -g pnpm@9",
+            "pip install --no-cache-dir uv",
+            # ---- hexgate (platform API + dashboard + marimo) at /app ----
+            f"git clone --depth 1 --branch {HEXGATE_REF} {HEXGATE_REPO} /app",
+            "cd /app/platform/api && uv sync",
+            "uv pip install --python /app/platform/api/.venv marimo",
+            "cd /app/platform/dashboard && pnpm install --frozen-lockfile && pnpm build",
+            # ---- hexkit (front-app + proxy + agent-server) at /hexkit ----
+            f"git clone --depth 1 --branch {HEXKIT_REF} {HEXKIT_REPO} /hexkit",
+            "cd /hexkit && make setup",            # venvs + custom-UI build + front-app npm install
+            "cd /hexkit && make install-hexgate",  # agent-server venv → py3.13 + hexgate (>=0.2.8, has mcp)
+            # ---- the gates demo's gdocs agent backend (its own py3.13 venv) ----
+            "cd /hexkit && uv venv --python 3.13 demo/gdocs-agent/.venv",
+            "cd /hexkit && uv pip install --python demo/gdocs-agent/.venv -e demo/gdocs-agent",
+        )
+        .workdir("/app")
+    )
+
+    def _create() -> None:
+        print("Building COMBINED snapshot (several minutes; logs stream)…\n")
+        daytona.snapshot.create(
+            CreateSnapshotParams(
+                name=SNAPSHOT,
+                image=image,
+                # Max Daytona allows. Two repos + two node builds + venvs is heavy;
+                # if disk overflows at build time, that's a signal we're too big.
+                resources=Resources(cpu=4, memory=8, disk=10),
+            ),
+            on_logs=lambda chunk: print(chunk, end=""),
+        )
+
+    try:
+        _create()
+    except Exception as exc:  # noqa: BLE001
+        if "already exists" not in str(exc).lower():
+            raise
+        if "--force" not in sys.argv:
+            print(f"\n✅ snapshot '{SNAPSHOT}' already exists — reusing it.")
+            print("   Run with --force to delete + rebuild.")
+            return
+        print(f"\nSnapshot '{SNAPSHOT}' exists — deleting + rebuilding (--force)…")
+        _delete_snapshot(daytona)
+        for _ in range(20):
+            try:
+                _create()
+                break
+            except Exception as e:  # noqa: BLE001
+                if "already exists" in str(e).lower():
+                    time.sleep(3)
+                    continue
+                raise
+        else:
+            raise SystemExit(f"'{SNAPSHOT}' still present after delete — clear it in the dashboard.")
+
+    print(f"\n\n✅ snapshot '{SNAPSHOT}' ready. Next: python deploy/daytona_full_spawn.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/daytona_full_spawn.py
+++ b/deploy/daytona_full_spawn.py
@@ -102,15 +102,28 @@ def main() -> None:
         print("\n==== MEMORY (cgroup — the whole point) ====")
         print(" ", _mem(sandbox))
         print("==== PORT READINESS  (proxy :8800 -> 404 is EXPECTED — it serves /api) ====")
+        any_up = False
         for label, port in ALL_PORTS.items():
             code = _stdout(sandbox.process.exec(
                 f"curl -s -o /dev/null -w '%{{http_code}}' http://localhost:{port} || echo 000"
             )).strip()
+            any_up = any_up or (code not in ("", "000", "000000"))
             print(f"  {label:16} :{port}  -> {code}")
-        for log in ("gates", "gates-hexgate", "gates-agent", "gates-proxy", "gates-frontend"):
-            oom = _stdout(sandbox.process.exec(f"grep -i -m1 killed /tmp/{log}.log || true")).strip()
+        # Only greps logs that actually exist — a MISSING log means the stack
+        # never launched (not an OOM). If nothing came up, dump the top-level
+        # log (the boot command's stdout/stderr) so the real error is visible.
+        for log in ("gates-hexgate", "gates-agent", "gates-proxy", "gates-frontend"):
+            oom = _stdout(sandbox.process.exec(
+                f"test -f /tmp/{log}.log && grep -i -m1 killed /tmp/{log}.log || true"
+            )).strip()
             if oom:
                 print(f"  ⚠ possible OOM in {log}.log: {oom}")
+        if not any_up:
+            print("\n==== NOTHING CAME UP — /tmp/gates.log (boot command output) ====")
+            print(_stdout(sandbox.process.exec(
+                "cat /tmp/gates.log 2>/dev/null || echo '(no /tmp/gates.log — run-integrated.sh never ran; "
+                "is deploy/gates-demo/ in the snapshot? check HEXGATE_REF)'"
+            )))
 
         print("\n==== SIGNED URLS ====")
         print("  marimo notebook :", _signed(sandbox, MARIMO_PORT))

--- a/deploy/daytona_full_spawn.py
+++ b/deploy/daytona_full_spawn.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Spawn the end-to-end gates demo in one Daytona sandbox: hexgate platform +
+marimo + hexkit (proxy + front-app + gdocs backend), all at once. Boots the
+stack via deploy/gates-demo/run-integrated.sh, reports memory + which ports
+answer, then hands you the signed URLs (marimo notebook, dashboard, hexkit UI).
+
+    export DAYTONA_API_KEY=dtn_...
+    uv run --with daytona python deploy/daytona_full_spawn.py   # after building the snapshot
+
+The sandbox is ephemeral (auto-stops when idle) and deleted on exit. Build the
+snapshot first with deploy/daytona_full_snapshot.py.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from daytona import CreateSandboxFromSnapshotParams, Daytona, DaytonaConfig, SessionExecuteRequest
+
+SNAPSHOT = "hexgate-hexkit-demo"
+HEXGATE_VENV = "/app/platform/api/.venv/bin"
+
+# Browser-facing ports (need signed preview URLs; must be in 3000–9999).
+MARIMO_PORT = 3000    # hexgate marimo notebook (the tour)
+DASH_PORT = 8000      # hexgate platform API + dashboard (policy)
+HEXKIT_PORT = 8873    # hexkit front-app (the agent UI)
+# Internal (not browser-facing): hexkit proxy 8800, agent-server 8880.
+ALL_PORTS = {"marimo": 3000, "dashboard": 8000, "hexkit-proxy": 8800,
+             "hexkit-frontend": 8873, "agent-server": 8880}
+
+
+def _stdout(r) -> str:
+    # Return the stdout attr even when empty ("") — do NOT fall back to repr(r),
+    # which made the OOM grep below false-positive on empty results.
+    for attr in ("result", "output", "stdout"):
+        if hasattr(r, attr):
+            v = getattr(r, attr)
+            if v is not None:
+                return v
+    return ""
+
+
+def _mem(sandbox) -> str:
+    """Container memory via cgroup v2 (the slim image has no `free`)."""
+    cur = _stdout(sandbox.process.exec("cat /sys/fs/cgroup/memory.current 2>/dev/null || echo")).strip()
+    mx = _stdout(sandbox.process.exec("cat /sys/fs/cgroup/memory.max 2>/dev/null || echo")).strip()
+    if cur.isdigit():
+        used = int(cur) / 2**30
+        limit = "unbounded" if mx == "max" else (f"{int(mx) / 2**30:.2f} GiB" if mx.isdigit() else mx or "?")
+        return f"used {used:.2f} GiB / limit {limit}"
+    mi = _stdout(sandbox.process.exec("head -3 /proc/meminfo 2>/dev/null || echo")).strip()
+    return mi or "memory unavailable"
+
+
+def _signed(sandbox, port: int) -> str:
+    try:
+        return sandbox.create_signed_preview_url(port, expires_in_seconds=3600).url
+    except AttributeError:
+        return getattr(sandbox.get_preview_link(port), "url", "?")
+
+
+def _session(sandbox, name: str, command: str) -> None:
+    sandbox.process.create_session(name)
+    sandbox.process.execute_session_command(name, SessionExecuteRequest(command=command, run_async=True))
+
+
+def _delete(daytona: Daytona, sandbox) -> None:
+    try:
+        sandbox.delete()
+    except Exception:
+        try:
+            daytona.delete(sandbox)
+        except Exception as exc:  # noqa: BLE001
+            print(f"⚠ auto-delete failed ({exc}) — delete it in the dashboard.")
+            return
+    print("✅ sandbox deleted.")
+
+
+def main() -> None:
+    daytona = Daytona(DaytonaConfig(api_key=os.environ["DAYTONA_API_KEY"]))
+    print(f"Creating sandbox from '{SNAPSHOT}'…")
+    sandbox = daytona.create(
+        CreateSandboxFromSnapshotParams(snapshot=SNAPSHOT, auto_stop_interval=15, ephemeral=True)
+    )
+    try:
+        dash_url = _signed(sandbox, DASH_PORT)
+        hexkit_url = _signed(sandbox, HEXKIT_PORT)
+
+        # One session runs the whole integrated gates demo: platform + marimo
+        # (gates notebook) + gdocs backend + proxy + front-app. The signed public
+        # URLs are passed in so the notebook can link to hexkit + the dashboard.
+        _session(sandbox, "gates",
+                 f"cd /app && HEXGATE_DASH_URL='{dash_url}' HEXGATE_HEXKIT_URL='{hexkit_url}' "
+                 f"HEXGATE_MARIMO_PORT={MARIMO_PORT} "
+                 f"bash deploy/gates-demo/run-integrated.sh > /tmp/gates.log 2>&1")
+
+        print("Booting the full stack (~90s: platform + marimo + gdocs backend + proxy + front-app)…")
+        time.sleep(100)
+
+        # --- fit report ---
+        print("\n==== MEMORY (cgroup — the whole point) ====")
+        print(" ", _mem(sandbox))
+        print("==== PORT READINESS  (proxy :8800 -> 404 is EXPECTED — it serves /api) ====")
+        for label, port in ALL_PORTS.items():
+            code = _stdout(sandbox.process.exec(
+                f"curl -s -o /dev/null -w '%{{http_code}}' http://localhost:{port} || echo 000"
+            )).strip()
+            print(f"  {label:16} :{port}  -> {code}")
+        for log in ("gates", "gates-hexgate", "gates-agent", "gates-proxy", "gates-frontend"):
+            oom = _stdout(sandbox.process.exec(f"grep -i -m1 killed /tmp/{log}.log || true")).strip()
+            if oom:
+                print(f"  ⚠ possible OOM in {log}.log: {oom}")
+
+        print("\n==== SIGNED URLS ====")
+        print("  marimo notebook :", _signed(sandbox, MARIMO_PORT))
+        print("  dashboard       :", dash_url, "(+ /v1/demo-login for auto-login)")
+        print("  hexkit UI       :", hexkit_url)
+        print("\nIf a port shows 000, tail its log: sandbox.process.exec('cat /tmp/gates*.log')")
+        input("\nPress Enter when done — the sandbox will be deleted… ")
+    finally:
+        print(f"\nDeleting sandbox {getattr(sandbox, 'id', '?')}…")
+        _delete(daytona, sandbox)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/daytona_snapshot.py
+++ b/deploy/daytona_snapshot.py
@@ -74,9 +74,12 @@ def main() -> None:
             CreateSnapshotParams(
                 name=SNAPSHOT,
                 image=image,
-                # Daytona's per-sandbox ceiling — the demo runs two heavy Python
-                # processes (API + marimo kernel), so give it the max.
-                resources=Resources(cpu=4, memory=8, disk=10),
+                # Small per-sandbox footprint so many demos run concurrently
+                # within the Daytona account quota (~10× at 1 GB vs 8 GB). The
+                # demo only uses ~0.76 GB at peak (measured on the bigger combined
+                # stack), so 1 GB is enough. Bump `memory` to 2 if a live LLM run
+                # OOMs, or `disk` if the image doesn't fit at build time.
+                resources=Resources(cpu=1, memory=1, disk=5),
             ),
             on_logs=lambda chunk: print(chunk, end=""),
         )

--- a/deploy/daytona_snapshot.py
+++ b/deploy/daytona_snapshot.py
@@ -75,11 +75,12 @@ def main() -> None:
                 name=SNAPSHOT,
                 image=image,
                 # Small per-sandbox footprint so many demos run concurrently
-                # within the Daytona account quota (~10× at 1 GB vs 8 GB). The
-                # demo only uses ~0.76 GB at peak (measured on the bigger combined
-                # stack), so 1 GB is enough. Bump `memory` to 2 if a live LLM run
-                # OOMs, or `disk` if the image doesn't fit at build time.
-                resources=Resources(cpu=1, memory=1, disk=5),
+                # within the Daytona account quota (~5× at 2 GB vs 8 GB). 2 GB
+                # leaves headroom over the ~0.76 GB idle peak for a live LLM turn
+                # (uvicorn + marimo kernel + ChatOpenAI) and the dashboard build.
+                # Drop to 1 to pack more in if runs stay light; raise `disk` if
+                # the image doesn't fit at build time.
+                resources=Resources(cpu=1, memory=2, disk=5),
             ),
             on_logs=lambda chunk: print(chunk, end=""),
         )

--- a/deploy/demo_notebook.py
+++ b/deploy/demo_notebook.py
@@ -51,6 +51,40 @@ def _(mo):
 
 @app.cell
 def _(mo):
+    # A picture of the one idea: every tool call detours through the gate, which
+    # answers allow / deny / approval from the policy + the caller's role.
+    _diagram = mo.mermaid(
+        """
+        flowchart LR
+            You["🧑 you<br/>define agent + tools"] --> Agent["🤖 agent"]
+            Agent -->|"tool call + args"| Gate
+            subgraph HG ["🛡️ hexgate"]
+                Gate["PolicyEnforcer"] --> Q{"role +<br/>args ok?"}
+            end
+            Q -->|allow| Tool["🔧 tool runs"]
+            Q -->|deny| Blk["⛔ blocked"]
+            Q -->|approval| Human["🙋 you approve<br/>in the Playground"]
+            Human -->|approved| Tool
+        """
+    )
+    mo.vstack(
+        [
+            mo.md("## How hexgate works"),
+            _diagram,
+            mo.md(
+                "Your agent runs behind the **gate**: every tool call is checked "
+                "against a **policy** — the caller's **role** and the call's "
+                "**arguments** — and comes back **allow / deny / approval** before "
+                "it runs. The policy lives on the platform; you watch decisions "
+                "and approve them live in the dashboard **Playground**."
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
     mo.md("""
     ## 1 · Define your tools
     """)
@@ -162,6 +196,38 @@ def _(api_key, build_agent, mo, serve_manager, start):
             "enter your key above and click **Start agent**."
         )
     out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## The policy that governs it
+
+    A policy is a small YAML file: **default-deny**, then per-tool rules with
+    optional **argument constraints**. Here's one for the tools above — view and
+    edit it live in the Playground's **Policies** tab, and the next message obeys
+    it.
+
+    ```yaml
+    version: 1
+
+    default_policy:
+      mode: deny                 # nothing runs unless a rule allows it
+
+    tools:
+      get_order_status:
+        mode: allow              # safe read — always allowed
+
+      refund_order:
+        mode: approval_required  # side-effecting — a human approves it
+        constraints:
+          - args.amount <= 100   # ...and only up to $100; larger is denied
+    ```
+
+    So a status lookup just **runs**, a small refund **pauses for your approval**
+    in the Playground, and a refund over $100 is **denied**.
+    """)
     return
 
 

--- a/deploy/gates-demo/README.md
+++ b/deploy/gates-demo/README.md
@@ -1,0 +1,80 @@
+# Gates demo — one agent, one MCP server, one policy
+
+A self-contained showcase of hexgate's **gate**: an agent connects to a
+third-party MCP server, inherits all its tools, and every call is run through a
+role-aware, constraint-based policy — **allow or deny, before the call reaches
+the server**.
+
+The story it tells: *hexgate plugs into whatever app you run your agents in.*
+The notebook is the agent's **definition** (code + tools + gate diagram +
+policy); the same gated agent then runs from a different UI (hexkit) with the
+policy console showing the exact policy loaded here.
+
+## Files
+
+| file | what it is |
+|---|---|
+| `notebook.py` | the marimo showcase — diagram, agent code, policy, and the live gate |
+| `gdocs_mcp_server.py` | a fake Google Docs MCP server (6 tools) we gate but don't control |
+| `policy.yaml` | the complex policy — default-deny, 3 roles, argument constraints |
+
+## Run it
+
+### 1 · Just the notebook (fastest — no OpenAI key)
+
+The gate runs in-kernel over the real MCP server, so you see every decision
+without a model. From the repo root:
+
+```bash
+uv run --active marimo edit deploy/gates-demo/notebook.py
+```
+
+(Needs `marimo` in the active env: `uv pip install --python platform/api/.venv marimo`.)
+
+Read it top to bottom: the gate diagram, the agent code you'd write, the policy,
+then the decision table + a "try it" form where you pick a role, edit the args,
+and watch the gate decide.
+
+### 2 · The one-box integrated demo (the full story)
+
+This is where "hexgate plugs into any app" becomes real: **platform + dashboard
++ marimo (this notebook) + hexkit**, all in one container, running the *same*
+gated agent.
+
+- The notebook is the landing page (the **definition**).
+- **hexkit** runs the agent (`docs` / "Docs Assistant") from a chat UI — the
+  gdocs backend is `github.com/.../hexkit` at `demo/gdocs-agent/`.
+- The **dashboard** holds the authoritative `docs_agent` policy (seeded by
+  `deploy/provision.py`); edit it there and hexkit's next call reflects it.
+
+`deploy/gates-demo/run-integrated.sh` brings the whole box up (platform + marimo
++ gdocs backend + proxy + front-app); the notebook's section 6 collects the BYOK
+key (posted in-memory to the backend) and links to hexkit + the dashboard.
+
+Sign in to hexkit as `ana` (analyst), `ed` (editor), or `adah` (admin) —
+password `hexademo` — to watch the same request allowed for one role and denied
+for another.
+
+Build/spawn it with the combined snapshot: `deploy/daytona_full_snapshot.py`
+then `deploy/daytona_full_spawn.py` (requires the hexgate + hexkit branches
+pushed, since the snapshot clones them).
+
+## What the policy shows
+
+`policy.yaml` is **default-deny** and governs three roles (`analyst` → `editor`
+→ `admin`) that inherit from a read-only base, so one file decides what each
+role may do. Every `allow` is narrowed by the constraint DSL:
+
+| feature | rule | stops |
+|---|---|---|
+| `startswith` | `read_doc` | reading `CONF-*` docs (admins excepted, by override) |
+| `every(...)` + `endswith` | `share_doc` | sharing outside `@hexamind.ai` |
+| `count(...)` | `share_doc` | mass fan-out (> 5 recipients) |
+| `in consts.*` | `create_doc` | writing to un-sanctioned folders |
+| `matches` (regex) | `export_doc` | exporting anywhere but the internal drive |
+| `== true` | `delete_doc` | accidental deletes (needs `confirm`) |
+
+The same DSL gates native tools and MCP tools identically — MCP tools are just
+named `mcp-<server>-<tool>`. See the DSL grammar in
+`hexgate/security/constraints.py` and more policy examples in
+`examples/demo_policy.yaml`.

--- a/deploy/gates-demo/README.md
+++ b/deploy/gates-demo/README.md
@@ -54,17 +54,17 @@ in one Daytona sandbox, running the *same* gated agent.
 The combined snapshot/spawn are `deploy/daytona_full_snapshot.py` +
 `deploy/daytona_full_spawn.py` (the manual end-to-end launcher).
 
-> **Interim (until #81 merges).** These default to cloning both repos from
-> `main`, but the gates code isn't on `main` yet — so **for now prepend
-> `HEXGATE_REF=feat/gates-demo`** to the build. Drop it once #81 lands. (Wiring
-> this combined build into CI + a one-click launch is the post-#81 follow-up.)
+> **Interim (until #81 merges).** `daytona_full_snapshot.py` defaults hexgate to
+> `feat/gates-demo` (the gates code isn't on `main` yet), so the build just
+> works. Once #81 lands, run with `HEXGATE_REF=main` — the post-#81
+> productionization flips the default and wires this into CI.
 
 ```bash
 export DAYTONA_API_KEY=dtn_...
 
-# Build the combined snapshot (few minutes; --force to rebuild after a push).
-# HEXGATE_REF pins hexgate to the gates branch until #81 is on main.
-HEXGATE_REF=feat/gates-demo uv run --with daytona python deploy/daytona_full_snapshot.py
+# Build the combined snapshot (few minutes). --force replaces a stale snapshot
+# (needed whenever you change branches or push new commits).
+uv run --with daytona python deploy/daytona_full_snapshot.py --force
 
 # Spawn a sandbox, boot the stack, print the signed URLs. Enter to delete.
 uv run --with daytona python deploy/daytona_full_spawn.py

--- a/deploy/gates-demo/README.md
+++ b/deploy/gates-demo/README.md
@@ -35,29 +35,96 @@ Read it top to bottom: the gate diagram, the agent code you'd write, the policy,
 then the decision table + a "try it" form where you pick a role, edit the args,
 and watch the gate decide.
 
-### 2 · The one-box integrated demo (the full story)
+### 2 · The one-box end-to-end demo (platform + marimo + hexkit)
 
-This is where "hexgate plugs into any app" becomes real: **platform + dashboard
-+ marimo (this notebook) + hexkit**, all in one container, running the *same*
-gated agent.
+The full story: **platform + dashboard + marimo (this notebook) + hexkit**, all
+in one Daytona sandbox, running the *same* gated agent.
 
 - The notebook is the landing page (the **definition**).
 - **hexkit** runs the agent (`docs` / "Docs Assistant") from a chat UI — the
-  gdocs backend is `github.com/.../hexkit` at `demo/gdocs-agent/`.
+  gdocs backend lives in the hexkit repo at `demo/gdocs-agent/`.
 - The **dashboard** holds the authoritative `docs_agent` policy (seeded by
   `deploy/provision.py`); edit it there and hexkit's next call reflects it.
 
 `deploy/gates-demo/run-integrated.sh` brings the whole box up (platform + marimo
-+ gdocs backend + proxy + front-app); the notebook's section 6 collects the BYOK
-key (posted in-memory to the backend) and links to hexkit + the dashboard.
++ gdocs backend + proxy + front-app).
 
-Sign in to hexkit as `ana` (analyst), `ed` (editor), or `adah` (admin) —
-password `hexademo` — to watch the same request allowed for one role and denied
-for another.
+#### Build + spawn
 
-Build/spawn it with the combined snapshot: `deploy/daytona_full_snapshot.py`
-then `deploy/daytona_full_spawn.py` (requires the hexgate + hexkit branches
-pushed, since the snapshot clones them).
+> **Interim (until #81 merges).** The combined snapshot/spawn are the local
+> scripts `deploy/daytona_full_snapshot.py` + `deploy/daytona_full_spawn.py`
+> (not committed yet). They default to cloning hexgate from `feat/gates-demo`
+> and hexkit from `main`; once #81 is on `main`, run with `HEXGATE_REF=main`.
+
+```bash
+export DAYTONA_API_KEY=dtn_...
+
+# Build the combined snapshot (few minutes; --force to rebuild after a push).
+uv run --with daytona python deploy/daytona_full_snapshot.py
+
+# Spawn a sandbox, boot the stack, print the signed URLs. Enter to delete.
+uv run --with daytona python deploy/daytona_full_spawn.py
+```
+
+The spawn prints three signed URLs: **marimo notebook** (:3000), **dashboard**
+(:8000), **hexkit UI** (:8873).
+
+#### 1. Notebook — start the agent (BYOK)
+
+Open the marimo URL, read top to bottom, and at **section 6** paste your OpenAI
+key → **Send**. The key is posted in-memory to the gdocs backend (never written
+to disk); the live hexkit agent uses it.
+
+#### 2. hexkit — chat as different roles
+
+Open the hexkit URL and sign in (password **`hexademo`** for all):
+
+| login | role | can do |
+|---|---|---|
+| `ana@hexamind.ai` | analyst | search + read (not confidential docs) |
+| `ed@hexamind.ai` | editor | + create, share inside `@hexamind.ai` |
+| `adah@hexamind.ai` | admin | everything, with guardrails |
+
+Pick **Docs Assistant**, then type these — the agent turns each into a
+`mcp-gdocs-*` tool call and the gate decides; a **denied** call shows as a failed
+call in the tool-calls widget. (Docs in the fake server: `DOC-101` "Q3 launch
+plan", `DOC-102` "Onboarding checklist", `CONF-900` "Acquisition terms".)
+
+**As `ana` (analyst):**
+| say | expect | why |
+|---|---|---|
+| `Search docs for "launch"` | ✅ allow | reads are always allowed |
+| `Read DOC-101` | ✅ allow | non-confidential read |
+| `Read CONF-900` | ❌ deny | `not startswith(doc_id, "CONF-")` |
+| `Create a doc called "Notes" in Drafts` | ❌ deny | analyst has no create rule (default-deny) |
+
+**As `ed` (editor):**
+| say | expect | why |
+|---|---|---|
+| `Create a doc "Sprint plan" in Drafts` | ✅ allow | title set + Drafts is a sanctioned folder |
+| `Share DOC-101 with dana@hexamind.ai` | ✅ allow | recipient is internal |
+| `Share DOC-101 with someone@gmail.com` | ❌ deny | `every(recipients, endswith "@hexamind.ai")` |
+| `Share DOC-101 with dana@hexamind.ai as owner` | ❌ deny | `role != "owner"` |
+| `Export DOC-101 to https://pastebin.com/x` | ❌ deny | editors can't export at all |
+| `Delete DOC-102` | ❌ deny | editors can't delete |
+
+**As `adah` (admin):**
+| say | expect | why |
+|---|---|---|
+| `Read CONF-900` | ✅ allow | admin overrides the confidential-read block |
+| `Export CONF-900 to https://drive.hexamind.ai/exports/1` | ✅ allow | `matches` the internal-drive URL |
+| `Export CONF-900 to https://pastebin.com/x` | ❌ deny | not the internal drive |
+| `Delete DOC-102 — yes, confirm` | ✅ allow | `confirm == true` |
+
+The headline moment: the **same** request (`share_doc`, `read_doc`, `delete_doc`)
+is allowed for one role/arg and denied for another — the tool name never
+changes, the gate does.
+
+#### 3. Dashboard — edit the policy live
+
+Open the dashboard URL + `/v1/demo-login` → **Policies → `docs_agent`**. Change a
+constraint (e.g. add `"@partner.com"` to the allowed share domains, or flip a
+`deny` to `allow`) and save — hexkit's **next** message reflects it, no restart.
 
 ## What the policy shows
 

--- a/deploy/gates-demo/README.md
+++ b/deploy/gates-demo/README.md
@@ -51,16 +51,20 @@ in one Daytona sandbox, running the *same* gated agent.
 
 #### Build + spawn
 
-> **Interim (until #81 merges).** The combined snapshot/spawn are the local
-> scripts `deploy/daytona_full_snapshot.py` + `deploy/daytona_full_spawn.py`
-> (not committed yet). They default to cloning hexgate from `feat/gates-demo`
-> and hexkit from `main`; once #81 is on `main`, run with `HEXGATE_REF=main`.
+The combined snapshot/spawn are `deploy/daytona_full_snapshot.py` +
+`deploy/daytona_full_spawn.py` (the manual end-to-end launcher).
+
+> **Interim (until #81 merges).** These default to cloning both repos from
+> `main`, but the gates code isn't on `main` yet — so **for now prepend
+> `HEXGATE_REF=feat/gates-demo`** to the build. Drop it once #81 lands. (Wiring
+> this combined build into CI + a one-click launch is the post-#81 follow-up.)
 
 ```bash
 export DAYTONA_API_KEY=dtn_...
 
 # Build the combined snapshot (few minutes; --force to rebuild after a push).
-uv run --with daytona python deploy/daytona_full_snapshot.py
+# HEXGATE_REF pins hexgate to the gates branch until #81 is on main.
+HEXGATE_REF=feat/gates-demo uv run --with daytona python deploy/daytona_full_snapshot.py
 
 # Spawn a sandbox, boot the stack, print the signed URLs. Enter to delete.
 uv run --with daytona python deploy/daytona_full_spawn.py

--- a/deploy/gates-demo/README.md
+++ b/deploy/gates-demo/README.md
@@ -54,17 +54,17 @@ in one Daytona sandbox, running the *same* gated agent.
 The combined snapshot/spawn are `deploy/daytona_full_snapshot.py` +
 `deploy/daytona_full_spawn.py` (the manual end-to-end launcher).
 
-> **Interim (until #81 merges).** `daytona_full_snapshot.py` defaults hexgate to
-> `feat/gates-demo` (the gates code isn't on `main` yet), so the build just
-> works. Once #81 lands, run with `HEXGATE_REF=main` — the post-#81
-> productionization flips the default and wires this into CI.
+> **Interim (until #81 merges).** `daytona_full_snapshot.py` defaults both repos
+> to `main`, but the gates code isn't on `main` yet — so **prepend
+> `HEXGATE_REF=feat/gates-demo`** to the build for now. Drop it once #81 lands.
 
 ```bash
 export DAYTONA_API_KEY=dtn_...
 
 # Build the combined snapshot (few minutes). --force replaces a stale snapshot
-# (needed whenever you change branches or push new commits).
-uv run --with daytona python deploy/daytona_full_snapshot.py --force
+# (needed whenever you change branches or push new commits). HEXGATE_REF pins
+# hexgate to the gates branch until #81 is on main; drop it after the merge.
+HEXGATE_REF=feat/gates-demo uv run --with daytona python deploy/daytona_full_snapshot.py --force
 
 # Spawn a sandbox, boot the stack, print the signed URLs. Enter to delete.
 uv run --with daytona python deploy/daytona_full_spawn.py

--- a/deploy/gates-demo/gdocs_mcp_server.py
+++ b/deploy/gates-demo/gdocs_mcp_server.py
@@ -1,0 +1,76 @@
+"""Fake Google Docs MCP server for the gates demo (deploy/gates-demo/notebook.py).
+
+Stands in for a real third-party MCP server (e.g. an official Google Docs one)
+so the demo has no external dependency and no OAuth. The notebook spawns it over
+stdio:
+
+    python deploy/gates-demo/gdocs_mcp_server.py
+
+The point of the demo is that we do NOT control this server — it decides which
+tools to expose; hexgate's policy decides what our agent may actually call. The
+tools are chosen to exercise the constraint DSL (arg values, list quantifiers,
+counts, prefixes), not to be a faithful Docs API.
+
+Its own file (not inline in the notebook) so marimo's format round-tripping
+can't strip it.
+"""
+
+from __future__ import annotations
+
+from mcp.server.fastmcp import FastMCP
+
+server = FastMCP("gdocs")
+
+# A tiny in-memory corpus. "CONF-" ids are confidential — the policy blocks
+# reads of them for everyone but admins.
+_DOCS = {
+    "DOC-101": {"title": "Q3 launch plan", "body": "Ship the gate on the 14th."},
+    "DOC-102": {"title": "Onboarding checklist", "body": "Laptop, badge, VPN."},
+    "CONF-900": {"title": "Acquisition terms", "body": "Project Falcon — $42M."},
+}
+
+
+@server.tool(description="Search docs by a keyword in the title. Read-only.")
+def search_docs(query: str) -> str:
+    hits = [
+        f"{doc_id}: {d['title']}"
+        for doc_id, d in _DOCS.items()
+        if query.lower() in d["title"].lower()
+    ]
+    return "\n".join(hits) if hits else f"no docs match {query!r}"
+
+
+@server.tool(description="Read a document's full body by id.")
+def read_doc(doc_id: str) -> str:
+    doc = _DOCS.get(doc_id)
+    return f"{doc['title']}\n\n{doc['body']}" if doc else f"no such doc: {doc_id}"
+
+
+@server.tool(description="Create a new doc in a folder. Returns the new id.")
+def create_doc(title: str, folder: str = "Drafts") -> str:
+    return f"created '{title}' in {folder} — id=DOC-{len(_DOCS) + 100}"
+
+
+@server.tool(
+    description="Share a doc with recipients at a given role (viewer/editor/owner)."
+)
+def share_doc(doc_id: str, recipients: list[str], role: str = "viewer") -> str:
+    return f"shared {doc_id} with {len(recipients)} recipient(s) as {role}"
+
+
+@server.tool(description="Export a doc by POSTing it to an external URL.")
+def export_doc(doc_id: str, url: str) -> str:
+    return f"exported {doc_id} to {url}"
+
+
+@server.tool(description="Permanently delete a doc. Destructive — needs confirm=true.")
+def delete_doc(doc_id: str, confirm: bool = False) -> str:
+    return (
+        f"deleted {doc_id}"
+        if confirm
+        else f"refused: pass confirm=true to delete {doc_id}"
+    )
+
+
+if __name__ == "__main__":
+    server.run("stdio")

--- a/deploy/gates-demo/notebook.py
+++ b/deploy/gates-demo/notebook.py
@@ -59,21 +59,14 @@ def _():
 @app.cell
 def _(mo):
     mo.md("""
-    # 🔌🛡️ Hexgate — gating an agent's MCP tools
+    # 🔌🛡️ Hexgate — govern what your agent can actually do
 
-    Point an agent at a third-party **MCP server** and it inherits *every*
-    tool that server exposes. The server decides what's on the menu; **you**
-    decide what your agent may actually order.
+    An agent on an **MCP server** inherits **all** its tools. Hexgate is the gate
+    between them: one policy says **allow / deny** on every call — by role, by
+    arguments — *before* it runs.
 
-    Hexgate is the gate in between. It runs every tool call — native or MCP —
-    through one policy engine that resolves the caller's **role**, checks the
-    **arguments** against a constraint DSL, and returns **allow** or **deny**
-    *before the call ever reaches the server*.
-
-    This notebook is the agent's **definition**: its code, its tools, the gate
-    diagram, and the policy. Then it runs the gate for real. The same agent
-    can run inside any app — the last section links to one (hexkit) plus the
-    policy console.
+    Below: the agent, the policy, the gate deciding live. Then the same agent
+    running in a real app.
     """)
     return
 
@@ -108,9 +101,8 @@ def _(mo):
         [
             _diagram,
             mo.md(
-                "The agent never talks to the MCP server directly — hexgate wraps "
-                "each tool, so a denied call is stopped here and the server never "
-                "sees it. Same engine, same DSL, whether the tool is native or MCP."
+                "Every tool call detours through the gate: **allowed** → it runs; "
+                "**denied** → the server never sees it."
             ),
         ]
     )
@@ -129,13 +121,10 @@ def _(Path, SERVER_PATH, mo):
     # indented code block and leak the file's `#` lines as headings.
     _intro = _textwrap.dedent(
         """\
-        ## 1 · The MCP server (we don't control this)
+        ## 1 · The tools (we don't own these)
 
-        A stock FastMCP server standing in for a real Google Docs MCP. It exposes
-        six tools — some safe, some destructive, some that could exfiltrate data.
-        We can't edit it; we only gate it. It's spawned over **stdio**
-        (`python gdocs_mcp_server.py`); a real deployment would point at, say, an
-        official `@google/docs-mcp` or a Slack MCP server instead.
+        A Google Docs MCP server — six tools, someone else's code. Our agent
+        inherits all of them. We can't edit it; we just gate it.
         """
     )
     mo.md(_intro + f"\n```python\n{_tools}\n```\n")
@@ -145,12 +134,10 @@ def _(Path, SERVER_PATH, mo):
 @app.cell
 def _(mo):
     mo.md("""
-    ## 2 · The agent (this is what runs in hexkit)
+    ## 2 · The agent — 3 lines to gate it
 
-    Wiring an MCP server into a hexgate agent is three lines: open the
-    toolset, hand its tools to `create_agent`, and bind the policy. This is
-    verbatim what the **hexkit** backend runs (`demo/gdocs-agent/`) — a normal
-    LangChain graph, gated on every call.
+    Open the MCP toolset, hand its tools to `create_agent`, bind the policy.
+    That's the whole thing — and it's exactly what runs in hexkit.
 
     ```python
     from hexgate import create_agent
@@ -175,11 +162,9 @@ def _(mo):
         #     docs_agent policy you edit in the dashboard (section 6)
     ```
 
-    The policy lives on the **platform**, not in the code — so you edit it in the
-    dashboard and the next call reflects it. Below, we run that *same* policy
-    directly in this notebook (no model, no key) so you can see every decision;
-    the model just decides *which* call to propose — the gate decides whether it
-    goes through.
+    The policy lives on the **platform**, not the code — edit it in the dashboard,
+    the next call obeys. Below we run that same policy right here (no key needed):
+    the model picks *which* tool to call; the gate decides *whether* it runs.
     """)
     return
 
@@ -193,23 +178,16 @@ def _(POLICY_PATH, Path, mo):
     # so the column-0 policy content doesn't defeat marimo's dedent.
     _intro = _textwrap.dedent(
         """\
-        ## 3 · The policy (this is what you control)
+        ## 3 · The policy (what you control)
 
-        This is the `docs_agent` policy — seeded to the platform, shown/edited in
-        the dashboard (section 6), and bound by the hexkit agent. One file governs
-        three roles. It's **default-deny**, so the six-tool server can't smuggle
-        in a tool you never vetted, and each `allow` is narrowed by **argument
-        constraints**. Note the DSL features in play:
+        **Default-deny**, three roles — `analyst` < `editor` < `admin`. In plain
+        English:
 
-        | feature | where | what it stops |
-        |---|---|---|
-        | `startswith` | `read_doc` | reading `CONF-*` docs |
-        | `every(...)` + `endswith` | `share_doc` | sharing outside `@hexamind.ai` |
-        | `count(...)` | `share_doc` | mass fan-out (> 5 recipients) |
-        | `in consts.*` | `create_doc` | writing to un-sanctioned folders |
-        | `matches` (regex) | `export_doc` | exporting anywhere but the internal drive |
-        | `== true` | `delete_doc` | accidental deletes (needs `confirm`) |
-        | role inheritance / override | `admin` | admin reads `CONF-*`; editors can't |
+        - **analysts** read docs, but not the confidential `CONF-*` ones
+        - **editors** create, and share only inside `@hexamind.ai`
+        - **admins** can delete — but only with `confirm`
+
+        One file, on the platform. Here it is:
         """
     )
     mo.md(_intro + f"\n```yaml\n{_policy}\n```\n")
@@ -283,50 +261,40 @@ def _(
 
 @app.cell
 async def _(POLICY_PATH, load_policy_set, run_batch):
-    # The same handful of calls, some fired by an editor and some by an admin, to
-    # show the gate deciding on role + arguments — not just tool name.
+    # Three crisp pairs — the SAME tool, split only by role or by an argument.
+    _internal = {
+        "doc_id": "DOC-101",
+        "recipients": ["dana@hexamind.ai"],
+        "role": "viewer",
+    }
+    _external = {
+        "doc_id": "DOC-101",
+        "recipients": ["someone@gmail.com"],
+        "role": "viewer",
+    }
     CASES = [
-        ("analyst", "mcp-gdocs-search_docs", {"query": "launch"}),
-        ("analyst", "mcp-gdocs-read_doc", {"doc_id": "DOC-101"}),
-        ("analyst", "mcp-gdocs-read_doc", {"doc_id": "CONF-900"}),  # confidential
-        ("admin", "mcp-gdocs-read_doc", {"doc_id": "CONF-900"}),  # admin may
-        ("editor", "mcp-gdocs-create_doc", {"title": "", "folder": "Drafts"}),  # empty
-        ("editor", "mcp-gdocs-create_doc", {"title": "Plan", "folder": "Drafts"}),
         (
-            "editor",
-            "mcp-gdocs-share_doc",
-            {"doc_id": "DOC-101", "recipients": ["dana@hexamind.ai"], "role": "viewer"},
-        ),
-        (
-            "editor",
-            "mcp-gdocs-share_doc",
-            {
-                "doc_id": "DOC-101",
-                "recipients": ["someone@gmail.com"],
-                "role": "viewer",
-            },
-        ),  # external
-        (
-            "editor",
-            "mcp-gdocs-export_doc",
-            {"doc_id": "DOC-101", "url": "https://pastebin.com/x"},
-        ),
+            "analyst",
+            "mcp-gdocs-read_doc",
+            {"doc_id": "CONF-900"},
+        ),  # confidential → deny
         (
             "admin",
-            "mcp-gdocs-export_doc",
-            {"doc_id": "DOC-101", "url": "https://drive.hexamind.ai/exports/1"},
-        ),
+            "mcp-gdocs-read_doc",
+            {"doc_id": "CONF-900"},
+        ),  # admin override → allow
+        ("editor", "mcp-gdocs-share_doc", _internal),  # internal recipient → allow
+        ("editor", "mcp-gdocs-share_doc", _external),  # outside domain → deny
         (
             "editor",
             "mcp-gdocs-delete_doc",
             {"doc_id": "DOC-101", "confirm": True},
-        ),  # editors can't
+        ),  # editor → deny
         (
             "admin",
             "mcp-gdocs-delete_doc",
-            {"doc_id": "DOC-101", "confirm": False},
-        ),  # needs confirm
-        ("admin", "mcp-gdocs-delete_doc", {"doc_id": "DOC-101", "confirm": True}),
+            {"doc_id": "DOC-101", "confirm": True},
+        ),  # admin → allow
     ]
     engine = load_policy_set(POLICY_PATH)
     catalog, demo_rows = await run_batch(engine, CASES)
@@ -339,9 +307,9 @@ def _(catalog, mo):
     for _t in catalog:
         _rows.append(f"| `{_t['name']}` | {_t['desc']} | {', '.join(_t['params'])} |")
     mo.md(
-        "### The server's tools, auto-registered\n\n"
-        "Enumerated live over the connection — the proxy namespaces each one "
-        "`mcp-gdocs-<tool>` so the policy can address it:\n\n" + "\n".join(_rows)
+        "### The six tools our agent inherited\n\n"
+        "Auto-enumerated from the server, namespaced `mcp-gdocs-<tool>` so the "
+        "policy can address each one:\n\n" + "\n".join(_rows)
     )
     return
 
@@ -358,11 +326,10 @@ def _(demo_rows, mo):
             f"{_icon[_r['outcome']]} {_label[_r['outcome']]} | {_detail} |"
         )
     mo.md(
-        "## 4 · The gate in action\n\n"
-        "One row per call. Watch the pairs that differ only by **role** "
-        "(`read_doc` on `CONF-900`) or by an **argument** (`share_doc` recipient "
-        "domain, `delete_doc` confirm) — the tool name is the same; the gate "
-        "splits them.\n\n" + "\n".join(_rows)
+        "## 4 · Watch it decide\n\n"
+        "Read it in pairs: the **same call**, split only by **role** or an "
+        "**argument**. The tool name never changes — the gate does.\n\n"
+        + "\n".join(_rows)
     )
     return
 
@@ -370,10 +337,10 @@ def _(demo_rows, mo):
 @app.cell
 def _(mo):
     mo.md("""
-    ## 5 · Try it yourself
+    ## 5 · Your turn
 
-    Pick a role and a call, edit the arguments, submit. Allowed calls run for
-    real against the MCP server; denied calls are stopped before it.
+    Pick a role, edit the arguments, fire it through the gate. Allowed calls hit
+    the real server; denied ones stop here.
     """)
     return
 
@@ -430,7 +397,9 @@ async def _(engine, mo, run_batch, try_it):
         try:
             _args = json.loads(_v["args"] or "{}")
             if not isinstance(_args, dict):
-                raise ValueError("arguments must be a JSON object, e.g. {\"doc_id\": \"DOC-101\"}")
+                raise ValueError(
+                    'arguments must be a JSON object, e.g. {"doc_id": "DOC-101"}'
+                )
             _catalog, _res = await run_batch(engine, [(_v["role"], _v["tool"], _args)])
             _r = _res[0]
             _kind = {"allow": "success", "deny": "danger"}.get(_r["outcome"], "neutral")
@@ -463,18 +432,14 @@ async def _(engine, mo, run_batch, try_it):
 @app.cell
 def _(mo):
     mo.md("""
-    ## 6 · Now run it for real — in a different app
+    ## 6 · The same agent, in a real app
 
-    Everything above is the **definition**. hexgate's point is that this same
-    gated agent runs wherever you already work — here, in **hexkit**, a chat
-    UI that never imported hexgate. The gate rides along; blocked calls show
-    up as denials right in the conversation.
+    This exact agent runs in **hexkit** — a chat UI that never imported hexgate.
+    The gate rides along; blocked calls show up right in the conversation.
 
-    The live agent needs an OpenAI key (**BYOK** — sent straight to the
-    throwaway hexkit backend's memory, never stored). Paste it and send, then
-    open hexkit and sign in as `ana` (analyst), `ed` (editor), or `adah`
-    (admin) — password `hexademo` — to see the same request allowed for one
-    role and denied for another.
+    Add your OpenAI key (**BYOK** — kept in the throwaway backend's memory, never
+    stored), open hexkit, and sign in as `ana`, `ed`, or `adah` (password
+    `hexademo`) to watch the same request allowed for one role, denied for another.
     """)
     return
 

--- a/deploy/gates-demo/notebook.py
+++ b/deploy/gates-demo/notebook.py
@@ -1,0 +1,566 @@
+"""Hexgate gates demo (marimo) — one agent, one MCP server, one policy, three roles.
+
+The story: hexgate plugs into whatever app you already run your agents in. This
+notebook is the *definition* side — the agent's code, the MCP tools it inherits,
+a diagram of the gate, and a complex allow/deny policy. The gate then runs live,
+in-kernel, over a real (fake) Google Docs MCP server, so you can watch the same
+call be allowed for one role and denied for another — no OpenAI key needed.
+
+The last section links out to the *runtime* side: the same agent driven from a
+different UI (hexkit), with the policy console (the dashboard) showing and
+editing the very policy loaded here.
+
+Files in this folder:
+  * gdocs_mcp_server.py — the third-party MCP server we do NOT control
+  * policy.yaml         — the gate we DO control
+  * README.md           — how to run it
+
+Run with `marimo edit deploy/gates-demo/notebook.py`.
+"""
+
+import marimo
+
+__generated_with = "0.23.13"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import sys
+    from pathlib import Path
+
+    import marimo as mo
+
+    HERE = Path(__file__).resolve().parent
+    SERVER_PATH = str(HERE / "gdocs_mcp_server.py")
+    POLICY_PATH = str(HERE / "policy.yaml")
+
+    from hexgate.adapters.langchain.tools import GuardedTool
+    from hexgate.mcp import MCPServerConfig, MCPToolset
+    from hexgate.runtime import User
+    from hexgate.security.enforcer import build_enforcer
+    from hexgate.security.policy_set import load_policy_set
+
+    return (
+        GuardedTool,
+        MCPServerConfig,
+        MCPToolset,
+        POLICY_PATH,
+        Path,
+        SERVER_PATH,
+        User,
+        build_enforcer,
+        load_policy_set,
+        mo,
+        sys,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    # 🔌🛡️ Hexgate — gating an agent's MCP tools
+
+    Point an agent at a third-party **MCP server** and it inherits *every*
+    tool that server exposes. The server decides what's on the menu; **you**
+    decide what your agent may actually order.
+
+    Hexgate is the gate in between. It runs every tool call — native or MCP —
+    through one policy engine that resolves the caller's **role**, checks the
+    **arguments** against a constraint DSL, and returns **allow** or **deny**
+    *before the call ever reaches the server*.
+
+    This notebook is the agent's **definition**: its code, its tools, the gate
+    diagram, and the policy. Then it runs the gate for real. The same agent
+    can run inside any app — the last section links to one (hexkit) plus the
+    policy console.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## How the gate works
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    # A picture of the one thing that matters: every tool call detours through
+    # the gate, which answers allow/deny from the policy + the caller's role.
+    _diagram = mo.mermaid(
+        """
+        flowchart LR
+            A["🤖 Agent<br/>(runs in any app)"] -->|"proposes<br/>tool call + args"| G
+            subgraph GATE ["🛡️ Hexgate gate"]
+                direction TB
+                G["PolicyEnforcer"] --> R{"role?<br/>constraints<br/>on args?"}
+            end
+            R -->|allow| M["🔌 MCP server<br/>(Google Docs)"]
+            R -->|deny| X["⛔ blocked<br/>call never sent"]
+            M -->|result| A
+            X -.->|"structured<br/>error"| A
+        """
+    )
+    mo.vstack(
+        [
+            _diagram,
+            mo.md(
+                "The agent never talks to the MCP server directly — hexgate wraps "
+                "each tool, so a denied call is stopped here and the server never "
+                "sees it. Same engine, same DSL, whether the tool is native or MCP."
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(Path, SERVER_PATH, mo):
+    _src = Path(SERVER_PATH).read_text()
+    _tools = _src[_src.index("server = FastMCP") :]
+    mo.md(
+        f"""
+        ## 1 · The MCP server (we don't control this)
+
+        A stock FastMCP server standing in for a real Google Docs MCP. It exposes
+        six tools — some safe, some destructive, some that could exfiltrate data.
+        We can't edit it; we only gate it. It's spawned over **stdio**
+        (`python gdocs_mcp_server.py`); a real deployment would point at, say, an
+        official `@google/docs-mcp` or a Slack MCP server instead.
+
+        ```python
+        {_tools}```
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 2 · The agent (this is what runs in hexkit)
+
+    Wiring an MCP server into a hexgate agent is three lines: open the
+    toolset, hand its tools to `create_agent`, and bind the policy. This is
+    verbatim what the **hexkit** backend runs (`demo/gdocs-agent/`) — a normal
+    LangChain graph, gated on every call.
+
+    ```python
+    from hexgate import create_agent
+    from hexgate.mcp import MCPServerConfig, MCPToolset
+
+    gdocs = MCPServerConfig(
+        name="gdocs",                       # tools land under mcp-gdocs-*
+        transport="stdio",
+        command="python",
+        args=("gdocs_mcp_server.py",),      # or: npx @google/docs-mcp
+    )
+
+    async with MCPToolset(gdocs) as mcp:
+        agent, _handler = create_agent(
+            model="gpt-4o-mini",
+            tools=mcp.tools,                # every MCP tool, auto-enumerated
+            system_prompt="You help manage the team's Google Docs.",
+            name="docs_agent",             # the policy's lookup key
+            bind_policy=True,              # fetch + enforce the PLATFORM policy,
+        )                                  #   hot-reloaded on every run
+        # ... agent.ainvoke(...) — every tool call is now policed by the
+        #     docs_agent policy you edit in the dashboard (section 6)
+    ```
+
+    The policy lives on the **platform**, not in the code — so you edit it in the
+    dashboard and the next call reflects it. Below, we run that *same* policy
+    directly in this notebook (no model, no key) so you can see every decision;
+    the model just decides *which* call to propose — the gate decides whether it
+    goes through.
+    """)
+    return
+
+
+@app.cell
+def _(POLICY_PATH, Path, mo):
+    _policy = Path(POLICY_PATH).read_text()
+    mo.md(
+        f"""
+        ## 3 · The policy (this is what you control)
+
+        This is the `docs_agent` policy — seeded to the platform, shown/edited in
+        the dashboard (section 6), and bound by the hexkit agent. One file governs
+        three roles. It's **default-deny**, so the six-tool server can't smuggle
+        in a tool you never vetted, and each `allow` is narrowed by **argument
+        constraints**. Note the DSL features in play:
+
+        | feature | where | what it stops |
+        |---|---|---|
+        | `startswith` | `read_doc` | reading `CONF-*` docs |
+        | `every(...)` + `endswith` | `share_doc` | sharing outside `@hexamind.ai` |
+        | `count(...)` | `share_doc` | mass fan-out (> 5 recipients) |
+        | `in consts.*` | `create_doc` | writing to un-sanctioned folders |
+        | `matches` (regex) | `export_doc` | exporting anywhere but the internal drive |
+        | `== true` | `delete_doc` | accidental deletes (needs `confirm`) |
+        | role inheritance / override | `admin` | admin reads `CONF-*`; editors can't |
+
+        ```yaml
+        {_policy}```
+        """
+    )
+    return
+
+
+@app.cell
+def _(
+    GuardedTool,
+    MCPServerConfig,
+    MCPToolset,
+    SERVER_PATH,
+    User,
+    build_enforcer,
+    sys,
+):
+    def _classify(env):
+        """Map a GuardedTool envelope onto (outcome, detail)."""
+        if isinstance(env, dict) and env.get("ok", False):
+            return "allow", str(env.get("content", ""))
+        err = env.get("error", {}) if isinstance(env, dict) else {}
+        return "deny", err.get("message", "") or ""
+
+    async def run_batch(engine, cases):
+        """Open ONE connection, enumerate tools, run each (role, tool, args) case.
+
+        The caller's role is set via the `User` scope for each call — exactly how
+        the platform resolves it from the signed-in user at runtime. Returns
+        (catalog, results); allowed calls carry the value the server returned.
+        """
+        cfg = MCPServerConfig(
+            name="gdocs", transport="stdio", command=sys.executable, args=(SERVER_PATH,)
+        )
+        enforcer = build_enforcer(engine, agent_name="docs_agent")
+        async with MCPToolset(cfg) as mcp:
+            catalog = [
+                {
+                    "name": p.qualified_name,
+                    "desc": (p.description or "").splitlines()[0],
+                    "params": list(p.input_schema.get("properties", {})),
+                }
+                for p in mcp.proxies
+            ]
+            wrapped = {
+                t.name: GuardedTool.wrap(t, enforcer=enforcer, approval_handler=None)
+                for t in mcp.tools
+            }
+            results = []
+            for role, tool, args in cases:
+                if tool not in wrapped:
+                    results.append(
+                        {"role": role, "tool": tool, "args": args, "outcome": "unknown"}
+                    )
+                    continue
+                async with User(user_id="demo", role=role):
+                    env = await wrapped[tool].ainvoke(args)
+                outcome, detail = _classify(env)
+                results.append(
+                    {
+                        "role": role,
+                        "tool": tool,
+                        "args": args,
+                        "outcome": outcome,
+                        "detail": detail,
+                    }
+                )
+        return catalog, results
+
+    return (run_batch,)
+
+
+@app.cell
+async def _(POLICY_PATH, load_policy_set, run_batch):
+    # The same handful of calls, some fired by an editor and some by an admin, to
+    # show the gate deciding on role + arguments — not just tool name.
+    CASES = [
+        ("analyst", "mcp-gdocs-search_docs", {"query": "launch"}),
+        ("analyst", "mcp-gdocs-read_doc", {"doc_id": "DOC-101"}),
+        ("analyst", "mcp-gdocs-read_doc", {"doc_id": "CONF-900"}),  # confidential
+        ("admin", "mcp-gdocs-read_doc", {"doc_id": "CONF-900"}),  # admin may
+        ("editor", "mcp-gdocs-create_doc", {"title": "", "folder": "Drafts"}),  # empty
+        ("editor", "mcp-gdocs-create_doc", {"title": "Plan", "folder": "Drafts"}),
+        (
+            "editor",
+            "mcp-gdocs-share_doc",
+            {"doc_id": "DOC-101", "recipients": ["dana@hexamind.ai"], "role": "viewer"},
+        ),
+        (
+            "editor",
+            "mcp-gdocs-share_doc",
+            {
+                "doc_id": "DOC-101",
+                "recipients": ["someone@gmail.com"],
+                "role": "viewer",
+            },
+        ),  # external
+        (
+            "editor",
+            "mcp-gdocs-export_doc",
+            {"doc_id": "DOC-101", "url": "https://pastebin.com/x"},
+        ),
+        (
+            "admin",
+            "mcp-gdocs-export_doc",
+            {"doc_id": "DOC-101", "url": "https://drive.hexamind.ai/exports/1"},
+        ),
+        (
+            "editor",
+            "mcp-gdocs-delete_doc",
+            {"doc_id": "DOC-101", "confirm": True},
+        ),  # editors can't
+        (
+            "admin",
+            "mcp-gdocs-delete_doc",
+            {"doc_id": "DOC-101", "confirm": False},
+        ),  # needs confirm
+        ("admin", "mcp-gdocs-delete_doc", {"doc_id": "DOC-101", "confirm": True}),
+    ]
+    engine = load_policy_set(POLICY_PATH)
+    catalog, demo_rows = await run_batch(engine, CASES)
+    return catalog, demo_rows, engine
+
+
+@app.cell
+def _(catalog, mo):
+    _rows = ["| tool (namespaced) | what it does | arguments |", "|---|---|---|"]
+    for _t in catalog:
+        _rows.append(f"| `{_t['name']}` | {_t['desc']} | {', '.join(_t['params'])} |")
+    mo.md(
+        "### The server's tools, auto-registered\n\n"
+        "Enumerated live over the connection — the proxy namespaces each one "
+        "`mcp-gdocs-<tool>` so the policy can address it:\n\n" + "\n".join(_rows)
+    )
+    return
+
+
+@app.cell
+def _(demo_rows, mo):
+    _icon = {"allow": "✅", "deny": "❌", "unknown": "•"}
+    _label = {"allow": "ALLOW", "deny": "DENY", "unknown": "—"}
+    _rows = ["| role | call | decision | why / result |", "|---|---|---|---|"]
+    for _r in demo_rows:
+        _detail = (_r.get("detail") or "").replace("\n", " ")[:64]
+        _rows.append(
+            f"| `{_r['role']}` | `{_r['tool'].split('-', 2)[-1]}({_r['args']})` | "
+            f"{_icon[_r['outcome']]} {_label[_r['outcome']]} | {_detail} |"
+        )
+    mo.md(
+        "## 4 · The gate in action\n\n"
+        "One row per call. Watch the pairs that differ only by **role** "
+        "(`read_doc` on `CONF-900`) or by an **argument** (`share_doc` recipient "
+        "domain, `delete_doc` confirm) — the tool name is the same; the gate "
+        "splits them.\n\n" + "\n".join(_rows)
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 5 · Try it yourself
+
+    Pick a role and a call, edit the arguments, submit. Allowed calls run for
+    real against the MCP server; denied calls are stopped before it.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    try_it = (
+        mo.md(
+            """
+            **role** {role}   **tool** {tool}
+
+            **arguments** (JSON)
+
+            {args}
+            """
+        )
+        .batch(
+            role=mo.ui.dropdown(["analyst", "editor", "admin"], value="editor"),
+            tool=mo.ui.dropdown(
+                [
+                    "mcp-gdocs-search_docs",
+                    "mcp-gdocs-read_doc",
+                    "mcp-gdocs-create_doc",
+                    "mcp-gdocs-share_doc",
+                    "mcp-gdocs-export_doc",
+                    "mcp-gdocs-delete_doc",
+                ],
+                value="mcp-gdocs-share_doc",
+            ),
+            args=mo.ui.text_area(
+                value='{"doc_id": "DOC-101", "recipients": ["dana@hexamind.ai"], "role": "viewer"}',
+                full_width=True,
+            ),
+        )
+        .form(submit_button_label="▶ Call through the gate")
+    )
+    try_it
+    return (try_it,)
+
+
+@app.cell
+async def _(engine, mo, run_batch, try_it):
+    import json
+
+    if try_it.value is None:
+        _out = mo.callout(
+            mo.md(
+                "Pick a role, tool, and arguments above, then **▶ Call through the gate**."
+            ),
+            kind="info",
+        )
+    else:
+        _v = try_it.value
+        try:
+            _args = json.loads(_v["args"] or "{}")
+            _catalog, _res = await run_batch(engine, [(_v["role"], _v["tool"], _args)])
+            _r = _res[0]
+            _kind = {"allow": "success", "deny": "danger"}.get(_r["outcome"], "neutral")
+            _head = {
+                "allow": "✅ ALLOW — call reached the server",
+                "deny": "❌ DENY — blocked before the server",
+            }.get(_r["outcome"], f"• {_r['outcome']}")
+            _body = _r.get("detail") or ""
+            _out = mo.vstack(
+                [
+                    mo.md(f"**{_v['role']}** → `{_v['tool']}({_args})`"),
+                    mo.callout(
+                        mo.md(f"### {_head}\n\n```\n{_body[:300]}\n```"), kind=_kind
+                    ),
+                ]
+            )
+        except json.JSONDecodeError as _exc:
+            _out = mo.callout(mo.md(f"Invalid JSON in arguments: {_exc}"), kind="warn")
+    _out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 6 · Now run it for real — in a different app
+
+        Everything above is the **definition**. hexgate's point is that this same
+        gated agent runs wherever you already work — here, in **hexkit**, a chat
+        UI that never imported hexgate. The gate rides along; blocked calls show
+        up as denials right in the conversation.
+
+        The live agent needs an OpenAI key (**BYOK** — sent straight to the
+        throwaway hexkit backend's memory, never stored). Paste it and send, then
+        open hexkit and sign in as `ana` (analyst), `ed` (editor), or `adah`
+        (admin) — password `hexademo` — to see the same request allowed for one
+        role and denied for another.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    # BYOK for the live hexkit agent. The value is live as you type; the button
+    # posts it. The key goes only to the local hexkit backend's memory.
+    byok_key = mo.ui.text(kind="password", placeholder="sk-...", full_width=True)
+    byok_send = mo.ui.run_button(label="↪ Send key to the hexkit agent")
+    mo.vstack(
+        [mo.md("**OpenAI API key** (for the live hexkit agent)"), byok_key, byok_send]
+    )
+    return byok_key, byok_send
+
+
+@app.cell
+def _(byok_key, byok_send, mo):
+    import json as _json
+    import os as _os
+    import urllib.request as _urllib
+
+    # The hexkit gdocs backend runs in this same container. run-integrated.sh
+    # exports its URL (single source of truth for the port); default matches the
+    # backend's own default (:8880). POST the key to /byok — in-memory handoff.
+    _backend = _os.environ.get("HEXGATE_GDOCS_BACKEND_URL", "http://127.0.0.1:8880")
+    if byok_send.value:
+        if not byok_key.value:
+            _o = mo.md("⚠️ **Enter your OpenAI key above**, then click Send.")
+        else:
+            try:
+                _req = _urllib.Request(
+                    f"{_backend}/byok",
+                    data=_json.dumps({"openai_key": byok_key.value}).encode(),
+                    headers={"content-type": "application/json"},
+                    method="POST",
+                )
+                _urllib.urlopen(_req, timeout=5).read()
+                _o = mo.md(
+                    f"✅ Key `…{byok_key.value[-4:]}` sent to the hexkit agent — "
+                    "open hexkit below and start chatting."
+                )
+            except Exception as _e:  # noqa: BLE001
+                _o = mo.md(
+                    f"❌ Couldn't reach the hexkit backend ({_e}). Is the "
+                    "integrated demo running? (Locally, this notebook alone "
+                    "doesn't start hexkit — see the README.)"
+                )
+    else:
+        _o = mo.md("_Paste your key and click Send before chatting in hexkit._")
+    _o
+    return
+
+
+@app.cell
+def _(Path, mo):
+    # boot.py writes the public dashboard + hexkit URLs here when the integrated
+    # demo runs in a sandbox. Locally they're absent — degrade to a note.
+    def _url(path: str) -> str | None:
+        p = Path(path)
+        if p.exists():
+            u = p.read_text().strip().rstrip("/")
+            return u or None
+        return None
+
+    _dash = _url("/tmp/hexgate_dash_url")
+    _hexkit = _url("/tmp/hexkit_url")
+
+    _links = []
+    if _hexkit:
+        _links.append(f"### [▶ Chat with this agent in hexkit →]({_hexkit})")
+    if _dash:
+        _links.append(f"### [🛡️ Open the policy console →]({_dash}/v1/demo-login)")
+    _body = (
+        "\n\n".join(_links)
+        if _links
+        else (
+            "_Running locally — start the integrated demo (see this folder's "
+            "README) to get live hexkit + dashboard links._"
+        )
+    )
+
+    mo.md(
+        f"""
+        And **the policy console** (the dashboard) shows this exact `docs_agent`
+        policy — edit a constraint there and hexkit's next call picks it up, no
+        redeploy. It's the single source of truth; the gate table above runs a
+        local mirror of it so this page works with no key.
+
+        {_body}
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/deploy/gates-demo/notebook.py
+++ b/deploy/gates-demo/notebook.py
@@ -423,6 +423,8 @@ async def _(engine, mo, run_batch, try_it):
         _v = try_it.value
         try:
             _args = json.loads(_v["args"] or "{}")
+            if not isinstance(_args, dict):
+                raise ValueError("arguments must be a JSON object, e.g. {\"doc_id\": \"DOC-101\"}")
             _catalog, _res = await run_batch(engine, [(_v["role"], _v["tool"], _args)])
             _r = _res[0]
             _kind = {"allow": "success", "deny": "danger"}.get(_r["outcome"], "neutral")
@@ -441,6 +443,13 @@ async def _(engine, mo, run_batch, try_it):
             )
         except json.JSONDecodeError as _exc:
             _out = mo.callout(mo.md(f"Invalid JSON in arguments: {_exc}"), kind="warn")
+        except Exception as _exc:  # noqa: BLE001
+            # Args that parse but don't fit the tool (wrong types, missing keys)
+            # would otherwise escape as a raw traceback — render them instead.
+            _out = mo.callout(
+                mo.md(f"⚠️ Couldn't run that call: `{type(_exc).__name__}: {_exc}`"),
+                kind="warn",
+            )
     _out
     return
 

--- a/deploy/gates-demo/notebook.py
+++ b/deploy/gates-demo/notebook.py
@@ -20,7 +20,7 @@ Run with `marimo edit deploy/gates-demo/notebook.py`.
 
 import marimo
 
-__generated_with = "0.23.13"
+__generated_with = "0.23.14"
 app = marimo.App(width="medium")
 
 
@@ -119,10 +119,16 @@ def _(mo):
 
 @app.cell
 def _(Path, SERVER_PATH, mo):
+    import textwrap as _textwrap
+
     _src = Path(SERVER_PATH).read_text()
     _tools = _src[_src.index("server = FastMCP") :]
-    mo.md(
-        f"""
+    # Dedent the prose, then append the fenced block flush-left. Interpolating
+    # the column-0 file content directly into an indented f-string defeats
+    # marimo's dedent (common indent → 0), which would render the prose as an
+    # indented code block and leak the file's `#` lines as headings.
+    _intro = _textwrap.dedent(
+        """\
         ## 1 · The MCP server (we don't control this)
 
         A stock FastMCP server standing in for a real Google Docs MCP. It exposes
@@ -130,11 +136,9 @@ def _(Path, SERVER_PATH, mo):
         We can't edit it; we only gate it. It's spawned over **stdio**
         (`python gdocs_mcp_server.py`); a real deployment would point at, say, an
         official `@google/docs-mcp` or a Slack MCP server instead.
-
-        ```python
-        {_tools}```
         """
     )
+    mo.md(_intro + f"\n```python\n{_tools}\n```\n")
     return
 
 
@@ -182,9 +186,13 @@ def _(mo):
 
 @app.cell
 def _(POLICY_PATH, Path, mo):
+    import textwrap as _textwrap
+
     _policy = Path(POLICY_PATH).read_text()
-    mo.md(
-        f"""
+    # See the section-1 cell: dedent the prose, append the fenced YAML flush-left
+    # so the column-0 policy content doesn't defeat marimo's dedent.
+    _intro = _textwrap.dedent(
+        """\
         ## 3 · The policy (this is what you control)
 
         This is the `docs_agent` policy — seeded to the platform, shown/edited in
@@ -202,11 +210,9 @@ def _(POLICY_PATH, Path, mo):
         | `matches` (regex) | `export_doc` | exporting anywhere but the internal drive |
         | `== true` | `delete_doc` | accidental deletes (needs `confirm`) |
         | role inheritance / override | `admin` | admin reads `CONF-*`; editors can't |
-
-        ```yaml
-        {_policy}```
         """
     )
+    mo.md(_intro + f"\n```yaml\n{_policy}\n```\n")
     return
 
 
@@ -456,22 +462,20 @@ async def _(engine, mo, run_batch, try_it):
 
 @app.cell
 def _(mo):
-    mo.md(
-        """
-        ## 6 · Now run it for real — in a different app
+    mo.md("""
+    ## 6 · Now run it for real — in a different app
 
-        Everything above is the **definition**. hexgate's point is that this same
-        gated agent runs wherever you already work — here, in **hexkit**, a chat
-        UI that never imported hexgate. The gate rides along; blocked calls show
-        up as denials right in the conversation.
+    Everything above is the **definition**. hexgate's point is that this same
+    gated agent runs wherever you already work — here, in **hexkit**, a chat
+    UI that never imported hexgate. The gate rides along; blocked calls show
+    up as denials right in the conversation.
 
-        The live agent needs an OpenAI key (**BYOK** — sent straight to the
-        throwaway hexkit backend's memory, never stored). Paste it and send, then
-        open hexkit and sign in as `ana` (analyst), `ed` (editor), or `adah`
-        (admin) — password `hexademo` — to see the same request allowed for one
-        role and denied for another.
-        """
-    )
+    The live agent needs an OpenAI key (**BYOK** — sent straight to the
+    throwaway hexkit backend's memory, never stored). Paste it and send, then
+    open hexkit and sign in as `ana` (analyst), `ed` (editor), or `adah`
+    (admin) — password `hexademo` — to see the same request allowed for one
+    role and denied for another.
+    """)
     return
 
 

--- a/deploy/gates-demo/policy.yaml
+++ b/deploy/gates-demo/policy.yaml
@@ -1,0 +1,75 @@
+# The gate for the fake Google Docs MCP server.
+#
+# Default-deny: the server ships six tools, but the agent can touch NOTHING
+# unless a rule allows it — so a server that later adds a seventh tool can't
+# smuggle it past you. Every rule below is allow/deny plus a constraint on the
+# call's arguments, resolved by hexgate's constraint DSL:
+#
+#   startswith / endswith / matches  — string checks
+#   count(...)                       — list length
+#   every(list, <cond>)              — quantifier over a list
+#   consts.<name>                    — named constants (single source of truth)
+#   role / tool                      — call-scope facts
+#
+# Three roles inherit from a read-only base; the caller's role is resolved at
+# call time from the platform user, so ONE policy governs the analyst, the
+# editor, and the admin.
+
+version: 1
+
+roles:
+  # ---- shared read-only base (is_mixin keeps it out of the selectable roles) ----
+  reader:
+    is_mixin: true
+    consts:
+      company_domain: "@hexamind.ai"     # documented here; endswith() takes a literal
+      max_recipients: 5                  # no fan-out sharing
+      writable_folders: ["Drafts", "Team Drive", "Shared"]
+    default_policy:
+      mode: deny                         # nothing is callable unless named below
+    tools:
+      "mcp-gdocs-search_docs":
+        mode: allow                      # searching titles is always safe
+      "mcp-gdocs-read_doc":
+        mode: allow
+        constraints:
+          - not startswith(args.doc_id, "CONF-")   # confidential docs are off-limits
+
+  # ---- analyst: read-only, nothing more ----
+  analyst:
+    inherits: [reader]
+
+  # ---- editor: create + share, but only inside the company ----
+  editor:
+    inherits: [reader]
+    tools:
+      "mcp-gdocs-create_doc":
+        mode: allow
+        constraints:
+          - args.title != ""                          # no untitled junk
+          - args.folder in consts.writable_folders    # only sanctioned folders
+      "mcp-gdocs-share_doc":
+        mode: allow
+        constraints:
+          - every(args.recipients, endswith(., "@hexamind.ai"))  # no external sharing
+          - count(args.recipients) <= consts.max_recipients      # no mass fan-out
+          - args.role != "owner"                                 # never hand off ownership
+      "mcp-gdocs-export_doc":
+        mode: deny                                    # exfiltration path — blocked
+      "mcp-gdocs-delete_doc":
+        mode: deny                                    # destructive — editors can't
+
+  # ---- admin: everything, with guardrails still on the dangerous calls ----
+  admin:
+    inherits: [editor]
+    tools:
+      "mcp-gdocs-read_doc":
+        mode: allow                                   # admins may read confidential docs
+      "mcp-gdocs-export_doc":
+        mode: allow
+        constraints:
+          - matches(args.url, "^https://drive\\.hexamind\\.ai/")  # only the internal drive
+      "mcp-gdocs-delete_doc":
+        mode: allow
+        constraints:
+          - args.confirm == true                      # deletes must be deliberate

--- a/deploy/gates-demo/run-integrated.sh
+++ b/deploy/gates-demo/run-integrated.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Bring up the WHOLE gates demo in one container: hexgate platform + marimo
+# (this notebook) + hexkit (the "different app" running the same gated agent).
+#
+# Assumes both repos are checked out and set up in the container (the combined
+# Daytona snapshot does this — see deploy/daytona_full_snapshot.py):
+#   HEXGATE_DIR  the hexgate repo (platform + SDK + this notebook)   default /app
+#   HEXKIT_DIR  the hexkit repo (gdocs backend + proxy + front-app) default /hexkit
+#
+# Public URLs (signed preview links in Daytona) are passed IN by the spawner:
+#   HEXGATE_DASH_URL    dashboard/platform origin (for the notebook + login)
+#   HEXGATE_HEXKIT_URL  hexkit front-app origin (the notebook links to it)
+# Locally you can omit them; the notebook shows its "running locally" note.
+#
+# Ports: platform :8000, marimo :3000, hexkit front-app :8873,
+#        hexkit proxy :8800 -> gdocs backend :8880 (the agent server).
+
+set -euo pipefail
+
+HEXGATE_DIR="${HEXGATE_DIR:-/app}"
+HEXKIT_DIR="${HEXKIT_DIR:-/hexkit}"
+HEXGATE_VENV="${HEXGATE_VENV:-$HEXGATE_DIR/platform/api/.venv/bin}"
+SERVE_KEY_FILE="${HEXGATE_SERVE_KEY_FILE:-/tmp/hexgate_serve_key}"
+# Single source of truth for the gdocs backend's port: the backend binds it, the
+# proxy proxies it, and the notebook (via boot.py's env) posts the BYOK key to it.
+GDOCS_PORT="${GDOCS_PORT:-8880}"
+GDOCS_URL="http://127.0.0.1:$GDOCS_PORT"
+
+echo "== gates demo: booting the one-box stack =="
+
+# 1. hexgate platform (:8000) + marimo gates notebook (:3000). boot.py seeds the
+#    docs_agent policy (provision.py) and mints the serve key file the hexkit
+#    backend adopts. HEXGATE_NOTEBOOK points marimo at the gates notebook;
+#    HEXGATE_GDOCS_BACKEND_URL tells the notebook where to POST the BYOK key.
+(
+  cd "$HEXGATE_DIR"
+  PATH="$HEXGATE_VENV:$PATH" \
+  HEXGATE_DEMO=1 HEXGATE_COOKIE_SECURE="${HEXGATE_COOKIE_SECURE:-1}" \
+  HEXGATE_MARIMO_PORT="${HEXGATE_MARIMO_PORT:-3000}" \
+  HEXGATE_NOTEBOOK="$HEXGATE_DIR/deploy/gates-demo/notebook.py" \
+  HEXGATE_GDOCS_BACKEND_URL="$GDOCS_URL" \
+  HEXGATE_DASH_URL="${HEXGATE_DASH_URL:-}" \
+  HEXGATE_HEXKIT_URL="${HEXGATE_HEXKIT_URL:-}" \
+  "$HEXGATE_VENV/python" deploy/boot.py
+) > /tmp/gates-hexgate.log 2>&1 &
+
+# Wait for the platform to seed + mint the serve key (the backend needs it to
+# bind the docs_agent policy).
+echo "waiting for the platform to mint the serve key…"
+for _ in $(seq 1 120); do [ -s "$SERVE_KEY_FILE" ] && break; sleep 1; done
+[ -s "$SERVE_KEY_FILE" ] || { echo "serve key never appeared; see /tmp/gates-hexgate.log"; exit 1; }
+
+# 2. hexkit gdocs backend (agent server). Binds the docs_agent policy from the
+#    platform using the minted key (adopted from SERVE_KEY_FILE).
+(
+  cd "$HEXKIT_DIR"
+  PYTHONPATH=demo/gdocs-agent/src \
+  AGENT_HOST=0.0.0.0 AGENT_PORT="$GDOCS_PORT" \
+  HEXGATE_API_URL=http://127.0.0.1:8000 \
+  HEXGATE_SERVE_KEY_FILE="$SERVE_KEY_FILE" \
+  demo/gdocs-agent/.venv/bin/python -m gdocs_agent
+) > /tmp/gates-agent.log 2>&1 &
+
+# Wait for the backend to finish startup (its lifespan connects the MCP server
+# before it serves /agents) so the proxy's first roster fetch doesn't race it.
+echo "waiting for the gdocs backend on :$GDOCS_PORT…"
+for _ in $(seq 1 60); do
+  curl -sf -o /dev/null "$GDOCS_URL/agents" && break
+  sleep 1
+done
+
+# 3. hexkit proxy (:8800) -> the gdocs backend, with the gdocs demo users.
+(
+  cd "$HEXKIT_DIR"
+  PLATFORM_DATABASE_URL="${PLATFORM_DATABASE_URL:-sqlite+aiosqlite:////tmp/hexa_dev.sqlite}" \
+  PLATFORM_AGENT_BACKEND_URL="$GDOCS_URL" \
+  PLATFORM_DEMO_USERS_FILE="$HEXKIT_DIR/demo/gdocs-agent/demo-users.yaml" \
+  PYTHONPATH=proxy-server/src:packages/hexa-events/src \
+  proxy-server/.venv/bin/python -m platform_backend
+) > /tmp/gates-proxy.log 2>&1 &
+
+# 4. hexkit front-app (:8873). --host so the preview proxy can reach it.
+(
+  cd "$HEXKIT_DIR/front-app"
+  npm run dev -- --host 0.0.0.0 --port 8873
+) > /tmp/gates-frontend.log 2>&1 &
+
+echo "== all four services launched =="
+echo "   platform :8000   marimo :3000   proxy :8800 -> agent :8880   front-app :8873"
+echo "   logs: /tmp/gates-*.log"
+wait

--- a/deploy/gates-demo/run-integrated.sh
+++ b/deploy/gates-demo/run-integrated.sh
@@ -64,10 +64,14 @@ for _ in $(seq 1 120); do [ -s "$SERVE_KEY_FILE" ] && break; sleep 1; done
 # Wait for the backend to finish startup (its lifespan connects the MCP server
 # before it serves /agents) so the proxy's first roster fetch doesn't race it.
 echo "waiting for the gdocs backend on :$GDOCS_PORT…"
+agent_ready=""
 for _ in $(seq 1 60); do
-  curl -sf -o /dev/null "$GDOCS_URL/agents" && break
+  if curl -sf -o /dev/null "$GDOCS_URL/agents"; then agent_ready=1; break; fi
   sleep 1
 done
+# Non-fatal (the notebook + dashboard still come up), but say so loudly — a
+# silently dead backend just looks like a broken chat UI otherwise.
+[ -n "$agent_ready" ] || echo "⚠ gdocs backend never answered on :$GDOCS_PORT — hexkit chat will be broken; see /tmp/gates-agent.log" >&2
 
 # 3. hexkit proxy (:8800) -> the gdocs backend, with the gdocs demo users.
 (

--- a/deploy/provision.py
+++ b/deploy/provision.py
@@ -25,10 +25,12 @@ _GDOCS_POLICY = Path(__file__).resolve().parent / "gates-demo" / "policy.yaml"
 _GDOCS_AGENT_NAME = "docs_agent"
 
 
-async def _seed_gdocs_agent(session) -> None:
+async def _seed_gdocs_agent() -> None:
     """Idempotently seed the ``docs_agent`` policy into the default project.
 
-    Mirrors ``ensure_seeded_agents`` for one agent: create the row with
+    Opens its OWN session so a seed failure (e.g. a commit-time DB error) can't
+    poison the token-mint session — the mint is what the demo actually depends
+    on. Mirrors ``ensure_seeded_agents`` for one agent: create the row with
     ``policy_yaml`` from :data:`_GDOCS_POLICY`. No bundle needed — the API's
     ``backfill_bundles`` compiles one at startup if ``opa`` is present, and the
     SDK bind path falls back to the pydantic engine from ``policy_yaml`` if not.
@@ -39,30 +41,32 @@ async def _seed_gdocs_agent(session) -> None:
         return
 
     from hexgate_api.constants import DEFAULT_PROJECT_ID
+    from hexgate_api.core.db import async_session_factory
     from hexgate_api.core.ids import new_id
     from hexgate_api.features.agents.service import get_agent
     from hexgate_api.models import Agent
 
-    if await get_agent(session, DEFAULT_PROJECT_ID, _GDOCS_AGENT_NAME) is not None:
-        return  # already seeded (warm DB)
+    async with async_session_factory() as session:
+        if await get_agent(session, DEFAULT_PROJECT_ID, _GDOCS_AGENT_NAME) is not None:
+            return  # already seeded (warm DB)
 
-    session.add(
-        Agent(
-            id=new_id(Agent),
-            project_id=DEFAULT_PROJECT_ID,
-            name=_GDOCS_AGENT_NAME,
-            agent_yaml=(
-                "name: docs_agent\nmodel: gpt-4o-mini\n"
-                "system_prompt: system.md\npolicy: policy.yaml\n"
-            ),
-            policy_yaml=_GDOCS_POLICY.read_text(),
-            system_md=(
-                "A Google-Docs assistant whose MCP tools (mcp-gdocs-*) are gated "
-                "by role — analyst < editor < admin. Runs inside hexkit.\n"
-            ),
+        session.add(
+            Agent(
+                id=new_id(Agent),
+                project_id=DEFAULT_PROJECT_ID,
+                name=_GDOCS_AGENT_NAME,
+                agent_yaml=(
+                    "name: docs_agent\nmodel: gpt-4o-mini\n"
+                    "system_prompt: system.md\npolicy: policy.yaml\n"
+                ),
+                policy_yaml=_GDOCS_POLICY.read_text(),
+                system_md=(
+                    "A Google-Docs assistant whose MCP tools (mcp-gdocs-*) are gated "
+                    "by role — analyst < editor < admin. Runs inside hexkit.\n"
+                ),
+            )
         )
-    )
-    await session.commit()
+        await session.commit()
     print(f"[provision] seeded {_GDOCS_AGENT_NAME} policy for the dashboard", file=sys.stderr)
 
 
@@ -77,13 +81,6 @@ async def _mint() -> str:
     keystore.ensure_keypair()
     async with async_session_factory() as session:
         await ensure_default_seed(session)
-        # Best-effort: the gates demo's docs_agent is enrichment for the
-        # dashboard/hexkit half. A bad policy.yaml or seed error must NOT take
-        # down the core BYOK notebook path — log and carry on.
-        try:
-            await _seed_gdocs_agent(session)
-        except Exception as exc:  # noqa: BLE001
-            print(f"[provision] docs_agent seed skipped: {exc}", file=sys.stderr)
         _, full_token = await mint_dev_token(
             session,
             DEFAULT_PROJECT_ID,
@@ -94,6 +91,14 @@ async def _mint() -> str:
             env="live",
             signing_key_bytes=keystore._private_key_bytes(),
         )
+
+    # Best-effort, in its OWN session (see _seed_gdocs_agent): the gates demo's
+    # docs_agent is enrichment for the dashboard/hexkit half. A seed error must
+    # NOT take down the token mint above (the core BYOK notebook path).
+    try:
+        await _seed_gdocs_agent()
+    except Exception as exc:  # noqa: BLE001
+        print(f"[provision] docs_agent seed skipped: {exc}", file=sys.stderr)
     return full_token
 
 

--- a/deploy/provision.py
+++ b/deploy/provision.py
@@ -13,9 +13,57 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from pathlib import Path
 
 # The API runs as `hexgate_api.main:app` with the api dir on sys.path, so
 # callers must add platform/api to sys.path before calling in here.
+
+# The gates demo's policy — the single source the dashboard shows/edits and the
+# hexkit `docs_agent` binds to. Seeded here (demo-only) rather than in the
+# platform's product SEED_AGENTS, so a plain platform boot stays clean.
+_GDOCS_POLICY = Path(__file__).resolve().parent / "gates-demo" / "policy.yaml"
+_GDOCS_AGENT_NAME = "docs_agent"
+
+
+async def _seed_gdocs_agent(session) -> None:
+    """Idempotently seed the ``docs_agent`` policy into the default project.
+
+    Mirrors ``ensure_seeded_agents`` for one agent: create the row with
+    ``policy_yaml`` from :data:`_GDOCS_POLICY`. No bundle needed — the API's
+    ``backfill_bundles`` compiles one at startup if ``opa`` is present, and the
+    SDK bind path falls back to the pydantic engine from ``policy_yaml`` if not.
+    """
+    # NOTE: stdout is the token channel (see __main__) — log to stderr only.
+    if not _GDOCS_POLICY.is_file():
+        print(f"[provision] {_GDOCS_POLICY} missing — skipping docs_agent seed", file=sys.stderr)
+        return
+
+    from hexgate_api.constants import DEFAULT_PROJECT_ID
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.features.agents.service import get_agent
+    from hexgate_api.models import Agent
+
+    if await get_agent(session, DEFAULT_PROJECT_ID, _GDOCS_AGENT_NAME) is not None:
+        return  # already seeded (warm DB)
+
+    session.add(
+        Agent(
+            id=new_id(Agent),
+            project_id=DEFAULT_PROJECT_ID,
+            name=_GDOCS_AGENT_NAME,
+            agent_yaml=(
+                "name: docs_agent\nmodel: gpt-4o-mini\n"
+                "system_prompt: system.md\npolicy: policy.yaml\n"
+            ),
+            policy_yaml=_GDOCS_POLICY.read_text(),
+            system_md=(
+                "A Google-Docs assistant whose MCP tools (mcp-gdocs-*) are gated "
+                "by role — analyst < editor < admin. Runs inside hexkit.\n"
+            ),
+        )
+    )
+    await session.commit()
+    print(f"[provision] seeded {_GDOCS_AGENT_NAME} policy for the dashboard", file=sys.stderr)
 
 
 async def _mint() -> str:
@@ -29,6 +77,7 @@ async def _mint() -> str:
     keystore.ensure_keypair()
     async with async_session_factory() as session:
         await ensure_default_seed(session)
+        await _seed_gdocs_agent(session)
         _, full_token = await mint_dev_token(
             session,
             DEFAULT_PROJECT_ID,

--- a/deploy/provision.py
+++ b/deploy/provision.py
@@ -77,7 +77,13 @@ async def _mint() -> str:
     keystore.ensure_keypair()
     async with async_session_factory() as session:
         await ensure_default_seed(session)
-        await _seed_gdocs_agent(session)
+        # Best-effort: the gates demo's docs_agent is enrichment for the
+        # dashboard/hexkit half. A bad policy.yaml or seed error must NOT take
+        # down the core BYOK notebook path — log and carry on.
+        try:
+            await _seed_gdocs_agent(session)
+        except Exception as exc:  # noqa: BLE001
+            print(f"[provision] docs_agent seed skipped: {exc}", file=sys.stderr)
         _, full_token = await mint_dev_token(
             session,
             DEFAULT_PROJECT_ID,

--- a/deploy/spawner/modal_app.py
+++ b/deploy/spawner/modal_app.py
@@ -242,35 +242,52 @@ background:#3b82f6;color:#fff;cursor:pointer;margin-top:1rem}}</style></head>
                 status_code=503,
             )
 
-        sandbox = daytona.create(
-            CreateSandboxFromSnapshotParams(
-                snapshot=SNAPSHOT,
-                # Cost control: stop 15 min after the visitor goes idle (compute
-                # billing stops), and ephemeral → auto-delete on stop so no
-                # storage lingers. Net: pay only while it's actively used.
-                auto_stop_interval=15,
-                ephemeral=True,
+        # Create + boot. Wrapped so a Daytona failure (commonly a concurrent
+        # sandbox / resource quota when another demo is already live) surfaces
+        # as a readable page + a log line, not a blank 500.
+        try:
+            sandbox = daytona.create(
+                CreateSandboxFromSnapshotParams(
+                    snapshot=SNAPSHOT,
+                    # Cost control: stop 15 min after the visitor goes idle (compute
+                    # billing stops), and ephemeral → auto-delete on stop so no
+                    # storage lingers. Net: pay only while it's actively used.
+                    auto_stop_interval=15,
+                    ephemeral=True,
+                )
             )
-        )
-        _record_launch(ip)  # only count a launch that actually created a sandbox
-        dash_url = _signed(sandbox, API_PORT)
-        notebook_url = _signed(sandbox, MARIMO_PORT)
+            _record_launch(ip)  # only count a launch that actually created a sandbox
+            dash_url = _signed(sandbox, API_PORT)
+            notebook_url = _signed(sandbox, MARIMO_PORT)
 
-        # Fire-and-forget the stack (process.exec would block on a server that
-        # never exits; a background session doesn't).
-        sandbox.process.create_session("boot")
-        sandbox.process.execute_session_command(
-            "boot",
-            SessionExecuteRequest(
-                command=(
-                    f"cd /app && PATH={VENV}:$PATH "
-                    f"HEXGATE_DEMO=1 HEXGATE_COOKIE_SECURE=1 "
-                    f"HEXGATE_MARIMO_PORT={MARIMO_PORT} HEXGATE_DASH_URL='{dash_url}' "
-                    f"{VENV}/python deploy/boot.py > /tmp/boot.log 2>&1"
+            # Fire-and-forget the stack (process.exec would block on a server that
+            # never exits; a background session doesn't).
+            sandbox.process.create_session("boot")
+            sandbox.process.execute_session_command(
+                "boot",
+                SessionExecuteRequest(
+                    command=(
+                        f"cd /app && PATH={VENV}:$PATH "
+                        f"HEXGATE_DEMO=1 HEXGATE_COOKIE_SECURE=1 "
+                        f"HEXGATE_MARIMO_PORT={MARIMO_PORT} HEXGATE_DASH_URL='{dash_url}' "
+                        f"{VENV}/python deploy/boot.py > /tmp/boot.log 2>&1"
+                    ),
+                    run_async=True,
                 ),
-                run_async=True,
-            ),
-        )
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(f"[spawner] launch failed: {type(exc).__name__}: {exc}", flush=True)
+            return HTMLResponse(
+                _page(
+                    "Couldn't start the demo",
+                    "<h2>Couldn't start a sandbox</h2>"
+                    f"<p style='opacity:.7'>{type(exc).__name__}: {exc}</p>"
+                    "<p style='opacity:.5;font-size:.85rem'>Often a Daytona "
+                    "concurrent-sandbox or resource quota when another demo is "
+                    "already running.</p>",
+                ),
+                status_code=502,
+            )
 
         # "Starting…" page polls /status until marimo answers, then redirects.
         poll = f"""<script>

--- a/deploy/spawner/modal_app.py
+++ b/deploy/spawner/modal_app.py
@@ -227,12 +227,13 @@ background:#3b82f6;color:#fff;cursor:pointer;margin-top:1rem}}</style></head>
                 status_code=503,
             )
 
-        # 4. Concurrent cap. If the live count can't be read, LOG and PROCEED
-        #    (fail-open) — a Daytona list() blip must not brick a live demo. The
-        #    daily budget above is the hard backstop. Hit /debug to see why a
-        #    read failed.
+        # 4. Concurrent cap — FAIL CLOSED: if the live count can't be read, block
+        #    rather than let a Daytona outage turn the cap into unlimited launches
+        #    (Guillaume's guarantee). _running_count logs the reason and /debug
+        #    surfaces it; the earlier "always at capacity" was the list()-generator
+        #    bug (now fixed), not fail-closed itself.
         count = _running_count()
-        if count is not None and count >= MAX_LIVE_SANDBOXES:
+        if count is None or count >= MAX_LIVE_SANDBOXES:
             return HTMLResponse(
                 _page(
                     "Demo at capacity",

--- a/deploy/spawner/modal_app.py
+++ b/deploy/spawner/modal_app.py
@@ -86,12 +86,13 @@ def web():
     TURNSTILE_SECRET = os.environ.get("TURNSTILE_SECRET", "")
 
     def _running_count() -> int | None:
-        """Live sandbox count (the shared source of truth), or None if Daytona
-        can't be reached — the caller FAILS CLOSED on None so an API blip can't
-        turn the cap into unlimited launches."""
+        """Live sandbox count, or None if Daytona can't be read (caller then
+        fails OPEN — see /launch). Logs the error so a persistent failure is
+        visible in `modal app logs` instead of silently bricking the demo."""
         try:
             return len(daytona.list())
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
+            print(f"[spawner] daytona.list() failed: {type(exc).__name__}: {exc}", flush=True)
             return None
 
     def _today() -> str:
@@ -224,9 +225,12 @@ background:#3b82f6;color:#fff;cursor:pointer;margin-top:1rem}}</style></head>
                 status_code=503,
             )
 
-        # 4. Concurrent cap — FAIL CLOSED if the live count can't be read.
+        # 4. Concurrent cap. If the live count can't be read, LOG and PROCEED
+        #    (fail-open) — a Daytona list() blip must not brick a live demo. The
+        #    daily budget above is the hard backstop. Hit /debug to see why a
+        #    read failed.
         count = _running_count()
-        if count is None or count >= MAX_LIVE_SANDBOXES:
+        if count is not None and count >= MAX_LIVE_SANDBOXES:
             return HTMLResponse(
                 _page(
                     "Demo at capacity",
@@ -290,6 +294,22 @@ tick();
                 tail=poll,
             )
         )
+
+    @web_app.get("/debug")
+    def debug():
+        # Quick health probe: does daytona.list() work with the deployed
+        # DAYTONA_API_KEY? Surfaces the real error (auth / SDK version / API
+        # change) instead of the generic "at capacity" page.
+        import importlib.metadata as _md
+
+        out = {"daytona_sdk": _md.version("daytona"), "api_url": os.environ.get("HEXGATE_API_URL")}
+        try:
+            out["sandbox_count"] = len(daytona.list())
+            out["ok"] = True
+        except Exception as exc:  # noqa: BLE001
+            out["ok"] = False
+            out["error"] = f"{type(exc).__name__}: {exc}"
+        return JSONResponse(out)
 
     @web_app.get("/status")
     def status(sb: str):

--- a/deploy/spawner/modal_app.py
+++ b/deploy/spawner/modal_app.py
@@ -90,7 +90,9 @@ def web():
         fails OPEN — see /launch). Logs the error so a persistent failure is
         visible in `modal app logs` instead of silently bricking the demo."""
         try:
-            return len(daytona.list())
+            # daytona.list() returns a generator (SDK >= 0.197) — materialize
+            # before len(). list(...) is harmless if a list is returned instead.
+            return len(list(daytona.list()))
         except Exception as exc:  # noqa: BLE001
             print(f"[spawner] daytona.list() failed: {type(exc).__name__}: {exc}", flush=True)
             return None
@@ -304,7 +306,7 @@ tick();
 
         out = {"daytona_sdk": _md.version("daytona"), "api_url": os.environ.get("HEXGATE_API_URL")}
         try:
-            out["sandbox_count"] = len(daytona.list())
+            out["sandbox_count"] = len(list(daytona.list()))
             out["ok"] = True
         except Exception as exc:  # noqa: BLE001
             out["ok"] = False

--- a/deploy/spawner/modal_app.py
+++ b/deploy/spawner/modal_app.py
@@ -42,7 +42,11 @@ API_PORT = 8000
 VENV = "/app/platform/api/.venv/bin"
 MAX_LIVE_SANDBOXES = 20  # hard concurrent cap (fail-closed)
 MAX_LAUNCHES_PER_DAY = 200  # daily budget backstop against a slow drip
-PER_IP_COOLDOWN_SECONDS = 20  # per-IP rate limit (shared across containers)
+# Per-IP cooldown (shared across containers). 0 = OFF, so one machine can open
+# several demos at once (live showcase). Set > 0 to throttle rapid launches from
+# a single IP on a public/abuse-prone deploy; the concurrent cap + daily budget
+# are the real cost guards either way.
+PER_IP_COOLDOWN_SECONDS = 0
 
 
 @app.function(
@@ -195,8 +199,12 @@ background:#3b82f6;color:#fff;cursor:pointer;margin-top:1rem}}</style></head>
         ip = _client_ip(request)
         now = time.time()
 
-        # 2. Per-IP cooldown (shared via the Dict).
-        if ip and now - float(state.get(f"ip:{ip}", 0)) < PER_IP_COOLDOWN_SECONDS:
+        # 2. Per-IP cooldown (shared via the Dict). Skipped entirely when 0.
+        if (
+            PER_IP_COOLDOWN_SECONDS
+            and ip
+            and now - float(state.get(f"ip:{ip}", 0)) < PER_IP_COOLDOWN_SECONDS
+        ):
             return HTMLResponse(
                 _page(
                     "Slow down",


### PR DESCRIPTION
This is the hexgate half of a one-click, end to end demo.

The point of the demo is that hexgate plugs into whatever app you already run your agents in. Three surfaces:
- marimo is the narrative. The notebook shows the agent code, its MCP tools, a picture of the gate, and the policy, and it runs the gate live in the page with no key needed.
- hexkit is the user-facing interface where the same agent actually runs (companion PR: HexamindOrganisation/hexkit#16).
- hexgate is where you review the policy. The dashboard holds the `docs_agent` policy and edits hot-reload into hexkit.

What's in it:
- `deploy/gates-demo/`: the marimo notebook, a fake Google Docs MCP server, the policy (default deny, three roles, per-argument constraints), and `run-integrated.sh` to bring the whole box up
- `provision.py`: seeds the `docs_agent` policy so the dashboard shows it and hexkit binds it
- `boot.py`: can point marimo at any notebook and publishes the hexkit url for the notebook to link to
- `make demo-gates`: opens the notebook on its own, no key and no sandbox

Pairs with the hexkit PR above. Both are needed to run the full demo.

Stacked on #78 for now, since it builds on that branch.
