### PR TITLE
docs(sdk): add public ban concepts page

### DIFF
--- a/docs/concepts/bans.mdx
+++ b/docs/concepts/bans.mdx
@@ -41,9 +41,34 @@ Only one active ban can target the same agent or user at a time.
 Bans take effect on the target's **next run**. The SDK re-checks the ban feed at the start of each run (a cheap `ETag`/`304` round-trip), so creating or lifting a ban does **not** interrupt a run that is already in progress — it applies from the next invocation.
 </Note>
 
-## What your integration sees
+## Handling the ban in your code
 
-When a banned agent or user tries to run, the SDK raises a typed [`AgentBannedError`](/sdk/index) **before the first token**. It is a real exception, never a disguised assistant message — so it can't be mistaken for model output, isn't written to conversation history, and gives your backend a single, explicit place to catch it.
+When a banned agent or user tries to run, the SDK raises a typed **`AgentBannedError`** **before the first token**. This is the one thing you need to handle as a developer: the ban surfaces as a real exception, never as a disguised assistant message — so it can't be mistaken for model output, isn't written to conversation history, and gives your backend a single, explicit place to catch it.
+
+`AgentBannedError` subclasses `RuntimeError`, so an unhandled ban won't silently pass as a normal result — it propagates like any other error until you catch it. Import it from `hexgate.security.errors`:
+
+```python
+from hexgate.security.errors import AgentBannedError
+```
+
+### The fields on the error
+
+| Field | Type | Use it for |
+|---|---|---|
+| `code` | `str` | Branching in your code — `"agent_banned"` or `"user_banned"`. Stable and machine-checkable. |
+| `ban_type` | `str` | Same distinction as `code`, without the suffix — `"agent"` or `"user"`. |
+| `target` | `str` | The banned `agent_name` (agent ban) or `user_id` (user ban) — handy for logging. |
+| `reason` | `str \| None` | The operator-supplied reason, if one was given. May be `None`. |
+| `user_message` | `str` | A safe, human-readable default you can show to the end-user verbatim. |
+
+The `user_message` default is written to be shown as-is:
+
+- **Agent ban** — "This agent is currently disabled by an administrator."
+- **User ban** — "Your access to this agent has been suspended by an administrator."
+
+### Catching it
+
+Wrap the run and decide what your product should do — return a clean error to the caller, log it, alert, or fall back:
 
 ```python
 from hexgate.security.errors import AgentBannedError
@@ -51,20 +76,30 @@ from hexgate.security.errors import AgentBannedError
 try:
     result = await agent.ainvoke(prompt)
 except AgentBannedError as exc:
-    # exc.ban_type   -> "agent" | "user"
-    # exc.code       -> "agent_banned" | "user_banned"  (stable, machine-checkable)
-    # exc.target     -> the banned agent_name or user_id
-    # exc.reason     -> operator-supplied reason, or None
-    # exc.user_message -> a safe, human-readable default you can show verbatim
-    return {"error": exc.user_message}
+    logger.warning("run refused: %s target=%s reason=%s",
+                   exc.code, exc.target, exc.reason)
+    # Show the safe default, or map exc.code to your own copy / i18n.
+    return {"blocked": True, "message": exc.user_message}
 ```
 
-The default `user_message` is safe to surface to end-users as-is:
+The same `try/except` works on every entrypoint — sync (`invoke` / `run_sync`), async (`ainvoke` / `run`), and streaming. If you want different behavior per ban type, branch on the stable `code`:
 
-- **Agent ban** — "This agent is currently disabled by an administrator."
-- **User ban** — "Your access to this agent has been suspended by an administrator."
+```python
+except AgentBannedError as exc:
+    if exc.code == "user_banned":
+        # e.g. sign this end-user out of the agent UI
+        ...
+    else:  # "agent_banned"
+        # e.g. surface an "agent temporarily unavailable" state
+        ...
+```
 
-On streaming entrypoints the check runs before the first chunk, so a banned run yields nothing — no partial output, no fake terminal message.
+<Note>
+On **streaming** entrypoints the check runs before the first chunk, so a banned
+run yields nothing — no partial output and no fake terminal message. Wrap the
+call that opens the stream in your `try/except`; the `AgentBannedError` is
+raised there, before you start iterating chunks.
+</Note>
 
 ## Seeing what was blocked
 
@@ -79,13 +114,6 @@ The ban check is wired into every run path across the native agent factory and a
 <Note>
 Bans require the platform. In fully local modes (`HEXGATE_LOCAL_MODE`, `HEXGATE_LOCAL_POLICY`, or no resolvable API key) there is no ban gate and bans are a no-op.
 </Note>
-
-## Known limitations
-
-- **Propagation is poll-based.** A ban applies on the next run, not instantly; a long-running conversation won't see a new ban until it next invokes the agent. Push invalidation is planned.
-- **No expiry.** A ban stays active until an operator revokes it — there is no time-based auto-lift yet.
-- **Fail-open on cold start.** If the SDK has never successfully fetched the ban feed (e.g. the control plane is unreachable at startup), it degrades to enforcing no bans rather than blocking everything. Once a feed has been fetched, a later outage keeps the last-known bans.
-- **`user_id` is trusted from the runtime scope.** User bans rely on the `user_id` your integration supplies. That is bypassable by your own process, not by your end-users, which matches the threat model — a trusted integrator stopping an abusive end-user.
 
 ## Where to next
 

--- a/docs/concepts/bans.mdx
+++ b/docs/concepts/bans.mdx
@@ -1,0 +1,94 @@
+---
+title: "Bans"
+description: "An operator kill-switch that refuses a run before the model executes, overriding policy."
+---
+
+A **ban** is an operator-controlled block that stops an agent from running at all. Unlike a policy `deny` — which decides whether a single tool call is allowed while the agent runs — a ban refuses the whole run **before the model executes**. No tokens are spent, no tool fires, and the ban wins over any `allow` or `approval_required` decision the policy would have made.
+
+Bans are the "stop it now" switch: an agent is misbehaving, or an end-user is abusing your product, and you need it off across every conversation without editing and re-signing a policy.
+
+There are exactly two ban types, both scoped to a single project:
+
+| Type | Blocks | Across |
+|---|---|---|
+| **Agent ban** | one agent | all users |
+| **User ban** | one `user_id` | all agents in the project |
+
+A user ban matches the `user_id` from the [`User` scope](/concepts/user-scope) your integration supplies at runtime. If a run has no `User`, only the agent dimension is evaluated.
+
+## Ban vs. policy
+
+A ban is a separate primitive, evaluated *around* policy rather than inside it. Reach for the right one:
+
+| You want to… | Use |
+|---|---|
+| Stop an agent or user from running **at all** | a **ban** |
+| Block **one tool** while the agent keeps running | policy [`deny`](/policy/yaml-shape) |
+| Require a human before a tool runs | [`approval_required`](/concepts/approval-required) |
+
+Bans live outside the policy on purpose: policy is per-agent, compiled to signed WASM, and evaluated locally, so folding a ban into it would mean recompiling and re-signing on every toggle — and a user ban spans *every* agent, so it can't live in any single agent's policy anyway.
+
+## Creating and lifting a ban
+
+Bans are managed from the **Bans page** in the [dashboard](/platform/dashboard) (org `owner`/`admin` only):
+
+- **Create** — pick a type (Agent or User), choose the target (an agent from the project, or a free-text `user_id`), and optionally add a reason. The reason is shown later alongside blocked attempts.
+- **Revoke** — lifting a ban is a soft delete: the record is kept as an audit trail of who banned what and when, but the target is allowed to run again.
+
+Only one active ban can target the same agent or user at a time.
+
+<Note>
+Bans take effect on the target's **next run**. The SDK re-checks the ban feed at the start of each run (a cheap `ETag`/`304` round-trip), so creating or lifting a ban does **not** interrupt a run that is already in progress — it applies from the next invocation.
+</Note>
+
+## What your integration sees
+
+When a banned agent or user tries to run, the SDK raises a typed [`AgentBannedError`](/sdk/index) **before the first token**. It is a real exception, never a disguised assistant message — so it can't be mistaken for model output, isn't written to conversation history, and gives your backend a single, explicit place to catch it.
+
+```python
+from hexgate.security.errors import AgentBannedError
+
+try:
+    result = await agent.ainvoke(prompt)
+except AgentBannedError as exc:
+    # exc.ban_type   -> "agent" | "user"
+    # exc.code       -> "agent_banned" | "user_banned"  (stable, machine-checkable)
+    # exc.target     -> the banned agent_name or user_id
+    # exc.reason     -> operator-supplied reason, or None
+    # exc.user_message -> a safe, human-readable default you can show verbatim
+    return {"error": exc.user_message}
+```
+
+The default `user_message` is safe to surface to end-users as-is:
+
+- **Agent ban** — "This agent is currently disabled by an administrator."
+- **User ban** — "Your access to this agent has been suspended by an administrator."
+
+On streaming entrypoints the check runs before the first chunk, so a banned run yields nothing — no partial output, no fake terminal message.
+
+## Seeing what was blocked
+
+Every refused run reports a best-effort **blocked attempt** to the audit pipeline. The dashboard's **Blocked attempts** panel (on the Bans page) lists them by time, type, target, and reason, with a detail drawer per attempt. Blocked attempts are retained for 90 days.
+
+These are distinct from the [audit trail](/concepts/audit-trail) of policy decisions — a ban is refused before any tool call, so it has no tool, arguments, or outcome to record.
+
+## Adapter coverage
+
+The ban check is wired into every run path across the native agent factory and all four framework adapters — OpenAI Agents, LangChain, Pydantic AI, and Google ADK — firing after the policy refresh and before the model call, on both sync and streaming entrypoints.
+
+<Note>
+Bans require the platform. In fully local modes (`HEXGATE_LOCAL_MODE`, `HEXGATE_LOCAL_POLICY`, or no resolvable API key) there is no ban gate and bans are a no-op.
+</Note>
+
+## Known limitations
+
+- **Propagation is poll-based.** A ban applies on the next run, not instantly; a long-running conversation won't see a new ban until it next invokes the agent. Push invalidation is planned.
+- **No expiry.** A ban stays active until an operator revokes it — there is no time-based auto-lift yet.
+- **Fail-open on cold start.** If the SDK has never successfully fetched the ban feed (e.g. the control plane is unreachable at startup), it degrades to enforcing no bans rather than blocking everything. Once a feed has been fetched, a later outage keeps the last-known bans.
+- **`user_id` is trusted from the runtime scope.** User bans rely on the `user_id` your integration supplies. That is bypassable by your own process, not by your end-users, which matches the threat model — a trusted integrator stopping an abusive end-user.
+
+## Where to next
+
+- [User scope](/concepts/user-scope) — how `user_id` reaches the runtime, the basis for user bans.
+- [Policy decision](/concepts/policy-decision) — the per-tool-call decisions a ban sits in front of.
+- [Audit trail](/concepts/audit-trail) — the decision telemetry that runs alongside blocked-attempt reporting.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -32,6 +32,7 @@
               "concepts/mcp",
               "concepts/approval-required",
               "concepts/approval-frameworks-compared",
+              "concepts/bans",
               "concepts/sandbox"
             ]
           },

--- a/docs/platform/dashboard.mdx
+++ b/docs/platform/dashboard.mdx
@@ -18,6 +18,7 @@ pnpm dev
 - `/graph` — read-only project overview (everyone → agents → tools)
 - `/playground` — chat with a serving agent, watch tool decisions stream live
 - `/tokens` — mint, list, revoke dev tokens
+- `/bans` — create and revoke [bans](/concepts/bans), review blocked attempts
 - `/settings` — project settings
 
 The dev server proxies `/v1/*` (HTTP and WebSocket) to `localhost:8000`, so HMR

--- a/platform/dashboard/src/components/bans/constants.ts
+++ b/platform/dashboard/src/components/bans/constants.ts
@@ -12,6 +12,9 @@ import type { AuditWindow } from "@/lib/api";
  */
 export const PROPAGATION_HINT = "the next run";
 
+/** Public documentation for the ban feature, linked from the page header. */
+export const BAN_DOCS_URL = "https://docs.hexgate.ai/concepts/bans";
+
 /** Blocked-attempts feed window options, in the order they render. */
 export const WINDOWS: AuditWindow[] = ["24h", "7d", "30d", "90d"];
 

--- a/platform/dashboard/src/routes/Bans.tsx
+++ b/platform/dashboard/src/routes/Bans.tsx
@@ -12,7 +12,7 @@ import {
   CreateBanDialog,
   type CreateBanInitial,
 } from "@/components/bans/CreateBanDialog";
-import { PROPAGATION_HINT } from "@/components/bans/constants";
+import { BAN_DOCS_URL, PROPAGATION_HINT } from "@/components/bans/constants";
 
 /** Non-admin block. Both ban reads (`GET …/bans` and the ban-enforcement
  * feed) are `require_project_admin` server-side, so members can't list at
@@ -120,9 +120,15 @@ export function BansPage() {
           </p>
         </div>
         <div className="flex flex-shrink-0 items-center gap-2">
-          <Button variant="ghost" className="gap-2 text-muted-foreground">
-            <BookOpen className="size-4" />
-            Ban docs
+          <Button
+            asChild
+            variant="ghost"
+            className="gap-2 text-muted-foreground"
+          >
+            <a href={BAN_DOCS_URL} target="_blank" rel="noreferrer">
+              <BookOpen className="size-4" />
+              Ban docs
+            </a>
           </Button>
           {canManage && projectId && (
             <Button


### PR DESCRIPTION
## What

Adds public documentation for the **ban** feature (agent/user kill-switch) and wires the dashboard's "Ban docs" button to it.

## Changes

- **`docs/concepts/bans.mdx`** — new developer-facing concept page: what a ban is, ban vs. policy, creating/lifting from the dashboard, and how to catch the typed `AgentBannedError` (fields + `try/except` across sync/async/streaming). Blocked-attempts and adapter coverage covered.
- **`docs/docs.json`** — register `concepts/bans` in the Concepts nav group.
- **`docs/platform/dashboard.mdx`** — add the `/bans` route, linking to the new page.
- **`platform/dashboard/src/components/bans/constants.ts`** — add `BAN_DOCS_URL` constant.
- **`platform/dashboard/src/routes/Bans.tsx`** — make the "Ban docs" button link to the docs (opens in new tab).

## Notes

Docs-only + one dashboard link. Dashboard `fmt`/`lint`/`typecheck` pass (no new warnings). Content verified against the SDK source and internal ban design doc — nothing fabricated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)