### PR TITLE
feat(dashboard): link key pages to hexgate docs

### DIFF
--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -5,13 +5,11 @@ import {
   BarChart3,
   Building2,
   FileCode,
-  Fingerprint,
   KeyRound,
   LogOut,
   MessageSquareCode,
   Network,
   ScrollText,
-  Server,
   Settings2,
   ShieldCheck,
   type LucideIcon,
@@ -99,11 +97,6 @@ const workspaceLinks = [
   { to: "/settings", label: "Settings", icon: Settings2 },
 ];
 
-const environmentLinks = [
-  { to: "/control-plane", label: "Control plane", icon: Server, status: "OK" },
-  { to: "/signing-key", label: "Signing key", icon: Fingerprint },
-];
-
 function NavItem({
   to,
   label,
@@ -169,17 +162,6 @@ export function AppShell() {
             </div>
             <div className="flex flex-col gap-0.5">
               {workspaceLinks.map((l) => (
-                <NavItem key={l.to} {...l} />
-              ))}
-            </div>
-          </div>
-
-          <div>
-            <div className="px-3 pb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-              Environment
-            </div>
-            <div className="flex flex-col gap-0.5">
-              {environmentLinks.map((l) => (
                 <NavItem key={l.to} {...l} />
               ))}
             </div>

--- a/platform/dashboard/src/components/DocsLink.tsx
+++ b/platform/dashboard/src/components/DocsLink.tsx
@@ -1,0 +1,14 @@
+import { BookOpen } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { docsUrl } from "@/lib/docs";
+
+export function DocsLink({ path, label }: { path: string; label: string }) {
+  return (
+    <Button asChild variant="ghost" className="gap-2 text-muted-foreground">
+      <a href={docsUrl(path)} target="_blank" rel="noopener noreferrer">
+        <BookOpen className="size-4" />
+        {label}
+      </a>
+    </Button>
+  );
+}

--- a/platform/dashboard/src/components/DocsLink.tsx
+++ b/platform/dashboard/src/components/DocsLink.tsx
@@ -2,7 +2,27 @@ import { BookOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { docsUrl } from "@/lib/docs";
 
-export function DocsLink({ path, label }: { path: string; label: string }) {
+type DocsLinkProps = {
+  path: string;
+  label: string;
+  compact?: boolean;
+};
+
+export function DocsLink({ path, label, compact = false }: DocsLinkProps) {
+  if (compact) {
+    return (
+      <a
+        href={docsUrl(path)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+      >
+        <BookOpen className="size-3" />
+        {label}
+      </a>
+    );
+  }
+
   return (
     <Button asChild variant="ghost" className="gap-2 text-muted-foreground">
       <a href={docsUrl(path)} target="_blank" rel="noopener noreferrer">

--- a/platform/dashboard/src/lib/docs.ts
+++ b/platform/dashboard/src/lib/docs.ts
@@ -1,0 +1,12 @@
+export const DOCS_BASE_URL = "https://docs.hexgate.ai";
+
+export const DOC_PATHS = {
+  tokens: "/platform/workflow",
+  policies: "/policy/yaml-shape",
+  playground: "/cli/serve",
+  registerAgent: "/cli/register",
+} as const;
+
+export function docsUrl(path: string): string {
+  return `${DOCS_BASE_URL}${path}`;
+}

--- a/platform/dashboard/src/routes/Agents.tsx
+++ b/platform/dashboard/src/routes/Agents.tsx
@@ -1,13 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAgentSelection } from "@/lib/agent_param";
-import {
-  Ban,
-  BookOpen,
-  Bot,
-  FileText,
-  ShieldCheck,
-  Wrench,
-} from "lucide-react";
+import { Ban, Bot, FileText, ShieldCheck, Wrench } from "lucide-react";
 import { Link } from "react-router-dom";
 import {
   api,
@@ -19,7 +12,8 @@ import { useProjectScoped } from "@/lib/active";
 import { useCanManageBans } from "@/lib/bans";
 import { Badge } from "@/components/ui/badge";
 import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
-import { DOC_PATHS, docsUrl } from "@/lib/docs";
+import { DocsLink } from "@/components/DocsLink";
+import { DOC_PATHS } from "@/lib/docs";
 
 /**
  * /agents — read-only manifest view.
@@ -70,15 +64,11 @@ export function AgentsPage() {
           loading={manifests.isLoading}
         />
         <div className="flex-1" />
-        <a
-          href={docsUrl(DOC_PATHS.registerAgent)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
-        >
-          <BookOpen className="size-3" />
-          register an agent →
-        </a>
+        <DocsLink
+          path={DOC_PATHS.registerAgent}
+          label="register an agent →"
+          compact
+        />
         {active && (
           <div className="flex items-center gap-4">
             <Link

--- a/platform/dashboard/src/routes/Agents.tsx
+++ b/platform/dashboard/src/routes/Agents.tsx
@@ -1,6 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { useAgentSelection } from "@/lib/agent_param";
-import { Ban, Bot, FileText, ShieldCheck, Wrench } from "lucide-react";
+import {
+  Ban,
+  BookOpen,
+  Bot,
+  FileText,
+  ShieldCheck,
+  Wrench,
+} from "lucide-react";
 import { Link } from "react-router-dom";
 import {
   api,
@@ -12,6 +19,7 @@ import { useProjectScoped } from "@/lib/active";
 import { useCanManageBans } from "@/lib/bans";
 import { Badge } from "@/components/ui/badge";
 import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { DOC_PATHS, docsUrl } from "@/lib/docs";
 
 /**
  * /agents — read-only manifest view.
@@ -62,6 +70,15 @@ export function AgentsPage() {
           loading={manifests.isLoading}
         />
         <div className="flex-1" />
+        <a
+          href={docsUrl(DOC_PATHS.registerAgent)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground"
+        >
+          <BookOpen className="size-3" />
+          register an agent →
+        </a>
         {active && (
           <div className="flex items-center gap-4">
             <Link

--- a/platform/dashboard/src/routes/Playground.tsx
+++ b/platform/dashboard/src/routes/Playground.tsx
@@ -24,6 +24,8 @@ import {
   type ChatMessage,
   type ToolCall,
 } from "@/lib/playground";
+import { DocsLink } from "@/components/DocsLink";
+import { DOC_PATHS } from "@/lib/docs";
 import { api, type AgentRead } from "@/lib/api";
 import { useProjectScoped } from "@/lib/active";
 import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
@@ -137,6 +139,9 @@ function PlaygroundLive({ projectId }: { projectId: string }) {
           <p className="mt-1 text-sm text-muted-foreground">
             Simulate an agent session against the active bundle.
           </p>
+          <div className="-ml-3 mt-1">
+            <DocsLink path={DOC_PATHS.playground} label="Playground docs" />
+          </div>
         </div>
 
         {state.agentName && (

--- a/platform/dashboard/src/routes/Policies.tsx
+++ b/platform/dashboard/src/routes/Policies.tsx
@@ -20,6 +20,8 @@ import { useProjectScoped } from "@/lib/active";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { DocsLink } from "@/components/DocsLink";
+import { DOC_PATHS } from "@/lib/docs";
 import { PolicyEditor } from "@/components/PolicyEditor";
 import { nodeTypes } from "@/components/graph/nodes";
 import { buildPolicyGraph } from "@/lib/policy_graph";
@@ -75,7 +77,10 @@ export function PoliciesPage() {
             loading={agents.isLoading}
           />
         </div>
-        <Tabs value={tab} onChange={setTab} />
+        <div className="flex items-center gap-2">
+          <Tabs value={tab} onChange={setTab} />
+          <DocsLink path={DOC_PATHS.policies} label="Policy docs" />
+        </div>
       </header>
 
       {/* URL asked for an agent this project doesn't have — show a banner

--- a/platform/dashboard/src/routes/Tokens.tsx
+++ b/platform/dashboard/src/routes/Tokens.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  BookOpen,
   Check,
   Copy,
   Fingerprint,
@@ -27,6 +26,8 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { DocsLink } from "@/components/DocsLink";
+import { DOC_PATHS } from "@/lib/docs";
 import { api, type TokenMintResponse } from "@/lib/api";
 import { useProjectScoped } from "@/lib/active";
 import { cn } from "@/lib/utils";
@@ -307,10 +308,7 @@ export function TokensPage() {
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <Button variant="ghost" className="gap-2 text-muted-foreground">
-            <BookOpen className="size-4" />
-            Token docs
-          </Button>
+          <DocsLink path={DOC_PATHS.tokens} label="Token docs" />
           {scope.projectId && (
             <MintDialog projectId={scope.projectId} onSuccess={setJustMinted} />
           )}


### PR DESCRIPTION
Wires the dashboard's documentation affordances to the live Mintlify docs
(docs.hexgate.ai) and trims dead navigation.

## Changes
- Add shared `docs.ts` (`DOCS_BASE_URL`, `DOC_PATHS`, `docsUrl()`) and a
  reusable `DocsLink` component — no hardcoded doc URLs scattered in pages.
- **Tokens** — wire the previously dead "Token docs" button → `/platform/workflow`.
- **Policies** — add "Policy docs" link → `/policy/yaml-shape`.
- **Playground** — add "Playground docs" link → `/cli/serve`.
- **Agents** — add "register an agent →" link → `/cli/register`.
- Remove the unbuilt **Environment** sidebar section (Control plane, Signing key)
  — no routes ever existed for those paths.