### PR TITLE
fix(sdk): resolve .env from consumer cwd, not installed package path

### DIFF
--- a/hexgate/bootstrap.py
+++ b/hexgate/bootstrap.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 
-from dotenv import find_dotenv, load_dotenv
+from dotenv import load_dotenv
 
 from hexgate import audit
 from hexgate.config.env import resolve_api_key
@@ -43,11 +44,11 @@ def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
     debug sessions later when they wonder why their policy edits
     aren't taking.
     """
-    # Search the consumer's cwd, not this installed module's dir — their
-    # .env lives where they run `hexgate register`. "" (not found) → no-op.
-    env_path = find_dotenv(env_file, usecwd=True)
-    # override=False: shell wins over .env (uvicorn/vite/cargo/npm convention).
-    load_dotenv(env_path, override=False)
+    # Resolve against the consumer's cwd, no upward walk — a stray ancestor
+    # .env must never load silently. Missing → no-op.
+    env_path = Path.cwd() / env_file
+    if env_path.is_file():
+        load_dotenv(env_path, override=False)
     if local_only:
         # Set BEFORE audit.configure() so the first call sees the gate.
         os.environ[_LOCAL_MODE_ENV] = "1"

--- a/hexgate/bootstrap.py
+++ b/hexgate/bootstrap.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import logging
 import os
-from pathlib import Path
 
-from dotenv import load_dotenv
+from dotenv import find_dotenv, load_dotenv
 
 from hexgate import audit
 from hexgate.config.env import resolve_api_key
@@ -44,11 +43,10 @@ def bootstrap(env_file: str = ".env", *, local_only: bool = False) -> Settings:
     debug sessions later when they wonder why their policy edits
     aren't taking.
     """
-    env_path = Path(__file__).parent.parent / env_file
-    # ``override=False``: shell wins over .env, matching the convention
-    # uvicorn / vite / cargo / npm follow. A pre-existing test
-    # (test_bootstrap_loads_requested_env_file) pinned this contract;
-    # the code had drifted to ``True``. Flipped back here.
+    # Search the consumer's cwd, not this installed module's dir — their
+    # .env lives where they run `hexgate register`. "" (not found) → no-op.
+    env_path = find_dotenv(env_file, usecwd=True)
+    # override=False: shell wins over .env (uvicorn/vite/cargo/npm convention).
     load_dotenv(env_path, override=False)
     if local_only:
         # Set BEFORE audit.configure() so the first call sees the gate.

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -15,27 +15,18 @@ from hexgate.tracing import _senders
 
 def _stub_dotenv_with_required_keys(
     monkeypatch: pytest.MonkeyPatch, **extra: str
-) -> dict[str, Path]:
-    """Replace ``load_dotenv`` with a stub that populates the provider keys
-    a typical CLI run reads into ``Settings``. Returns a dict the caller can
-    inspect for the captured env path."""
-    seen: dict[str, Path] = {}
-
-    def fake_load_dotenv(path: Path, override: bool) -> None:
-        seen["path"] = path
-        # Phase 7: ``override=False`` so the shell wins over .env,
-        # matching uvicorn/vite/cargo/npm convention.
-        assert override is False
-        monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
-        monkeypatch.setenv("LINKUP_API_KEY", "linkup-key")
-        monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
-        monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public-key")
-        monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret-key")
-        for k, v in extra.items():
-            monkeypatch.setenv(k, v)
-
-    monkeypatch.setattr(bootstrap, "load_dotenv", fake_load_dotenv)
-    return seen
+) -> None:
+    """Set the provider keys a typical CLI run reads into ``Settings`` and
+    stub ``load_dotenv`` to a no-op, so tests exercising downstream behavior
+    don't depend on a real ``.env`` on disk."""
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-key")
+    monkeypatch.setenv("LINKUP_API_KEY", "linkup-key")
+    monkeypatch.setenv("TAVILY_API_KEY", "tavily-key")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "public-key")
+    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "secret-key")
+    for k, v in extra.items():
+        monkeypatch.setenv(k, v)
+    monkeypatch.setattr(bootstrap, "load_dotenv", lambda *a, **k: None)
 
 
 @pytest.fixture(autouse=True)
@@ -72,26 +63,54 @@ def test_bootstrap_loads_env_file_from_cwd(
     assert settings.langfuse_secret_key == "cwd-secret-key"
 
 
-def test_bootstrap_searches_cwd_upward_with_override_false(
-    monkeypatch: pytest.MonkeyPatch,
+def test_bootstrap_shell_var_wins_over_env_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """``find_dotenv`` searches from the cwd (``usecwd=True``) for the
-    requested filename, and the resolved path is loaded with
-    ``override=False`` so a shell-set var still wins over ``.env``."""
-    seen = _stub_dotenv_with_required_keys(monkeypatch)
-    find_calls: dict[str, object] = {}
+    """``override=False``: a shell-set var wins over the same key in ``.env``,
+    matching the uvicorn/vite/cargo/npm convention."""
+    (tmp_path / ".env").write_text("LANGFUSE_PUBLIC_KEY=from-env-file\n")
+    monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "from-shell")
+    monkeypatch.chdir(tmp_path)
 
-    def fake_find_dotenv(filename: str, usecwd: bool) -> str:
-        find_calls["filename"] = filename
-        find_calls["usecwd"] = usecwd
-        return f"/resolved/{filename}"
+    settings = bootstrap.bootstrap()
 
-    monkeypatch.setattr(bootstrap, "find_dotenv", fake_find_dotenv)
+    assert settings.langfuse_public_key == "from-shell"
 
-    bootstrap.bootstrap("test.env")
 
-    assert find_calls == {"filename": "test.env", "usecwd": True}
-    assert seen["path"] == "/resolved/test.env"
+def test_bootstrap_ignores_ancestor_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``.env`` in a parent directory must NOT be loaded — resolution is
+    scoped to the cwd, with no upward walk. Regression guard for the silent
+    ancestor-load introduced by ``find_dotenv(usecwd=True)``."""
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "LANGFUSE_PUBLIC_KEY=ancestor-public-key\n"
+        "LANGFUSE_SECRET_KEY=ancestor-secret-key\n"
+    )
+    subdir = tmp_path / "sub"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+
+    settings = bootstrap.bootstrap()
+
+    assert settings.langfuse_public_key != "ancestor-public-key"
+    assert settings.langfuse_secret_key != "ancestor-secret-key"
+
+
+def test_bootstrap_no_env_file_is_noop(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A missing ``.env`` is a clean no-op — no raise, no keys populated."""
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    settings = bootstrap.bootstrap()
+
+    assert settings.langfuse_public_key is None
+    assert settings.langfuse_secret_key is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -52,15 +52,46 @@ def _isolate_audit_and_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     _senders._logged_local_mode_suppressed.clear()
 
 
-def test_bootstrap_loads_requested_env_file(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Load environment values from the requested repo-relative env file."""
+def test_bootstrap_loads_env_file_from_cwd(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Load ``.env`` from the consumer's working directory — not relative to
+    the installed ``hexgate`` package. Regression: an SDK consumer running
+    ``hexgate register`` from their own project had their ``.env`` ignored
+    because the path was resolved against ``site-packages/hexgate/``."""
+    monkeypatch.delenv("LANGFUSE_PUBLIC_KEY", raising=False)
+    monkeypatch.delenv("LANGFUSE_SECRET_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "LANGFUSE_PUBLIC_KEY=cwd-public-key\nLANGFUSE_SECRET_KEY=cwd-secret-key\n"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    settings = bootstrap.bootstrap()
+
+    assert settings.langfuse_public_key == "cwd-public-key"
+    assert settings.langfuse_secret_key == "cwd-secret-key"
+
+
+def test_bootstrap_searches_cwd_upward_with_override_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``find_dotenv`` searches from the cwd (``usecwd=True``) for the
+    requested filename, and the resolved path is loaded with
+    ``override=False`` so a shell-set var still wins over ``.env``."""
     seen = _stub_dotenv_with_required_keys(monkeypatch)
+    find_calls: dict[str, object] = {}
 
-    settings = bootstrap.bootstrap("test.env")
+    def fake_find_dotenv(filename: str, usecwd: bool) -> str:
+        find_calls["filename"] = filename
+        find_calls["usecwd"] = usecwd
+        return f"/resolved/{filename}"
 
-    assert seen["path"] == Path(bootstrap.__file__).parent.parent / "test.env"
-    assert settings.langfuse_public_key == "public-key"
-    assert settings.langfuse_secret_key == "secret-key"
+    monkeypatch.setattr(bootstrap, "find_dotenv", fake_find_dotenv)
+
+    bootstrap.bootstrap("test.env")
+
+    assert find_calls == {"filename": "test.env", "usecwd": True}
+    assert seen["path"] == "/resolved/test.env"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`bootstrap()` now resolves `.env` from the consumer's current working directory instead of relative to the installed package.

```python
# before — resolved to site-packages/hexgate/../.env once pip-installed
env_path = Path(__file__).parent.parent / env_file
# after — scoped to the consumer's cwd, no upward walk, no-op if missing
env_path = Path.cwd() / env_file
if env_path.is_file():
    load_dotenv(env_path, override=False)
```

## Why

For a pip-installed SDK, `__file__` lives in `site-packages/`, so `hexgate register` looked for `.env` there and never found the consumer's. Result: `HEXGATE_API_KEY must be set` even with a valid `.env` in the project — breaking the first-run quickstart for every external developer. It only "worked" from a source checkout, where that path happens to be the repo root.

Resolution is deliberately scoped to `Path.cwd()` with **no upward directory walk**: a stray `.env` in an ancestor directory (e.g. `~/.env` left over from another project) must never be loaded silently and point the SDK at the wrong credentials.

`override=False` is unchanged (shell still wins over `.env`); a missing `.env` degrades gracefully to a no-op, falling back to shell env vars.

## Tests

- `test_bootstrap_loads_env_file_from_cwd` — real-fs regression: `.env` in a temp cwd loads.
- `test_bootstrap_shell_var_wins_over_env_file` — asserts `override=False` (shell wins over `.env`).
- `test_bootstrap_ignores_ancestor_env` — guards against loading a `.env` from a parent directory (no upward walk).
- `test_bootstrap_no_env_file_is_noop` — a missing `.env` is a clean no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
