### PR TITLE
fix(hexgate): pydantic ai run sync no loop drop

### DIFF
--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -108,8 +108,16 @@ class AuditSender:
         )
 
     def _new_sync_client(self) -> httpx.Client:
+        # Connect gets its own short budget, separate from the read/write/pool
+        # timeout: an unreachable host (dead IP, packet black hole) fails at
+        # the connect stage, and this thread is non-daemon, so a slow connect
+        # timeout directly extends how long process exit can hang on it
+        # (see close()'s finalizer-thread comment for why that thread can
+        # outlive an explicit close() entirely). A live host's TCP handshake
+        # is sub-second, so 2s is generous for the happy path while still
+        # capping the unreachable-host case well below self._http_timeout.
         return httpx.Client(
-            timeout=self._http_timeout,
+            timeout=httpx.Timeout(self._http_timeout, connect=2.0),
             headers={"Authorization": f"Bearer {self._api_key}"},
         )
 
@@ -249,15 +257,18 @@ class AuditSender:
         Runs entirely on its own thread; always releases
         ``self._sync_semaphore`` so the next caller past the cap can
         proceed, and discards itself from ``self._sync_threads`` so close()
-        isn't left waiting on threads that already finished."""
+        isn't left waiting on threads that already finished.
+
+        Unlike ``_send``, does not retry on a 503: this thread is
+        non-daemon (see ``_spawn_sync_send``), so on a run_sync()-only
+        script that never calls ``hexgate.shutdown()``, whatever it's
+        blocked on directly extends how long process exit hangs. A retry
+        would add a full extra ``self._http_timeout`` plus jitter sleep to
+        that; one attempt keeps the bound to a single request."""
         try:
             payload = event.as_payload()
             try:
                 response = self._sync_client.post(self._endpoint, json=payload)
-                if response.status_code == 503:
-                    delay = min(self._http_timeout, 2.0)
-                    time.sleep(random.uniform(delay / 2, delay))
-                    response = self._sync_client.post(self._endpoint, json=payload)
                 if response.status_code >= 400:
                     _log.error(
                         "audit ingest failed: %s %s",
@@ -308,33 +319,58 @@ class AuditSender:
         # time aclose() fires — Thread.join(timeout=...) timing out leaves
         # the thread genuinely alive with no way to cancel it (no forced
         # thread termination in Python). So on a timed-out sync drain, skip
-        # closing the client rather than racing whatever's still running:
-        # leave it for the OS to reclaim at process exit, and let a later
-        # close() call (safe to call multiple times) finish the job once
-        # the thread has actually completed.
+        # closing the client here rather than racing whatever's still
+        # running, and hand the close off to a finalizer thread that blocks
+        # on the stragglers instead. A *later* close() call can't be counted
+        # on to finish the job: shutdown() (the only realistic caller,
+        # hexgate/audit.py:4) clears the shared registry and closes each
+        # sender exactly once, so once this call returns nothing will ever
+        # call close() on this sender again — without the finalizer,
+        # self._sync_client (and its connection pool) would leak for the
+        # rest of the process. The finalizer thread is non-daemon, same as
+        # the sync-fallback send threads, so the interpreter still waits
+        # for it at exit.
         if pending:
-            timed_out = await asyncio.to_thread(
+            stragglers = await asyncio.to_thread(
                 self._join_sync_threads, pending, drain_timeout
             )
-            if timed_out:
+            if stragglers:
                 _log.warning(
                     "audit close: sync drain timed out with %d thread(s) still "
-                    "running; leaving the sync client open rather than closing "
-                    "it out from under them",
-                    timed_out,
+                    "running; handing off to a finalizer thread to close the "
+                    "sync client once they finish",
+                    len(stragglers),
                 )
+                threading.Thread(
+                    target=self._finalize_sync_close,
+                    args=(stragglers,),
+                    daemon=False,
+                    name="hexgate-audit-close-finalizer",
+                ).start()
                 return
         self._sync_client.close()
 
     @staticmethod
-    def _join_sync_threads(threads: list[threading.Thread], timeout: float) -> int:
+    def _join_sync_threads(
+        threads: list[threading.Thread], timeout: float
+    ) -> list[threading.Thread]:
         """Join every thread within one shared ``timeout`` budget (not
         ``timeout`` each — mirrors ``asyncio.wait_for``'s total-time bound
-        for the async drain above). Returns how many are still alive."""
+        for the async drain above). Returns whichever threads are still
+        alive once the budget runs out."""
         deadline = time.monotonic() + timeout
         for t in threads:
             t.join(timeout=max(0.0, deadline - time.monotonic()))
-        return sum(1 for t in threads if t.is_alive())
+        return [t for t in threads if t.is_alive()]
+
+    def _finalize_sync_close(self, stragglers: list[threading.Thread]) -> None:
+        """Run off the event loop, on its own thread, when close() times out
+        waiting for sync-fallback sends: block on the stragglers (no
+        timeout — they will finish) and only then close self._sync_client,
+        so it's never torn down out from under an in-flight send."""
+        for t in stragglers:
+            t.join()
+        self._sync_client.close()
 
 
 # --- Shared (api_key, path) registry ----------------------------------------

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -12,6 +12,8 @@ import asyncio
 import logging
 import os
 import random
+import threading
+import time
 from typing import Any, Protocol
 
 import httpx
@@ -30,11 +32,17 @@ class _PayloadEvent(Protocol):
 
 
 class AuditSender:
-    """Fire-and-forget POST for a single ``(api_key, path)`` pair. Bounded
-    by an asyncio.Semaphore.
+    """Fire-and-forget POST for a single ``(api_key, path)`` pair.
 
-    emit() is sync and non-blocking — schedules a background task. Drops with
-    a periodic log when the semaphore is saturated (platform slow/unreachable).
+    emit() is sync and non-blocking. When a live event loop is available it
+    schedules an asyncio task, bounded by ``self._semaphore``
+    (``max_in_flight``). When none is available anywhere in the process
+    (e.g. a purely-synchronous caller like pydantic_ai's ``run_sync()``,
+    which drives its own loop internally and closes it before returning
+    control here), it spawns a plain background thread instead, bounded the
+    same way by ``self._sync_semaphore``. Both paths drop with a periodic
+    log when saturated (platform slow/unreachable, or too many concurrent
+    callers) rather than growing an unbounded backlog.
     Named for its original use (policy decisions); reused unmodified for any
     event type whose payload is a flat JSON dict via ``as_payload()``.
     """
@@ -67,10 +75,25 @@ class AuditSender:
         self._tasks: set[asyncio.Task[None]] = set()
         self._closing = False
         self._dropped = 0
-        self._warned_no_loop = False
+        # Fallback for when no asyncio loop exists anywhere in the process
+        # (e.g. a caller built purely on pydantic_ai's run_sync()): a plain
+        # background thread instead of an asyncio task. Bounded by the same
+        # max_in_flight ceiling as self._semaphore, just applied to a
+        # different resource (OS threads instead of asyncio tasks).
+        # httpx.Client, unlike AsyncClient, has no event-loop affinity, so
+        # it's safe to build eagerly here rather than lazily on first use.
+        self._sync_semaphore = threading.Semaphore(max_in_flight)
+        self._sync_client = self._new_sync_client()
+        self._sync_dropped = 0
 
     def _new_client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
+            timeout=self._http_timeout,
+            headers={"Authorization": f"Bearer {self._api_key}"},
+        )
+
+    def _new_sync_client(self) -> httpx.Client:
+        return httpx.Client(
             timeout=self._http_timeout,
             headers={"Authorization": f"Bearer {self._api_key}"},
         )
@@ -94,21 +117,20 @@ class AuditSender:
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
-            # Called off-loop (sync tool on a run_in_executor thread): route
-            # to the build-time loop instead of dropping the event.
+            # Called off-loop: either a sync tool dispatched to a
+            # run_in_executor thread (a live loop is still bound, just not
+            # running on *this* thread), or a purely synchronous caller with
+            # no loop anywhere in the process (e.g. pydantic_ai's
+            # run_sync()). Prefer handing back to the bound loop; only fall
+            # to a plain background thread when no loop exists at all.
             loop = self._loop
-            if loop is None or loop.is_closed():
-                if not self._warned_no_loop:
-                    _log.warning(
-                        "audit emit called with no running loop and no live "
-                        "bound loop; skipping"
-                    )
-                    self._warned_no_loop = True
-                return
-            try:
-                loop.call_soon_threadsafe(self._spawn_send, event)
-            except RuntimeError:
-                pass  # loop torn down between the is_closed() check and the call
+            if loop is not None and not loop.is_closed():
+                try:
+                    loop.call_soon_threadsafe(self._spawn_send, event)
+                    return
+                except RuntimeError:
+                    pass  # loop torn down between the is_closed() check and the call
+            self._spawn_sync_send(event)
             return
         self._ensure_loop_state(loop)
         self._spawn_send(event)
@@ -155,8 +177,62 @@ class AuditSender:
             except httpx.RequestError as exc:
                 _log.warning("audit ingest network error: %s", exc)
 
+    def _spawn_sync_send(self, event: _PayloadEvent) -> None:
+        """Fallback for when no asyncio loop exists anywhere to schedule
+        ``_spawn_send`` on. Bounded by ``self._sync_semaphore`` the same way
+        ``_spawn_send`` is bounded by ``self._semaphore`` — saturated
+        callers are dropped immediately rather than piling up an unbounded
+        number of OS threads. Threads are non-daemon: a short-lived
+        run_sync()-only script is the common caller here, and a daemon
+        thread would get killed the instant that script exits, before the
+        send completes — silently reproducing the exact bug this fallback
+        exists to fix. CPython's own interpreter-shutdown sequence joins
+        non-daemon threads instead, bounded by ``self._http_timeout``."""
+        if self._closing:
+            return
+        if not self._sync_semaphore.acquire(blocking=False):
+            self._sync_dropped += 1
+            if self._sync_dropped % 100 == 1:
+                _log.warning(
+                    "audit sender saturated (no event loop path); %d events "
+                    "dropped (platform slow, or too many concurrent "
+                    "synchronous callers?)",
+                    self._sync_dropped,
+                )
+            return
+        threading.Thread(
+            target=self._send_sync,
+            args=(event,),
+            daemon=False,
+            name="hexgate-audit-send-sync",
+        ).start()
+
+    def _send_sync(self, event: _PayloadEvent) -> None:
+        """Synchronous mirror of ``_send`` for the no-event-loop fallback.
+        Runs entirely on its own thread; always releases
+        ``self._sync_semaphore`` so the next caller past the cap can
+        proceed."""
+        try:
+            payload = event.as_payload()
+            try:
+                response = self._sync_client.post(self._endpoint, json=payload)
+                if response.status_code == 503:
+                    delay = min(self._http_timeout, 2.0)
+                    time.sleep(random.uniform(delay / 2, delay))
+                    response = self._sync_client.post(self._endpoint, json=payload)
+                if response.status_code >= 400:
+                    _log.error(
+                        "audit ingest failed: %s %s",
+                        response.status_code,
+                        response.text[:200],
+                    )
+            except httpx.RequestError as exc:
+                _log.warning("audit ingest network error: %s", exc)
+        finally:
+            self._sync_semaphore.release()
+
     async def close(self, drain_timeout: float = 5.0) -> None:
-        """Stop accepting new emits; drain in-flight tasks; close the HTTP client."""
+        """Stop accepting new emits; drain in-flight tasks; close the HTTP clients."""
         self._closing = True
         if self._tasks:
             try:
@@ -171,6 +247,12 @@ class AuditSender:
                 )
         if self._client is not None:
             await self._client.aclose()
+        # Sync-fallback sends aren't tracked/drained here (see
+        # _spawn_sync_send): that branch is only reachable when no loop
+        # exists anywhere in the process, and close()/shutdown() are only
+        # reachable from a caller that has one — the two can't overlap in
+        # any realistic single-sender lifetime.
+        self._sync_client.close()
 
 
 # --- Shared (api_key, path) registry ----------------------------------------

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -302,15 +302,28 @@ class AuditSender:
         # out from under it would abort the send (a bare RuntimeError if
         # the client closes before the request starts, since that's not an
         # httpx.RequestError and isn't caught by _send_sync's handler).
+        #
+        # Unlike the async drain above — where a asyncio.wait_for timeout
+        # actually cancels the tasks, so nothing is still running by the
+        # time aclose() fires — Thread.join(timeout=...) timing out leaves
+        # the thread genuinely alive with no way to cancel it (no forced
+        # thread termination in Python). So on a timed-out sync drain, skip
+        # closing the client rather than racing whatever's still running:
+        # leave it for the OS to reclaim at process exit, and let a later
+        # close() call (safe to call multiple times) finish the job once
+        # the thread has actually completed.
         if pending:
             timed_out = await asyncio.to_thread(
                 self._join_sync_threads, pending, drain_timeout
             )
             if timed_out:
                 _log.warning(
-                    "audit close: sync drain timed out with %d thread(s) pending",
+                    "audit close: sync drain timed out with %d thread(s) still "
+                    "running; leaving the sync client open rather than closing "
+                    "it out from under them",
                     timed_out,
                 )
+                return
         self._sync_client.close()
 
     @staticmethod

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -92,8 +92,14 @@ class AuditSender:
         # documented shutdown pattern, hexgate/audit.py:4) — a fresh loop
         # started just for that call reaches close() same as any other
         # caller, so this can and does overlap with an in-flight sync send.
+        #
+        # Also guards self._sync_dropped: unlike self._dropped (only ever
+        # touched on the single event-loop thread), _spawn_sync_send can
+        # run concurrently on real OS threads whenever several no-loop
+        # callers hit saturation at once — a plain += there would be a
+        # lost-update race.
         self._sync_threads: set[threading.Thread] = set()
-        self._sync_threads_lock = threading.Lock()
+        self._sync_lock = threading.Lock()
 
     def _new_client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
@@ -200,13 +206,15 @@ class AuditSender:
         if self._closing:
             return
         if not self._sync_semaphore.acquire(blocking=False):
-            self._sync_dropped += 1
-            if self._sync_dropped % 100 == 1:
+            with self._sync_lock:
+                self._sync_dropped += 1
+                dropped = self._sync_dropped
+            if dropped % 100 == 1:
                 _log.warning(
                     "audit sender saturated (no event loop path); %d events "
                     "dropped (platform slow, or too many concurrent "
                     "synchronous callers?)",
-                    self._sync_dropped,
+                    dropped,
                 )
             return
         thread = threading.Thread(
@@ -217,7 +225,7 @@ class AuditSender:
         )
         # Add before start(): close() must never observe a thread that's
         # already running but not yet tracked.
-        with self._sync_threads_lock:
+        with self._sync_lock:
             self._sync_threads.add(thread)
         thread.start()
 
@@ -245,7 +253,7 @@ class AuditSender:
                 _log.warning("audit ingest network error: %s", exc)
         finally:
             self._sync_semaphore.release()
-            with self._sync_threads_lock:
+            with self._sync_lock:
                 self._sync_threads.discard(threading.current_thread())
 
     async def close(self, drain_timeout: float = 5.0) -> None:
@@ -272,7 +280,7 @@ class AuditSender:
         # out from under it would abort the send (a bare RuntimeError if
         # the client closes before the request starts, since that's not an
         # httpx.RequestError and isn't caught by _send_sync's handler).
-        with self._sync_threads_lock:
+        with self._sync_lock:
             pending = list(self._sync_threads)
         if pending:
             timed_out = await asyncio.to_thread(

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -202,7 +202,17 @@ class AuditSender:
         thread would get killed the instant that script exits, before the
         send completes — silently reproducing the exact bug this fallback
         exists to fix. CPython's own interpreter-shutdown sequence joins
-        non-daemon threads instead, bounded by ``self._http_timeout``."""
+        non-daemon threads instead, bounded by ``self._http_timeout``.
+
+        The ``self._closing`` check below is a fast path only, not the
+        authoritative one — it's rechecked under ``self._sync_lock`` right
+        before registering the thread, in the same critical section
+        ``close()`` uses to flip ``self._closing`` and snapshot
+        ``self._sync_threads`` together. Without that, a thread could read
+        ``self._closing`` as ``False`` here, then still be constructing/
+        registering itself when ``close()`` takes its snapshot moments
+        later — landing after the snapshot, never joined, and racing
+        ``self._sync_client.close()``."""
         if self._closing:
             return
         if not self._sync_semaphore.acquire(blocking=False):
@@ -223,9 +233,14 @@ class AuditSender:
             daemon=False,
             name="hexgate-audit-send-sync",
         )
-        # Add before start(): close() must never observe a thread that's
-        # already running but not yet tracked.
+        # Authoritative recheck + registration, one atomic step: if close()
+        # already flipped _closing and took its snapshot, don't hand it a
+        # thread it'll never wait for — give the semaphore slot back and
+        # drop instead of starting a thread that'll race a closed client.
         with self._sync_lock:
+            if self._closing:
+                self._sync_semaphore.release()
+                return
             self._sync_threads.add(thread)
         thread.start()
 
@@ -258,7 +273,14 @@ class AuditSender:
 
     async def close(self, drain_timeout: float = 5.0) -> None:
         """Stop accepting new emits; drain in-flight tasks; close the HTTP clients."""
-        self._closing = True
+        # Flip _closing and snapshot _sync_threads as one atomic step, under
+        # the same lock _spawn_sync_send uses for its own closing-recheck +
+        # registration. Otherwise a thread could pass _spawn_sync_send's
+        # check just before this line, and still be registering itself when
+        # the snapshot below is taken — landing after it, never joined.
+        with self._sync_lock:
+            self._closing = True
+            pending = list(self._sync_threads)
         if self._tasks:
             try:
                 await asyncio.wait_for(
@@ -280,8 +302,6 @@ class AuditSender:
         # out from under it would abort the send (a bare RuntimeError if
         # the client closes before the request starts, since that's not an
         # httpx.RequestError and isn't caught by _send_sync's handler).
-        with self._sync_lock:
-            pending = list(self._sync_threads)
         if pending:
             timed_out = await asyncio.to_thread(
                 self._join_sync_threads, pending, drain_timeout

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -85,6 +85,15 @@ class AuditSender:
         self._sync_semaphore = threading.Semaphore(max_in_flight)
         self._sync_client = self._new_sync_client()
         self._sync_dropped = 0
+        # Tracked so close() can join outstanding sends before tearing down
+        # self._sync_client out from under them. Needed for real: a script
+        # built purely on run_sync() can still spin up its own
+        # asyncio.run(hexgate.shutdown()) as its very last action (the
+        # documented shutdown pattern, hexgate/audit.py:4) — a fresh loop
+        # started just for that call reaches close() same as any other
+        # caller, so this can and does overlap with an in-flight sync send.
+        self._sync_threads: set[threading.Thread] = set()
+        self._sync_threads_lock = threading.Lock()
 
     def _new_client(self) -> httpx.AsyncClient:
         return httpx.AsyncClient(
@@ -200,18 +209,24 @@ class AuditSender:
                     self._sync_dropped,
                 )
             return
-        threading.Thread(
+        thread = threading.Thread(
             target=self._send_sync,
             args=(event,),
             daemon=False,
             name="hexgate-audit-send-sync",
-        ).start()
+        )
+        # Add before start(): close() must never observe a thread that's
+        # already running but not yet tracked.
+        with self._sync_threads_lock:
+            self._sync_threads.add(thread)
+        thread.start()
 
     def _send_sync(self, event: _PayloadEvent) -> None:
         """Synchronous mirror of ``_send`` for the no-event-loop fallback.
         Runs entirely on its own thread; always releases
         ``self._sync_semaphore`` so the next caller past the cap can
-        proceed."""
+        proceed, and discards itself from ``self._sync_threads`` so close()
+        isn't left waiting on threads that already finished."""
         try:
             payload = event.as_payload()
             try:
@@ -230,6 +245,8 @@ class AuditSender:
                 _log.warning("audit ingest network error: %s", exc)
         finally:
             self._sync_semaphore.release()
+            with self._sync_threads_lock:
+                self._sync_threads.discard(threading.current_thread())
 
     async def close(self, drain_timeout: float = 5.0) -> None:
         """Stop accepting new emits; drain in-flight tasks; close the HTTP clients."""
@@ -247,12 +264,36 @@ class AuditSender:
                 )
         if self._client is not None:
             await self._client.aclose()
-        # Sync-fallback sends aren't tracked/drained here (see
-        # _spawn_sync_send): that branch is only reachable when no loop
-        # exists anywhere in the process, and close()/shutdown() are only
-        # reachable from a caller that has one — the two can't overlap in
-        # any realistic single-sender lifetime.
+        # Join outstanding sync-fallback sends before closing the client
+        # they share: a run_sync()-only script commonly wraps its final
+        # cleanup in its own asyncio.run(hexgate.shutdown()), so close()
+        # reaching here concurrently with an in-flight _send_sync() thread
+        # is a real case, not a hypothetical one — closing self._sync_client
+        # out from under it would abort the send (a bare RuntimeError if
+        # the client closes before the request starts, since that's not an
+        # httpx.RequestError and isn't caught by _send_sync's handler).
+        with self._sync_threads_lock:
+            pending = list(self._sync_threads)
+        if pending:
+            timed_out = await asyncio.to_thread(
+                self._join_sync_threads, pending, drain_timeout
+            )
+            if timed_out:
+                _log.warning(
+                    "audit close: sync drain timed out with %d thread(s) pending",
+                    timed_out,
+                )
         self._sync_client.close()
+
+    @staticmethod
+    def _join_sync_threads(threads: list[threading.Thread], timeout: float) -> int:
+        """Join every thread within one shared ``timeout`` budget (not
+        ``timeout`` each — mirrors ``asyncio.wait_for``'s total-time bound
+        for the async drain above). Returns how many are still alive."""
+        deadline = time.monotonic() + timeout
+        for t in threads:
+            t.join(timeout=max(0.0, deadline - time.monotonic()))
+        return sum(1 for t in threads if t.is_alive())
 
 
 # --- Shared (api_key, path) registry ----------------------------------------

--- a/tests/adapters/pydantic_ai/test_integration.py
+++ b/tests/adapters/pydantic_ai/test_integration.py
@@ -1,0 +1,91 @@
+"""End-to-end verification that HexgatePydanticAgent.run_sync() delivers
+its LLM-usage event even with no asyncio event loop anywhere in the
+process — the exact condition AuditSender.emit()'s no-loop fallback
+exists for.
+
+Requires: `make clickhouse-up` and `make platform-api` running, and
+`HEXGATE_API_KEY` set to a token minted via the dashboard (or the
+platform API directly).
+
+Opt in with: `pytest -m integration`.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import httpx
+import pytest
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from hexgate.adapters.pydantic_ai.wrapper import wrap_pydantic_agent
+from hexgate.cli.register.register import register_agent
+from hexgate.runtime import User
+
+pytestmark = pytest.mark.integration
+
+PLATFORM_URL = os.environ.get("HEXGATE_API_URL", "http://localhost:8000").rstrip("/")
+CLICKHOUSE_URL = os.environ.get("HEXGATE_CLICKHOUSE_URL", "http://localhost:8124")
+CLICKHOUSE_USER = os.environ.get("HEXGATE_CLICKHOUSE_USER", "hexgate")
+CLICKHOUSE_PASSWORD = os.environ.get(
+    "HEXGATE_CLICKHOUSE_PASSWORD", "hexgate-dev-password"
+)
+TOKEN = os.environ.get("HEXGATE_API_KEY")
+
+
+def _need_token() -> None:
+    if not TOKEN:
+        pytest.skip("HEXGATE_API_KEY not set; mint a token via the dashboard")
+
+
+def _clickhouse_count(agent_name: str, session_id: str) -> int:
+    """Parameterized query via ClickHouse's HTTP interface — no string
+    interpolation of test-controlled values into SQL."""
+    response = httpx.get(
+        CLICKHOUSE_URL,
+        params={
+            "query": (
+                "SELECT count() FROM hexgate_audit.llm_invocation "
+                "WHERE agent_name = {agent_name:String} "
+                "AND session_id = {session_id:String}"
+            ),
+            "param_agent_name": agent_name,
+            "param_session_id": session_id,
+        },
+        auth=(CLICKHOUSE_USER, CLICKHOUSE_PASSWORD),
+        timeout=5,
+    )
+    response.raise_for_status()
+    return int(response.text.strip())
+
+
+def test_run_sync_with_no_event_loop_delivers_llm_usage_event() -> None:
+    """Regression: run_sync(), called from a plain synchronous test with no
+    asyncio.run() anywhere, used to silently drop its usage event —
+    AuditSender.emit() had no loop to fall back to and just warned once.
+    It now delivers via a bounded, non-daemon background thread instead."""
+    _need_token()
+    os.environ["HEXGATE_API_KEY"] = TOKEN
+    os.environ["HEXGATE_API_URL"] = PLATFORM_URL
+
+    agent_name = f"integration_test_agent_{uuid.uuid4().hex[:8]}"
+    session_id = f"s-{uuid.uuid4().hex[:8]}"
+
+    raw_agent = Agent(model=TestModel(), name=agent_name)
+    register_agent(raw_agent)
+    wrapped = wrap_pydantic_agent(agent=raw_agent, api_key=TOKEN)
+
+    user = User(user_id="u-integration", session_id=session_id, role="tester")
+    result = wrapped.run_sync("Say hello", user=user)
+    assert result.output
+
+    # The send runs on a background thread — poll briefly rather than
+    # assuming it's landed the instant run_sync() returns.
+    for _ in range(20):
+        if _clickhouse_count(agent_name, session_id) == 1:
+            return
+        time.sleep(0.5)
+    pytest.fail("LLM-usage event never landed in ClickHouse")

--- a/tests/tracing/test_sender.py
+++ b/tests/tracing/test_sender.py
@@ -408,9 +408,15 @@ async def test_close_joins_in_flight_sync_send_before_closing_the_client() -> No
     client.post.assert_called_once()
 
 
-async def test_close_when_sync_drain_times_out_then_warning_is_logged(
+async def test_close_when_sync_drain_times_out_then_client_is_not_closed(
     caplog: "logging.LogCaptureFixture",
 ) -> None:
+    """Unlike the async drain — where a asyncio.wait_for timeout actually
+    cancels the tasks, so aclose() never races anything still running — a
+    timed-out Thread.join() leaves the thread genuinely alive with no way
+    to cancel it. So close() must NOT close the client in this case: doing
+    so would race the still-running thread's in-flight _sync_client.post()
+    exactly like the TOCTOU this module already guards against."""
     sender = AuditSender("http://x/y", "k")
     hang = threading.Event()
     client = MagicMock()
@@ -430,12 +436,43 @@ async def test_close_when_sync_drain_times_out_then_warning_is_logged(
         await sender.close(drain_timeout=0.01)
 
     assert any("sync drain timed out" in r.message for r in caplog.records)
-    client.close.assert_called_once()  # still closes even after a timed-out drain
+    client.close.assert_not_called()  # would race the still-running thread
 
     hang.set()  # release the still-running thread so it doesn't outlive the test
     for t in threading.enumerate():
         if t.name == "hexgate-audit-send-sync":
             t.join(timeout=2)
+
+
+async def test_close_when_called_again_after_a_timed_out_drain_then_it_closes() -> None:
+    """The deferral above isn't a permanent leak: close() is safe to call
+    multiple times, so a second call — once the thread has actually
+    finished — picks up where the first left off and closes normally."""
+    sender = AuditSender("http://x/y", "k")
+    hang = threading.Event()
+    client = MagicMock()
+
+    def _post(endpoint: str, json: dict) -> MagicMock:
+        hang.wait(timeout=2)
+        return MagicMock(status_code=202, text="")
+
+    client.post = MagicMock(side_effect=_post)
+    client.close = MagicMock()
+    sender._sync_client = client
+
+    sender._spawn_sync_send(_event())
+    await asyncio.sleep(0.05)
+
+    await sender.close(drain_timeout=0.01)
+    client.close.assert_not_called()
+
+    hang.set()
+    for t in threading.enumerate():
+        if t.name == "hexgate-audit-send-sync":
+            t.join(timeout=2)
+
+    await sender.close()  # nothing left to join now — safe to close
+    client.close.assert_called_once()
 
 
 async def test_close_when_client_is_none_then_no_error_is_raised() -> None:

--- a/tests/tracing/test_sender.py
+++ b/tests/tracing/test_sender.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 from unittest.mock import AsyncMock, MagicMock
 
 import httpx
@@ -32,6 +33,13 @@ def _stub_client(status: int = 202) -> MagicMock:
     client = MagicMock()
     client.post = AsyncMock(return_value=MagicMock(status_code=status, text=""))
     client.aclose = AsyncMock()
+    return client
+
+
+def _stub_sync_client(status: int = 202) -> MagicMock:
+    client = MagicMock()
+    client.post = MagicMock(return_value=MagicMock(status_code=status, text=""))
+    client.close = MagicMock()
     return client
 
 
@@ -95,12 +103,14 @@ async def test_503_triggers_one_retry() -> None:
 async def test_close_drains_in_flight_then_acloses_client() -> None:
     sender = AuditSender("http://x/y", "k")
     sender._client = _stub_client()
+    sender._sync_client = MagicMock()
     sender.emit(_event())
     sender.emit(_event())
     assert len(sender._tasks) == 2
     await sender.close()
     assert len(sender._tasks) == 0
     sender._client.aclose.assert_awaited_once()
+    sender._sync_client.close.assert_called_once()
 
 
 async def test_post_close_emit_is_noop() -> None:
@@ -124,18 +134,137 @@ async def test_network_error_logged_not_raised(
     assert any("network error" in r.message for r in caplog.records)
 
 
-def test_no_running_loop_skips_silently(caplog: "logging.LogCaptureFixture") -> None:
-    """No running loop and no bound loop (built outside any loop): emit
-    no-ops with a one-time warning."""
+def test_emit_when_no_running_loop_then_falls_back_to_spawn_sync_send() -> None:
+    """No running loop and no bound loop (built outside any loop, e.g. a
+    pydantic_ai run_sync()-only caller): emit dispatches to the bounded
+    background-thread fallback instead of dropping the event."""
     sender = AuditSender("http://x/y", "k")
     assert sender._loop is None
-    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
-        sender.emit(_event())
-        sender.emit(_event())  # second call: silent
+    sender._spawn_sync_send = MagicMock()
+    event = _event()
+
+    sender.emit(event)
+
+    sender._spawn_sync_send.assert_called_once_with(event)
+
+
+def test_emit_when_call_soon_threadsafe_raises_then_falls_back_to_sync_send() -> None:
+    """Loop torn down between the is_closed() check and call_soon_threadsafe:
+    this race no longer drops the event — it falls back to the same path
+    used when there's no loop at all, instead of being swallowed silently."""
+    sender = AuditSender("http://x/y", "k")
+    assert sender._loop is None  # built outside any running loop
+    fake_loop = MagicMock()
+    fake_loop.is_closed.return_value = False
+    fake_loop.call_soon_threadsafe.side_effect = RuntimeError("loop closed mid-call")
+    sender._loop = fake_loop
+    sender._spawn_sync_send = MagicMock()
+    event = _event()
+
+    sender.emit(event)  # must not raise
+
     assert len(sender._tasks) == 0
-    assert sender._warned_no_loop is True
-    no_loop_warnings = [r for r in caplog.records if "no live bound loop" in r.message]
-    assert len(no_loop_warnings) == 1
+    sender._spawn_sync_send.assert_called_once_with(event)
+
+
+def test_spawn_sync_send_happy_path() -> None:
+    """Spawns a non-daemon background thread that sends the event via
+    _send_sync. Non-daemon is the invariant under test: a run_sync()-only
+    script commonly exits moments after emit() returns, and a daemon thread
+    would get killed before the send completes — silently reproducing the
+    exact drop this fallback exists to fix."""
+    sender = AuditSender("http://x/y", "k")
+    release = threading.Event()
+    client = MagicMock()
+
+    def _post(endpoint: str, json: dict) -> MagicMock:
+        release.wait(timeout=2)
+        return MagicMock(status_code=202, text="")
+
+    client.post = MagicMock(side_effect=_post)
+    sender._sync_client = client
+
+    sender._spawn_sync_send(_event())
+
+    matching = [t for t in threading.enumerate() if t.name == "hexgate-audit-send-sync"]
+    assert len(matching) == 1
+    assert matching[0].daemon is False
+    release.set()
+    matching[0].join(timeout=2)
+    client.post.assert_called_once()
+
+
+def test_spawn_sync_send_when_closing_then_no_thread_is_created() -> None:
+    sender = AuditSender("http://x/y", "k")
+    sender._closing = True
+    before = {t.ident for t in threading.enumerate()}
+
+    sender._spawn_sync_send(_event())
+
+    assert {t.ident for t in threading.enumerate()} == before
+
+
+def test_spawn_sync_send_when_saturated_then_event_is_dropped(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    """Mirrors test_semaphore_saturation_drops_events, but for the
+    thread-based fallback path: bounded the same way, by the same
+    max_in_flight value, applied to threading.Semaphore instead of
+    asyncio.Semaphore."""
+    sender = AuditSender("http://x/y", "k", max_in_flight=1)
+    sender._sync_semaphore.acquire()  # simulate one send already in flight
+    try:
+        with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+            for _ in range(5):
+                sender._spawn_sync_send(_event())
+        assert sender._sync_dropped == 5
+        assert any("dropped" in r.message for r in caplog.records)
+    finally:
+        sender._sync_semaphore.release()
+
+
+def test_send_sync_happy_path() -> None:
+    """_send_sync has no loop dependency, unlike _send, so it can be called
+    directly from the test thread — no need to spawn or join anything."""
+    sender = AuditSender("http://x/y", "k")
+    sender._sync_client = _stub_sync_client()
+
+    sender._send_sync(_event())
+
+    sender._sync_client.post.assert_called_once()
+    args, kwargs = sender._sync_client.post.call_args
+    assert args[0] == "http://x/y"
+    assert kwargs["json"]["outcome"] == "deny"
+
+
+def test_send_sync_when_status_is_503_then_retries_once() -> None:
+    sender = AuditSender("http://x/y", "k", http_timeout=0.01)
+    client = MagicMock()
+    client.post = MagicMock(
+        side_effect=[
+            MagicMock(status_code=503, text="busy"),
+            MagicMock(status_code=202, text=""),
+        ]
+    )
+    sender._sync_client = client
+
+    sender._send_sync(_event())
+
+    assert client.post.call_count == 2
+
+
+def test_send_sync_when_request_error_then_logged_not_raised(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    sender = AuditSender("http://x/y", "k")
+    client = MagicMock()
+    client.post = MagicMock(side_effect=httpx.ConnectError("refused"))
+    sender._sync_client = client
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        sender._send_sync(_event())
+
+    assert any("network error" in r.message for r in caplog.records)
 
 
 async def test_emit_from_executor_thread_routes_to_bound_loop() -> None:
@@ -155,22 +284,8 @@ async def test_emit_from_executor_thread_routes_to_bound_loop() -> None:
             break
         await asyncio.sleep(0)
 
-    assert sender._warned_no_loop is False  # routed, not dropped
     await asyncio.gather(*sender._tasks)
     sender._client.post.assert_called_once()
-
-
-def test_emit_when_call_soon_threadsafe_raises_then_error_is_swallowed() -> None:
-    """Loop torn down between the is_closed() check and call_soon_threadsafe:
-    the race is swallowed, not raised."""
-    sender = AuditSender("http://x/y", "k")
-    assert sender._loop is None  # built outside any running loop
-    fake_loop = MagicMock()
-    fake_loop.is_closed.return_value = False
-    fake_loop.call_soon_threadsafe.side_effect = RuntimeError("loop closed mid-call")
-    sender._loop = fake_loop
-    sender.emit(_event())  # must not raise
-    assert len(sender._tasks) == 0
 
 
 def test_spawn_send_when_closing_then_no_task_is_created() -> None:

--- a/tests/tracing/test_sender.py
+++ b/tests/tracing/test_sender.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -202,6 +202,49 @@ def test_spawn_sync_send_when_closing_then_no_thread_is_created() -> None:
     sender._spawn_sync_send(_event())
 
     assert {t.ident for t in threading.enumerate()} == before
+
+
+def test_spawn_sync_send_when_closing_flips_mid_construction_then_not_registered() -> (
+    None
+):
+    """Regression: the fast self._closing check at the top of
+    _spawn_sync_send isn't authoritative — a thread can pass it, then still
+    be constructing/registering when close() flips _closing and snapshots
+    _sync_threads moments later. The authoritative recheck happens under
+    self._sync_lock, in the same critical section close() uses, so it must
+    catch this case: freeze a caller right after it constructs its Thread
+    object (before the lock-protected recheck), flip _closing + snapshot
+    exactly as close() does, then let it proceed and confirm it backs out
+    cleanly instead of registering into a snapshot that's already been
+    taken."""
+    sender = AuditSender("http://x/y", "k")
+    constructed = threading.Event()
+    proceed = threading.Event()
+    real_thread_cls = threading.Thread
+
+    class _PausingThread(real_thread_cls):
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            super().__init__(*args, **kwargs)
+            constructed.set()
+            proceed.wait(timeout=2)
+
+    with patch("hexgate.tracing._senders.threading.Thread", _PausingThread):
+        spawner = real_thread_cls(target=sender._spawn_sync_send, args=(_event(),))
+        spawner.start()
+        assert constructed.wait(timeout=2), "thread construction never happened"
+
+        # Simulate close()'s atomic flip+snapshot while the caller above is
+        # paused between constructing its thread and registering it.
+        with sender._sync_lock:
+            sender._closing = True
+            pending = list(sender._sync_threads)
+        assert pending == [], "race window: nothing registered yet"
+
+        proceed.set()
+        spawner.join(timeout=2)
+
+    assert sender._sync_threads == set()  # backed out, didn't register
+    assert sender._sync_semaphore.acquire(blocking=False)  # slot given back, not leaked
 
 
 def test_spawn_sync_send_when_saturated_then_event_is_dropped(

--- a/tests/tracing/test_sender.py
+++ b/tests/tracing/test_sender.py
@@ -70,6 +70,17 @@ def test_constructor_sets_bearer_header() -> None:
     assert sender._client.headers["Authorization"] == "Bearer k"
 
 
+def test_sync_client_uses_a_short_dedicated_connect_timeout() -> None:
+    """The sync-fallback client's connect timeout is much shorter than
+    http_timeout: its send thread is non-daemon, so a slow connect to an
+    unreachable host directly extends how long process exit can hang for a
+    run_sync()-only script that never calls hexgate.shutdown()."""
+    sender = AuditSender("http://x/y", "k", http_timeout=5.0)
+    timeout = sender._sync_client.timeout
+    assert timeout.connect == 2.0
+    assert timeout.read == 5.0
+
+
 async def test_semaphore_saturation_drops_events(
     caplog: "logging.LogCaptureFixture",
 ) -> None:
@@ -280,20 +291,23 @@ def test_send_sync_happy_path() -> None:
     assert kwargs["json"]["outcome"] == "deny"
 
 
-def test_send_sync_when_status_is_503_then_retries_once() -> None:
+def test_send_sync_when_status_is_503_then_no_retry(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    """Unlike the async path's _send, _send_sync does not retry on a 503:
+    this thread is non-daemon, so a retry (a full http_timeout plus jitter
+    sleep) would directly extend how long process exit hangs for a
+    run_sync()-only script that never calls hexgate.shutdown()."""
     sender = AuditSender("http://x/y", "k", http_timeout=0.01)
     client = MagicMock()
-    client.post = MagicMock(
-        side_effect=[
-            MagicMock(status_code=503, text="busy"),
-            MagicMock(status_code=202, text=""),
-        ]
-    )
+    client.post = MagicMock(return_value=MagicMock(status_code=503, text="busy"))
     sender._sync_client = client
 
-    sender._send_sync(_event())
+    with caplog.at_level(logging.ERROR, logger=_LOGGER_NAME):
+        sender._send_sync(_event())
 
-    assert client.post.call_count == 2
+    assert client.post.call_count == 1
+    assert any("ingest failed" in r.message for r in caplog.records)
 
 
 def test_send_sync_when_request_error_then_logged_not_raised(
@@ -440,14 +454,17 @@ async def test_close_when_sync_drain_times_out_then_client_is_not_closed(
 
     hang.set()  # release the still-running thread so it doesn't outlive the test
     for t in threading.enumerate():
-        if t.name == "hexgate-audit-send-sync":
+        if t.name in ("hexgate-audit-send-sync", "hexgate-audit-close-finalizer"):
             t.join(timeout=2)
 
 
-async def test_close_when_called_again_after_a_timed_out_drain_then_it_closes() -> None:
-    """The deferral above isn't a permanent leak: close() is safe to call
-    multiple times, so a second call — once the thread has actually
-    finished — picks up where the first left off and closes normally."""
+async def test_close_when_sync_drain_times_out_then_finalizer_closes_client() -> None:
+    """The deferral above isn't a permanent leak: close() hands the timed-out
+    straggler off to a finalizer thread that blocks on it and closes the
+    client once it actually finishes — no second close() call needed.
+    shutdown() only ever calls close() once per sender (it clears the
+    registry right after), so relying on a later call would leak the client
+    for good."""
     sender = AuditSender("http://x/y", "k")
     hang = threading.Event()
     client = MagicMock()
@@ -468,10 +485,9 @@ async def test_close_when_called_again_after_a_timed_out_drain_then_it_closes() 
 
     hang.set()
     for t in threading.enumerate():
-        if t.name == "hexgate-audit-send-sync":
+        if t.name in ("hexgate-audit-send-sync", "hexgate-audit-close-finalizer"):
             t.join(timeout=2)
 
-    await sender.close()  # nothing left to join now — safe to close
     client.close.assert_called_once()
 
 

--- a/tests/tracing/test_sender.py
+++ b/tests/tracing/test_sender.py
@@ -330,6 +330,71 @@ async def test_close_when_drain_times_out_then_warning_is_logged(
     assert task.cancelled()
 
 
+async def test_close_joins_in_flight_sync_send_before_closing_the_client() -> None:
+    """Regression: close() must not tear down self._sync_client while a
+    fallback thread is still using it. A run_sync()-only script commonly
+    wraps its final cleanup in a fresh asyncio.run(hexgate.shutdown()) —
+    that reaches close() on a brand-new loop while a _send_sync() thread
+    spawned moments earlier may still be in flight, so this race is real,
+    not hypothetical."""
+    sender = AuditSender("http://x/y", "k")
+    started = threading.Event()
+    release = threading.Event()
+    client = MagicMock()
+
+    def _post(endpoint: str, json: dict) -> MagicMock:
+        started.set()
+        release.wait(timeout=2)
+        return MagicMock(status_code=202, text="")
+
+    client.post = MagicMock(side_effect=_post)
+    client.close = MagicMock()
+    sender._sync_client = client
+
+    sender._spawn_sync_send(_event())
+    assert started.wait(timeout=2), "sync send never started"
+
+    close_task = asyncio.create_task(sender.close())
+    await asyncio.sleep(0.05)  # let close() reach the join
+    assert not client.close.called, "client closed while a send was still in flight"
+
+    release.set()
+    await close_task
+
+    client.close.assert_called_once()
+    client.post.assert_called_once()
+
+
+async def test_close_when_sync_drain_times_out_then_warning_is_logged(
+    caplog: "logging.LogCaptureFixture",
+) -> None:
+    sender = AuditSender("http://x/y", "k")
+    hang = threading.Event()
+    client = MagicMock()
+
+    def _post(endpoint: str, json: dict) -> MagicMock:
+        hang.wait(timeout=5)
+        return MagicMock(status_code=202, text="")
+
+    client.post = MagicMock(side_effect=_post)
+    client.close = MagicMock()
+    sender._sync_client = client
+
+    sender._spawn_sync_send(_event())
+    await asyncio.sleep(0.05)  # let the thread actually start
+
+    with caplog.at_level(logging.WARNING, logger=_LOGGER_NAME):
+        await sender.close(drain_timeout=0.01)
+
+    assert any("sync drain timed out" in r.message for r in caplog.records)
+    client.close.assert_called_once()  # still closes even after a timed-out drain
+
+    hang.set()  # release the still-running thread so it doesn't outlive the test
+    for t in threading.enumerate():
+        if t.name == "hexgate-audit-send-sync":
+            t.join(timeout=2)
+
+
 async def test_close_when_client_is_none_then_no_error_is_raised() -> None:
     sender = AuditSender("http://x/y", "k")
     sender._client = None

--- a/tests/tracing/test_senders.py
+++ b/tests/tracing/test_senders.py
@@ -4,8 +4,7 @@ than through hexgate.audit or hexgate.tracing.usage.
 
 Moved here from tests/audit/test_configure.py under Design C: this is the
 generic registry machinery both audit.py and usage.py import, not
-decisions-specific behavior — see Specs/token_counts.md for the full
-writeup.
+decisions-specific behavior.
 """
 
 from __future__ import annotations
@@ -62,7 +61,7 @@ def test_same_key_distinct_paths_get_distinct_senders() -> None:
     """The whole point of the (api_key, path) composite key: one
     HEXGATE_API_KEY covers both decisions and LLM usage for the same
     project, but each event type needs its own live connection to its own
-    endpoint — see Specs/token_counts.md."""
+    endpoint."""
     decisions_sender = senders_mod.get_or_create_sender(_DECISIONS_PATH, "k1")
     usage_sender = senders_mod.get_or_create_sender(_USAGE_PATH, "k1")
     assert decisions_sender is not usage_sender

--- a/tests/tracing/test_usage_configure.py
+++ b/tests/tracing/test_usage_configure.py
@@ -50,8 +50,7 @@ def test_get_usage_sender_scoped_by_key() -> None:
 
 def test_same_key_gets_distinct_sender_from_audit() -> None:
     """The one HEXGATE_API_KEY that covers a project's decisions also
-    covers its LLM usage, but each event type gets its own live sender —
-    see Specs/token_counts.md."""
+    covers its LLM usage, but each event type gets its own live sender."""
     decisions_sender = audit_mod.configure("k1")
     usage_sender = usage_mod.configure_usage_sender("k1")
     assert decisions_sender is not usage_sender


### PR DESCRIPTION
## What is changing

`AuditSender.emit()` (`hexgate/tracing/_senders.py`) now falls back to a bounded, non-daemon background thread + a plain `httpx.Client` when no asyncio event loop exists anywhere in the process, instead of warning once and silently dropping the event. `close()` now tracks and joins those fallback threads before tearing down the shared sync client, and the diagnostic drop counter is now lock-guarded against concurrent OS threads.

To read more about daemon / non-daemon threads, see [this Notion doc](https://app.notion.com/p/How-CPython-shuts-down-threads-at-exit-daemon-vs-non-daemon-3a3fb45dbae281e1afabc5bf16fa1fb4).

## Why is this change necessary

For a caller built purely on `pydantic_ai`'s `run_sync()` (no event loop ever present), every decision/LLM-usage event was being dropped deterministically — `AuditSender` had no live loop to schedule the send on. The two follow-up commits close two races the initial fix introduced: `close()` could tear down the sync client while a send was still in flight (a real case, since `run_sync()` scripts commonly call `asyncio.run(hexgate.shutdown())` as their last action), and the saturation counter could lose updates under concurrent callers.

## Tests

- make check-all
- `tests/adapters/pydantic_ai/test_integration.py` — opt-in (`pytest -m integration`) end-to-end test against a real platform-api + ClickHouse, asserting the event actually lands (not just "no exception").
- Manually verified live: reverted the fix, reproduced the silent drop against real ClickHouse; restored it, confirmed delivery; reproduced the `run_sync()` → `asyncio.run(shutdown())` race live, confirmed no error and the event still lands.