### PR TITLE
docs(sdk): fix readme badge row spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 On every tool call, Hexgate decides whether *this user*, in *this role*, may run *this tool* with *these arguments* — allow, deny, or require approval. For OpenAI Agents, LangChain, Google ADK, Pydantic AI, or a native runtime.
 
 [**Website**](https://hexgate.ai) · [**Docs**](https://docs.hexgate.ai) · [PyPI](https://pypi.org/project/hexgate/)
+<br>
 [![PyPI](https://img.shields.io/pypi/v/hexgate?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/hexgate/)
 [![CI](https://github.com/HexamindOrganisation/hexgate/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/HexamindOrganisation/hexgate/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/HexamindOrganisation/hexgate/branch/main/graph/badge.svg?flag=sdk)](https://codecov.io/gh/HexamindOrganisation/hexgate)


### PR DESCRIPTION
## Summary
- Adds a `<br>` between the link row and the badge row in the README so the badges render on their own line.

Before:
<img width="920" height="566" alt="Screenshot 2026-07-16 at 12 30 01" src="https://github.com/user-attachments/assets/81be4b7d-2909-4c6a-9d61-69f3e947f048" />


After:
<img width="768" height="427" alt="Screenshot 2026-07-16 at 12 29 29" src="https://github.com/user-attachments/assets/f06e18a0-29f1-486c-8f85-897992bb4616" />
