### PR TITLE
feat(dashboard): usage dashboard page

### DIFF
--- a/platform/dashboard/src/App.tsx
+++ b/platform/dashboard/src/App.tsx
@@ -18,6 +18,7 @@ import { SettingsPage } from "@/routes/Settings";
 import { SignInPage } from "@/routes/SignIn";
 import { SignUpPage } from "@/routes/SignUp";
 import { TokensPage } from "@/routes/Tokens";
+import { UsagePage } from "@/routes/Usage";
 import { VerifyEmailPage } from "@/routes/VerifyEmail";
 
 export default function App() {
@@ -62,6 +63,7 @@ export default function App() {
           <Route path="playground" element={<PlaygroundPage />} />
           <Route path="audit" element={<AuditPage />} />
           <Route path="bans" element={<BansPage />} />
+          <Route path="usage" element={<UsagePage />} />
           <Route path="tokens" element={<TokensPage />} />
           <Route path="orgs" element={<OrgsPage />} />
           <Route path="orgs/:orgId/settings" element={<OrgSettingsPage />} />

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useNavigate, NavLink, Outlet } from "react-router-dom";
 import {
   Ban,
+  BarChart3,
   Building2,
   FileCode,
   Fingerprint,
@@ -92,6 +93,7 @@ const workspaceLinks = [
   { to: "/playground", label: "Playground", icon: MessageSquareCode },
   { to: "/audit", label: "Audit", icon: ScrollText },
   { to: "/bans", label: "Bans", icon: Ban },
+  { to: "/usage", label: "Usage", icon: BarChart3 },
   { to: "/tokens", label: "Tokens", icon: KeyRound },
   { to: "/orgs", label: "Organizations", icon: Building2 },
   { to: "/settings", label: "Settings", icon: Settings2 },

--- a/platform/dashboard/src/components/audit/chart-tokens.ts
+++ b/platform/dashboard/src/components/audit/chart-tokens.ts
@@ -26,11 +26,22 @@ export const OUT_SWATCH: Record<AuditOutcome, string> = {
   needs_approval: "bg-approval",
 };
 
-// Display label for the empty-role bucket. Local to the dashboard — the
-// wire carries the raw "" key (and `role=` filters it), so the stored data
-// and API never reserve this string. A role literally named "(none)" would
-// be display-ambiguous here, but its data stays intact and queryable.
+// Display label for an empty-string ("no value recorded") bucket — used for
+// any dimension whose wire value can be "" (role, user, ...). Local to the
+// dashboard: the wire carries the raw "" key (and filters on it as such), so
+// stored data and the API never reserve this string. A role or user literally
+// named "(none)" would be display-ambiguous here, but its data stays intact
+// and queryable.
 export const NO_VALUE_LABEL = "(none)";
+
+// Wire → display: relabel the "" key so it never reaches Radix's
+// <Select.Item>, which throws at render for an empty-string value.
+export const displayNoValue = <T extends { key: string }>(r: T): T =>
+  r.key === "" ? { ...r, key: NO_VALUE_LABEL } : r;
+
+// Display → wire: inverse of displayNoValue for a filter's current value.
+export const scopeNoValue = (v: string): string | undefined =>
+  v === NO_VALUE_LABEL ? "" : v || undefined;
 
 // The outcome stack, in render order, for the generic ui/charts primitives.
 export const OUTCOME_SERIES: ChartSeries[] = [

--- a/platform/dashboard/src/components/audit/charts.tsx
+++ b/platform/dashboard/src/components/audit/charts.tsx
@@ -7,6 +7,7 @@
 import { Check, CircleDashed, X } from "lucide-react";
 import type { AuditOutcome } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
+import { BarRow } from "@/components/ui/breakdown-card";
 import { OUT_LABEL } from "./chart-tokens";
 
 export interface Counts {
@@ -47,30 +48,28 @@ export function BreakdownBar({
   const seg = (k: AuditOutcome) => (row.total ? (row[k] / row.total) * 100 : 0);
   const widthPct = max ? (row.total / max) * 100 : 0;
   return (
-    <div
+    <BarRow
       onClick={onClick}
-      className={`mb-[11px] transition-opacity ${onClick ? "cursor-pointer" : ""} ${active === false ? "opacity-45" : ""}`}
-    >
-      <div className="mb-1 flex justify-between gap-2 text-[12.5px]">
-        <span className="truncate font-mono">{label}</span>
-        <span className="shrink-0 text-muted-foreground">
-          {row.deny > 0 && (
-            <span className="mr-2 text-deny">{row.deny} denied</span>
-          )}
-          <span className="text-foreground">{row.total.toLocaleString()}</span>
-        </span>
-      </div>
-      <div
-        className="flex h-1.5 min-w-6 overflow-hidden rounded-[3px] bg-secondary"
-        style={{ width: `${Math.max(widthPct, 4)}%` }}
-      >
-        <div className="bg-allow" style={{ width: `${seg("allow")}%` }} />
-        <div
-          className="bg-approval"
-          style={{ width: `${seg("needs_approval")}%` }}
-        />
-        <div className="bg-deny" style={{ width: `${seg("deny")}%` }} />
-      </div>
-    </div>
+      active={active}
+      widthPct={widthPct}
+      header={
+        <>
+          <span className="truncate font-mono">{label}</span>
+          <span className="shrink-0 text-muted-foreground">
+            {row.deny > 0 && (
+              <span className="mr-2 text-deny">{row.deny} denied</span>
+            )}
+            <span className="text-foreground">
+              {row.total.toLocaleString()}
+            </span>
+          </span>
+        </>
+      }
+      segments={[
+        { className: "bg-allow", widthPct: seg("allow") },
+        { className: "bg-approval", widthPct: seg("needs_approval") },
+        { className: "bg-deny", widthPct: seg("deny") },
+      ]}
+    />
   );
 }

--- a/platform/dashboard/src/components/audit/pieces.tsx
+++ b/platform/dashboard/src/components/audit/pieces.tsx
@@ -38,9 +38,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { Sparkline } from "@/components/ui/charts";
+import { BreakdownCardShell } from "@/components/ui/breakdown-card";
 import { BreakdownBar, type BreakdownDatum, DecisionBadge } from "./charts";
 import { OUTCOME_SERIES } from "./chart-tokens";
 import { fmtTs } from "./fmt";
@@ -314,62 +314,43 @@ export function BreakdownCard({
   const fkey = dim;
 
   return (
-    <Card className="flex flex-col p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <Tabs value={dim} onValueChange={(v) => setDim(v as typeof dim)}>
-          <TabsList>
-            {DIMS.map((d) => (
-              <TabsTrigger key={d.id} value={d.id}>
-                {d.label}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-        <Select
-          value={sort}
-          onValueChange={(v) => setSort(v as "volume" | "denials")}
-        >
-          <SelectTrigger className="h-7 w-auto gap-1.5 text-xs">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="volume">by volume</SelectItem>
-            <SelectItem value="denials">by denials</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="grid flex-1 grid-cols-2 gap-x-8">
-        {data.map((row) => (
-          <BreakdownBar
-            key={row.key}
-            label={row.key}
-            row={row}
-            max={max}
-            active={!f[fkey] || f[fkey] === row.key}
-            onClick={() =>
-              setF((p) => ({
-                ...p,
-                [fkey]: p[fkey] === row.key ? "" : row.key,
-              }))
-            }
-          />
-        ))}
-        {!data.length && (
-          <div className="py-2 text-[12.5px] text-muted-foreground">
-            No decisions match.
-          </div>
-        )}
-      </div>
-      <div className="mt-1 flex gap-3.5 border-t border-border pt-3 text-[11px] text-muted-foreground">
-        {OUTCOME_SERIES.map((s) => (
-          <span key={s.key} className="flex items-center gap-1.5">
-            <span className={`size-2 rounded-sm ${s.swatchClass}`} />
-            {s.label}
-          </span>
-        ))}
-        <span className="ml-auto">click a bar to filter →</span>
-      </div>
-    </Card>
+    <BreakdownCardShell
+      dims={DIMS}
+      dim={dim}
+      onDimChange={setDim}
+      metric={sort}
+      metricOptions={[
+        { value: "volume", label: "by volume" },
+        { value: "denials", label: "by denials" },
+      ]}
+      onMetricChange={setSort}
+      emptyMessage="No decisions match."
+      legend={
+        <>
+          {OUTCOME_SERIES.map((s) => (
+            <span key={s.key} className="flex items-center gap-1.5">
+              <span className={`size-2 rounded-sm ${s.swatchClass}`} />
+              {s.label}
+            </span>
+          ))}
+        </>
+      }
+      rows={data.map((row) => (
+        <BreakdownBar
+          key={row.key}
+          label={row.key}
+          row={row}
+          max={max}
+          active={!f[fkey] || f[fkey] === row.key}
+          onClick={() =>
+            setF((p) => ({
+              ...p,
+              [fkey]: p[fkey] === row.key ? "" : row.key,
+            }))
+          }
+        />
+      ))}
+    />
   );
 }
 

--- a/platform/dashboard/src/components/audit/pieces.tsx
+++ b/platform/dashboard/src/components/audit/pieces.tsx
@@ -57,8 +57,10 @@ const toDatum = (r: AuditBreakdownRow): BreakdownDatum => ({
 // Radix Select items can't carry value="" — UI-local stand-in for "all".
 const ALL = "__all__";
 
-// Module-level (not re-created per render).
-function FilterSelect({
+// Module-level (not re-created per render). Exported — reused by the
+// Usage page's filter bar (components/usage/pieces.tsx), which needs the
+// same "select with an all-option" shape for agent/model/user.
+export function FilterSelect({
   value,
   all,
   opts,

--- a/platform/dashboard/src/components/audit/pieces.tsx
+++ b/platform/dashboard/src/components/audit/pieces.tsx
@@ -23,13 +23,7 @@ import type {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { FilterSelect } from "@/components/ui/filter-select";
 import {
   Table,
   TableBody,
@@ -56,40 +50,6 @@ const toDatum = (r: AuditBreakdownRow): BreakdownDatum => ({
 
 // Radix Select items can't carry value="" — UI-local stand-in for "all".
 const ALL = "__all__";
-
-// Module-level (not re-created per render). Exported — reused by the
-// Usage page's filter bar (components/usage/pieces.tsx), which needs the
-// same "select with an all-option" shape for agent/model/user.
-export function FilterSelect({
-  value,
-  all,
-  opts,
-  onChange,
-}: {
-  value: string;
-  all: string;
-  opts: string[];
-  onChange: (v: string) => void;
-}) {
-  return (
-    <Select
-      value={value || ALL}
-      onValueChange={(v) => onChange(v === ALL ? "" : v)}
-    >
-      <SelectTrigger className="h-8 w-auto min-w-32 gap-1.5 text-[13px]">
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value={ALL}>{all}</SelectItem>
-        {opts.map((o) => (
-          <SelectItem key={o} value={o} className="font-mono text-xs">
-            {o}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
 
 // ————————————————————————————————————————————— Filter bar
 export function FilterBar({

--- a/platform/dashboard/src/components/audit/pieces.tsx
+++ b/platform/dashboard/src/components/audit/pieces.tsx
@@ -20,10 +20,11 @@ import type {
   AuditFilters as Filters,
   SetAuditFilters as SetFilters,
 } from "@/lib/audit-filters";
+import { ActiveFilterChips } from "@/components/ui/active-filter-chips";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { FilterSelect } from "@/components/ui/filter-select";
+import { ALL, FilterSelect } from "@/components/ui/filter-select";
 import {
   Table,
   TableBody,
@@ -47,9 +48,6 @@ const toDatum = (r: AuditBreakdownRow): BreakdownDatum => ({
   deny: r.deny,
   needs_approval: r.needs_approval,
 });
-
-// Radix Select items can't carry value="" — UI-local stand-in for "all".
-const ALL = "__all__";
 
 // ————————————————————————————————————————————— Filter bar
 export function FilterBar({
@@ -133,55 +131,34 @@ export function FilterBar({
   );
 }
 
+const CHIP_KEYS: (keyof Filters)[] = [
+  "agent",
+  "role",
+  "tool",
+  "user",
+  "outcome",
+];
+
 export function ActiveChips({ f, setF }: { f: Filters; setF: SetFilters }) {
-  const set = <K extends keyof Filters>(k: K, v: Filters[K]) =>
-    setF((p) => ({ ...p, [k]: v }));
-  const lbl: Record<string, string> = {
-    agent: "agent",
-    role: "role",
-    tool: "tool",
-    user: "user",
-    outcome: "outcome",
-  };
-  const chips = (["agent", "role", "tool", "user", "outcome"] as const).filter(
-    (k) => f[k],
-  );
-  if (!chips.length) return null;
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-1.5">
-      <span className="text-[11.5px] text-muted-foreground">Filters</span>
-      {chips.map((k) => (
-        <Badge key={k} className="gap-1 pr-1 text-muted-foreground">
-          {lbl[k]}: <span className="font-mono text-foreground">{f[k]}</span>
-          <button
-            onClick={() => set(k, "")}
-            className="inline-flex cursor-pointer text-muted-foreground hover:text-foreground"
-          >
-            <X className="size-3" />
-          </button>
-        </Badge>
-      ))}
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-6 px-2 text-xs"
-        onClick={() =>
-          setF((p) => ({
-            ...p,
-            agent: "",
-            role: "",
-            tool: "",
-            outcome: "",
-            customMode: false,
-            start_date: null,
-            end_date: null,
-            user: "",
-          }))
-        }
-      >
-        Clear all
-      </Button>
-    </div>
+    <ActiveFilterChips
+      f={f}
+      setF={setF}
+      chipKeys={CHIP_KEYS}
+      onClearAll={() =>
+        setF((p) => ({
+          ...p,
+          agent: "",
+          role: "",
+          tool: "",
+          outcome: "",
+          customMode: false,
+          start_date: null,
+          end_date: null,
+          user: "",
+        }))
+      }
+    />
   );
 }
 
@@ -295,21 +272,18 @@ export function BreakdownCard({
           ))}
         </>
       }
-      rows={data.map((row) => (
+      rows={data}
+      activeFilterValue={f[fkey]}
+      onFilterChange={(v) => setF((p) => ({ ...p, [fkey]: v }))}
+      renderRow={(row, { active, onClick }) => (
         <BreakdownBar
-          key={row.key}
           label={row.key}
           row={row}
           max={max}
-          active={!f[fkey] || f[fkey] === row.key}
-          onClick={() =>
-            setF((p) => ({
-              ...p,
-              [fkey]: p[fkey] === row.key ? "" : row.key,
-            }))
-          }
+          active={active}
+          onClick={onClick}
         />
-      ))}
+      )}
     />
   );
 }

--- a/platform/dashboard/src/components/ui/active-filter-chips.tsx
+++ b/platform/dashboard/src/components/ui/active-filter-chips.tsx
@@ -1,0 +1,49 @@
+/**
+ * Active-filter chip row + "Clear all" — one chip per set filter key, each
+ * clearable individually. Shared by Audit's and Usage's filter bars, which
+ * differ only in which keys are chip-eligible and what "clear all" resets.
+ */
+
+import { X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+export function ActiveFilterChips<F extends object>({
+  f,
+  setF,
+  chipKeys,
+  onClearAll,
+}: {
+  f: F;
+  setF: (updater: (prev: F) => F) => void;
+  chipKeys: (keyof F)[];
+  onClearAll: () => void;
+}) {
+  const active = chipKeys.filter((k) => f[k]);
+  if (!active.length) return null;
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-1.5">
+      <span className="text-[11.5px] text-muted-foreground">Filters</span>
+      {active.map((k) => (
+        <Badge key={String(k)} className="gap-1 pr-1 text-muted-foreground">
+          {String(k)}:{" "}
+          <span className="font-mono text-foreground">{String(f[k])}</span>
+          <button
+            onClick={() => setF((p) => ({ ...p, [k]: "" }) as F)}
+            className="inline-flex cursor-pointer text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3" />
+          </button>
+        </Badge>
+      ))}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 px-2 text-xs"
+        onClick={onClearAll}
+      >
+        Clear all
+      </Button>
+    </div>
+  );
+}

--- a/platform/dashboard/src/components/ui/breakdown-card.tsx
+++ b/platform/dashboard/src/components/ui/breakdown-card.tsx
@@ -3,10 +3,11 @@
  * metric/sort Select, a two-column grid of bar rows, an empty state, and a
  * footer legend. Shared by Audit's outcome-stacked breakdown and Usage's
  * single-metric breakdown; each caller supplies its own row markup via
- * `BarRow` and passes the rendered rows in.
+ * `renderRow`, while the shell owns the filter-toggle click semantics so
+ * it isn't reimplemented (and can't drift) per caller.
  */
 
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import { Card } from "@/components/ui/card";
 import {
   Select,
@@ -55,7 +56,11 @@ export function BarRow({
   );
 }
 
-export function BreakdownCardShell<Dim extends string, Metric extends string>({
+export function BreakdownCardShell<
+  Dim extends string,
+  Metric extends string,
+  Row extends { key: string },
+>({
   dims,
   dim,
   onDimChange,
@@ -63,6 +68,9 @@ export function BreakdownCardShell<Dim extends string, Metric extends string>({
   metricOptions,
   onMetricChange,
   rows,
+  renderRow,
+  activeFilterValue,
+  onFilterChange,
   emptyMessage,
   legend,
 }: {
@@ -72,7 +80,13 @@ export function BreakdownCardShell<Dim extends string, Metric extends string>({
   metric: Metric;
   metricOptions: { value: Metric; label: string }[];
   onMetricChange: (m: Metric) => void;
-  rows: ReactNode[];
+  rows: Row[];
+  renderRow: (
+    row: Row,
+    opts: { active: boolean; onClick: () => void },
+  ) => ReactNode;
+  activeFilterValue: string;
+  onFilterChange: (next: string) => void;
   emptyMessage: string;
   legend: ReactNode;
 }) {
@@ -106,7 +120,16 @@ export function BreakdownCardShell<Dim extends string, Metric extends string>({
       </div>
       <div className="grid flex-1 grid-cols-2 gap-x-8">
         {rows.length ? (
-          rows
+          rows.map((row) => {
+            const active = !activeFilterValue || activeFilterValue === row.key;
+            const onClick = () =>
+              onFilterChange(activeFilterValue === row.key ? "" : row.key);
+            return (
+              <Fragment key={row.key}>
+                {renderRow(row, { active, onClick })}
+              </Fragment>
+            );
+          })
         ) : (
           <div className="py-2 text-[12.5px] text-muted-foreground">
             {emptyMessage}

--- a/platform/dashboard/src/components/ui/breakdown-card.tsx
+++ b/platform/dashboard/src/components/ui/breakdown-card.tsx
@@ -1,0 +1,122 @@
+/**
+ * Generic "ranked bar breakdown" card — a dimension-switching Tabs strip, a
+ * metric/sort Select, a two-column grid of bar rows, an empty state, and a
+ * footer legend. Shared by Audit's outcome-stacked breakdown and Usage's
+ * single-metric breakdown; each caller supplies its own row markup via
+ * `BarRow` and passes the rendered rows in.
+ */
+
+import type { ReactNode } from "react";
+import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+// ——— Bar row: label/value header + a track of one or more colored segments
+export function BarRow({
+  header,
+  segments,
+  widthPct,
+  onClick,
+  active,
+}: {
+  header: ReactNode;
+  segments: { className: string; widthPct: number }[];
+  widthPct: number;
+  onClick?: () => void;
+  active?: boolean;
+}) {
+  return (
+    <div
+      onClick={onClick}
+      className={`mb-[11px] transition-opacity ${onClick ? "cursor-pointer" : ""} ${active === false ? "opacity-45" : ""}`}
+    >
+      <div className="mb-1 flex justify-between gap-2 text-[12.5px]">
+        {header}
+      </div>
+      <div
+        className="flex h-1.5 min-w-6 overflow-hidden rounded-[3px] bg-secondary"
+        style={{ width: `${Math.max(widthPct, 4)}%` }}
+      >
+        {segments.map((s, i) => (
+          <div
+            key={i}
+            className={s.className}
+            style={{ width: `${s.widthPct}%` }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function BreakdownCardShell<Dim extends string, Metric extends string>({
+  dims,
+  dim,
+  onDimChange,
+  metric,
+  metricOptions,
+  onMetricChange,
+  rows,
+  emptyMessage,
+  legend,
+}: {
+  dims: { id: Dim; label: string }[];
+  dim: Dim;
+  onDimChange: (d: Dim) => void;
+  metric: Metric;
+  metricOptions: { value: Metric; label: string }[];
+  onMetricChange: (m: Metric) => void;
+  rows: ReactNode[];
+  emptyMessage: string;
+  legend: ReactNode;
+}) {
+  return (
+    <Card className="flex flex-col p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <Tabs value={dim} onValueChange={(v) => onDimChange(v as Dim)}>
+          <TabsList>
+            {dims.map((d) => (
+              <TabsTrigger key={d.id} value={d.id}>
+                {d.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <Select
+          value={metric}
+          onValueChange={(v) => onMetricChange(v as Metric)}
+        >
+          <SelectTrigger className="h-7 w-auto gap-1.5 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {metricOptions.map((o) => (
+              <SelectItem key={o.value} value={o.value}>
+                {o.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid flex-1 grid-cols-2 gap-x-8">
+        {rows.length ? (
+          rows
+        ) : (
+          <div className="py-2 text-[12.5px] text-muted-foreground">
+            {emptyMessage}
+          </div>
+        )}
+      </div>
+      <div className="mt-1 flex gap-3.5 border-t border-border pt-3 text-[11px] text-muted-foreground">
+        {legend}
+        <span className="ml-auto">click a bar to filter →</span>
+      </div>
+    </Card>
+  );
+}

--- a/platform/dashboard/src/components/ui/dashboard-range-picker.tsx
+++ b/platform/dashboard/src/components/ui/dashboard-range-picker.tsx
@@ -1,0 +1,97 @@
+/**
+ * Range/Custom toggle + date-range popover for a dashboard page header —
+ * preset buttons (24h/7d/30d/90d) plus a "Custom" mode that opens a
+ * two-date calendar. Shared by Audit's and Usage's headers, which operate
+ * on identical fields (range, customMode, start_date, end_date) already
+ * unified under the Range type in date-range.ts.
+ */
+
+import { endOfDay, format } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  RANGE_DAYS,
+  type Range,
+  type RangePickerFilters,
+} from "@/lib/date-range";
+
+const DATE_FMT = "MMM d, yyyy";
+
+function impliedRangeLabel(range: Range): string {
+  const now = new Date();
+  const start = new Date(now.getTime() - RANGE_DAYS[range] * 86_400_000);
+  return `${format(start, DATE_FMT)} → ${format(now, DATE_FMT)}`;
+}
+
+export function DashboardRangePicker<F extends RangePickerFilters>({
+  f,
+  setF,
+}: {
+  f: F;
+  setF: (updater: (prev: F) => F) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <ToggleGroup
+        type="single"
+        value={f.customMode ? "custom" : f.range}
+        onValueChange={(v) => {
+          if (!v) return;
+          if (v === "custom") {
+            setF((p) => ({ ...p, customMode: true }));
+          } else {
+            setF((p) => ({
+              ...p,
+              range: v as Range,
+              customMode: false,
+              start_date: null,
+              end_date: null,
+            }));
+          }
+        }}
+      >
+        {(["24h", "7d", "30d", "90d"] as const).map((r) => (
+          <ToggleGroupItem key={r} value={r}>
+            {r}
+          </ToggleGroupItem>
+        ))}
+        <ToggleGroupItem value="custom">Custom</ToggleGroupItem>
+      </ToggleGroup>
+      {f.customMode && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant="outline" className="h-8 text-[13px] font-normal">
+              {f.start_date && f.end_date
+                ? `${format(f.start_date, DATE_FMT)} → ${format(f.end_date, DATE_FMT)}`
+                : f.start_date
+                  ? `${format(f.start_date, DATE_FMT)} → …`
+                  : impliedRangeLabel(f.range)}
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="end">
+            <Calendar
+              mode="range"
+              selected={{
+                from: f.start_date ?? undefined,
+                to: f.end_date ?? undefined,
+              }}
+              onSelect={(range) =>
+                setF((p) => ({
+                  ...p,
+                  start_date: range?.from ?? null,
+                  end_date: range?.to ? endOfDay(range.to) : null,
+                }))
+              }
+            />
+          </PopoverContent>
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/platform/dashboard/src/components/ui/filter-select.tsx
+++ b/platform/dashboard/src/components/ui/filter-select.tsx
@@ -13,7 +13,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const ALL = "__all__";
+export const ALL = "__all__";
 
 export function FilterSelect({
   value,

--- a/platform/dashboard/src/components/ui/filter-select.tsx
+++ b/platform/dashboard/src/components/ui/filter-select.tsx
@@ -1,0 +1,47 @@
+/**
+ * Select with an "all" option — the value that maps to no filter is
+ * represented on the wire as "", but Radix Select items can't carry
+ * value="". ALL is a UI-local stand-in swapped at the boundary.
+ * Shared by Audit's and Usage's filter bars.
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const ALL = "__all__";
+
+export function FilterSelect({
+  value,
+  all,
+  opts,
+  onChange,
+}: {
+  value: string;
+  all: string;
+  opts: string[];
+  onChange: (v: string) => void;
+}) {
+  return (
+    <Select
+      value={value || ALL}
+      onValueChange={(v) => onChange(v === ALL ? "" : v)}
+    >
+      <SelectTrigger className="h-8 w-auto min-w-32 gap-1.5 text-[13px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value={ALL}>{all}</SelectItem>
+        {opts.map((o) => (
+          <SelectItem key={o} value={o} className="font-mono text-xs">
+            {o}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/platform/dashboard/src/components/usage/pieces.tsx
+++ b/platform/dashboard/src/components/usage/pieces.tsx
@@ -1,0 +1,249 @@
+import { useMemo, useState } from "react";
+import { X } from "lucide-react";
+import type { LlmInvocationBreakdownRow } from "@/lib/api";
+import type {
+  SetUsageFilters as SetFilters,
+  UsageFilters as Filters,
+} from "@/lib/usage-filters";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { FilterSelect } from "@/components/audit/pieces";
+
+// ————————————————————————————————————————————— Filter bar
+export function UsageFilterBar({
+  f,
+  setF,
+  shown,
+  total,
+  agents,
+  models,
+  users,
+}: {
+  f: Filters;
+  setF: SetFilters;
+  shown: number;
+  total: number;
+  agents: string[];
+  models: string[];
+  users: string[];
+}) {
+  const set = <K extends keyof Filters>(k: K, v: Filters[K]) =>
+    setF((p) => ({ ...p, [k]: v }));
+  return (
+    <div className="mb-3.5 flex flex-wrap items-center gap-2">
+      <FilterSelect
+        value={f.agent}
+        all="All agents"
+        opts={agents}
+        onChange={(v) => set("agent", v)}
+      />
+      <FilterSelect
+        value={f.model}
+        all="All models"
+        opts={models}
+        onChange={(v) => set("model", v)}
+      />
+      <FilterSelect
+        value={f.user}
+        all="All users"
+        opts={users}
+        onChange={(v) => set("user", v)}
+      />
+      <span className="ml-auto whitespace-nowrap text-xs text-muted-foreground">
+        <span className="text-foreground">{shown.toLocaleString()}</span> of{" "}
+        <span className="font-mono">{total.toLocaleString()}</span> LLM calls
+      </span>
+    </div>
+  );
+}
+
+export function UsageActiveChips({
+  f,
+  setF,
+}: {
+  f: Filters;
+  setF: SetFilters;
+}) {
+  const set = <K extends keyof Filters>(k: K, v: Filters[K]) =>
+    setF((p) => ({ ...p, [k]: v }));
+  const lbl: Record<string, string> = {
+    agent: "agent",
+    model: "model",
+    user: "user",
+  };
+  const chips = (["agent", "model", "user"] as const).filter((k) => f[k]);
+  if (!chips.length) return null;
+  return (
+    <div className="mb-4 flex flex-wrap items-center gap-1.5">
+      <span className="text-[11.5px] text-muted-foreground">Filters</span>
+      {chips.map((k) => (
+        <Badge key={k} className="gap-1 pr-1 text-muted-foreground">
+          {lbl[k]}: <span className="font-mono text-foreground">{f[k]}</span>
+          <button
+            onClick={() => set(k, "")}
+            className="inline-flex cursor-pointer text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3" />
+          </button>
+        </Badge>
+      ))}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="h-6 px-2 text-xs"
+        onClick={() =>
+          setF((p) => ({
+            ...p,
+            agent: "",
+            model: "",
+            user: "",
+            customMode: false,
+            start_date: null,
+            end_date: null,
+          }))
+        }
+      >
+        Clear all
+      </Button>
+    </div>
+  );
+}
+
+// ————————————————————————————————————————————— Breakdown bar (single
+// volume metric, no outcome mix — unlike audit/charts.tsx's BreakdownBar)
+function UsageBar({
+  row,
+  max,
+  metric,
+  active,
+  onClick,
+}: {
+  row: LlmInvocationBreakdownRow;
+  max: number;
+  metric: "total_tokens" | "calls";
+  active?: boolean;
+  onClick?: () => void;
+}) {
+  const value = row[metric];
+  const widthPct = max ? (value / max) * 100 : 0;
+  return (
+    <div
+      onClick={onClick}
+      className={`mb-[11px] transition-opacity ${onClick ? "cursor-pointer" : ""} ${active === false ? "opacity-45" : ""}`}
+    >
+      <div className="mb-1 flex justify-between gap-2 text-[12.5px]">
+        <span className="truncate font-mono">{row.key}</span>
+        <span className="shrink-0 text-foreground">
+          {value.toLocaleString()}
+        </span>
+      </div>
+      <div
+        className="flex h-1.5 min-w-6 overflow-hidden rounded-[3px] bg-secondary"
+        style={{ width: `${Math.max(widthPct, 4)}%` }}
+      >
+        <div className="bg-primary" style={{ width: "100%" }} />
+      </div>
+    </div>
+  );
+}
+
+// ————————————————————————————————————————————— Breakdown card
+const DIMS = [
+  { id: "model" as const, label: "Models" },
+  { id: "agent" as const, label: "Agents" },
+  { id: "user" as const, label: "Users" },
+];
+
+export function UsageBreakdownCard({
+  byModel,
+  byAgent,
+  byUser,
+  f,
+  setF,
+}: {
+  byModel: LlmInvocationBreakdownRow[];
+  byAgent: LlmInvocationBreakdownRow[];
+  byUser: LlmInvocationBreakdownRow[];
+  f: Filters;
+  setF: SetFilters;
+}) {
+  const [dim, setDim] = useState<"model" | "agent" | "user">("model");
+  const [metric, setMetric] = useState<"total_tokens" | "calls">(
+    "total_tokens",
+  );
+  const source = dim === "model" ? byModel : dim === "agent" ? byAgent : byUser;
+  const data = useMemo(() => {
+    return source
+      .slice()
+      .sort((a, b) => b[metric] - a[metric])
+      .slice(0, 10);
+  }, [source, metric]);
+  const max = Math.max(...data.map((d) => d[metric]), 1);
+  const fkey = dim;
+
+  return (
+    <Card className="flex flex-col p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <Tabs value={dim} onValueChange={(v) => setDim(v as typeof dim)}>
+          <TabsList>
+            {DIMS.map((d) => (
+              <TabsTrigger key={d.id} value={d.id}>
+                {d.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <Select
+          value={metric}
+          onValueChange={(v) => setMetric(v as typeof metric)}
+        >
+          <SelectTrigger className="h-7 w-auto gap-1.5 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="total_tokens">by tokens</SelectItem>
+            <SelectItem value="calls">by calls</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="grid flex-1 grid-cols-2 gap-x-8">
+        {data.map((row) => (
+          <UsageBar
+            key={row.key}
+            row={row}
+            max={max}
+            metric={metric}
+            active={!f[fkey] || f[fkey] === row.key}
+            onClick={() =>
+              setF((p) => ({
+                ...p,
+                [fkey]: p[fkey] === row.key ? "" : row.key,
+              }))
+            }
+          />
+        ))}
+        {!data.length && (
+          <div className="py-2 text-[12.5px] text-muted-foreground">
+            No LLM calls match.
+          </div>
+        )}
+      </div>
+      <div className="mt-1 flex gap-3.5 border-t border-border pt-3 text-[11px] text-muted-foreground">
+        <span className="flex items-center gap-1.5">
+          <span className="size-2 rounded-sm bg-primary" />
+          {metric === "total_tokens" ? "total tokens" : "calls"}
+        </span>
+        <span className="ml-auto">click a bar to filter →</span>
+      </div>
+    </Card>
+  );
+}

--- a/platform/dashboard/src/components/usage/pieces.tsx
+++ b/platform/dashboard/src/components/usage/pieces.tsx
@@ -8,7 +8,7 @@ import type {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { BarRow, BreakdownCardShell } from "@/components/ui/breakdown-card";
-import { FilterSelect } from "@/components/audit/pieces";
+import { FilterSelect } from "@/components/ui/filter-select";
 
 // ————————————————————————————————————————————— Filter bar
 export function UsageFilterBar({

--- a/platform/dashboard/src/components/usage/pieces.tsx
+++ b/platform/dashboard/src/components/usage/pieces.tsx
@@ -7,15 +7,7 @@ import type {
 } from "@/lib/usage-filters";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { BarRow, BreakdownCardShell } from "@/components/ui/breakdown-card";
 import { FilterSelect } from "@/components/audit/pieces";
 
 // ————————————————————————————————————————————— Filter bar
@@ -136,23 +128,20 @@ function UsageBar({
   const value = row[metric];
   const widthPct = max ? (value / max) * 100 : 0;
   return (
-    <div
+    <BarRow
       onClick={onClick}
-      className={`mb-[11px] transition-opacity ${onClick ? "cursor-pointer" : ""} ${active === false ? "opacity-45" : ""}`}
-    >
-      <div className="mb-1 flex justify-between gap-2 text-[12.5px]">
-        <span className="truncate font-mono">{row.key}</span>
-        <span className="shrink-0 text-foreground">
-          {value.toLocaleString()}
-        </span>
-      </div>
-      <div
-        className="flex h-1.5 min-w-6 overflow-hidden rounded-[3px] bg-secondary"
-        style={{ width: `${Math.max(widthPct, 4)}%` }}
-      >
-        <div className="bg-primary" style={{ width: "100%" }} />
-      </div>
-    </div>
+      active={active}
+      widthPct={widthPct}
+      header={
+        <>
+          <span className="truncate font-mono">{row.key}</span>
+          <span className="shrink-0 text-foreground">
+            {value.toLocaleString()}
+          </span>
+        </>
+      }
+      segments={[{ className: "bg-primary", widthPct: 100 }]}
+    />
   );
 }
 
@@ -191,59 +180,38 @@ export function UsageBreakdownCard({
   const fkey = dim;
 
   return (
-    <Card className="flex flex-col p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <Tabs value={dim} onValueChange={(v) => setDim(v as typeof dim)}>
-          <TabsList>
-            {DIMS.map((d) => (
-              <TabsTrigger key={d.id} value={d.id}>
-                {d.label}
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
-        <Select
-          value={metric}
-          onValueChange={(v) => setMetric(v as typeof metric)}
-        >
-          <SelectTrigger className="h-7 w-auto gap-1.5 text-xs">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="total_tokens">by tokens</SelectItem>
-            <SelectItem value="calls">by calls</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="grid flex-1 grid-cols-2 gap-x-8">
-        {data.map((row) => (
-          <UsageBar
-            key={row.key}
-            row={row}
-            max={max}
-            metric={metric}
-            active={!f[fkey] || f[fkey] === row.key}
-            onClick={() =>
-              setF((p) => ({
-                ...p,
-                [fkey]: p[fkey] === row.key ? "" : row.key,
-              }))
-            }
-          />
-        ))}
-        {!data.length && (
-          <div className="py-2 text-[12.5px] text-muted-foreground">
-            No LLM calls match.
-          </div>
-        )}
-      </div>
-      <div className="mt-1 flex gap-3.5 border-t border-border pt-3 text-[11px] text-muted-foreground">
+    <BreakdownCardShell
+      dims={DIMS}
+      dim={dim}
+      onDimChange={setDim}
+      metric={metric}
+      metricOptions={[
+        { value: "total_tokens", label: "by tokens" },
+        { value: "calls", label: "by calls" },
+      ]}
+      onMetricChange={setMetric}
+      emptyMessage="No LLM calls match."
+      legend={
         <span className="flex items-center gap-1.5">
           <span className="size-2 rounded-sm bg-primary" />
           {metric === "total_tokens" ? "total tokens" : "calls"}
         </span>
-        <span className="ml-auto">click a bar to filter →</span>
-      </div>
-    </Card>
+      }
+      rows={data.map((row) => (
+        <UsageBar
+          key={row.key}
+          row={row}
+          max={max}
+          metric={metric}
+          active={!f[fkey] || f[fkey] === row.key}
+          onClick={() =>
+            setF((p) => ({
+              ...p,
+              [fkey]: p[fkey] === row.key ? "" : row.key,
+            }))
+          }
+        />
+      ))}
+    />
   );
 }

--- a/platform/dashboard/src/components/usage/pieces.tsx
+++ b/platform/dashboard/src/components/usage/pieces.tsx
@@ -1,12 +1,10 @@
 import { useMemo, useState } from "react";
-import { X } from "lucide-react";
 import type { LlmInvocationBreakdownRow } from "@/lib/api";
 import type {
   SetUsageFilters as SetFilters,
   UsageFilters as Filters,
 } from "@/lib/usage-filters";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { ActiveFilterChips } from "@/components/ui/active-filter-chips";
 import { BarRow, BreakdownCardShell } from "@/components/ui/breakdown-card";
 import { FilterSelect } from "@/components/ui/filter-select";
 
@@ -58,6 +56,8 @@ export function UsageFilterBar({
   );
 }
 
+const CHIP_KEYS: (keyof Filters)[] = ["agent", "model", "user"];
+
 export function UsageActiveChips({
   f,
   setF,
@@ -65,48 +65,23 @@ export function UsageActiveChips({
   f: Filters;
   setF: SetFilters;
 }) {
-  const set = <K extends keyof Filters>(k: K, v: Filters[K]) =>
-    setF((p) => ({ ...p, [k]: v }));
-  const lbl: Record<string, string> = {
-    agent: "agent",
-    model: "model",
-    user: "user",
-  };
-  const chips = (["agent", "model", "user"] as const).filter((k) => f[k]);
-  if (!chips.length) return null;
   return (
-    <div className="mb-4 flex flex-wrap items-center gap-1.5">
-      <span className="text-[11.5px] text-muted-foreground">Filters</span>
-      {chips.map((k) => (
-        <Badge key={k} className="gap-1 pr-1 text-muted-foreground">
-          {lbl[k]}: <span className="font-mono text-foreground">{f[k]}</span>
-          <button
-            onClick={() => set(k, "")}
-            className="inline-flex cursor-pointer text-muted-foreground hover:text-foreground"
-          >
-            <X className="size-3" />
-          </button>
-        </Badge>
-      ))}
-      <Button
-        variant="ghost"
-        size="sm"
-        className="h-6 px-2 text-xs"
-        onClick={() =>
-          setF((p) => ({
-            ...p,
-            agent: "",
-            model: "",
-            user: "",
-            customMode: false,
-            start_date: null,
-            end_date: null,
-          }))
-        }
-      >
-        Clear all
-      </Button>
-    </div>
+    <ActiveFilterChips
+      f={f}
+      setF={setF}
+      chipKeys={CHIP_KEYS}
+      onClearAll={() =>
+        setF((p) => ({
+          ...p,
+          agent: "",
+          model: "",
+          user: "",
+          customMode: false,
+          start_date: null,
+          end_date: null,
+        }))
+      }
+    />
   );
 }
 
@@ -197,21 +172,18 @@ export function UsageBreakdownCard({
           {metric === "total_tokens" ? "total tokens" : "calls"}
         </span>
       }
-      rows={data.map((row) => (
+      rows={data}
+      activeFilterValue={f[fkey]}
+      onFilterChange={(v) => setF((p) => ({ ...p, [fkey]: v }))}
+      renderRow={(row, { active, onClick }) => (
         <UsageBar
-          key={row.key}
           row={row}
           max={max}
           metric={metric}
-          active={!f[fkey] || f[fkey] === row.key}
-          onClick={() =>
-            setF((p) => ({
-              ...p,
-              [fkey]: p[fkey] === row.key ? "" : row.key,
-            }))
-          }
+          active={active}
+          onClick={onClick}
         />
-      ))}
+      )}
     />
   );
 }

--- a/platform/dashboard/src/lib/api.ts
+++ b/platform/dashboard/src/lib/api.ts
@@ -366,6 +366,38 @@ export interface AuditAnomaly {
   last_seen: string;
 }
 
+// --- Usage dashboard (mirrors platform/api/schemas.py LlmInvocation*) -------
+
+/** Totals for a slice: call volume + token counts. */
+export interface LlmInvocationTotals {
+  calls: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}
+
+/** One model/agent/user bucket. */
+export interface LlmInvocationBreakdownRow extends LlmInvocationTotals {
+  key: string;
+}
+
+export interface LlmInvocationSummary {
+  totals: LlmInvocationTotals;
+  by_model: LlmInvocationBreakdownRow[];
+  by_agent: LlmInvocationBreakdownRow[];
+  by_user: LlmInvocationBreakdownRow[];
+}
+
+/** Scope filters for the usage summary. `undefined` = no filter. */
+export interface LlmUsageScope {
+  window?: AuditWindow;
+  agent?: string;
+  model?: string;
+  user?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
 function qs(params: Record<string, string | number | undefined>): string {
   const search = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
@@ -461,4 +493,9 @@ export const api = {
     request<void>(`/v1/projects/${projectId}/bans/${banId}`, {
       method: "DELETE",
     }),
+
+  getLlmUsageSummary: (scope: LlmUsageScope, projectId: string) =>
+    request<LlmInvocationSummary>(
+      `/v1/projects/${projectId}/llm/summary${qs({ ...scope })}`,
+    ),
 };

--- a/platform/dashboard/src/lib/audit-filters.ts
+++ b/platform/dashboard/src/lib/audit-filters.ts
@@ -14,21 +14,15 @@
 import { create } from "zustand";
 
 import type { AuditOutcome } from "./api";
-import { type Range, RANGE_DAYS } from "./date-range";
+import { type BaseDashboardFilters, RANGE_DAYS } from "./date-range";
 
 export { RANGE_DAYS };
 
 // '' = "all"; outcome applies to the events table only.
-export interface AuditFilters {
-  agent: string;
+export interface AuditFilters extends BaseDashboardFilters {
   role: string;
   tool: string;
-  user: string;
   outcome: "" | AuditOutcome;
-  range: Range;
-  customMode: boolean;
-  start_date: Date | null;
-  end_date: Date | null;
 }
 
 export type SetAuditFilters = (

--- a/platform/dashboard/src/lib/audit-filters.ts
+++ b/platform/dashboard/src/lib/audit-filters.ts
@@ -14,6 +14,9 @@
 import { create } from "zustand";
 
 import type { AuditOutcome } from "./api";
+import { type Range, RANGE_DAYS } from "./date-range";
+
+export { RANGE_DAYS };
 
 // '' = "all"; outcome applies to the events table only.
 export interface AuditFilters {
@@ -22,7 +25,7 @@ export interface AuditFilters {
   tool: string;
   user: string;
   outcome: "" | AuditOutcome;
-  range: "24h" | "7d" | "30d" | "90d";
+  range: Range;
   customMode: boolean;
   start_date: Date | null;
   end_date: Date | null;
@@ -31,13 +34,6 @@ export interface AuditFilters {
 export type SetAuditFilters = (
   updater: (prev: AuditFilters) => AuditFilters,
 ) => void;
-
-export const RANGE_DAYS: Record<AuditFilters["range"], number> = {
-  "24h": 1,
-  "7d": 7,
-  "30d": 30,
-  "90d": 90,
-};
 
 export const EMPTY_AUDIT_FILTERS: AuditFilters = {
   agent: "",

--- a/platform/dashboard/src/lib/date-range.ts
+++ b/platform/dashboard/src/lib/date-range.ts
@@ -14,6 +14,22 @@ export const RANGE_DAYS: Record<Range, number> = {
   "90d": 90,
 };
 
+// The preset/custom range fields DashboardRangePicker operates on.
+export interface RangePickerFilters {
+  range: Range;
+  customMode: boolean;
+  start_date: Date | null;
+  end_date: Date | null;
+}
+
+/** Fields every dashboard filter store (Audit, Usage) carries in common —
+ * kept here, not duplicated per-store, so a shared field added to one
+ * filter store is a type error until it's added to the other. */
+export interface BaseDashboardFilters extends RangePickerFilters {
+  agent: string;
+  user: string;
+}
+
 /** Effective day count for a window: explicit custom dates win when both
  * are set, otherwise falls back to the preset range's day count. */
 export function rangeDays(

--- a/platform/dashboard/src/lib/date-range.ts
+++ b/platform/dashboard/src/lib/date-range.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared window/range math for dashboard pages with a preset-range +
+ * custom-date-picker toggle (Audit, Usage). Neutral module — both
+ * audit-filters.ts and usage-filters.ts import from here rather than one
+ * page's filter store owning logic the other needs too.
+ */
+
+export type Range = "24h" | "7d" | "30d" | "90d";
+
+export const RANGE_DAYS: Record<Range, number> = {
+  "24h": 1,
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+};
+
+/** Effective day count for a window: explicit custom dates win when both
+ * are set, otherwise falls back to the preset range's day count. */
+export function rangeDays(
+  range: Range,
+  start: Date | null,
+  end: Date | null,
+): number {
+  if (start && end) {
+    return Math.max(
+      1,
+      Math.round((end.getTime() - start.getTime()) / 86_400_000),
+    );
+  }
+  return RANGE_DAYS[range];
+}

--- a/platform/dashboard/src/lib/usage-filters.ts
+++ b/platform/dashboard/src/lib/usage-filters.ts
@@ -1,0 +1,48 @@
+/**
+ * Usage-page filter state.
+ *
+ * Zustand (like ``useAuditFilters``) so the dialled-in slice survives
+ * navigating away and back within the session — deliberately NOT
+ * ``persist``-ed, same reasoning as audit-filters: a stale filter from
+ * last week silently narrowing today's usage view would read as missing
+ * data. No ``tableLimit``/``loadMore`` here — Usage has no events table.
+ */
+
+import { create } from "zustand";
+
+import type { Range } from "./date-range";
+
+// '' = "all".
+export interface UsageFilters {
+  agent: string;
+  model: string;
+  user: string;
+  range: Range;
+  customMode: boolean;
+  start_date: Date | null;
+  end_date: Date | null;
+}
+
+export type SetUsageFilters = (
+  updater: (prev: UsageFilters) => UsageFilters,
+) => void;
+
+export const EMPTY_USAGE_FILTERS: UsageFilters = {
+  agent: "",
+  model: "",
+  user: "",
+  range: "30d",
+  customMode: false,
+  start_date: null,
+  end_date: null,
+};
+
+interface UsageFilterState {
+  filters: UsageFilters;
+  setFilters: SetUsageFilters;
+}
+
+export const useUsageFilters = create<UsageFilterState>()((set) => ({
+  filters: EMPTY_USAGE_FILTERS,
+  setFilters: (updater) => set((s) => ({ filters: updater(s.filters) })),
+}));

--- a/platform/dashboard/src/lib/usage-filters.ts
+++ b/platform/dashboard/src/lib/usage-filters.ts
@@ -10,17 +10,11 @@
 
 import { create } from "zustand";
 
-import type { Range } from "./date-range";
+import type { BaseDashboardFilters } from "./date-range";
 
 // '' = "all".
-export interface UsageFilters {
-  agent: string;
+export interface UsageFilters extends BaseDashboardFilters {
   model: string;
-  user: string;
-  range: Range;
-  customMode: boolean;
-  start_date: Date | null;
-  end_date: Date | null;
 }
 
 export type SetUsageFilters = (

--- a/platform/dashboard/src/routes/Audit.test.tsx
+++ b/platform/dashboard/src/routes/Audit.test.tsx
@@ -12,9 +12,11 @@
  *      and the "Same session" list cross-links to the sibling event.
  *   5. The date filter row opens via the Custom toggle, reflects custom
  *      date selections, and collapses when a preset range is selected.
+ *   6. Clicking a breakdown bar sets the dimension filter; clicking it
+ *      again clears it.
  */
 
-import { act, screen, waitFor } from "@testing-library/react";
+import { act, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Route, Routes, useSearchParams } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -271,6 +273,33 @@ describe("AuditPage", () => {
     await user.click(screen.getByText("Denied"));
     await waitFor(() => {
       expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+    });
+  });
+
+  it("clicking a breakdown bar sets the dimension filter; clicking it again clears it", async () => {
+    stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<AuditPage />);
+
+    await screen.findByText("blocked by policy");
+    // "read_file" also appears in the events table — scope the query to
+    // the breakdown card (identified by its Tabs) to avoid ambiguity, and
+    // grab the row once since a second lookup would stay ambiguous too.
+    const breakdownCard = screen
+      .getByRole("tablist")
+      .closest(".p-6") as HTMLElement;
+    const bar = within(breakdownCard)
+      .getByText("read_file")
+      .closest(".mb-\\[11px\\]") as HTMLElement;
+
+    await user.click(bar);
+    await waitFor(() => {
+      expect(useAuditFilters.getState().filters.tool).toBe("read_file");
+    });
+
+    await user.click(bar);
+    await waitFor(() => {
+      expect(useAuditFilters.getState().filters.tool).toBe("");
     });
   });
 

--- a/platform/dashboard/src/routes/Audit.tsx
+++ b/platform/dashboard/src/routes/Audit.tsx
@@ -36,6 +36,7 @@ import {
   type AuditFilters as Filters,
   useAuditFilters,
 } from "@/lib/audit-filters";
+import { rangeDays } from "@/lib/date-range";
 import { fmtTs } from "@/components/audit/fmt";
 import {
   ActiveChips,
@@ -454,15 +455,7 @@ export function AuditPage() {
   const apprPct = counts.total
     ? Math.round((counts.needs_approval / counts.total) * 100)
     : 0;
-  const nDays =
-    f.start_date && f.end_date
-      ? Math.max(
-          1,
-          Math.round(
-            (f.end_date.getTime() - f.start_date.getTime()) / 86_400_000,
-          ),
-        )
-      : RANGE_DAYS[f.range];
+  const nDays = rangeDays(f.range, f.start_date, f.end_date);
   const avgLabel =
     !f.start_date && f.range === "24h"
       ? `${(counts.total / 24).toFixed(1)}/hr avg`

--- a/platform/dashboard/src/routes/Audit.tsx
+++ b/platform/dashboard/src/routes/Audit.tsx
@@ -8,7 +8,7 @@ import {
   Lightbulb,
   X,
 } from "lucide-react";
-import { endOfDay, format, startOfDay } from "date-fns";
+import { endOfDay, startOfDay } from "date-fns";
 import { useNavigate } from "react-router-dom";
 import { api, type AuditDecisionRow, type AuditOutcome } from "@/lib/api";
 import { useActive, useProjectScoped } from "@/lib/active";
@@ -17,13 +17,7 @@ import { useProjects } from "@/lib/projects";
 import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { DashboardRangePicker } from "@/components/ui/dashboard-range-picker";
 import { AreaChart, type ChartBucket, Donut } from "@/components/ui/charts";
 import { type Counts, DecisionBadge } from "@/components/audit/charts";
 import {
@@ -33,7 +27,6 @@ import {
   scopeNoValue,
 } from "@/components/audit/chart-tokens";
 import {
-  RANGE_DAYS,
   type AuditFilters as Filters,
   useAuditFilters,
 } from "@/lib/audit-filters";
@@ -47,14 +40,6 @@ import {
   FilterBar,
   KpiCard,
 } from "@/components/audit/pieces";
-
-const DATE_FMT = "MMM d, yyyy";
-
-function impliedRangeLabel(range: Filters["range"]): string {
-  const now = new Date();
-  const start = new Date(now.getTime() - RANGE_DAYS[range] * 86_400_000);
-  return `${format(start, DATE_FMT)} → ${format(now, DATE_FMT)}`;
-}
 
 const ZERO_COUNTS: Counts = { allow: 0, deny: 0, needs_approval: 0, total: 0 };
 
@@ -332,7 +317,6 @@ export function AuditPage() {
   const tableLimit = useAuditFilters((s) => s.tableLimit);
   const loadMore = useAuditFilters((s) => s.loadMore);
   const [sel, setSel] = useState<AuditDecisionRow | null>(null);
-  const showDateRow = f.customMode;
 
   // UI state → wire: '' = "all" locally, so unset filters are omitted
   // (undefined). The "(none)" label (role/user) maps back to '' — the
@@ -502,65 +486,7 @@ export function AuditPage() {
               <span className="font-mono text-foreground">{projectName}</span>
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            <ToggleGroup
-              type="single"
-              value={f.customMode ? "custom" : f.range}
-              onValueChange={(v) => {
-                if (!v) return;
-                if (v === "custom") {
-                  setF((p) => ({ ...p, customMode: true }));
-                } else {
-                  setF((p) => ({
-                    ...p,
-                    range: v as Filters["range"],
-                    customMode: false,
-                    start_date: null,
-                    end_date: null,
-                  }));
-                }
-              }}
-            >
-              {(["24h", "7d", "30d", "90d"] as const).map((r) => (
-                <ToggleGroupItem key={r} value={r}>
-                  {r}
-                </ToggleGroupItem>
-              ))}
-              <ToggleGroupItem value="custom">Custom</ToggleGroupItem>
-            </ToggleGroup>
-            {showDateRow && (
-              <Popover>
-                <PopoverTrigger asChild>
-                  <Button
-                    variant="outline"
-                    className="h-8 text-[13px] font-normal"
-                  >
-                    {f.start_date && f.end_date
-                      ? `${format(f.start_date, DATE_FMT)} → ${format(f.end_date, DATE_FMT)}`
-                      : f.start_date
-                        ? `${format(f.start_date, DATE_FMT)} → …`
-                        : impliedRangeLabel(f.range)}
-                  </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="end">
-                  <Calendar
-                    mode="range"
-                    selected={{
-                      from: f.start_date ?? undefined,
-                      to: f.end_date ?? undefined,
-                    }}
-                    onSelect={(range) =>
-                      setF((p) => ({
-                        ...p,
-                        start_date: range?.from ?? null,
-                        end_date: range?.to ? endOfDay(range.to) : null,
-                      }))
-                    }
-                  />
-                </PopoverContent>
-              </Popover>
-            )}
-          </div>
+          <DashboardRangePicker f={f} setF={setF} />
         </header>
 
         <FilterBar

--- a/platform/dashboard/src/routes/Audit.tsx
+++ b/platform/dashboard/src/routes/Audit.tsx
@@ -27,9 +27,10 @@ import {
 import { AreaChart, type ChartBucket, Donut } from "@/components/ui/charts";
 import { type Counts, DecisionBadge } from "@/components/audit/charts";
 import {
-  NO_VALUE_LABEL,
+  displayNoValue,
   OUT_LABEL,
   OUTCOME_SERIES,
+  scopeNoValue,
 } from "@/components/audit/chart-tokens";
 import {
   RANGE_DAYS,
@@ -334,16 +335,16 @@ export function AuditPage() {
   const showDateRow = f.customMode;
 
   // UI state → wire: '' = "all" locally, so unset filters are omitted
-  // (undefined). The "(none)" label maps to `role: ''` — the wire's
-  // no-role bucket; no sentinel string leaves the dashboard.
+  // (undefined). The "(none)" label (role/user) maps back to '' — the
+  // wire's no-value bucket; no sentinel string leaves the dashboard.
   const scope = {
     window: f.range,
     agent: f.agent || undefined,
-    role: f.role === NO_VALUE_LABEL ? "" : f.role || undefined,
+    role: scopeNoValue(f.role),
     tool: f.tool || undefined,
     start_date: f.start_date ? f.start_date.toISOString() : undefined,
     end_date: f.end_date ? f.end_date.toISOString() : undefined,
-    user: f.user || undefined,
+    user: scopeNoValue(f.user),
   };
 
   // Range-only (unscoped) summary: filter dropdown options + the "X of Y"
@@ -465,10 +466,6 @@ export function AuditPage() {
 
   const options = optionsQ.data;
   const rangeTotal = options?.totals.all ?? 0;
-  // Wire → display: the empty-role bucket arrives as a raw "" key; label
-  // it locally. Filter state then holds the label, mapped back in `scope`.
-  const displayRole = <T extends { key: string }>(r: T): T =>
-    r.key === "" ? { ...r, key: NO_VALUE_LABEL } : r;
   const related = (relatedQ.data?.rows ?? [])
     .filter((r) => r.event_id !== sel?.event_id)
     .slice(0, 6);
@@ -572,7 +569,7 @@ export function AuditPage() {
           shown={listQ.data?.total ?? 0}
           total={rangeTotal}
           agents={options?.by_agent.map((r) => r.key) ?? []}
-          roles={options?.by_role.map((r) => displayRole(r).key) ?? []}
+          roles={options?.by_role.map((r) => displayNoValue(r).key) ?? []}
           tools={options?.by_tool.map((r) => r.key) ?? []}
         />
         <ActiveChips f={f} setF={setF} />
@@ -688,7 +685,7 @@ export function AuditPage() {
           <BreakdownCard
             byTool={summary?.by_tool ?? []}
             byAgent={summary?.by_agent ?? []}
-            byRole={summary?.by_role.map(displayRole) ?? []}
+            byRole={summary?.by_role.map(displayNoValue) ?? []}
             f={f}
             setF={setF}
           />

--- a/platform/dashboard/src/routes/Usage.test.tsx
+++ b/platform/dashboard/src/routes/Usage.test.tsx
@@ -1,0 +1,350 @@
+/**
+ * Smoke tests for the /usage page.
+ *
+ * Load-bearing invariants:
+ *
+ *   1. KPI tiles render compact token counts and range-based averages
+ *      (24h → hourly average, everything else → daily average).
+ *   2. Filter selection (model) lands in the next query URL.
+ *   3. The empty-user bucket ("" over the wire) displays as "(none)" and
+ *      round-trips back to `user=` (empty) — the crash this page used to
+ *      hit before FilterSelect got a NO_VALUE_LABEL mapping.
+ *   4. The breakdown card's dimension tabs and metric select switch what's
+ *      rendered, and clicking a bar sets/clears the matching filter.
+ *   5. Active chips render the current filter and "Clear all" resets it.
+ *   6. The no-project empty state renders when the active org has none.
+ */
+
+import { act, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useActive } from "@/lib/active";
+import { EMPTY_USAGE_FILTERS, useUsageFilters } from "@/lib/usage-filters";
+import { UsagePage } from "@/routes/Usage";
+import { renderWithProviders } from "@/test/render";
+
+const PROJECT = "p1";
+
+const row = (
+  key: string,
+  calls: number,
+  input_tokens: number,
+  output_tokens: number,
+) => ({
+  key,
+  calls,
+  input_tokens,
+  output_tokens,
+  total_tokens: input_tokens + output_tokens,
+});
+
+const SUMMARY = {
+  totals: {
+    calls: 1234,
+    input_tokens: 900_000,
+    output_tokens: 300_000,
+    total_tokens: 1_200_000,
+  },
+  by_model: [
+    row("gpt-4", 800, 600_000, 200_000),
+    row("gpt-3.5", 434, 300_000, 100_000),
+  ],
+  by_agent: [
+    row("example_agent", 1000, 700_000, 200_000),
+    row("scraper", 234, 200_000, 100_000),
+  ],
+  by_user: [
+    row("alice", 900, 700_000, 200_000),
+    // The no-user bucket arrives as a raw "" key over the wire.
+    row("", 334, 200_000, 100_000),
+  ],
+};
+
+const SUMMARY_EMPTY = {
+  totals: { calls: 0, input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+  by_model: [],
+  by_agent: [],
+  by_user: [],
+};
+
+function json(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const ORGS = [
+  {
+    id: "org-1",
+    slug: "acme",
+    name: "Acme Inc",
+    created_at: "2026-01-01T00:00:00Z",
+    role: "owner",
+  },
+];
+
+/** Same fetch-stub helper pattern as Audit.test.tsx, recording every
+ * requested URL so tests can assert what filter state reached the API. */
+function stubFetch(summary: unknown = SUMMARY): string[] {
+  const calls: string[] = [];
+  vi.spyOn(window, "fetch").mockImplementation(
+    async (input: RequestInfo | URL) => {
+      const raw = typeof input === "string" ? input : input.toString();
+      const url = new URL(raw, "http://localhost");
+      calls.push(url.pathname + url.search);
+
+      switch (url.pathname) {
+        case "/v1/orgs":
+          return json(ORGS);
+        case "/v1/orgs/org-1/projects":
+          return json([
+            {
+              id: PROJECT,
+              org_id: "org-1",
+              name: "demo-project",
+              created_at: "2026-01-01T00:00:00Z",
+            },
+          ]);
+        case `/v1/projects/${PROJECT}/llm/summary`:
+          return json(summary);
+        default:
+          return new Response("not found", { status: 404 });
+      }
+    },
+  );
+  return calls;
+}
+
+/** Active org with zero projects — drives the `no-project` branch. */
+function stubFetchNoProjects(): void {
+  vi.spyOn(window, "fetch").mockImplementation(
+    async (input: RequestInfo | URL) => {
+      const raw = typeof input === "string" ? input : input.toString();
+      const url = new URL(raw, "http://localhost");
+      switch (url.pathname) {
+        case "/v1/orgs":
+          return json(ORGS);
+        case "/v1/orgs/org-1/projects":
+          return json([]);
+        default:
+          return new Response("not found", { status: 404 });
+      }
+    },
+  );
+}
+
+describe("UsagePage", () => {
+  beforeEach(() => {
+    act(() => {
+      useActive.setState({ activeOrgId: "org-1", activeProjectId: PROJECT });
+      // The filter store is module-global — reset so a filter dialled in
+      // by test A doesn't narrow test B's queries.
+      useUsageFilters.setState({ filters: EMPTY_USAGE_FILTERS });
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders KPI tiles with compact token counts and a daily average", async () => {
+    stubFetch();
+    renderWithProviders(<UsagePage />);
+
+    expect(await screen.findByText("demo-project")).toBeInTheDocument();
+    expect(await screen.findByText("1.20M")).toBeInTheDocument();
+    expect(screen.getByText("900.0K")).toBeInTheDocument();
+    expect(screen.getByText("300.0K")).toBeInTheDocument();
+    expect(screen.getByText("75% of total")).toBeInTheDocument();
+    expect(screen.getByText("25% of total")).toBeInTheDocument();
+    expect(screen.getByText("41/day avg")).toBeInTheDocument();
+    expect(screen.getByText("40000/day avg")).toBeInTheDocument();
+  });
+
+  it("shows zero percentages and the empty breakdown message with no calls yet", async () => {
+    stubFetch(SUMMARY_EMPTY);
+    renderWithProviders(<UsagePage />);
+
+    expect(await screen.findByText("demo-project")).toBeInTheDocument();
+    expect(screen.getAllByText("0% of total")).toHaveLength(2);
+    expect(screen.getByText("No LLM calls match.")).toBeInTheDocument();
+  });
+
+  it("shows an hourly average for the 24h range", async () => {
+    stubFetch();
+    act(() => {
+      useUsageFilters.setState((s) => ({
+        filters: { ...s.filters, range: "24h" },
+      }));
+    });
+    renderWithProviders(<UsagePage />);
+
+    expect(await screen.findByText("51.4/hr avg")).toBeInTheDocument();
+  });
+
+  it("agent and model filter selections land in the next query URL", async () => {
+    const calls = stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<UsagePage />);
+
+    await screen.findByText("demo-project");
+    // With no filters set, optionsQ and summaryQ dedupe into one fetch.
+    expect(
+      calls.filter(
+        (u) => u === `/v1/projects/${PROJECT}/llm/summary?window=30d`,
+      ),
+    ).toHaveLength(1);
+
+    await user.click(screen.getByText("All agents").closest("button")!);
+    await user.click(
+      await screen.findByRole("option", { name: "example_agent" }),
+    );
+    await waitFor(() => {
+      expect(calls.some((u) => u.includes("agent=example_agent"))).toBe(true);
+    });
+
+    await user.click(screen.getByText("All models").closest("button")!);
+    await user.click(await screen.findByRole("option", { name: "gpt-4" }));
+
+    await waitFor(() => {
+      expect(calls.some((u) => u.includes("model=gpt-4"))).toBe(true);
+    });
+  });
+
+  it('maps the empty-user bucket to "(none)" locally and queries user=', async () => {
+    const calls = stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<UsagePage />);
+
+    // The "" key from the wire displays as "(none)" in the dropdown…
+    await screen.findByText("demo-project");
+    await user.click(screen.getByText("All users").closest("button")!);
+    await user.click(await screen.findByRole("option", { name: "(none)" }));
+
+    // …and selecting it sends `user=` (empty value) — no "(none)" sentinel
+    // ever leaves the dashboard, and the page doesn't crash rendering it
+    // (Radix throws on an empty-string <Select.Item> value).
+    await waitFor(() => {
+      expect(calls.some((u) => /[?&]user=(&|$)/.test(u))).toBe(true);
+    });
+    expect(
+      calls.some((u) => u.includes("(none)") || u.includes("%28none%29")),
+    ).toBe(false);
+  });
+
+  it("breakdown dimension tabs switch rows, including the (none) user bucket", async () => {
+    stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<UsagePage />);
+
+    await screen.findByText("gpt-4");
+    expect(screen.getByText("gpt-3.5")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Agents" }));
+    expect(await screen.findByText("example_agent")).toBeInTheDocument();
+    expect(screen.getByText("scraper")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("tab", { name: "Users" }));
+    expect(await screen.findByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("(none)")).toBeInTheDocument();
+  });
+
+  it("metric select toggles the footer legend between tokens and calls", async () => {
+    stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<UsagePage />);
+
+    await screen.findByText("gpt-4");
+    expect(screen.getByText("total tokens")).toBeInTheDocument();
+
+    await user.click(screen.getByText("by tokens").closest("button")!);
+    await user.click(await screen.findByRole("option", { name: "by calls" }));
+
+    expect(await screen.findByText("calls")).toBeInTheDocument();
+  });
+
+  it("clicking a breakdown bar sets the filter; clicking it again clears it", async () => {
+    stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<UsagePage />);
+
+    // Grab the row once — after the first click, "gpt-4" also shows up in
+    // the model filter select and the active chip, so re-querying by text
+    // would be ambiguous.
+    const bar = (await screen.findByText("gpt-4")).closest(
+      ".mb-\\[11px\\]",
+    ) as HTMLElement;
+
+    await user.click(bar);
+    await waitFor(() => {
+      expect(useUsageFilters.getState().filters.model).toBe("gpt-4");
+    });
+    expect(screen.getByText("Clear all")).toBeInTheDocument();
+
+    await user.click(bar);
+    await waitFor(() => {
+      expect(useUsageFilters.getState().filters.model).toBe("");
+    });
+  });
+
+  it("a chip's own remove button clears just that filter; Clear all resets the rest", async () => {
+    stubFetch();
+    act(() => {
+      useUsageFilters.setState((s) => ({
+        filters: { ...s.filters, model: "gpt-4", agent: "example_agent" },
+      }));
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<UsagePage />);
+
+    const chipsRow = (await screen.findByText("Filters")).closest(
+      "div",
+    ) as HTMLElement;
+    // One remove ("×") button per active chip (agent, model) + "Clear all".
+    const buttons = within(chipsRow).getAllByRole("button");
+    expect(buttons).toHaveLength(3);
+
+    // Chips render in ["agent", "model", "user"] order — remove the first
+    // (agent) and confirm the model filter is untouched.
+    await user.click(buttons[0]);
+    await waitFor(() => {
+      expect(useUsageFilters.getState().filters.agent).toBe("");
+    });
+    expect(useUsageFilters.getState().filters.model).toBe("gpt-4");
+    expect(screen.getByText("Clear all")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Clear all"));
+    await waitFor(() => {
+      expect(useUsageFilters.getState().filters.model).toBe("");
+    });
+    expect(screen.queryByText("Clear all")).not.toBeInTheDocument();
+  });
+
+  it("Custom toggles the date range picker row; a preset range updates the filter", async () => {
+    stubFetch();
+    const user = userEvent.setup();
+    renderWithProviders(<UsagePage />);
+
+    await screen.findByText("demo-project");
+    await user.click(screen.getByText("Custom"));
+    expect(screen.getByRole("button", { name: /→/ })).toBeInTheDocument();
+
+    await user.click(screen.getByText("7d"));
+    await waitFor(() => {
+      expect(useUsageFilters.getState().filters.range).toBe("7d");
+    });
+    expect(screen.queryByRole("button", { name: /→/ })).not.toBeInTheDocument();
+  });
+
+  it("renders the empty-project state when the active org has no projects", async () => {
+    stubFetchNoProjects();
+    act(() => {
+      useActive.setState({ activeOrgId: "org-1", activeProjectId: null });
+    });
+    renderWithProviders(<UsagePage />);
+
+    expect(await screen.findByText("No project selected")).toBeInTheDocument();
+  });
+});

--- a/platform/dashboard/src/routes/Usage.tsx
+++ b/platform/dashboard/src/routes/Usage.tsx
@@ -98,10 +98,10 @@ export function UsagePage() {
   const rangeTotal = options?.totals.calls ?? 0;
 
   const nDays = rangeDays(f.range, f.start_date, f.end_date);
-  const avgLabel =
+  const avgLabel = (count: number) =>
     !f.start_date && f.range === "24h"
-      ? `${(totals.calls / 24).toFixed(1)}/hr avg`
-      : `${(totals.calls / nDays).toFixed(0)}/day avg`;
+      ? `${(count / 24).toFixed(1)}/hr avg`
+      : `${(count / nDays).toFixed(0)}/day avg`;
   const inputPct = totals.total_tokens
     ? Math.round((totals.input_tokens / totals.total_tokens) * 100)
     : 0;
@@ -200,7 +200,7 @@ export function UsagePage() {
           label="Calls"
           icon={Activity}
           value={totals.calls.toLocaleString()}
-          sub={avgLabel}
+          sub={avgLabel(totals.calls)}
         />
         <KpiCard
           label="Input tokens"
@@ -218,7 +218,7 @@ export function UsagePage() {
           label="Total tokens"
           icon={Sigma}
           value={fmtTokens(totals.total_tokens)}
-          sub={`${(totals.total_tokens / nDays).toFixed(0)}/day avg`}
+          sub={avgLabel(totals.total_tokens)}
         />
       </div>
 

--- a/platform/dashboard/src/routes/Usage.tsx
+++ b/platform/dashboard/src/routes/Usage.tsx
@@ -1,0 +1,233 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import {
+  Activity,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Sigma,
+} from "lucide-react";
+import { endOfDay, format } from "date-fns";
+import { api } from "@/lib/api";
+import { useActive, useProjectScoped } from "@/lib/active";
+import { useProjects } from "@/lib/projects";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { Button } from "@/components/ui/button";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { KpiCard } from "@/components/audit/pieces";
+import { RANGE_DAYS, rangeDays } from "@/lib/date-range";
+import {
+  UsageActiveChips,
+  UsageBreakdownCard,
+  UsageFilterBar,
+} from "@/components/usage/pieces";
+import {
+  type UsageFilters as Filters,
+  useUsageFilters,
+} from "@/lib/usage-filters";
+
+const DATE_FMT = "MMM d, yyyy";
+
+function impliedRangeLabel(range: Filters["range"]): string {
+  const now = new Date();
+  const start = new Date(now.getTime() - RANGE_DAYS[range] * 86_400_000);
+  return `${format(start, DATE_FMT)} → ${format(now, DATE_FMT)}`;
+}
+
+// Compact token counts (1.2M / 84.6K) — KpiCard values elsewhere use
+// toLocaleString() directly, but raw token counts run into the millions
+// and read poorly uncompacted at this tile size.
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return n.toLocaleString();
+}
+
+export function UsagePage() {
+  const projectScope = useProjectScoped();
+  const projectId = projectScope.projectId;
+  const activeOrgId = useActive((s) => s.activeOrgId);
+  const projectsQ = useProjects(activeOrgId);
+  const projectName =
+    projectsQ.data?.find((p) => p.id === projectId)?.name ?? projectId;
+
+  const f = useUsageFilters((s) => s.filters);
+  const setF = useUsageFilters((s) => s.setFilters);
+  const showDateRow = f.customMode;
+
+  const scope = {
+    window: f.range,
+    agent: f.agent || undefined,
+    model: f.model || undefined,
+    user: f.user || undefined,
+    start_date: f.start_date ? f.start_date.toISOString() : undefined,
+    end_date: f.end_date ? f.end_date.toISOString() : undefined,
+  };
+  // Range-only (unscoped) summary: filter dropdown options + the "X of Y"
+  // total — same dedup-via-matching-query-key trick as Audit's optionsQ.
+  const optionsScope = {
+    window: f.range,
+    start_date: scope.start_date,
+    end_date: scope.end_date,
+  };
+  const optionsQ = useQuery({
+    queryKey: ["usage", "summary", projectId, optionsScope],
+    enabled: !!projectId,
+    queryFn: () => api.getLlmUsageSummary(optionsScope, projectId as string),
+  });
+  const summaryQ = useQuery({
+    queryKey: ["usage", "summary", projectId, scope],
+    enabled: !!projectId,
+    queryFn: () => api.getLlmUsageSummary(scope, projectId as string),
+    placeholderData: keepPreviousData,
+    refetchInterval: 30_000,
+  });
+
+  const totals = summaryQ.data?.totals ?? {
+    calls: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    total_tokens: 0,
+  };
+  const options = optionsQ.data;
+  const rangeTotal = options?.totals.calls ?? 0;
+
+  const nDays = rangeDays(f.range, f.start_date, f.end_date);
+  const avgLabel =
+    !f.start_date && f.range === "24h"
+      ? `${(totals.calls / 24).toFixed(1)}/hr avg`
+      : `${(totals.calls / nDays).toFixed(0)}/day avg`;
+  const inputPct = totals.total_tokens
+    ? Math.round((totals.input_tokens / totals.total_tokens) * 100)
+    : 0;
+  const outputPct = totals.total_tokens
+    ? Math.round((totals.output_tokens / totals.total_tokens) * 100)
+    : 0;
+
+  if (projectScope.status === "no-project") {
+    return <NoProjectEmptyState resource="LLM usage" />;
+  }
+
+  return (
+    <div className="mx-auto max-w-[1400px]">
+      <header className="mb-6 flex items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Usage</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            LLM token usage for project{" "}
+            <span className="font-mono text-foreground">{projectName}</span>
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <ToggleGroup
+            type="single"
+            value={f.customMode ? "custom" : f.range}
+            onValueChange={(v) => {
+              if (!v) return;
+              if (v === "custom") {
+                setF((p) => ({ ...p, customMode: true }));
+              } else {
+                setF((p) => ({
+                  ...p,
+                  range: v as Filters["range"],
+                  customMode: false,
+                  start_date: null,
+                  end_date: null,
+                }));
+              }
+            }}
+          >
+            {(["24h", "7d", "30d", "90d"] as const).map((r) => (
+              <ToggleGroupItem key={r} value={r}>
+                {r}
+              </ToggleGroupItem>
+            ))}
+            <ToggleGroupItem value="custom">Custom</ToggleGroupItem>
+          </ToggleGroup>
+          {showDateRow && (
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="h-8 text-[13px] font-normal"
+                >
+                  {f.start_date && f.end_date
+                    ? `${format(f.start_date, DATE_FMT)} → ${format(f.end_date, DATE_FMT)}`
+                    : f.start_date
+                      ? `${format(f.start_date, DATE_FMT)} → …`
+                      : impliedRangeLabel(f.range)}
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-auto p-0" align="end">
+                <Calendar
+                  mode="range"
+                  selected={{
+                    from: f.start_date ?? undefined,
+                    to: f.end_date ?? undefined,
+                  }}
+                  onSelect={(range) =>
+                    setF((p) => ({
+                      ...p,
+                      start_date: range?.from ?? null,
+                      end_date: range?.to ? endOfDay(range.to) : null,
+                    }))
+                  }
+                />
+              </PopoverContent>
+            </Popover>
+          )}
+        </div>
+      </header>
+
+      <UsageFilterBar
+        f={f}
+        setF={setF}
+        shown={totals.calls}
+        total={rangeTotal}
+        agents={options?.by_agent.map((r) => r.key) ?? []}
+        models={options?.by_model.map((r) => r.key) ?? []}
+        users={options?.by_user.map((r) => r.key) ?? []}
+      />
+      <UsageActiveChips f={f} setF={setF} />
+
+      <div className="mb-4 grid grid-cols-4 gap-4">
+        <KpiCard
+          label="Calls"
+          icon={Activity}
+          value={totals.calls.toLocaleString()}
+          sub={avgLabel}
+        />
+        <KpiCard
+          label="Input tokens"
+          icon={ArrowDownToLine}
+          value={fmtTokens(totals.input_tokens)}
+          sub={`${inputPct}% of total`}
+        />
+        <KpiCard
+          label="Output tokens"
+          icon={ArrowUpFromLine}
+          value={fmtTokens(totals.output_tokens)}
+          sub={`${outputPct}% of total`}
+        />
+        <KpiCard
+          label="Total tokens"
+          icon={Sigma}
+          value={fmtTokens(totals.total_tokens)}
+          sub={`${(totals.total_tokens / nDays).toFixed(0)}/day avg`}
+        />
+      </div>
+
+      <UsageBreakdownCard
+        byModel={summaryQ.data?.by_model ?? []}
+        byAgent={summaryQ.data?.by_agent ?? []}
+        byUser={summaryQ.data?.by_user ?? []}
+        f={f}
+        setF={setF}
+      />
+    </div>
+  );
+}

--- a/platform/dashboard/src/routes/Usage.tsx
+++ b/platform/dashboard/src/routes/Usage.tsx
@@ -19,6 +19,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { KpiCard } from "@/components/audit/pieces";
+import { displayNoValue, scopeNoValue } from "@/components/audit/chart-tokens";
 import { RANGE_DAYS, rangeDays } from "@/lib/date-range";
 import {
   UsageActiveChips,
@@ -63,7 +64,7 @@ export function UsagePage() {
     window: f.range,
     agent: f.agent || undefined,
     model: f.model || undefined,
-    user: f.user || undefined,
+    user: scopeNoValue(f.user),
     start_date: f.start_date ? f.start_date.toISOString() : undefined,
     end_date: f.end_date ? f.end_date.toISOString() : undefined,
   };
@@ -190,7 +191,7 @@ export function UsagePage() {
         total={rangeTotal}
         agents={options?.by_agent.map((r) => r.key) ?? []}
         models={options?.by_model.map((r) => r.key) ?? []}
-        users={options?.by_user.map((r) => r.key) ?? []}
+        users={options?.by_user.map((r) => displayNoValue(r).key) ?? []}
       />
       <UsageActiveChips f={f} setF={setF} />
 
@@ -224,7 +225,7 @@ export function UsagePage() {
       <UsageBreakdownCard
         byModel={summaryQ.data?.by_model ?? []}
         byAgent={summaryQ.data?.by_agent ?? []}
-        byUser={summaryQ.data?.by_user ?? []}
+        byUser={summaryQ.data?.by_user.map(displayNoValue) ?? []}
         f={f}
         setF={setF}
       />

--- a/platform/dashboard/src/routes/Usage.tsx
+++ b/platform/dashboard/src/routes/Usage.tsx
@@ -5,39 +5,20 @@ import {
   ArrowUpFromLine,
   Sigma,
 } from "lucide-react";
-import { endOfDay, format } from "date-fns";
 import { api } from "@/lib/api";
 import { useActive, useProjectScoped } from "@/lib/active";
 import { useProjects } from "@/lib/projects";
 import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
-import { Button } from "@/components/ui/button";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import { Calendar } from "@/components/ui/calendar";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
+import { DashboardRangePicker } from "@/components/ui/dashboard-range-picker";
 import { KpiCard } from "@/components/audit/pieces";
 import { displayNoValue, scopeNoValue } from "@/components/audit/chart-tokens";
-import { RANGE_DAYS, rangeDays } from "@/lib/date-range";
+import { rangeDays } from "@/lib/date-range";
 import {
   UsageActiveChips,
   UsageBreakdownCard,
   UsageFilterBar,
 } from "@/components/usage/pieces";
-import {
-  type UsageFilters as Filters,
-  useUsageFilters,
-} from "@/lib/usage-filters";
-
-const DATE_FMT = "MMM d, yyyy";
-
-function impliedRangeLabel(range: Filters["range"]): string {
-  const now = new Date();
-  const start = new Date(now.getTime() - RANGE_DAYS[range] * 86_400_000);
-  return `${format(start, DATE_FMT)} → ${format(now, DATE_FMT)}`;
-}
+import { useUsageFilters } from "@/lib/usage-filters";
 
 // Compact token counts (1.2M / 84.6K) — KpiCard values elsewhere use
 // toLocaleString() directly, but raw token counts run into the millions
@@ -58,7 +39,6 @@ export function UsagePage() {
 
   const f = useUsageFilters((s) => s.filters);
   const setF = useUsageFilters((s) => s.setFilters);
-  const showDateRow = f.customMode;
 
   const scope = {
     window: f.range,
@@ -123,65 +103,7 @@ export function UsagePage() {
             <span className="font-mono text-foreground">{projectName}</span>
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <ToggleGroup
-            type="single"
-            value={f.customMode ? "custom" : f.range}
-            onValueChange={(v) => {
-              if (!v) return;
-              if (v === "custom") {
-                setF((p) => ({ ...p, customMode: true }));
-              } else {
-                setF((p) => ({
-                  ...p,
-                  range: v as Filters["range"],
-                  customMode: false,
-                  start_date: null,
-                  end_date: null,
-                }));
-              }
-            }}
-          >
-            {(["24h", "7d", "30d", "90d"] as const).map((r) => (
-              <ToggleGroupItem key={r} value={r}>
-                {r}
-              </ToggleGroupItem>
-            ))}
-            <ToggleGroupItem value="custom">Custom</ToggleGroupItem>
-          </ToggleGroup>
-          {showDateRow && (
-            <Popover>
-              <PopoverTrigger asChild>
-                <Button
-                  variant="outline"
-                  className="h-8 text-[13px] font-normal"
-                >
-                  {f.start_date && f.end_date
-                    ? `${format(f.start_date, DATE_FMT)} → ${format(f.end_date, DATE_FMT)}`
-                    : f.start_date
-                      ? `${format(f.start_date, DATE_FMT)} → …`
-                      : impliedRangeLabel(f.range)}
-                </Button>
-              </PopoverTrigger>
-              <PopoverContent className="w-auto p-0" align="end">
-                <Calendar
-                  mode="range"
-                  selected={{
-                    from: f.start_date ?? undefined,
-                    to: f.end_date ?? undefined,
-                  }}
-                  onSelect={(range) =>
-                    setF((p) => ({
-                      ...p,
-                      start_date: range?.from ?? null,
-                      end_date: range?.to ? endOfDay(range.to) : null,
-                    }))
-                  }
-                />
-              </PopoverContent>
-            </Popover>
-          )}
-        </div>
+        <DashboardRangePicker f={f} setF={setF} />
       </header>
 
       <UsageFilterBar


### PR DESCRIPTION
## What is changing?

- New standalone Usage page: LLM call/token volume, a filterable breakdown card (by model/agent/user), and a time-range picker, mirroring the Audit page's UX.
- New api.getLlmUsageSummary client calling the already-merged /v1/projects/{id}/llm/summary endpoint (no backend changes in this PR).
- Fix: empty user_id values (untracked/system LLM calls) now map to a "(none)" display label instead of crashing the Users filter dropdown — applied to both Usage's user dimension and Audit's role/user dimensions.
- Refactor: extracted shared BarRow / BreakdownCardShell primitives so Audit's and Usage's breakdown cards stop duplicating the same Tabs/Select/grid/legend markup.

## Tests 
- make check-all 
- manual:

https://github.com/user-attachments/assets/0270a4b6-c308-44cb-aec1-3544877e98ab

