### PR TITLE
feat(platform-api): add llm invocation summary API endpoint

### DIFF
--- a/platform/api/hexgate_api/features/audit/router.py
+++ b/platform/api/hexgate_api/features/audit/router.py
@@ -9,16 +9,18 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from hexgate_api.features.audit.service import (
-    WINDOW_HOURS,
-    AuditEventOutOfWindow,
     AuditPayloadTooLarge,
     anomalies,
     insert_ban_enforcement,
     insert_decision,
     list_decisions,
-    prepare_date_range,
     summarize,
     timeseries,
+)
+from hexgate_api.query_scope import (
+    WINDOW_HOURS,
+    EventOutOfWindow,
+    prepare_date_range,
     validate_event_window,
 )
 from hexgate_api.core.db import get_session
@@ -68,7 +70,7 @@ async def ingest_decision(
     """
     try:
         validate_event_window(body.occurred_at)
-    except AuditEventOutOfWindow as exc:
+    except EventOutOfWindow as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
     agent_version_id = await get_latest_agent_version_id(
@@ -113,7 +115,7 @@ async def ingest_ban_enforcement(
     agent_version_id are server-resolved; idempotent on event_id."""
     try:
         validate_event_window(body.occurred_at)
-    except AuditEventOutOfWindow as exc:
+    except EventOutOfWindow as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
     agent_version_id = await get_latest_agent_version_id(

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -13,11 +13,12 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from collections import deque
 
 from clickhouse_connect.driver.client import Client
 
+from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import (
     AnomalySeverity,
     AuditAnomaly,
@@ -38,33 +39,14 @@ class AuditPayloadTooLarge(Exception):
         self.limit = limit
 
 
-class AuditEventOutOfWindow(Exception):
-    """occurred_at falls outside the accepted ingest window."""
-
-
 MAX_ARGS_BYTES = 8 * 1024
 MAX_HINT_BYTES = 4 * 1024
-
-# Accepted occurred_at window: small future skew for client clocks, and no
-# older than retention — rows past TTL would be merged away on arrival.
-CLOCK_SKEW_FUTURE = timedelta(minutes=5)
-RETENTION_WINDOW = timedelta(days=90)
 
 _ANOMALY_MIN_REQUESTS = 5
 _TIMEDELTA_ANOMALY_HOURS = 1
 _WINDOW_TD = timedelta(hours=_TIMEDELTA_ANOMALY_HOURS)
 _DENY_RATE_MEDIUM = 0.3
 _DENY_RATE_HIGH = 0.5
-
-
-def validate_event_window(occurred_at: datetime) -> None:
-    """Raise :class:`AuditEventOutOfWindow` when occurred_at is outside
-    [now - retention, now + skew]. Mapped to 400 in main.py."""
-    now = datetime.now(timezone.utc)
-    if occurred_at > now + CLOCK_SKEW_FUTURE:
-        raise AuditEventOutOfWindow("occurred_at is in the future")
-    if occurred_at < now - RETENTION_WINDOW:
-        raise AuditEventOutOfWindow("occurred_at is older than retention window")
 
 
 # Order matches schema.sql; received_at absent (server-stamped via column default).
@@ -191,9 +173,6 @@ def insert_ban_enforcement(
 
 # --- Read path: dashboard aggregation (query-time GROUP BY, no rollups) -------
 
-# Dashboard windows → hours; 90d is the 90-day TTL ceiling.
-WINDOW_HOURS: dict[str, int] = {"24h": 24, "7d": 24 * 7, "30d": 24 * 30, "90d": 24 * 90}
-
 
 def bucket_minutes_for_timedelta(delta: timedelta) -> int:
     """Bucket size (minutes) for a free-form date range.
@@ -220,16 +199,6 @@ def _zero_counts() -> dict[str, int]:
     return {"all": 0, **{e.value: 0 for e in AuditOutcome}}
 
 
-def _date_range_valid(start: datetime | None, end: datetime | None) -> bool:
-    """True if both dates are present and start <= end."""
-    if not (start and end):
-        return False
-    if start > end:
-        _log.warning(f"Date range invalid, start > end: {start} > {end}")
-        return False
-    return True
-
-
 def _scope(
     project_id: str,
     since_hours: int,
@@ -243,22 +212,9 @@ def _scope(
 ) -> tuple[list[str], dict[str, object]]:
     """Shared WHERE + params for the scope filters (project/window/agent/role/
     tool) that all reads narrow by. Pass role="" for the no-role bucket."""
-    where = [
-        "project_id = {pid:String}",
-    ]
-    params: dict[str, object] = {"pid": project_id}
-    if _date_range_valid(start_date, end_date):
-        where.append(
-            "occurred_at >= {start_date:DateTime} AND occurred_at <= {end_date:DateTime}"
-        )
-        params["start_date"] = start_date
-        params["end_date"] = end_date
-    else:
-        params["hrs"] = since_hours
-        where.append("occurred_at >= now() - INTERVAL {hrs:UInt32} HOUR")
-    if agent:
-        where.append("agent_name = {agent:String}")
-        params["agent"] = agent
+    where, params = scope_filters(
+        project_id, since_hours, agent=agent, start_date=start_date, end_date=end_date
+    )
     if role is not None:
         where.append("role = {role:String}")
         params["role"] = role
@@ -636,26 +592,3 @@ def anomalies(
     )
     result = client.query(anomalies_sql, parameters=params)
     return _sliding_window_anomalies(result.result_rows)
-
-
-def _ensure_utc(dt: datetime | None) -> datetime | None:
-    if dt is None:
-        return None
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
-
-
-def prepare_date_range(
-    start_date: datetime | None, end_date: datetime | None
-) -> tuple[datetime | None, datetime | None]:
-    start_date = _ensure_utc(start_date)
-    end_date = _ensure_utc(end_date)
-
-    if end_date:
-        end_date = min(end_date, datetime.now(timezone.utc) + CLOCK_SKEW_FUTURE)
-
-    if start_date and end_date:
-        start_date = max(start_date, end_date - RETENTION_WINDOW)
-
-    return start_date, end_date

--- a/platform/api/hexgate_api/features/llm_invocations/router.py
+++ b/platform/api/hexgate_api/features/llm_invocations/router.py
@@ -2,20 +2,32 @@
 
 import asyncio
 import logging
+from datetime import datetime
 
 from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from hexgate_api.features.audit.service import (
-    AuditEventOutOfWindow,
+from hexgate_api.query_scope import (
+    WINDOW_HOURS,
+    EventOutOfWindow,
+    prepare_date_range,
     validate_event_window,
 )
-from hexgate_api.features.llm_invocations.service import insert_llm_invocation
+from hexgate_api.features.llm_invocations.service import (
+    insert_llm_invocation,
+    summarize_llm_invocations,
+)
 from hexgate_api.core.db import get_session
 from hexgate_api.deps.clickhouse import _audit_unavailable, require_clickhouse
+from hexgate_api.deps.org import require_org_member
 from hexgate_api.deps.tokens import require_project
-from hexgate_api.schemas import LlmInvocationAccepted, LlmInvocationEvent
+from hexgate_api.schemas import (
+    AuditWindow,
+    LlmInvocationAccepted,
+    LlmInvocationEvent,
+    LlmInvocationSummary,
+)
 from hexgate_api.features.agents.service import get_latest_agent_version_id
 
 _log = logging.getLogger(__name__)
@@ -47,7 +59,7 @@ async def ingest_llm_invocation(
     """
     try:
         validate_event_window(body.occurred_at)
-    except AuditEventOutOfWindow as exc:
+    except EventOutOfWindow as exc:
         raise HTTPException(status_code=400, detail=str(exc))
 
     agent_version_id = await get_latest_agent_version_id(
@@ -74,3 +86,41 @@ async def ingest_llm_invocation(
         )
 
     return LlmInvocationAccepted(event_id=body.event_id)
+
+
+# Dashboard read — project-scoped aggregation, cookie-authed like the
+# audit summary endpoint (require_org_member via the project path param).
+@router.get(
+    "/projects/{project_id}/llm/summary",
+    response_model=LlmInvocationSummary,
+    dependencies=[Depends(require_org_member)],
+    tags=["llm_invocations"],
+)
+async def api_llm_invocation_summary(
+    project_id: str,
+    window: AuditWindow = "24h",
+    agent: str | None = None,
+    user: str | None = None,
+    model: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+    clickhouse_client=Depends(require_clickhouse),
+) -> LlmInvocationSummary:
+    start_date, end_date = prepare_date_range(start_date, end_date)
+    try:
+        # The clickhouse_connect client is sync — run it off the event loop
+        # so a slow aggregation can't stall every other in-flight request.
+        data = await asyncio.to_thread(
+            summarize_llm_invocations,
+            clickhouse_client,
+            project_id=project_id,
+            since_hours=WINDOW_HOURS[window],
+            agent=agent,
+            user=user,
+            model=model,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except ClickHouseError:
+        raise _audit_unavailable()
+    return LlmInvocationSummary.model_validate(data)

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -1,5 +1,8 @@
 from clickhouse_connect.driver.client import Client
 
+from datetime import datetime
+
+from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import LlmInvocationEvent
 
 # Order matches schema.sql; received_at absent (server-stamped via column default).
@@ -65,3 +68,139 @@ def insert_llm_invocation(
         column_names=_LLM_INVOCATION_COLUMNS,
         settings=_LLM_INVOCATION_INSERT_SETTINGS,
     )
+
+
+def _scope(
+    project_id: str,
+    since_hours: int,
+    *,
+    agent: str | None = None,
+    user: str | None = None,
+    model: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+) -> tuple[list[str], dict[str, object]]:
+    """WHERE + params for llm_invocation reads: the shared project/window/agent
+    scope, plus this table's own user/model filters (no role/tool — those
+    columns don't exist here)."""
+    where, params = scope_filters(
+        project_id, since_hours, agent=agent, start_date=start_date, end_date=end_date
+    )
+    if user is not None:
+        where.append("user_id = {user:String}")
+        params["user"] = user
+    if model:
+        where.append("model = {model:String}")
+        params["model"] = model
+    return where, params
+
+
+# Grand total + per-(model|agent|user) in one scan. Rows are classified by
+# their GROUPING() flags (1 = column rolled up); only the () set rolls up
+# every dimension, so that's the grand-total row.
+_GROUPING_SETS = "GROUPING SETS ((), (model), (agent_name), (user_id))"
+_SELECT_COLS = [
+    "model",
+    "agent_name",
+    "user_id",
+    "GROUPING(model) AS g_model",
+    "GROUPING(agent_name) AS g_agent",
+    "GROUPING(user_id) AS g_user",
+    "count() AS calls",
+    "sum(input_tokens) AS input_tokens",
+    "sum(output_tokens) AS output_tokens",
+]
+
+
+def summarize_llm_invocations(
+    client: Client,
+    *,
+    project_id: str,
+    since_hours: int,
+    agent: str | None = None,
+    user: str | None = None,
+    model: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+) -> dict:
+    """Totals + breakdowns for the scoped slice. Returns ``{totals, by_model,
+    by_agent, by_user}``; each breakdown is ``{key, calls, input_tokens,
+    output_tokens, total_tokens}`` sorted by ``total_tokens`` desc."""
+    where, params = _scope(
+        project_id,
+        since_hours,
+        agent=agent,
+        user=user,
+        model=model,
+        start_date=start_date,
+        end_date=end_date,
+    )
+    where_sql = " AND ".join(where)
+    summary_sql = (
+        f"SELECT {', '.join(_SELECT_COLS)} "
+        f"FROM llm_invocation WHERE {where_sql} GROUP BY {_GROUPING_SETS}"
+    )
+    result = client.query(summary_sql, parameters=params)
+
+    totals = {"calls": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    by_model: dict[str, dict[str, int]] = {}
+    by_agent: dict[str, dict[str, int]] = {}
+    by_user: dict[str, dict[str, int]] = {}
+
+    def _bucket(
+        store: dict[str, dict[str, int]],
+        key: str,
+        calls: int,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> None:
+        bucket = store.setdefault(
+            key,
+            {"calls": 0, "input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        )
+        bucket["calls"] += calls
+        bucket["input_tokens"] += input_tokens
+        bucket["output_tokens"] += output_tokens
+        bucket["total_tokens"] += input_tokens + output_tokens
+
+    for (
+        row_model,
+        row_agent,
+        row_user,
+        g_model,
+        g_agent,
+        g_user,
+        calls,
+        input_tokens,
+        output_tokens,
+    ) in result.result_rows:
+        calls = int(calls)
+        input_tokens = int(input_tokens)
+        output_tokens = int(output_tokens)
+        if g_model and g_agent and g_user:  # () grand total
+            totals = {
+                "calls": calls,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "total_tokens": input_tokens + output_tokens,
+            }
+        elif not g_model:  # (model)
+            _bucket(by_model, row_model, calls, input_tokens, output_tokens)
+        elif not g_agent:  # (agent_name)
+            _bucket(by_agent, row_agent, calls, input_tokens, output_tokens)
+        else:  # (user_id)
+            _bucket(by_user, row_user, calls, input_tokens, output_tokens)
+
+    def _ranked(store: dict[str, dict[str, int]]) -> list[dict]:
+        return sorted(
+            ({"key": k, **v} for k, v in store.items()),
+            key=lambda r: r["total_tokens"],
+            reverse=True,
+        )
+
+    return {
+        "totals": totals,
+        "by_model": _ranked(by_model),
+        "by_agent": _ranked(by_agent),
+        "by_user": _ranked(by_user),
+    }

--- a/platform/api/hexgate_api/query_scope.py
+++ b/platform/api/hexgate_api/query_scope.py
@@ -1,0 +1,103 @@
+"""Shared window/scope utilities for ClickHouse event-envelope reads.
+
+Every event table (``policy_decision``, ``llm_invocation``, ...) shares the
+same envelope columns — ``project_id``, ``occurred_at``, ``agent_name``,
+``user_id`` — and the same accepted ingest window / dashboard time-range
+handling (schema.sql's own header comment already anticipates future event
+tables sharing this envelope). This module holds that shared logic once;
+each feature's ``service.py`` imports from here instead of reaching into a
+sibling feature's module.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+_log = logging.getLogger(__name__)
+
+
+class EventOutOfWindow(Exception):
+    """occurred_at falls outside the accepted ingest window."""
+
+
+# Accepted occurred_at window: small future skew for client clocks, and no
+# older than retention — rows past TTL would be merged away on arrival.
+CLOCK_SKEW_FUTURE = timedelta(minutes=5)
+RETENTION_WINDOW = timedelta(days=90)
+
+# Dashboard windows → hours; 90d is the 90-day TTL ceiling.
+WINDOW_HOURS: dict[str, int] = {"24h": 24, "7d": 24 * 7, "30d": 24 * 30, "90d": 24 * 90}
+
+
+def validate_event_window(occurred_at: datetime) -> None:
+    """Raise :class:`EventOutOfWindow` when occurred_at is outside
+    [now - retention, now + skew]. Mapped to 400 in each feature's router."""
+    now = datetime.now(timezone.utc)
+    if occurred_at > now + CLOCK_SKEW_FUTURE:
+        raise EventOutOfWindow("occurred_at is in the future")
+    if occurred_at < now - RETENTION_WINDOW:
+        raise EventOutOfWindow("occurred_at is older than retention window")
+
+
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def prepare_date_range(
+    start_date: datetime | None, end_date: datetime | None
+) -> tuple[datetime | None, datetime | None]:
+    start_date = _ensure_utc(start_date)
+    end_date = _ensure_utc(end_date)
+
+    if end_date:
+        end_date = min(end_date, datetime.now(timezone.utc) + CLOCK_SKEW_FUTURE)
+
+    if start_date and end_date:
+        start_date = max(start_date, end_date - RETENTION_WINDOW)
+
+    return start_date, end_date
+
+
+def _date_range_valid(start: datetime | None, end: datetime | None) -> bool:
+    """True if both dates are present and start <= end."""
+    if not (start and end):
+        return False
+    if start > end:
+        _log.warning(f"Date range invalid, start > end: {start} > {end}")
+        return False
+    return True
+
+
+def scope_filters(
+    project_id: str,
+    since_hours: int,
+    *,
+    agent: str | None = None,
+    start_date: datetime | None = None,
+    end_date: datetime | None = None,
+) -> tuple[list[str], dict[str, object]]:
+    """WHERE + params shared by every envelope-scoped read: project, time
+    window (an explicit date range when valid, else a rolling since_hours),
+    and agent. Table-specific filters (role/tool, user, model, ...) are
+    appended by each feature's own ``_scope()`` wrapper, in whatever order
+    that feature's dashboard needs."""
+    where = ["project_id = {pid:String}"]
+    params: dict[str, object] = {"pid": project_id}
+    if _date_range_valid(start_date, end_date):
+        where.append(
+            "occurred_at >= {start_date:DateTime} AND occurred_at <= {end_date:DateTime}"
+        )
+        params["start_date"] = start_date
+        params["end_date"] = end_date
+    else:
+        params["hrs"] = since_hours
+        where.append("occurred_at >= now() - INTERVAL {hrs:UInt32} HOUR")
+    if agent:
+        where.append("agent_name = {agent:String}")
+        params["agent"] = agent
+    return where, params

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -516,6 +516,30 @@ class AuditSummary(BaseModel):
     by_user: list[AuditBreakdownRow]
 
 
+class LlmInvocationTotals(BaseModel):
+    """Call volume + token counts for a slice."""
+
+    calls: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    total_tokens: int = 0
+
+
+class LlmInvocationBreakdownRow(LlmInvocationTotals):
+    """One model/agent/user bucket."""
+
+    key: str
+
+
+class LlmInvocationSummary(BaseModel):
+    """Totals + breakdowns powering the token-usage dashboard panel."""
+
+    totals: LlmInvocationTotals
+    by_model: list[LlmInvocationBreakdownRow]
+    by_agent: list[LlmInvocationBreakdownRow]
+    by_user: list[LlmInvocationBreakdownRow]
+
+
 class AuditTimeseriesPoint(BaseModel):
     """One time bucket of the outcome-over-time chart."""
 

--- a/platform/api/tests/features/audit/test_audit.py
+++ b/platform/api/tests/features/audit/test_audit.py
@@ -22,10 +22,14 @@ from pydantic import ValidationError
 from hexgate_api.core import keystore as keystore_mod
 from hexgate_api.features.audit import service as audit
 from hexgate_api.features.audit.service import (
-    CLOCK_SKEW_FUTURE,
     list_decisions,
     summarize,
     _sliding_window_anomalies,
+)
+from hexgate_api.query_scope import (
+    CLOCK_SKEW_FUTURE,
+    RETENTION_WINDOW,
+    prepare_date_range,
 )
 from hexgate_api.core.keystore import FileKeyStore
 from hexgate_api.core.db import get_session
@@ -35,8 +39,6 @@ from hexgate_api.deps.org import require_org_member
 from hexgate_api.deps.tokens import require_project
 from hexgate_api.main import app
 from hexgate_api.schemas import AnomalySeverity, AuditOutcome, DecisionEvent
-
-from hexgate_api.features.audit.service import prepare_date_range
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -902,7 +904,7 @@ def test_when_window_exceeds_90d_then_start_date_is_clamped_to_end_minus_retenti
 ):
     far_start = datetime(2024, 9, 1, tzinfo=timezone.utc)  # >90d before _END
     start, _ = prepare_date_range(far_start, _END)
-    assert start == _END - audit.RETENTION_WINDOW
+    assert start == _END - RETENTION_WINDOW
 
 
 def test_when_only_start_date_provided_then_no_clamping_occurs() -> None:

--- a/platform/api/tests/features/llm_invocations/test_llm_invocation.py
+++ b/platform/api/tests/features/llm_invocations/test_llm_invocation.py
@@ -11,10 +11,14 @@ from clickhouse_connect.driver.exceptions import DataError, OperationalError
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
+from hexgate_api.core import keystore as keystore_mod
 from hexgate_api.core.db import get_session
+from hexgate_api.core.keystore import FileKeyStore
 from hexgate_api.deps.clickhouse import require_clickhouse
+from hexgate_api.deps.org import require_org_member
 from hexgate_api.deps.tokens import require_project
 from hexgate_api.features.llm_invocations import service as llm_invocations
+from hexgate_api.features.llm_invocations.service import summarize_llm_invocations
 from hexgate_api.main import app
 from hexgate_api.schemas import LlmInvocationEvent
 
@@ -109,7 +113,9 @@ _STUB_AGENT_VERSION_ID = "stub_v_id_xyz"
 
 
 @pytest.fixture
-def client(fake_clickhouse: MagicMock, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def client(
+    fake_clickhouse: MagicMock, monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> TestClient:
     """TestClient with auth, ClickHouse, session, and version-lookup stubbed."""
     app.dependency_overrides[require_project] = lambda: "proj_test"
     app.dependency_overrides[require_clickhouse] = lambda: fake_clickhouse
@@ -122,10 +128,17 @@ def client(fake_clickhouse: MagicMock, monkeypatch: pytest.MonkeyPatch) -> TestC
         "hexgate_api.features.llm_invocations.router.get_latest_agent_version_id",
         _stub_version_lookup,
     )
+    # The /llm/summary gating tests run the real require_org_member chain,
+    # whose cookie transport needs an initialised keystore (same swap as the
+    # client fixture in test_audit.py).
+    original_keystore = keystore_mod.keystore
+    keystore_mod.keystore = FileKeyStore(base_dir=tmp_path / "keystore")
+    keystore_mod.keystore.ensure_keypair()
     try:
         yield TestClient(app)
     finally:
         app.dependency_overrides.clear()
+        keystore_mod.keystore = original_keystore
 
 
 def test_ingest_llm_invocation_happy_path(
@@ -203,6 +216,230 @@ def test_when_clickhouse_rejects_the_row_then_422_is_returned(
 
 
 # ---------------------------------------------------------------------------
+# _scope() — llm_invocation's own filters layered on the shared scope_filters
+# ---------------------------------------------------------------------------
+
+_BASE_WHERE = [
+    "project_id = {pid:String}",
+    "occurred_at >= now() - INTERVAL {hrs:UInt32} HOUR",
+]
+
+
+def test_scope_no_filters() -> None:
+    where, params = llm_invocations._scope("p1", 24)
+    assert where == _BASE_WHERE
+    assert params == {"pid": "p1", "hrs": 24}
+
+
+def test_scope_all_filters() -> None:
+    where, params = llm_invocations._scope(
+        "p1", 24, agent="researcher", user="u_1", model="gpt-4o"
+    )
+    assert where == _BASE_WHERE + [
+        "agent_name = {agent:String}",
+        "user_id = {user:String}",
+        "model = {model:String}",
+    ]
+    assert params == {
+        "pid": "p1",
+        "hrs": 24,
+        "agent": "researcher",
+        "user": "u_1",
+        "model": "gpt-4o",
+    }
+
+
+def test_scope_empty_user_filters_no_user_bucket() -> None:
+    """user="" (no-user drill-down) must still emit the filter clause —
+    `if user:` instead of `if user is not None:` would silently widen it."""
+    where, params = llm_invocations._scope("p1", 24, user="")
+    assert "user_id = {user:String}" in where
+    assert params["user"] == ""
+
+
+# ---------------------------------------------------------------------------
+# summarize_llm_invocations() — GROUPING SETS row classification
+# ---------------------------------------------------------------------------
+
+# Rows are (model, agent_name, user_id, g_model, g_agent, g_user, calls,
+# input_tokens, output_tokens). GROUPING() flags: 1 = column rolled up.
+# Only the () set rolls up every dimension.
+
+
+def _summary_result(rows: list[tuple]) -> MagicMock:
+    client = MagicMock()
+    client.query.return_value.result_rows = rows
+    return client
+
+
+def test_summarize_filters_reach_query() -> None:
+    client = _summary_result([])
+    summarize_llm_invocations(
+        client,
+        project_id="p1",
+        since_hours=24,
+        agent="researcher",
+        user="u_1",
+        model="gpt-4o",
+    )
+    params = client.query.call_args.kwargs["parameters"]
+    assert params["agent"] == "researcher"
+    assert params["user"] == "u_1"
+    assert params["model"] == "gpt-4o"
+
+
+def test_summarize_classifies_grouping_sets() -> None:
+    client = _summary_result(
+        [
+            # () — grand total (the ONLY row where every grouping flag is 1)
+            ("", "", "", 1, 1, 1, 10, 1000, 400),
+            # (model)
+            ("gpt-4o", "", "", 0, 1, 1, 7, 700, 300),
+            ("gpt-4o-mini", "", "", 0, 1, 1, 3, 300, 100),
+            # (agent_name)
+            ("", "researcher", "", 1, 0, 1, 6, 600, 250),
+            ("", "scraper", "", 1, 0, 1, 4, 400, 150),
+            # (user_id) — empty user_id keeps its raw "" key on the wire
+            ("", "", "Alice", 1, 1, 0, 6, 600, 250),
+            ("", "", "Bob", 1, 1, 0, 4, 400, 150),
+        ]
+    )
+
+    data = summarize_llm_invocations(client, project_id="p1", since_hours=24)
+
+    assert data["totals"] == {
+        "calls": 10,
+        "input_tokens": 1000,
+        "output_tokens": 400,
+        "total_tokens": 1400,
+    }
+    assert data["by_model"] == [
+        {
+            "key": "gpt-4o",
+            "calls": 7,
+            "input_tokens": 700,
+            "output_tokens": 300,
+            "total_tokens": 1000,
+        },
+        {
+            "key": "gpt-4o-mini",
+            "calls": 3,
+            "input_tokens": 300,
+            "output_tokens": 100,
+            "total_tokens": 400,
+        },
+    ]
+    assert data["by_agent"] == [
+        {
+            "key": "researcher",
+            "calls": 6,
+            "input_tokens": 600,
+            "output_tokens": 250,
+            "total_tokens": 850,
+        },
+        {
+            "key": "scraper",
+            "calls": 4,
+            "input_tokens": 400,
+            "output_tokens": 150,
+            "total_tokens": 550,
+        },
+    ]
+    assert data["by_user"] == [
+        {
+            "key": "Alice",
+            "calls": 6,
+            "input_tokens": 600,
+            "output_tokens": 250,
+            "total_tokens": 850,
+        },
+        {
+            "key": "Bob",
+            "calls": 4,
+            "input_tokens": 400,
+            "output_tokens": 150,
+            "total_tokens": 550,
+        },
+    ]
+
+
+def test_summarize_empty_result() -> None:
+    data = summarize_llm_invocations(
+        _summary_result([]), project_id="p1", since_hours=24
+    )
+    assert data == {
+        "totals": {
+            "calls": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        },
+        "by_model": [],
+        "by_agent": [],
+        "by_user": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/projects/{project_id}/llm/summary — require_org_member gating
+# ---------------------------------------------------------------------------
+
+
+def test_llm_summary_rejects_anonymous(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    """No cookie / dev header → the require_org_member chain 401s before
+    the handler runs, so ClickHouse is never queried."""
+    r = client.get("/v1/projects/proj_test/llm/summary")
+    assert r.status_code == 401
+    fake_clickhouse.query.assert_not_called()
+
+
+def test_llm_summary_allows_org_member(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    """With membership satisfied, the same request reaches the handler —
+    proving the 401 above comes from the auth gate, not the route."""
+    app.dependency_overrides[require_org_member] = lambda: MagicMock()
+    fake_clickhouse.query.return_value.result_rows = []
+    r = client.get("/v1/projects/proj_test/llm/summary")
+    assert r.status_code == 200, r.text
+    assert r.json() == {
+        "totals": {
+            "calls": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+        },
+        "by_model": [],
+        "by_agent": [],
+        "by_user": [],
+    }
+
+
+def test_llm_summary_passes_filters_to_clickhouse_query(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    app.dependency_overrides[require_org_member] = lambda: MagicMock()
+    fake_clickhouse.query.return_value.result_rows = []
+    r = client.get(
+        "/v1/projects/proj_test/llm/summary",
+        params={
+            "window": "7d",
+            "agent": "researcher",
+            "user": "u_1",
+            "model": "gpt-4o",
+        },
+    )
+    assert r.status_code == 200, r.text
+    params = fake_clickhouse.query.call_args.kwargs["parameters"]
+    assert params["agent"] == "researcher"
+    assert params["user"] == "u_1"
+    assert params["model"] == "gpt-4o"
+    assert params["hrs"] == 24 * 7
+
+
+# ---------------------------------------------------------------------------
 # Integration — requires `make clickhouse-up` first; opt-in via marker
 # ---------------------------------------------------------------------------
 
@@ -262,6 +499,114 @@ def test_real_clickhouse_round_trip() -> None:
         assert output_tokens == 45
         assert received_at is not None  # server-stamped via column default
         assert av_id == "9f1e3c5a-test"
+    finally:
+        clickhouse_client.command(
+            "ALTER TABLE llm_invocation DELETE WHERE project_id = {pid:String}",
+            parameters={"pid": project_id},
+        )
+
+
+@pytest.mark.integration
+def test_summarize_llm_invocations_happy_path() -> None:
+    """Insert a handful of rows through the real write path, then exercise the
+    actual GROUPING SETS SQL (never run against real ClickHouse anywhere else)
+    to confirm it's valid ClickHouse syntax and classifies rows correctly."""
+    from hexgate_api.core.clickhouse import get_clickhouse as real_get_clickhouse
+
+    clickhouse_client = real_get_clickhouse()
+    project_id = f"test_proj_{uuid.uuid4().hex[:8]}"
+
+    # Distinct totals per bucket so sort order (desc by total_tokens) is
+    # unambiguous — no two rows in the same breakdown should tie.
+    rows = [
+        _llm_event(
+            agent_name="researcher",
+            model="gpt-4o",
+            user_id="alice",
+            input_tokens=100,
+            output_tokens=50,
+        ),
+        _llm_event(
+            agent_name="researcher",
+            model="gpt-4o",
+            user_id="bob",
+            input_tokens=200,
+            output_tokens=100,
+        ),
+        _llm_event(
+            agent_name="scraper",
+            model="gpt-4o-mini",
+            user_id="alice",
+            input_tokens=50,
+            output_tokens=25,
+        ),
+    ]
+    for payload in rows:
+        llm_invocations.insert_llm_invocation(
+            clickhouse_client,
+            event=LlmInvocationEvent(**payload),
+            project_id=project_id,
+            agent_version_id="9f1e3c5a-test",
+        )
+
+    try:
+        data = summarize_llm_invocations(
+            clickhouse_client, project_id=project_id, since_hours=24
+        )
+        assert data["totals"] == {
+            "calls": 3,
+            "input_tokens": 350,
+            "output_tokens": 175,
+            "total_tokens": 525,
+        }
+        assert data["by_model"] == [
+            {
+                "key": "gpt-4o",
+                "calls": 2,
+                "input_tokens": 300,
+                "output_tokens": 150,
+                "total_tokens": 450,
+            },
+            {
+                "key": "gpt-4o-mini",
+                "calls": 1,
+                "input_tokens": 50,
+                "output_tokens": 25,
+                "total_tokens": 75,
+            },
+        ]
+        assert data["by_agent"] == [
+            {
+                "key": "researcher",
+                "calls": 2,
+                "input_tokens": 300,
+                "output_tokens": 150,
+                "total_tokens": 450,
+            },
+            {
+                "key": "scraper",
+                "calls": 1,
+                "input_tokens": 50,
+                "output_tokens": 25,
+                "total_tokens": 75,
+            },
+        ]
+        assert data["by_user"] == [
+            {
+                "key": "bob",
+                "calls": 1,
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "total_tokens": 300,
+            },
+            {
+                "key": "alice",
+                "calls": 2,
+                "input_tokens": 150,
+                "output_tokens": 75,
+                "total_tokens": 225,
+            },
+        ]
     finally:
         clickhouse_client.command(
             "ALTER TABLE llm_invocation DELETE WHERE project_id = {pid:String}",

--- a/platform/api/tests/test_query_scope.py
+++ b/platform/api/tests/test_query_scope.py
@@ -1,0 +1,120 @@
+"""Tests for hexgate_api.query_scope — the shared window/scope helpers
+reused by audit/service.py and llm_invocations/service.py."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hexgate_api.query_scope import (
+    CLOCK_SKEW_FUTURE,
+    RETENTION_WINDOW,
+    EventOutOfWindow,
+    prepare_date_range,
+    scope_filters,
+    validate_event_window,
+)
+
+# ---------------------------------------------------------------------------
+# validate_event_window()
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def test_validate_event_window_happy_path() -> None:
+    validate_event_window(_now())  # no raise
+
+
+def test_when_occurred_at_is_in_the_future_then_event_out_of_window_is_raised() -> None:
+    with pytest.raises(EventOutOfWindow, match="future"):
+        validate_event_window(_now() + CLOCK_SKEW_FUTURE + timedelta(minutes=1))
+
+
+def test_when_occurred_at_is_older_than_retention_then_event_out_of_window_is_raised() -> (
+    None
+):
+    with pytest.raises(EventOutOfWindow, match="retention"):
+        validate_event_window(_now() - RETENTION_WINDOW - timedelta(days=1))
+
+
+# ---------------------------------------------------------------------------
+# scope_filters() — base project/window/agent WHERE builder
+# ---------------------------------------------------------------------------
+
+_BASE_WHERE = [
+    "project_id = {pid:String}",
+    "occurred_at >= now() - INTERVAL {hrs:UInt32} HOUR",
+]
+
+
+def test_scope_filters_no_filters() -> None:
+    where, params = scope_filters("p1", 24)
+    assert where == _BASE_WHERE
+    assert params == {"pid": "p1", "hrs": 24}
+
+
+def test_scope_filters_agent_only() -> None:
+    where, params = scope_filters("p1", 24, agent="example_agent")
+    assert where == _BASE_WHERE + ["agent_name = {agent:String}"]
+    assert params == {"pid": "p1", "hrs": 24, "agent": "example_agent"}
+
+
+_START = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+_END = datetime(2025, 1, 7, 23, 59, 59, tzinfo=timezone.utc)
+
+
+def test_scope_filters_appends_date_range_clause_when_both_dates_provided() -> None:
+    where, params = scope_filters("p1", 24, start_date=_START, end_date=_END)
+    assert where == [
+        "project_id = {pid:String}",
+        "occurred_at >= {start_date:DateTime} AND occurred_at <= {end_date:DateTime}",
+    ]
+    assert params == {"pid": "p1", "start_date": _START, "end_date": _END}
+
+
+def test_scope_filters_falls_back_to_since_hours_when_one_date_missing() -> None:
+    where, params = scope_filters("p1", 24, start_date=_START)
+    assert where == _BASE_WHERE
+    assert "start_date" not in params and "end_date" not in params
+
+
+def test_scope_filters_falls_back_to_since_hours_when_start_date_is_after_end_date() -> (
+    None
+):
+    where, params = scope_filters("p1", 24, start_date=_END, end_date=_START)
+    assert where == _BASE_WHERE
+    assert "start_date" not in params and "end_date" not in params
+
+
+# ---------------------------------------------------------------------------
+# prepare_date_range() — UTC normalization + 90-day retention clamping
+# ---------------------------------------------------------------------------
+
+
+def test_when_both_inputs_are_none_then_returns_none_none() -> None:
+    assert prepare_date_range(None, None) == (None, None)
+
+
+def test_when_naive_datetimes_provided_then_utc_is_attached() -> None:
+    naive_start = datetime(2025, 1, 1)
+    naive_end = datetime(2025, 1, 2)
+    start, end = prepare_date_range(naive_start, naive_end)
+    assert start.tzinfo is not None and end.tzinfo is not None
+
+
+def test_when_window_exceeds_90d_then_start_date_is_clamped_to_end_minus_retention() -> (
+    None
+):
+    far_start = _END - timedelta(days=200)
+    start, _ = prepare_date_range(far_start, _END)
+    assert start == _END - RETENTION_WINDOW
+
+
+def test_when_end_date_is_in_the_future_then_end_date_is_clamped_to_now() -> None:
+    future_end = _now() + timedelta(days=5)
+    _, end = prepare_date_range(None, future_end)
+    assert end <= _now() + CLOCK_SKEW_FUTURE

--- a/platform/api/uv.lock
+++ b/platform/api/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "hexgate"
-version = "0.2.7"
+version = "0.2.8"
 source = { editable = "../../" }
 dependencies = [
     { name = "bashlex" },
@@ -1028,7 +1028,7 @@ requires-dist = [
     { name = "bashlex", specifier = ">=0.18" },
     { name = "biscuit-python", specifier = ">=0.4" },
     { name = "cryptography", specifier = ">=42" },
-    { name = "google-adk", specifier = ">=1.0" },
+    { name = "google-adk", specifier = ">=1.14" },
     { name = "google-genai", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ipykernel", marker = "extra == 'dev'" },


### PR DESCRIPTION
## What is changing
- new llm invocation summary API endpoint to summarise llm invocation per user/model/agent
- refactor of scoping utility functions into a shared query_scope.py file, so that both llm_invocation.py and audit.py can use them 

## Test
1) make check-all
2) Local integration test:
- Went to http://localhost:8000/docs
- Under llm_invocations, executed the GET request with the default project id:
<img width="830" height="675" alt="Screenshot 2026-07-13 at 10 13 52" src="https://github.com/user-attachments/assets/08e43aab-363e-4da9-b00e-f9a66253f411" />

Result:
```
{
  "totals": {
    "calls": 3,
    "input_tokens": 995,
    "output_tokens": 117,
    "total_tokens": 1112
  },
  "by_model": [
    {
      "calls": 2,
      "input_tokens": 872,
      "output_tokens": 72,
      "total_tokens": 944,
      "key": "gpt-4o-mini-2024-07-18"
    },
    {
      "calls": 1,
      "input_tokens": 123,
      "output_tokens": 45,
      "total_tokens": 168,
      "key": "gpt-4o-2024-08-06"
    }
  ],
  "by_agent": [
    {
      "calls": 2,
      "input_tokens": 872,
      "output_tokens": 72,
      "total_tokens": 944,
      "key": "customer_bot"
    },
    {
      "calls": 1,
      "input_tokens": 123,
      "output_tokens": 45,
      "total_tokens": 168,
      "key": "e2e-test-agent"
    }
  ],
  "by_user": [
    {
      "calls": 2,
      "input_tokens": 872,
      "output_tokens": 72,
      "total_tokens": 944,
      "key": "playground"
    },
    {
      "calls": 1,
      "input_tokens": 123,
      "output_tokens": 45,
      "total_tokens": 168,
      "key": "user-e2e-1"
    }
  ]
}
```
