### PR TITLE
build(claude): add per-file format-on-edit hook

### DIFF
--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -8,17 +8,29 @@
 # project venv against whatever's active in the caller's shell, which
 # can otherwise churn packages or rewrite uv.lock as a side effect.
 
+warn() { echo "format-on-edit: $*" >&2; }
+
+if ! command -v jq >/dev/null 2>&1; then
+  warn "jq not found, skipping format"
+  exit 0
+fi
+
 f=$(jq -r '.tool_input.file_path // empty')
 [ -z "$f" ] && exit 0
 
 case "$f" in
   */platform/api/*.py)
-    (cd platform/api && uv run --no-sync ruff format "$f")
+    command -v uv >/dev/null 2>&1 || { warn "uv not found, skipping format for $f"; exit 0; }
+    (cd platform/api && uv run --no-sync ruff format "$f") || warn "ruff format failed for $f"
     ;;
   *.py)
-    uv run --no-sync ruff format "$f"
+    command -v uv >/dev/null 2>&1 || { warn "uv not found, skipping format for $f"; exit 0; }
+    uv run --no-sync ruff format "$f" || warn "ruff format failed for $f"
     ;;
   */platform/dashboard/src/*.ts | */platform/dashboard/src/*.tsx | */platform/dashboard/src/*.js | */platform/dashboard/src/*.jsx | */platform/dashboard/src/*.css | */platform/dashboard/src/*.json)
-    (cd platform/dashboard && pnpm exec prettier --write "$f")
+    command -v pnpm >/dev/null 2>&1 || { warn "pnpm not found, skipping format for $f"; exit 0; }
+    (cd platform/dashboard && pnpm exec prettier --write "$f") || warn "prettier failed for $f"
     ;;
 esac
+
+exit 0

--- a/.claude/hooks/format-on-edit.sh
+++ b/.claude/hooks/format-on-edit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# PostToolUse hook (Edit|Write): formats the single file that was just
+# touched, using each project's own toolchain — mirrors `make fmt` /
+# `make dashboard-fmt` but scoped to one file so every edit doesn't
+# trigger a full-repo reformat. Reads the hook payload from stdin.
+#
+# `uv run --no-sync` (not `--active`) deliberately avoids syncing the
+# project venv against whatever's active in the caller's shell, which
+# can otherwise churn packages or rewrite uv.lock as a side effect.
+
+f=$(jq -r '.tool_input.file_path // empty')
+[ -z "$f" ] && exit 0
+
+case "$f" in
+  */platform/api/*.py)
+    (cd platform/api && uv run --no-sync ruff format "$f")
+    ;;
+  *.py)
+    uv run --no-sync ruff format "$f"
+    ;;
+  */platform/dashboard/src/*.ts | */platform/dashboard/src/*.tsx | */platform/dashboard/src/*.js | */platform/dashboard/src/*.jsx | */platform/dashboard/src/*.css | */platform/dashboard/src/*.json)
+    (cd platform/dashboard && pnpm exec prettier --write "$f")
+    ;;
+esac

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Edit|Write",
+      "hooks": [{"type": "command", "command": "bash .claude/hooks/format-on-edit.sh 2>/dev/null || true"}]
+    }]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,7 @@
   "hooks": {
     "PostToolUse": [{
       "matcher": "Edit|Write",
-      "hooks": [{"type": "command", "command": "bash .claude/hooks/format-on-edit.sh 2>/dev/null || true"}]
+      "hooks": [{"type": "command", "command": "bash .claude/hooks/format-on-edit.sh"}]
     }]
   }
 }


### PR DESCRIPTION
## Summary
- Adds a PostToolUse hook that runs on every Edit/Write and formats only the touched file, scoped by path (`ruff format` for `platform/api/*.py` and other `*.py`, `prettier --write` for dashboard `src/*.{ts,tsx,js,jsx,css,json}`)
- Wires it up in `.claude/settings.json` so it's shared across the team instead of living in local-only config

🤖 Generated with [Claude Code](https://claude.com/claude-code)