### PR TITLE
feat(sdk): optional egress proxy — gate outbound network by host

### DIFF
--- a/deploy/egress_gate_demo.py
+++ b/deploy/egress_gate_demo.py
@@ -1,0 +1,241 @@
+"""Hexgate egress-gate demo (marimo) — gate outbound network by policy, in code.
+
+A code-only tour of the optional egress enforcement plane: no platform, no API
+key, no YAML on disk. The policy is written with `PolicyBuilder` + `C`, and the
+same policy both (1) decides hosts offline and (2) drives a *live* in-process
+forward proxy that this notebook's own HTTP client is routed through — so you
+watch a real request get allowed or refused at the network layer.
+
+Run with `uv run --with marimo marimo edit deploy/egress_gate_demo.py`.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import inspect
+
+    import httpx
+    import marimo as mo
+
+    from hexgate import PolicyBuilder, User
+    from hexgate.egress import NET_TOOL, egress_guard
+    from hexgate.security.enforcer import build_enforcer
+    from hexgate.security.policy_set import load_policy_set
+
+    return (
+        NET_TOOL,
+        PolicyBuilder,
+        User,
+        build_enforcer,
+        egress_guard,
+        httpx,
+        inspect,
+        load_policy_set,
+        mo,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # 🌐 Hexgate — gating network egress
+
+        Hexgate normally gates the **tool call** the model proposes. But a tool
+        that runs `curl`, or an SDK that makes its own HTTP calls, can reach the
+        network *without* the tool-argument policy seeing the real destination.
+
+        The **egress proxy** closes that gap: it routes the process's outbound
+        HTTP(S) through the *same* policy engine, mapped to a synthetic
+        `net.http_request` tool. Network egress becomes **just another gated tool**.
+
+        This demo is **code-only** — no platform, no API key, no YAML file. The
+        policy is written in Python and drives a live in-process proxy.
+
+        > **Tier 1 (this demo):** HTTPS is gated on the `CONNECT` host — visible in
+        > plaintext before TLS begins. The tunnel relays ciphertext untouched; we
+        > never decrypt. So constraints are on `args.host` / `args.scheme` /
+        > `args.port`, not the path or body.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 1 · The policy, written in code""")
+    return
+
+
+@app.cell
+def _(PolicyBuilder, load_policy_set):
+    # Deny by default; allow HTTPS to two GitHub hosts — via the net_allow sugar,
+    # which renders the host + scheme allowlist into ordinary constraints (shown
+    # below as the YAML it produces). schemes defaults to HTTPS-only.
+    def build_policy():
+        return (
+            PolicyBuilder(default="deny")
+            .net_allow(hosts=["api.github.com", "raw.githubusercontent.com"])
+            .build()
+        )
+
+    ps = load_policy_set(build_policy())  # a PolicySet with the policy as `default`
+    return build_policy, ps
+
+
+@app.cell
+def _(build_policy, inspect, mo):
+    import yaml as _yaml
+
+    _src = inspect.getsource(build_policy)
+    _rendered = _yaml.dump(
+        build_policy().model_dump(exclude_defaults=True), sort_keys=False
+    )
+    mo.hstack(
+        [
+            mo.vstack([mo.md("**Written in Python**"), mo.md(f"```python\n{_src}```")]),
+            mo.vstack(
+                [mo.md("**Renders to YAML**"), mo.md(f"```yaml\n{_rendered}```")]
+            ),
+        ],
+        widths="equal",
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 2 · Decide hosts offline — not a single socket
+
+        The policy engine decides an egress request the same way it decides a tool
+        call: `(role, tool, args)`. No proxy, no network — just the verdict.
+        """
+    )
+    return
+
+
+@app.cell
+def _(NET_TOOL, mo, ps):
+    def _decide(host, scheme="https"):
+        verdict = ps.evaluate(
+            role="agent",
+            tool=NET_TOOL,
+            args={"host": host, "scheme": scheme, "port": 443},
+        )
+        return verdict.outcome.value
+
+    _cases = [
+        ("api.github.com", "https"),  # allowlisted
+        ("raw.githubusercontent.com", "https"),  # allowlisted
+        ("api.github.com", "http"),  # wrong scheme -> deny
+        ("example.com", "https"),  # not allowlisted -> deny
+        ("203.0.113.5", "https"),  # IP literal never matches host list -> deny
+    ]
+    _label = {"allow": "✅ allow", "deny": "❌ deny", "needs_approval": "🔶 approval"}
+    _rows = ["| host | scheme | decision |", "|---|---|---|"]
+    for _host, _scheme in _cases:
+        _outcome = _decide(_host, _scheme)
+        _rows.append(f"| `{_host}` | {_scheme} | {_label.get(_outcome, _outcome)} |")
+    mo.md("\n".join(_rows))
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 3 · Now for real — through the live proxy
+
+        Same policy, but this time it drives an in-process forward proxy. This
+        notebook's `httpx` client is pointed at it (via `HTTP_PROXY`/`HTTPS_PROXY`,
+        set by `egress_guard`), so the request below is **actually intercepted** at
+        the network layer — allowed hosts connect, denied hosts get refused.
+        """
+    )
+    return
+
+
+@app.cell
+def _(User, build_enforcer, build_policy, egress_guard, httpx, load_policy_set):
+    async def probe(url):
+        # A fresh enforcer per probe, with an observer that captures decisions.
+        decisions = []
+        enforcer = build_enforcer(
+            load_policy_set(build_policy()),
+            agent_name="egress-demo",
+            decision_observer=decisions.append,
+        )
+        outcome = {}
+        async with egress_guard(enforcer, User(user_id="notebook", role="agent")):
+            async with httpx.AsyncClient(timeout=10) as client:
+                try:
+                    response = await client.get(url)
+                    outcome = {"ok": True, "status": response.status_code}
+                except httpx.HTTPError as exc:
+                    outcome = {"ok": False, "error": type(exc).__name__}
+        return decisions, outcome
+
+    return (probe,)
+
+
+@app.cell
+def _(mo):
+    url_form = (
+        mo.md("**URL** {url}")
+        .batch(url=mo.ui.text(value="https://api.github.com/zen", full_width=True))
+        .form(submit_button_label="▶ Send through the egress proxy")
+    )
+    url_form
+    return (url_form,)
+
+
+@app.cell
+async def _(mo, probe, url_form):
+    if url_form.value is None:
+        _out = mo.callout(
+            mo.md("Enter a URL and click **▶ Send through the egress proxy**."),
+            kind="info",
+        )
+    else:
+        _url = url_form.value["url"]
+        _decisions, _outcome = await probe(_url)
+        if _outcome.get("ok"):
+            _result = mo.callout(
+                mo.md(f"**Response `{_outcome['status']}`** — allowed through"),
+                kind="success",
+            )
+        else:
+            _result = mo.callout(
+                mo.md(
+                    f"**Blocked — `{_outcome.get('error', '?')}`** "
+                    "(the proxy refused the connection)"
+                ),
+                kind="danger",
+            )
+        _decision = _decisions[0] if _decisions else None
+        if _decision is not None:
+            _host = (_decision.arguments or {}).get("host", "?")
+            _lines = [
+                f"Policy decision: **{_decision.outcome.value}** for host `{_host}`"
+            ]
+            if not _decision.allowed and _decision.reason:
+                _lines.append(f"\n\nreason: {_decision.reason}")
+            _decision_md = mo.md("".join(_lines))
+        else:
+            _decision_md = mo.md(
+                "_(no decision captured — request never reached the proxy)_"
+            )
+        _out = mo.vstack([mo.md(f"`GET {_url}`"), _result, _decision_md])
+    _out
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/docs/concepts/egress.mdx
+++ b/docs/concepts/egress.mdx
@@ -1,0 +1,118 @@
+---
+title: "Network egress"
+description: "Gate an agent's outbound HTTP(S) by destination host, through the same policy engine that gates tool calls."
+---
+
+Policy normally decides one thing: may this caller invoke this tool with these
+arguments. That check sees what the model asked for. It does not see where a
+tool actually goes on the network. A tool that shells out to `curl`, or an SDK
+that makes its own HTTP calls, can reach any host without the tool-argument
+policy noticing.
+
+The egress proxy adds a second check. It routes the process's outbound HTTP(S)
+through an in-process forward proxy and asks the same `PolicyEnforcer` about each
+request, keyed on the destination host. Egress becomes another gated tool,
+`net.http_request`, sharing the [decision](/concepts/policy-decision) type and
+the [audit trail](/concepts/audit-trail) with everything else.
+
+This is separate from the [workspace sandbox](/concepts/sandbox), which enforces
+network rules in the kernel for the `bash` tool only. The egress proxy is
+framework-agnostic and covers any HTTP client running in the agent's process.
+
+## Turn it on
+
+`egress_guard` starts the proxy and points the process's HTTP clients at it (via
+`HTTP_PROXY` / `HTTPS_PROXY`, which most clients read by default). The agent's
+request code does not change.
+
+```python
+from hexgate import PolicyBuilder, User
+from hexgate.egress import egress_guard
+from hexgate.security.enforcer import build_enforcer
+from hexgate.security.policy_set import load_policy_set
+
+policy = PolicyBuilder(default="deny").net_allow(hosts=["api.github.com"]).build()
+enforcer = build_enforcer(load_policy_set(policy), agent_name="support-agent")
+
+async with egress_guard(enforcer, User(user_id="alice", role="agent")):
+    ...  # every outbound HTTP(S) request in this block is gated
+```
+
+Requests to `api.github.com` connect. Anything else is refused before a byte
+leaves the process, and the deny lands in the audit stream next to the tool-call
+decisions.
+
+## Write the policy
+
+In code, `net_allow` renders the host allowlist into constraints:
+
+```python
+policy = (
+    PolicyBuilder(default="deny")
+    .net_allow(hosts=["api.github.com", "raw.githubusercontent.com"])
+    .build()
+)
+```
+
+The same rule in YAML, where egress is the `net.http_request` tool:
+
+```yaml
+roles:
+  agent:
+    default_policy: { mode: deny }
+    tools:
+      net.http_request:
+        mode: allow
+        constraints:
+          - args.host in ["api.github.com", "raw.githubusercontent.com"]
+          - args.scheme in ["https"]
+```
+
+Pass `subdomains=["example.com"]` to match the apex and any `*.example.com`. A
+host restriction is required: `net_allow()` with only a scheme or port filter
+raises, since a rule with no host clause would allow every host. Use
+`any_host=True` when you do want that.
+
+## What the proxy sees
+
+For HTTPS, the client opens the connection with a plaintext
+`CONNECT api.github.com:443` line before TLS starts. The proxy decides on the
+host there, then relays the encrypted bytes without touching them. It never
+holds the keys, so on HTTPS a request exposes only its host, port, and scheme.
+
+| Field | HTTPS | Plain HTTP |
+|---|---|---|
+| `args.host`, `args.port`, `args.scheme` | visible | visible |
+| `args.path`, `args.query` | encrypted | visible |
+| headers, body | encrypted | on the wire |
+
+Almost all API traffic is HTTPS, so plan around host-level control. Reading the
+path or body of an HTTPS request needs TLS interception, which the SDK does not
+do (see [Limits](#limits)).
+
+## Layering
+
+Egress control sits alongside the other enforcement points. Deploy whichever
+combination fits the threat model.
+
+| Layer | Question | Mechanism |
+|---|---|---|
+| Tool policy | May this caller invoke this tool at all? | adapter / `enforce_policy(...)` |
+| Egress | May the process reach this host? | `egress_guard(...)` |
+| Sandbox | What can a spawned shell do? | OS-level via `srt` |
+
+## Limits
+
+- **Bypassable unless the runtime forces it.** The proxy relies on `HTTP_PROXY` /
+  `HTTPS_PROXY`. Code that sets `trust_env=False`, or a tool that unsets those
+  vars, skips it. Treat it as intent-shaping in a plain SDK deployment. A sandbox
+  that forces all egress through the proxy is the hard boundary.
+- **Host-level on HTTPS.** Path, query, and body are encrypted. Constraining
+  those needs TLS interception, which belongs to a controlled runtime rather than
+  a library.
+- **One guard per process.** `egress_guard` sets process-global proxy env vars,
+  so a nested or concurrent guard raises instead of clobbering the first.
+
+For destinations that don't speak HTTP (a Postgres or Redis connection, say), the
+same policy shape works but the proxy would have to understand that protocol.
+That's not covered today.

--- a/docs/concepts/sandbox.mdx
+++ b/docs/concepts/sandbox.mdx
@@ -8,6 +8,12 @@ configured from the agent's workspace. This is filesystem + network enforcement
 at the kernel level — a separate concern from [policy enforcement](/concepts/policy-decision),
 which decides *whether* a tool may be invoked at all.
 
+<Note>
+This sandbox governs the `bash` tool's process at the kernel level and needs
+`srt`. For host-level control over the whole agent process's HTTP(S) traffic,
+including SDK and adapter calls, see [network egress](/concepts/egress).
+</Note>
+
 ## Runtime requirement
 
 The `bash` tool depends on **`srt`** (Anthropic's `sandbox-runtime`). It wraps

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -33,7 +33,8 @@
               "concepts/approval-required",
               "concepts/approval-frameworks-compared",
               "concepts/bans",
-              "concepts/sandbox"
+              "concepts/sandbox",
+              "concepts/egress"
             ]
           },
           {

--- a/docs/policy/in-code.mdx
+++ b/docs/policy/in-code.mdx
@@ -62,6 +62,29 @@ policies = (
 )
 ```
 
+## Gate network egress
+
+`net_allow` and `net_approve` are builder sugar for the [egress
+plane](/concepts/egress). They render a host/scheme/port allowlist into ordinary
+`net.http_request` constraints, so an egress rule enforces the same way in both
+the pydantic and WASM engines.
+
+```python
+from hexgate import PolicyBuilder
+
+policy = (
+    PolicyBuilder(default="deny")
+    .net_allow(hosts=["api.github.com"], subdomains=["githubusercontent.com"])
+    .net_approve(hosts=["api.stripe.com"])
+    .build()
+)
+```
+
+`subdomains` matches the apex and any child (`example.com` and `*.example.com`).
+A host restriction is required: pass `hosts=`, `subdomains=`, or `any_host=True`.
+Calling `net_allow()` with only a scheme or port filter raises, because it would
+authorize every host.
+
 ## Unit-test a policy
 
 The `assert_*` helpers evaluate a policy the same way the runtime enforces it:

--- a/examples/egress_demo.py
+++ b/examples/egress_demo.py
@@ -1,0 +1,63 @@
+"""Egress proxy demo — gate outbound HTTP(S) by host, no API keys needed.
+
+Builds a code-first policy with `PolicyBuilder.net_allow` that allows HTTPS to
+`api.github.com` and denies everything else, starts the in-process egress proxy,
+points this process's HTTP clients at it, and makes two requests through plain
+`httpx` — one allowed, one denied — printing each policy decision as it happens.
+
+    python examples/egress_demo.py
+
+Note: the requests use ``httpx.AsyncClient`` (awaited), not the sync API,
+because the proxy runs on this same event loop — a blocking sync call would
+deadlock it. In a real deployment the agent's own async HTTP client picks up
+the ``HTTPS_PROXY`` env var that ``egress_guard`` sets, with no code changes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+
+from hexgate import PolicyBuilder, User
+from hexgate.egress import egress_guard
+from hexgate.security.decision import Decision
+from hexgate.security.enforcer import build_enforcer
+from hexgate.security.policy_set import load_policy_set
+
+
+def _print_decision(decision: Decision) -> None:
+    mark = "✓" if decision.allowed else "✗"
+    url = (decision.arguments or {}).get("url", "?")
+    print(f"  {mark} {decision.outcome.value:15} {url}")
+    if not decision.allowed and decision.reason:
+        print(f"      reason: {decision.reason}")
+
+
+async def main() -> None:
+    # Network egress is just another gated tool — deny by default, allow HTTPS to
+    # one host. `net_allow` renders this into ordinary constraints on
+    # `net.http_request`, so it works on both the pydantic and WASM engines.
+    policy = PolicyBuilder(default="deny").net_allow(hosts=["api.github.com"]).build()
+    enforcer = build_enforcer(
+        load_policy_set(policy),
+        agent_name="egress-demo",
+        decision_observer=_print_decision,
+    )
+    user = User(user_id="demo", role="agent")
+
+    # no_proxy would include the Hexgate control-plane host if audit were on,
+    # so audit POSTs bypass the proxy. This demo runs without an API key.
+    async with egress_guard(enforcer, user):
+        async with httpx.AsyncClient(timeout=10) as client:
+            for url in ("https://api.github.com/zen", "https://example.com/"):
+                print(f"\nGET {url}")
+                try:
+                    response = await client.get(url)
+                    print(f"  -> {response.status_code}")
+                except httpx.HTTPError as exc:
+                    print(f"  -> blocked: {type(exc).__name__}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/hexgate/egress/__init__.py
+++ b/hexgate/egress/__init__.py
@@ -5,9 +5,11 @@ gates tool calls, mapped to the synthetic ``net.http_request`` tool. A second
 enforcement plane alongside the declared-tool-call one: it gates the *actual*
 destination a process reaches, not just the tool the model asked for.
 
-Framework-agnostic and base-install — stdlib ``asyncio`` only, depends only on
-``hexgate.security`` / ``hexgate.runtime`` / ``hexgate.audit``. See
-``egress-proxy-plan.md``.
+Framework-agnostic and base-install: stdlib ``asyncio`` plus the
+framework-agnostic ``hexgate.security``, ``hexgate.runtime``, and
+``hexgate.approvals`` modules (``hexgate.audit`` comes in transitively via the
+enforcer). No agent framework is imported. See the network-egress concept doc
+(``docs/concepts/egress.mdx``).
 
     from hexgate.egress import egress_guard
     from hexgate.runtime.context import User

--- a/hexgate/egress/__init__.py
+++ b/hexgate/egress/__init__.py
@@ -1,0 +1,40 @@
+"""Optional network-egress enforcement plane for Hexgate.
+
+Routes an agent's outbound HTTP(S) through the same ``PolicyEnforcer`` that
+gates tool calls, mapped to the synthetic ``net.http_request`` tool. A second
+enforcement plane alongside the declared-tool-call one: it gates the *actual*
+destination a process reaches, not just the tool the model asked for.
+
+Framework-agnostic and base-install — stdlib ``asyncio`` only, depends only on
+``hexgate.security`` / ``hexgate.runtime`` / ``hexgate.audit``. See
+``egress-proxy-plan.md``.
+
+    from hexgate.egress import egress_guard
+    from hexgate.runtime.context import User
+
+    async with egress_guard(enforcer, User(user_id="u", role="agent")):
+        ...  # this process's HTTP(S) egress is now policy-gated
+"""
+
+from hexgate.egress.gate import Gate, GateResult
+from hexgate.egress.model import (
+    NET_TOOL,
+    connect_to_args,
+    http_to_args,
+    split_authority,
+)
+from hexgate.egress.proxy import EgressProxy, egress_guard
+from hexgate.egress.transport import Transport, TunnelTransport
+
+__all__ = [
+    "NET_TOOL",
+    "EgressProxy",
+    "Gate",
+    "GateResult",
+    "Transport",
+    "TunnelTransport",
+    "connect_to_args",
+    "egress_guard",
+    "http_to_args",
+    "split_authority",
+]

--- a/hexgate/egress/gate.py
+++ b/hexgate/egress/gate.py
@@ -1,0 +1,98 @@
+"""The enforcement seam between the proxy transport and the policy engine.
+
+:class:`Gate` is the one place egress talks to
+:class:`~hexgate.security.enforcer.PolicyEnforcer`. A transport hands it the
+enforcer args for a request; it resolves the caller's :class:`User`, asks the
+enforcer for a :class:`~hexgate.security.decision.Decision` (which emits the
+audit event and fires the decision observer as a side effect), and reduces it
+to an allow/deny result — awaiting the approval handler on ``NEEDS_APPROVAL``.
+
+Keeping every policy interaction behind this one method is what lets a future
+MITM transport reuse the whole enforcement path unchanged: the tunnel
+transport calls :meth:`check` once (host-level); a MITM transport would call
+it a second time with the decrypted request's full URL. Neither knows or
+cares which engine ran.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from inspect import isawaitable
+from typing import Any
+
+from hexgate.approvals import ApprovalHandler
+from hexgate.egress.model import NET_TOOL
+from hexgate.runtime.context import User
+from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.security.enforcer import PolicyEnforcer
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class GateResult:
+    """The effective verdict for one egress request.
+
+    ``allowed`` folds approval resolution in: an ``approval_required`` decision
+    whose handler approved reports ``allowed=True`` while ``decision`` still
+    carries the original ``NEEDS_APPROVAL`` outcome and reason (useful for
+    logging what was approved).
+    """
+
+    allowed: bool
+    decision: Decision
+
+
+class Gate:
+    """Reduce an egress request to a :class:`GateResult` via the enforcer."""
+
+    def __init__(
+        self,
+        enforcer: PolicyEnforcer,
+        user: User,
+        *,
+        approval_handler: ApprovalHandler | None = None,
+    ) -> None:
+        self._enforcer = enforcer
+        self._user = user
+        self._approval_handler = approval_handler
+
+    async def check(self, args: dict[str, Any]) -> GateResult:
+        """Decide one egress request, resolving approval when required.
+
+        The caller identity lives in a contextvar the enforcer reads on
+        ``decide()``. Connection handlers run in their own asyncio task, which
+        does not inherit the agent's ``async with User(...)`` scope, so we
+        re-bind the run's user in *this* task via ``sync_scope()`` for the
+        duration of the synchronous decide call.
+        """
+        with self._user.sync_scope():
+            decision = self._enforcer.decide(NET_TOOL, args)
+
+        if decision.allowed:
+            return GateResult(True, decision)
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+        ):
+            return GateResult(await self._resolve_approval(decision), decision)
+        return GateResult(False, decision)
+
+    async def _resolve_approval(self, decision: Decision) -> bool:
+        """Normalize the approval handler (bool / sync / async) to a bool.
+
+        Fails closed: a handler that raises denies the request rather than
+        letting the exception escape into the connection handler.
+        """
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception:
+            _log.exception("egress approval_handler raised; denying (fail-closed)")
+            return False

--- a/hexgate/egress/model.py
+++ b/hexgate/egress/model.py
@@ -4,8 +4,8 @@ The egress proxy translates each outbound request into the same
 ``(tool_name, arguments)`` shape the
 :class:`~hexgate.security.enforcer.PolicyEnforcer` already evaluates for tool
 calls, so network egress is gated by the same policy engine, ``Decision``
-type, and audit path as everything else — network egress is *just another
-gated tool*. See ``egress-proxy-plan.md`` for the design rationale.
+type, and audit path as everything else. Network egress is just another gated
+tool. See the network-egress concept doc (``docs/concepts/egress.mdx``).
 """
 
 from __future__ import annotations
@@ -51,11 +51,12 @@ def http_to_args(method: str, absolute_uri: str) -> dict[str, Any]:
     without dropping the query string).
     """
     parts = urlsplit(absolute_uri)
+    scheme = parts.scheme or "http"
     return {
         "method": method,
-        "scheme": parts.scheme or "http",
+        "scheme": scheme,
         "host": parts.hostname or "",
-        "port": parts.port or 80,
+        "port": parts.port or (443 if scheme == "https" else 80),
         "url": absolute_uri,
         "path": parts.path or "/",
         "query": parts.query,

--- a/hexgate/egress/model.py
+++ b/hexgate/egress/model.py
@@ -1,0 +1,86 @@
+"""Map a proxied HTTP request onto the synthetic ``net.http_request`` tool call.
+
+The egress proxy translates each outbound request into the same
+``(tool_name, arguments)`` shape the
+:class:`~hexgate.security.enforcer.PolicyEnforcer` already evaluates for tool
+calls, so network egress is gated by the same policy engine, ``Decision``
+type, and audit path as everything else — network egress is *just another
+gated tool*. See ``egress-proxy-plan.md`` for the design rationale.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import urlsplit
+
+from hexgate.security.network import NET_HTTP_REQUEST as NET_TOOL
+
+__all__ = ["NET_TOOL", "connect_to_args", "http_to_args", "split_authority"]
+
+# ``NET_TOOL`` is the synthetic tool name every egress request is attributed to.
+# Its canonical definition lives in ``hexgate.security.network`` so the policy
+# layer (``PolicyBuilder.net_allow``) and the proxy share one source of truth.
+# Add a policy entry under this name to allow egress; without one,
+# ``default_policy`` (deny-by-default) applies and all egress is denied.
+
+
+def connect_to_args(host: str, port: int) -> dict[str, Any]:
+    """Build enforcer args for an HTTPS ``CONNECT`` tunnel request.
+
+    Only the host and port are visible before TLS begins — the path, headers,
+    and body are encrypted end-to-end — so constraints on an HTTPS request are
+    limited to ``args.host`` / ``args.port`` / ``args.scheme``.
+    """
+    display = f"[{host}]" if ":" in host else host  # bracket IPv6 literals in the URL
+    return {
+        "method": "CONNECT",
+        "scheme": "https",
+        "host": host,
+        "port": port,
+        "url": f"https://{display}:{port}",
+    }
+
+
+def http_to_args(method: str, absolute_uri: str) -> dict[str, Any]:
+    """Build enforcer args for a plain-HTTP forward-proxy request.
+
+    A forward-proxied HTTP request carries the absolute URI on the request
+    line (``GET http://host/path?q=1 HTTP/1.1``), so the full URL — including
+    ``args.path`` and ``args.query`` — is available to constraints on the
+    plain-HTTP path (and both are needed to reconstruct the origin-form line
+    without dropping the query string).
+    """
+    parts = urlsplit(absolute_uri)
+    return {
+        "method": method,
+        "scheme": parts.scheme or "http",
+        "host": parts.hostname or "",
+        "port": parts.port or 80,
+        "url": absolute_uri,
+        "path": parts.path or "/",
+        "query": parts.query,
+    }
+
+
+def split_authority(target: str) -> tuple[str, int]:
+    """Split a ``CONNECT`` target into ``(host, port)``.
+
+    Handles bracketed IPv6 literals (``[::1]`` / ``[2606:4700::1]:443``) as well
+    as ``host`` / ``host:port``. Brackets are stripped so the host is directly
+    usable with :func:`asyncio.open_connection`. Defaults to port 443 when the
+    target omits it. Raises ``ValueError`` on a malformed target (unterminated
+    bracket, junk after ``]``, non-integer port) so the proxy fails closed.
+    """
+    if target.startswith("["):
+        end = target.index("]")  # ValueError if unterminated → refused as malformed
+        host = target[1:end]
+        rest = target[end + 1 :]
+        if rest.startswith(":"):
+            return host, int(rest[1:])
+        if rest:
+            raise ValueError(f"malformed IPv6 authority: {target!r}")
+        return host, 443
+    host, sep, port_str = target.rpartition(":")
+    if not sep:
+        return target, 443
+    return host, int(port_str)

--- a/hexgate/egress/proxy.py
+++ b/hexgate/egress/proxy.py
@@ -1,0 +1,193 @@
+"""In-process forward proxy that gates outbound egress through policy.
+
+``EgressProxy`` is an optional second enforcement plane. Point an agent's
+process at it (via ``HTTP_PROXY`` / ``HTTPS_PROXY``, which ``egress_guard``
+sets for you) and every outbound HTTP(S) request is routed through the same
+:class:`~hexgate.security.enforcer.PolicyEnforcer` that gates tool calls —
+mapped to the synthetic ``net.http_request`` tool. See ``egress-proxy-plan.md``.
+
+Scope (Tier 1): host-level filtering. HTTPS is gated on the ``CONNECT`` host;
+the tunnel relays ciphertext untouched (no TLS interception). Like
+``runtime/command_policy.py``, the env-proxy hookup is *intent-shaping, not a
+hard boundary* — a tool that unsets the proxy env vars bypasses it. A sandbox
+that forces all egress through the proxy is the hard-boundary follow-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+from collections.abc import AsyncIterator, Sequence
+
+from hexgate.approvals import ApprovalHandler
+from hexgate.egress.gate import Gate
+from hexgate.egress.model import split_authority
+from hexgate.egress.transport import Transport, TunnelTransport
+from hexgate.egress.wire import close_writer, parse_request_line, read_headers, refuse
+from hexgate.runtime.context import User
+from hexgate.security.enforcer import PolicyEnforcer
+
+_log = logging.getLogger(__name__)
+
+_PROXY_ENV_VARS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "NO_PROXY",
+    "no_proxy",
+)
+
+# Only one egress_guard may be live per process: it mutates global proxy env
+# vars, so a second (nested or concurrent) guard would clobber the first's and
+# restore stale values on exit. We fail loud rather than corrupt silently.
+_guard_active = False
+
+
+class EgressProxy:
+    """An asyncio forward proxy that authorizes each request via ``Gate``.
+
+    One proxy serves one agent run: the ``user`` fixes the identity every
+    egress decision is attributed to. Start it, point the process's HTTP
+    clients at ``http://{host}:{port}``, and every request is gated.
+    """
+
+    def __init__(
+        self,
+        enforcer: PolicyEnforcer,
+        user: User,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        approval_handler: ApprovalHandler | None = None,
+        transport: Transport | None = None,
+    ) -> None:
+        self._gate = Gate(enforcer, user, approval_handler=approval_handler)
+        self._transport: Transport = (
+            transport if transport is not None else TunnelTransport()
+        )
+        self._host = host
+        self._requested_port = port
+        self._server: asyncio.AbstractServer | None = None
+        self._port: int | None = None
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def port(self) -> int:
+        """The bound port. Raises if the proxy has not been started."""
+        if self._port is None:
+            raise RuntimeError("EgressProxy is not started; call start() first")
+        return self._port
+
+    async def start(self) -> None:
+        """Bind and begin accepting connections. Idempotent."""
+        if self._server is not None:
+            return
+        self._server = await asyncio.start_server(
+            self._handle_client, self._host, self._requested_port
+        )
+        self._port = self._server.sockets[0].getsockname()[1]
+        _log.info("egress proxy listening on %s:%s", self._host, self._port)
+
+    async def stop(self) -> None:
+        """Stop accepting and close the listening socket. Idempotent."""
+        if self._server is None:
+            return
+        self._server.close()
+        with contextlib.suppress(Exception):
+            await self._server.wait_closed()
+        self._server = None
+        self._port = None
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            request_line = await reader.readline()
+            if not request_line:
+                close_writer(writer)
+                return
+            method, target = parse_request_line(request_line)
+            if method == "CONNECT":
+                host, port = split_authority(target)
+                await read_headers(reader)  # drain the CONNECT request headers
+                await self._transport.handle_connect(
+                    host, port, reader, writer, self._gate
+                )
+            else:
+                header_block = await read_headers(reader)
+                await self._transport.handle_http(
+                    method, target, header_block, reader, writer, self._gate
+                )
+        except ValueError:
+            # Malformed request line / CONNECT target / oversized headers.
+            await refuse(writer, 400, "Bad Request", "malformed request")
+        except Exception:
+            _log.exception("egress proxy connection handler failed")
+            close_writer(writer)
+
+
+@contextlib.asynccontextmanager
+async def egress_guard(
+    enforcer: PolicyEnforcer,
+    user: User,
+    *,
+    host: str = "127.0.0.1",
+    port: int = 0,
+    approval_handler: ApprovalHandler | None = None,
+    no_proxy: Sequence[str] = (),
+) -> AsyncIterator[EgressProxy]:
+    """Start an :class:`EgressProxy` and point this process's HTTP clients at it.
+
+    Sets ``HTTP_PROXY`` / ``HTTPS_PROXY`` (both cases) for the duration of the
+    block and restores the prior environment on exit. ``no_proxy`` hosts are
+    added to ``NO_PROXY`` so they bypass the proxy — **always include the
+    Hexgate control-plane host** (e.g. ``app.hexgate.ai``) when audit is
+    enabled, otherwise the audit sender's own POSTs would route through the
+    proxy and be denied (or recurse). Loopback is excluded by default.
+
+    Only one guard may be live per process (it mutates global env vars) — a
+    nested or concurrent :func:`egress_guard` raises ``RuntimeError`` rather
+    than silently clobbering the outer guard's proxy configuration.
+
+    Yields the running proxy (``proxy.port`` is the bound port).
+    """
+    global _guard_active
+    if _guard_active:
+        raise RuntimeError(
+            "an egress_guard is already active in this process; nested or "
+            "concurrent egress_guard is unsupported because it mutates global "
+            "HTTP(S)_PROXY env vars. Use one guard per process, or drive "
+            "EgressProxy directly with an explicitly-configured client."
+        )
+    _guard_active = True
+    proxy = EgressProxy(
+        enforcer, user, host=host, port=port, approval_handler=approval_handler
+    )
+    saved = {name: os.environ.get(name) for name in _PROXY_ENV_VARS}
+    try:
+        await proxy.start()
+        url = f"http://{proxy.host}:{proxy.port}"
+        bypass = ",".join(["127.0.0.1", "localhost", *no_proxy])
+        os.environ.update(
+            HTTP_PROXY=url,
+            HTTPS_PROXY=url,
+            http_proxy=url,
+            https_proxy=url,
+            NO_PROXY=bypass,
+            no_proxy=bypass,
+        )
+        yield proxy
+    finally:
+        for name, previous in saved.items():
+            if previous is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = previous
+        await proxy.stop()
+        _guard_active = False

--- a/hexgate/egress/proxy.py
+++ b/hexgate/egress/proxy.py
@@ -3,8 +3,9 @@
 ``EgressProxy`` is an optional second enforcement plane. Point an agent's
 process at it (via ``HTTP_PROXY`` / ``HTTPS_PROXY``, which ``egress_guard``
 sets for you) and every outbound HTTP(S) request is routed through the same
-:class:`~hexgate.security.enforcer.PolicyEnforcer` that gates tool calls —
-mapped to the synthetic ``net.http_request`` tool. See ``egress-proxy-plan.md``.
+:class:`~hexgate.security.enforcer.PolicyEnforcer` that gates tool calls,
+mapped to the synthetic ``net.http_request`` tool. See the network-egress
+concept doc (``docs/concepts/egress.mdx``).
 
 Scope (Tier 1): host-level filtering. HTTPS is gated on the ``CONNECT`` host;
 the tunnel relays ciphertext untouched (no TLS interception). Like
@@ -72,6 +73,9 @@ class EgressProxy:
         self._requested_port = port
         self._server: asyncio.AbstractServer | None = None
         self._port: int | None = None
+        # In-flight connection-handler tasks, so stop() can cancel open tunnels
+        # instead of leaving them relaying after the guard restores env vars.
+        self._conns: set[asyncio.Task[None]] = set()
 
     @property
     def host(self) -> str:
@@ -95,10 +99,18 @@ class EgressProxy:
         _log.info("egress proxy listening on %s:%s", self._host, self._port)
 
     async def stop(self) -> None:
-        """Stop accepting and close the listening socket. Idempotent."""
+        """Stop accepting, cancel open connections, close the socket. Idempotent."""
         if self._server is None:
             return
         self._server.close()
+        # Cancel handlers still relaying (e.g. an open CONNECT tunnel) BEFORE
+        # wait_closed(): on Python 3.12+ wait_closed() blocks until active
+        # connections finish, so an open tunnel would otherwise deadlock it.
+        for task in list(self._conns):
+            task.cancel()
+        if self._conns:
+            await asyncio.gather(*self._conns, return_exceptions=True)
+            self._conns.clear()
         with contextlib.suppress(Exception):
             await self._server.wait_closed()
         self._server = None
@@ -107,6 +119,9 @@ class EgressProxy:
     async def _handle_client(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
+        task = asyncio.current_task()
+        if task is not None:
+            self._conns.add(task)
         try:
             request_line = await reader.readline()
             if not request_line:
@@ -130,6 +145,9 @@ class EgressProxy:
         except Exception:
             _log.exception("egress proxy connection handler failed")
             close_writer(writer)
+        finally:
+            if task is not None:
+                self._conns.discard(task)
 
 
 @contextlib.asynccontextmanager

--- a/hexgate/egress/transport.py
+++ b/hexgate/egress/transport.py
@@ -1,0 +1,129 @@
+"""HTTP proxy transports — the swappable byte-plumbing layer.
+
+A transport owns what happens after a client connects: turn the proxied
+request into enforcer args, ask the :class:`~hexgate.egress.gate.Gate` for a
+decision, and either relay bytes or refuse. The enforcement seam (``Gate``) is
+transport-agnostic, so Tier 2 TLS interception can land later as a second
+:class:`Transport` implementation without touching the policy path.
+
+:class:`TunnelTransport` is Tier 1: it host-filters HTTPS via the ``CONNECT``
+verb (no TLS interception — the tunnel relays ciphertext untouched) and sees
+the full URL on plain-HTTP requests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Protocol
+
+from hexgate.egress.gate import Gate
+from hexgate.egress.model import connect_to_args, http_to_args
+from hexgate.egress.wire import pipe, refuse, strip_proxy_headers
+
+_log = logging.getLogger(__name__)
+
+
+class Transport(Protocol):
+    """What happens after a client connects to the proxy.
+
+    Implementations own the bytes; the enforcement decision is delegated to
+    ``gate``. A future ``MitmTransport`` implements these same two methods.
+    """
+
+    async def handle_connect(
+        self,
+        host: str,
+        port: int,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        gate: Gate,
+    ) -> None: ...
+
+    async def handle_http(
+        self,
+        method: str,
+        target: str,
+        header_block: bytes,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        gate: Gate,
+    ) -> None: ...
+
+
+class TunnelTransport:
+    """Tier 1 transport: host-level filtering, no TLS interception."""
+
+    async def handle_connect(
+        self,
+        host: str,
+        port: int,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        gate: Gate,
+    ) -> None:
+        result = await gate.check(connect_to_args(host, port))
+        if not result.allowed:
+            _log.info(
+                "egress DENY CONNECT %s:%s — %s", host, port, result.decision.reason
+            )
+            await refuse(
+                writer, 403, "Forbidden", result.decision.reason or "denied by policy"
+            )
+            return
+        upstream = await _open(host, port, writer)
+        if upstream is None:
+            return
+        upstream_reader, upstream_writer = upstream
+        writer.write(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+        await writer.drain()
+        await pipe(reader, writer, upstream_reader, upstream_writer)
+
+    async def handle_http(
+        self,
+        method: str,
+        target: str,
+        header_block: bytes,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+        gate: Gate,
+    ) -> None:
+        args = http_to_args(method, target)
+        result = await gate.check(args)
+        if not result.allowed:
+            _log.info("egress DENY %s %s — %s", method, target, result.decision.reason)
+            await refuse(
+                writer, 403, "Forbidden", result.decision.reason or "denied by policy"
+            )
+            return
+        host = str(args["host"])
+        port = int(args["port"])
+        if not host:
+            await refuse(writer, 400, "Bad Request", "proxy request missing host")
+            return
+        upstream = await _open(host, port, writer)
+        if upstream is None:
+            return
+        upstream_reader, upstream_writer = upstream
+        # Rewrite the absolute-form request line to origin-form (keeping the
+        # query string) and forward the client's headers minus proxy-scoped
+        # hop-by-hop ones, then relay the response and close.
+        request_target = args["path"]
+        if args.get("query"):
+            request_target = f"{request_target}?{args['query']}"
+        origin_line = f"{method} {request_target} HTTP/1.1\r\n".encode("latin-1")
+        upstream_writer.write(origin_line + strip_proxy_headers(header_block))
+        await upstream_writer.drain()
+        await pipe(reader, writer, upstream_reader, upstream_writer)
+
+
+async def _open(
+    host: str, port: int, writer: asyncio.StreamWriter
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter] | None:
+    """Open an upstream connection, or write a 502 and return ``None``."""
+    try:
+        return await asyncio.open_connection(host, port)
+    except OSError as exc:
+        _log.info("egress upstream connect failed for %s:%s: %s", host, port, exc)
+        await refuse(writer, 502, "Bad Gateway", f"cannot reach {host}:{port}")
+        return None

--- a/hexgate/egress/wire.py
+++ b/hexgate/egress/wire.py
@@ -36,15 +36,18 @@ async def read_headers(reader: asyncio.StreamReader) -> bytes:
 
     The returned bytes include the final ``\\r\\n`` separator, so a plain-HTTP
     forwarder can concatenate a rewritten request line and send it verbatim.
-    Bounded by ``_MAX_HEADER_BYTES`` — a client that never sends the blank line
-    raises ``ValueError`` (fail closed) rather than growing unbounded.
+    Raises ``ValueError`` (fail closed) if the client disconnects before the
+    blank line, or if the block exceeds ``_MAX_HEADER_BYTES``, rather than
+    forwarding a truncated request.
     """
     blocks: list[bytes] = []
     total = 0
     while True:
         line = await reader.readline()
+        if line == b"":
+            raise ValueError("connection closed before end of headers")
         blocks.append(line)
-        if line in (b"\r\n", b"\n", b""):
+        if line in (b"\r\n", b"\n"):
             break
         total += len(line)
         if total > _MAX_HEADER_BYTES:

--- a/hexgate/egress/wire.py
+++ b/hexgate/egress/wire.py
@@ -1,0 +1,128 @@
+"""Low-level HTTP/1.x wire helpers shared by the proxy and its transports.
+
+Deliberately tiny and dependency-free — just enough to parse a proxied
+request line, read a header block, relay bytes between two streams, and write
+an error response. Not a general HTTP implementation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+_CHUNK = 64 * 1024
+_MAX_HEADER_BYTES = 64 * 1024
+
+
+def parse_request_line(line: bytes) -> tuple[str, str]:
+    """Parse ``b"METHOD target HTTP/1.1\\r\\n"`` into ``(method, target)``.
+
+    Raises ``ValueError`` if the line is not three space-separated tokens, so
+    the caller can fail the request closed with a 400.
+    """
+    try:
+        text = line.decode("latin-1").rstrip("\r\n")
+    except UnicodeDecodeError as exc:
+        raise ValueError("non-latin1 request line") from exc
+    parts = text.split(" ")
+    if len(parts) != 3:
+        raise ValueError(f"malformed request line: {text!r}")
+    method, target, _version = parts
+    return method.upper(), target
+
+
+async def read_headers(reader: asyncio.StreamReader) -> bytes:
+    """Read header lines through the terminating blank line; return them raw.
+
+    The returned bytes include the final ``\\r\\n`` separator, so a plain-HTTP
+    forwarder can concatenate a rewritten request line and send it verbatim.
+    Bounded by ``_MAX_HEADER_BYTES`` — a client that never sends the blank line
+    raises ``ValueError`` (fail closed) rather than growing unbounded.
+    """
+    blocks: list[bytes] = []
+    total = 0
+    while True:
+        line = await reader.readline()
+        blocks.append(line)
+        if line in (b"\r\n", b"\n", b""):
+            break
+        total += len(line)
+        if total > _MAX_HEADER_BYTES:
+            raise ValueError("header block exceeds limit")
+    return b"".join(blocks)
+
+
+async def refuse(
+    writer: asyncio.StreamWriter, status: int, phrase: str, detail: str
+) -> None:
+    """Write a short ``text/plain`` error response and close the connection."""
+    body = detail.encode("utf-8", "replace")
+    header = (
+        f"HTTP/1.1 {status} {phrase}\r\n"
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        f"Content-Length: {len(body)}\r\n"
+        "Connection: close\r\n"
+        "\r\n"
+    ).encode("latin-1")
+    with contextlib.suppress(OSError):
+        writer.write(header + body)
+        await writer.drain()
+    close_writer(writer)
+
+
+async def pipe(
+    client_reader: asyncio.StreamReader,
+    client_writer: asyncio.StreamWriter,
+    upstream_reader: asyncio.StreamReader,
+    upstream_writer: asyncio.StreamWriter,
+) -> None:
+    """Relay bytes both ways until either side closes, then tear both down.
+
+    When one direction reaches EOF it half-closes the peer's write side
+    (``write_eof``) so the peer observes the close and its own copy can finish
+    — without this a keep-alive client would hang after the response arrives.
+    """
+
+    async def copy(src: asyncio.StreamReader, dst: asyncio.StreamWriter) -> None:
+        # Catch Exception (not just OSError) so a relay hiccup ends this
+        # direction cleanly instead of escaping through gather() and skipping
+        # the teardown below. CancelledError is BaseException, so a genuine
+        # cancellation still propagates and is handled by the finally.
+        try:
+            while data := await src.read(_CHUNK):
+                dst.write(data)
+                await dst.drain()
+        except Exception:
+            pass
+        finally:
+            with contextlib.suppress(OSError):
+                if dst.can_write_eof():
+                    dst.write_eof()
+
+    try:
+        await asyncio.gather(
+            copy(client_reader, upstream_writer),
+            copy(upstream_reader, client_writer),
+        )
+    finally:
+        # Always tear both sockets down — including on cancellation of pipe().
+        close_writer(upstream_writer)
+        close_writer(client_writer)
+
+
+def strip_proxy_headers(header_block: bytes) -> bytes:
+    """Drop proxy-scoped hop-by-hop headers before forwarding upstream.
+
+    Removes ``Proxy-Connection`` / ``Proxy-Authorization`` (any ``Proxy-*``
+    header) so they don't leak to the origin server (RFC 7230 §6.1). Other
+    headers and the terminating blank line are preserved verbatim.
+    """
+    lines = header_block.split(b"\r\n")
+    kept = [line for line in lines if not line.lower().startswith(b"proxy-")]
+    return b"\r\n".join(kept)
+
+
+def close_writer(writer: asyncio.StreamWriter) -> None:
+    """Close a stream writer, swallowing the error if it's already gone."""
+    with contextlib.suppress(OSError):
+        writer.close()

--- a/hexgate/security/builder.py
+++ b/hexgate/security/builder.py
@@ -29,6 +29,7 @@ from hexgate.security.models import (
     PolicyMode,
     ToolPolicy,
 )
+from hexgate.security.network import NET_HTTP_REQUEST, net_constraints
 from hexgate.security.policy_set import PolicySet, load_policy_map
 
 
@@ -162,6 +163,73 @@ class PolicyBuilder:
         )
         self._tools[tool] = FileToolPolicy(
             mode=mode, constraints=_normalize(when), file_scope=scope
+        )
+        return self
+
+    def net_allow(
+        self,
+        *,
+        hosts: Iterable[str] = (),
+        subdomains: Iterable[str] = (),
+        schemes: Iterable[str] = ("https",),
+        ports: Iterable[int] = (),
+        when: WhenArg = (),
+        any_host: bool = False,
+    ) -> PolicyBuilder:
+        """Allow outbound egress to matching hosts (the ``net.http_request`` tool).
+
+        Sugar over :meth:`allow` for the egress plane: renders host / subdomain /
+        scheme / port allowlists into ordinary constraint strings (see
+        :mod:`hexgate.security.network`), so the rule compiles to both the
+        pydantic and WASM engines with no special-casing. ``schemes`` defaults to
+        HTTPS only — pass ``schemes=()`` to allow any scheme. Extra ``when``
+        constraints are AND-ed on.
+
+        A host restriction is **required**: pass ``hosts=``, ``subdomains=``, or
+        the explicit ``any_host=True`` opt-in. Omitting all three raises
+        ``ValueError`` — a scheme/port filter alone would silently authorize
+        egress to *every* host, which is almost never intended.
+        """
+        return self._net("allow", hosts, subdomains, schemes, ports, when, any_host)
+
+    def net_approve(
+        self,
+        *,
+        hosts: Iterable[str] = (),
+        subdomains: Iterable[str] = (),
+        schemes: Iterable[str] = ("https",),
+        ports: Iterable[int] = (),
+        when: WhenArg = (),
+        any_host: bool = False,
+    ) -> PolicyBuilder:
+        """Require approval for egress to matching hosts (see :meth:`net_allow`)."""
+        return self._net(
+            "approval_required", hosts, subdomains, schemes, ports, when, any_host
+        )
+
+    def _net(
+        self,
+        mode: PolicyMode,
+        hosts: Iterable[str],
+        subdomains: Iterable[str],
+        schemes: Iterable[str],
+        ports: Iterable[int],
+        when: WhenArg,
+        any_host: bool,
+    ) -> PolicyBuilder:
+        hosts, subdomains = list(hosts), list(subdomains)
+        if not any_host and not hosts and not subdomains:
+            raise ValueError(
+                "net_allow/net_approve requires a host restriction: pass hosts=, "
+                "subdomains=, or any_host=True to deliberately allow every host. "
+                "A scheme/port filter alone would authorize egress to ALL hosts."
+            )
+        constraints = net_constraints(
+            hosts=hosts, subdomains=subdomains, schemes=schemes, ports=ports
+        )
+        constraints.extend(_normalize(when))
+        self._tools[NET_HTTP_REQUEST] = BaseToolPolicy(
+            mode=mode, constraints=constraints
         )
         return self
 

--- a/hexgate/security/network.py
+++ b/hexgate/security/network.py
@@ -1,0 +1,74 @@
+"""Network-egress policy contract — the synthetic tool name and constraint emitters.
+
+Network egress is enforced as an ordinary tool call named ``net.http_request``:
+the egress proxy maps each outbound HTTP(S) request onto it. This module is the
+single source of truth for that name and for turning host/scheme/port allowlists
+into constraint *strings* — the same grammar tool-call constraints use — so the
+network rules compile to both engines (pydantic + WASM) with no special-casing.
+
+Nothing here is a new enforcement path: it renders strings the existing
+constraint parser (:mod:`hexgate.security.constraints`) and the Rego compiler
+already accept.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable
+
+# The synthetic tool every egress request is attributed to. Defined here (not in
+# hexgate.egress) so the policy layer (PolicyBuilder.net_allow) and the proxy
+# share one definition — egress depends downward on security, never the reverse.
+NET_HTTP_REQUEST = "net.http_request"
+
+
+def host_match_constraint(
+    hosts: Iterable[str] = (), subdomains: Iterable[str] = ()
+) -> str | None:
+    """Render one constraint matching an exact-host allowlist and/or domains.
+
+    ``hosts`` match exactly. Each ``subdomains`` entry ``d`` matches both the
+    apex ``d`` and any ``*.d`` — via ``endswith(args.host, ".d")``, whose leading
+    dot stops ``d`` from also matching ``evil-d``. Terms are OR-ed into one
+    expression so the whole host check is a single AND-clause in the tool's
+    constraint list.
+
+    Returns ``None`` when neither is given (no host restriction).
+    """
+    hosts = list(hosts)
+    subdomains = list(subdomains)
+    terms: list[str] = []
+    if hosts:
+        terms.append(f"args.host in {json.dumps(hosts)}")
+    for domain in subdomains:
+        terms.append(f"args.host == {json.dumps(domain)}")
+        terms.append(f"endswith(args.host, {json.dumps('.' + domain)})")
+    if not terms:
+        return None
+    return " or ".join(terms)
+
+
+def net_constraints(
+    *,
+    hosts: Iterable[str] = (),
+    subdomains: Iterable[str] = (),
+    schemes: Iterable[str] = (),
+    ports: Iterable[int] = (),
+) -> list[str]:
+    """Render the AND-ed constraint list for an egress rule.
+
+    Each returned string is one clause (all must hold). Host/subdomain matching
+    collapses to a single OR clause; ``schemes`` and ``ports`` become their own
+    ``in`` clauses. An empty facet contributes no clause (no restriction on it).
+    """
+    constraints: list[str] = []
+    host_clause = host_match_constraint(hosts, subdomains)
+    if host_clause is not None:
+        constraints.append(host_clause)
+    schemes = list(schemes)
+    if schemes:
+        constraints.append(f"args.scheme in {json.dumps(schemes)}")
+    ports = list(ports)
+    if ports:
+        constraints.append(f"args.port in {json.dumps(ports)}")
+    return constraints

--- a/tests/egress/test_gate.py
+++ b/tests/egress/test_gate.py
@@ -1,0 +1,106 @@
+"""Tests for the egress enforcement seam (Gate).
+
+Exercises the real ``PolicyEnforcer`` + ``PolicySet`` — no mocks — so the
+tests also pin that network egress rides the existing policy engine, identity
+binding, and decision-observer hook.
+"""
+
+from __future__ import annotations
+
+from hexgate.egress.gate import Gate
+from hexgate.egress.model import connect_to_args
+from hexgate.runtime.context import User
+from hexgate.security.decision import Decision
+from hexgate.security.enforcer import build_enforcer
+from hexgate.security.policy_set import load_policy_set_from_dict
+
+
+def _enforcer(mode: str, constraints: list[str] | None = None, observer=None):
+    policy = load_policy_set_from_dict(
+        {
+            "roles": {
+                "agent": {
+                    "default_policy": {"mode": "deny"},
+                    "tools": {
+                        "net.http_request": {
+                            "mode": mode,
+                            "constraints": constraints or [],
+                        }
+                    },
+                }
+            }
+        }
+    )
+    return build_enforcer(policy, agent_name="test-egress", decision_observer=observer)
+
+
+def _agent() -> User:
+    return User(user_id="u", role="agent")
+
+
+async def test_allows_matching_host() -> None:
+    gate = Gate(_enforcer("allow", ['args.host == "ok.example.com"']), _agent())
+    result = await gate.check(connect_to_args("ok.example.com", 443))
+    assert result.allowed
+    assert result.decision.outcome.value == "allow"
+
+
+async def test_denies_other_host() -> None:
+    gate = Gate(_enforcer("allow", ['args.host == "ok.example.com"']), _agent())
+    result = await gate.check(connect_to_args("evil.example.com", 443))
+    assert not result.allowed
+
+
+async def test_ip_literal_is_denied_by_host_allowlist() -> None:
+    gate = Gate(_enforcer("allow", ['args.host in ["ok.example.com"]']), _agent())
+    result = await gate.check(connect_to_args("203.0.113.5", 443))
+    assert not result.allowed
+
+
+async def test_binds_identity_and_emits_to_observer() -> None:
+    seen: list[Decision] = []
+    gate = Gate(_enforcer("allow", observer=seen.append), _agent())
+    await gate.check(connect_to_args("anything.example.com", 443))
+    assert len(seen) == 1
+    # sync_scope bound the run's user inside the handler task, so the enforcer
+    # attributed the decision to role "agent" (not None).
+    assert seen[0].role == "agent"
+    assert seen[0].tool_name == "net.http_request"
+
+
+async def test_approval_required_bool_true_allows() -> None:
+    gate = Gate(_enforcer("approval_required"), _agent(), approval_handler=True)
+    result = await gate.check(connect_to_args("any.example.com", 443))
+    assert result.allowed
+    # The recorded decision still reflects the original NEEDS_APPROVAL verdict.
+    assert result.decision.outcome.value == "needs_approval"
+
+
+async def test_approval_required_bool_false_denies() -> None:
+    gate = Gate(_enforcer("approval_required"), _agent(), approval_handler=False)
+    result = await gate.check(connect_to_args("any.example.com", 443))
+    assert not result.allowed
+
+
+async def test_approval_required_async_handler() -> None:
+    async def approve(_decision: Decision) -> bool:
+        return True
+
+    gate = Gate(_enforcer("approval_required"), _agent(), approval_handler=approve)
+    result = await gate.check(connect_to_args("any.example.com", 443))
+    assert result.allowed
+
+
+async def test_approval_handler_raising_fails_closed() -> None:
+    def boom(_decision: Decision) -> bool:
+        raise RuntimeError("handler blew up")
+
+    gate = Gate(_enforcer("approval_required"), _agent(), approval_handler=boom)
+    result = await gate.check(connect_to_args("any.example.com", 443))
+    assert not result.allowed
+
+
+async def test_approval_required_without_handler_denies() -> None:
+    gate = Gate(_enforcer("approval_required"), _agent())
+    result = await gate.check(connect_to_args("any.example.com", 443))
+    assert not result.allowed

--- a/tests/egress/test_model.py
+++ b/tests/egress/test_model.py
@@ -32,6 +32,12 @@ def test_http_to_args_explicit_port() -> None:
     assert args["port"] == 8080
 
 
+def test_http_to_args_https_absolute_uri_defaults_443() -> None:
+    args = http_to_args("GET", "https://example.com/x")
+    assert args["scheme"] == "https"
+    assert args["port"] == 443
+
+
 def test_http_to_args_root_path() -> None:
     assert http_to_args("GET", "http://example.com")["path"] == "/"
 

--- a/tests/egress/test_model.py
+++ b/tests/egress/test_model.py
@@ -1,0 +1,74 @@
+"""Unit tests for the request -> tool-call arg mapping."""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate.egress.model import connect_to_args, http_to_args, split_authority
+
+
+def test_connect_to_args() -> None:
+    assert connect_to_args("api.github.com", 443) == {
+        "method": "CONNECT",
+        "scheme": "https",
+        "host": "api.github.com",
+        "port": 443,
+        "url": "https://api.github.com:443",
+    }
+
+
+def test_http_to_args_defaults_port_80() -> None:
+    args = http_to_args("GET", "http://example.com/path?q=1")
+    assert args["method"] == "GET"
+    assert args["scheme"] == "http"
+    assert args["host"] == "example.com"
+    assert args["port"] == 80
+    assert args["path"] == "/path"
+    assert args["url"] == "http://example.com/path?q=1"
+
+
+def test_http_to_args_explicit_port() -> None:
+    args = http_to_args("POST", "http://example.com:8080/x")
+    assert args["port"] == 8080
+
+
+def test_http_to_args_root_path() -> None:
+    assert http_to_args("GET", "http://example.com")["path"] == "/"
+
+
+def test_http_to_args_keeps_query() -> None:
+    args = http_to_args("GET", "http://example.com/search?q=hello&n=2")
+    assert args["path"] == "/search"
+    assert args["query"] == "q=hello&n=2"
+
+
+def test_connect_to_args_brackets_ipv6_in_url() -> None:
+    args = connect_to_args("2606:4700::1", 443)
+    assert args["host"] == "2606:4700::1"  # host itself is bracket-free
+    assert args["url"] == "https://[2606:4700::1]:443"
+
+
+def test_split_authority_with_port() -> None:
+    assert split_authority("api.github.com:443") == ("api.github.com", 443)
+
+
+def test_split_authority_defaults_443() -> None:
+    assert split_authority("api.github.com") == ("api.github.com", 443)
+
+
+def test_split_authority_rejects_non_integer_port() -> None:
+    with pytest.raises(ValueError):
+        split_authority("host:not-a-port")
+
+
+def test_split_authority_ipv6_with_port() -> None:
+    assert split_authority("[2606:4700::1]:443") == ("2606:4700::1", 443)
+
+
+def test_split_authority_ipv6_without_port() -> None:
+    assert split_authority("[::1]") == ("::1", 443)
+
+
+def test_split_authority_ipv6_unterminated_bracket_raises() -> None:
+    with pytest.raises(ValueError):
+        split_authority("[::1")

--- a/tests/egress/test_proxy.py
+++ b/tests/egress/test_proxy.py
@@ -1,0 +1,217 @@
+"""End-to-end tests for the egress proxy over real loopback sockets.
+
+Uses ``httpx.AsyncClient`` (awaited) for the plain-HTTP path and raw asyncio
+streams for the CONNECT tunnel path. The proxy runs on the test's own event
+loop, so every client must be async — a blocking sync request would deadlock.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+
+from hexgate.egress.proxy import EgressProxy, egress_guard
+from hexgate.runtime.context import User
+from hexgate.security.enforcer import build_enforcer
+from hexgate.security.policy_set import load_policy_set_from_dict
+
+
+def _enforcer(allowed_host: str):
+    policy = load_policy_set_from_dict(
+        {
+            "roles": {
+                "agent": {
+                    "default_policy": {"mode": "deny"},
+                    "tools": {
+                        "net.http_request": {
+                            "mode": "allow",
+                            "constraints": [f'args.host == "{allowed_host}"'],
+                        }
+                    },
+                }
+            }
+        }
+    )
+    return build_enforcer(policy, agent_name="test-egress")
+
+
+def _proxy(allowed_host: str) -> EgressProxy:
+    return EgressProxy(_enforcer(allowed_host), User(user_id="u", role="agent"))
+
+
+async def _start_http_upstream() -> tuple[asyncio.AbstractServer, int]:
+    """A minimal HTTP/1.1 server that answers every request with 'hello'."""
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        while await reader.readline() not in (b"\r\n", b""):
+            pass
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello"
+        )
+        await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1]
+
+
+async def _start_tcp_echo() -> tuple[asyncio.AbstractServer, int]:
+    """A raw TCP echo server — stands in for a TLS origin behind CONNECT."""
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            while data := await reader.read(1024):
+                writer.write(data)
+                await writer.drain()
+        except OSError:
+            pass
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1]
+
+
+async def test_http_forward_allowed() -> None:
+    upstream, up_port = await _start_http_upstream()
+    proxy = _proxy("127.0.0.1")
+    await proxy.start()
+    try:
+        async with httpx.AsyncClient(
+            proxy=f"http://127.0.0.1:{proxy.port}", trust_env=False, timeout=5
+        ) as client:
+            response = await client.get(f"http://127.0.0.1:{up_port}/")
+        assert response.status_code == 200
+        assert response.text == "hello"
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+
+async def _start_reflect_upstream() -> tuple[asyncio.AbstractServer, int]:
+    """An HTTP server that echoes the request line it received in the body."""
+
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        request_line = await reader.readline()
+        while await reader.readline() not in (b"\r\n", b""):
+            pass
+        body = request_line
+        writer.write(
+            b"HTTP/1.1 200 OK\r\nContent-Length: %d\r\nConnection: close\r\n\r\n%s"
+            % (len(body), body)
+        )
+        await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1]
+
+
+async def test_http_forward_preserves_query() -> None:
+    upstream, up_port = await _start_reflect_upstream()
+    proxy = _proxy("127.0.0.1")
+    await proxy.start()
+    try:
+        async with httpx.AsyncClient(
+            proxy=f"http://127.0.0.1:{proxy.port}", trust_env=False, timeout=5
+        ) as client:
+            response = await client.get(f"http://127.0.0.1:{up_port}/search?q=hi&n=2")
+        # The upstream echoes the origin-form request line it received.
+        assert "/search?q=hi&n=2" in response.text
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+
+async def test_egress_guard_reentrancy_raises() -> None:
+    enforcer = _enforcer("127.0.0.1")
+    user = User(user_id="u", role="agent")
+    async with egress_guard(enforcer, user):
+        with pytest.raises(RuntimeError, match="already active"):
+            async with egress_guard(enforcer, user):
+                pass
+    # The guard flag is released after the outer exits — a fresh guard works.
+    async with egress_guard(enforcer, user):
+        pass
+
+
+async def test_http_forward_denied_returns_403() -> None:
+    upstream, up_port = await _start_http_upstream()
+    proxy = _proxy("allowed.example.com")  # upstream host 127.0.0.1 not allowed
+    await proxy.start()
+    try:
+        async with httpx.AsyncClient(
+            proxy=f"http://127.0.0.1:{proxy.port}", trust_env=False, timeout=5
+        ) as client:
+            response = await client.get(f"http://127.0.0.1:{up_port}/")
+        assert response.status_code == 403
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()
+
+
+async def test_connect_allowed_tunnels_bytes() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy("127.0.0.1")
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        writer.write(f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\n\r\n".encode())
+        await writer.drain()
+        status = await asyncio.wait_for(reader.readline(), timeout=5)
+        assert b"200" in status
+        await asyncio.wait_for(reader.readline(), timeout=5)  # trailing blank line
+        writer.write(b"ping")
+        await writer.drain()
+        echoed = await asyncio.wait_for(reader.readexactly(4), timeout=5)
+        assert echoed == b"ping"
+        writer.close()
+    finally:
+        await proxy.stop()
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_connect_denied_returns_403() -> None:
+    proxy = _proxy("allowed.example.com")
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        writer.write(b"CONNECT blocked.example.com:443 HTTP/1.1\r\n\r\n")
+        await writer.drain()
+        status = await asyncio.wait_for(reader.readline(), timeout=5)
+        assert b"403" in status
+        writer.close()
+    finally:
+        await proxy.stop()
+
+
+async def test_malformed_request_line_returns_400() -> None:
+    proxy = _proxy("anything")
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        writer.write(b"GARBAGE\r\n\r\n")
+        await writer.drain()
+        status = await asyncio.wait_for(reader.readline(), timeout=5)
+        assert b"400" in status
+        writer.close()
+    finally:
+        await proxy.stop()
+
+
+def test_port_before_start_raises() -> None:
+    proxy = _proxy("anything")
+    with pytest.raises(RuntimeError):
+        _ = proxy.port

--- a/tests/egress/test_proxy.py
+++ b/tests/egress/test_proxy.py
@@ -211,6 +211,44 @@ async def test_malformed_request_line_returns_400() -> None:
         await proxy.stop()
 
 
+async def test_connect_upstream_unreachable_returns_502() -> None:
+    # Grab a port, then close its server so the upstream connect is refused.
+    dead, dead_port = await _start_tcp_echo()
+    dead.close()
+    await dead.wait_closed()
+    proxy = _proxy("127.0.0.1")
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        writer.write(f"CONNECT 127.0.0.1:{dead_port} HTTP/1.1\r\n\r\n".encode())
+        await writer.drain()
+        status = await asyncio.wait_for(reader.readline(), timeout=5)
+        assert b"502" in status
+        writer.close()
+    finally:
+        await proxy.stop()
+
+
+async def test_stop_cancels_inflight_tunnel() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy("127.0.0.1")
+    await proxy.start()
+    reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+    writer.write(f"CONNECT 127.0.0.1:{echo_port} HTTP/1.1\r\n\r\n".encode())
+    await writer.drain()
+    assert b"200" in await asyncio.wait_for(reader.readline(), timeout=5)
+    await asyncio.wait_for(reader.readline(), timeout=5)  # trailing blank line
+    try:
+        # The tunnel is open. stop() must cancel the handler, not leave it
+        # relaying — the client then sees EOF.
+        await proxy.stop()
+        assert await asyncio.wait_for(reader.read(100), timeout=5) == b""
+        writer.close()
+    finally:
+        echo.close()
+        await echo.wait_closed()
+
+
 def test_port_before_start_raises() -> None:
     proxy = _proxy("anything")
     with pytest.raises(RuntimeError):

--- a/tests/egress/test_wire.py
+++ b/tests/egress/test_wire.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from hexgate.egress.wire import parse_request_line, strip_proxy_headers
+import asyncio
+
+import pytest
+
+from hexgate.egress.wire import parse_request_line, read_headers, strip_proxy_headers
 
 
 def test_parse_request_line() -> None:
@@ -34,3 +38,18 @@ def test_strip_proxy_headers_removes_proxy_scoped() -> None:
 def test_strip_proxy_headers_noop_when_absent() -> None:
     block = b"Host: example.com\r\nAccept: */*\r\n\r\n"
     assert strip_proxy_headers(block) == block
+
+
+async def test_read_headers_reads_full_block() -> None:
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"Host: example.com\r\nAccept: */*\r\n\r\n")
+    reader.feed_eof()
+    assert await read_headers(reader) == b"Host: example.com\r\nAccept: */*\r\n\r\n"
+
+
+async def test_read_headers_raises_on_truncated_block() -> None:
+    reader = asyncio.StreamReader()
+    reader.feed_data(b"Host: example.com\r\n")  # client dies before the blank line
+    reader.feed_eof()
+    with pytest.raises(ValueError):
+        await read_headers(reader)

--- a/tests/egress/test_wire.py
+++ b/tests/egress/test_wire.py
@@ -1,0 +1,36 @@
+"""Unit tests for the low-level HTTP wire helpers."""
+
+from __future__ import annotations
+
+from hexgate.egress.wire import parse_request_line, strip_proxy_headers
+
+
+def test_parse_request_line() -> None:
+    assert parse_request_line(b"GET http://h/x HTTP/1.1\r\n") == (
+        "GET",
+        "http://h/x",
+    )
+
+
+def test_parse_request_line_lowercase_method_upcased() -> None:
+    assert parse_request_line(b"connect h:443 HTTP/1.1\r\n")[0] == "CONNECT"
+
+
+def test_strip_proxy_headers_removes_proxy_scoped() -> None:
+    block = (
+        b"Host: example.com\r\n"
+        b"Proxy-Connection: keep-alive\r\n"
+        b"Proxy-Authorization: Basic abc\r\n"
+        b"User-Agent: demo\r\n"
+        b"\r\n"
+    )
+    result = strip_proxy_headers(block)
+    assert b"proxy-" not in result.lower()
+    assert b"Host: example.com" in result
+    assert b"User-Agent: demo" in result
+    assert result.endswith(b"\r\n\r\n")  # terminating blank line preserved
+
+
+def test_strip_proxy_headers_noop_when_absent() -> None:
+    block = b"Host: example.com\r\nAccept: */*\r\n\r\n"
+    assert strip_proxy_headers(block) == block

--- a/tests/security/test_network_builder.py
+++ b/tests/security/test_network_builder.py
@@ -1,0 +1,179 @@
+"""Tests for the network-egress builder sugar and its constraint emitters.
+
+Covers three things: the rendered constraint strings, that they decide correctly
+on the pydantic engine, and that the *same* policy agrees on the compiled WASM
+engine (skipped when `opa` is not on PATH).
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from hexgate import C, PolicyBuilder
+from hexgate.security.network import (
+    NET_HTTP_REQUEST,
+    host_match_constraint,
+    net_constraints,
+)
+from hexgate.security.policy_set import load_policy_set, load_policy_set_from_dict
+
+_OPA = shutil.which("opa") is not None
+
+
+# --- constraint emitters ------------------------------------------------------
+
+
+def test_host_match_exact_only() -> None:
+    assert (
+        host_match_constraint(["a.com", "b.com"]) == 'args.host in ["a.com", "b.com"]'
+    )
+
+
+def test_host_match_subdomain_covers_apex_and_wildcard() -> None:
+    clause = host_match_constraint(subdomains=["example.com"])
+    assert clause == (
+        'args.host == "example.com" or endswith(args.host, ".example.com")'
+    )
+
+
+def test_host_match_empty_is_none() -> None:
+    assert host_match_constraint() is None
+
+
+def test_net_constraints_full() -> None:
+    assert net_constraints(
+        hosts=["api.github.com"], schemes=["https"], ports=[443]
+    ) == [
+        'args.host in ["api.github.com"]',
+        'args.scheme in ["https"]',
+        "args.port in [443]",
+    ]
+
+
+# --- net_allow decides correctly (pydantic engine) ----------------------------
+
+
+def _ps(builder: PolicyBuilder):
+    return load_policy_set(builder.build())
+
+
+def _decide(ps, host, scheme="https", port=443):
+    return ps.evaluate(
+        role="default",
+        tool=NET_HTTP_REQUEST,
+        args={"host": host, "scheme": scheme, "port": port},
+    ).outcome.value
+
+
+def test_net_allow_exact_host() -> None:
+    ps = _ps(PolicyBuilder(default="deny").net_allow(hosts=["api.github.com"]))
+    assert _decide(ps, "api.github.com") == "allow"
+    assert _decide(ps, "evil.com") == "deny"
+
+
+def test_net_allow_subdomain_matches_apex_and_children() -> None:
+    ps = _ps(PolicyBuilder(default="deny").net_allow(subdomains=["github.com"]))
+    assert _decide(ps, "github.com") == "allow"
+    assert _decide(ps, "api.github.com") == "allow"
+    assert _decide(ps, "notgithub.com") == "deny"  # leading-dot guard
+    assert _decide(ps, "github.com.evil.com") == "deny"
+
+
+def test_net_allow_scheme_and_port_gate() -> None:
+    ps = _ps(
+        PolicyBuilder(default="deny").net_allow(
+            hosts=["api.github.com"], schemes=["https"], ports=[443]
+        )
+    )
+    assert _decide(ps, "api.github.com", scheme="https", port=443) == "allow"
+    assert _decide(ps, "api.github.com", scheme="http", port=443) == "deny"
+    assert _decide(ps, "api.github.com", scheme="https", port=8080) == "deny"
+
+
+def test_net_allow_extra_when_constraints() -> None:
+    ps = _ps(
+        PolicyBuilder(default="deny").net_allow(
+            hosts=["api.github.com"], when=[C("args.method") == "GET"]
+        )
+    )
+    assert (
+        ps.evaluate(
+            role="default",
+            tool=NET_HTTP_REQUEST,
+            args={"host": "api.github.com", "scheme": "https", "method": "GET"},
+        ).outcome.value
+        == "allow"
+    )
+    assert (
+        ps.evaluate(
+            role="default",
+            tool=NET_HTTP_REQUEST,
+            args={"host": "api.github.com", "scheme": "https", "method": "DELETE"},
+        ).outcome.value
+        == "deny"
+    )
+
+
+def test_net_approve_mode() -> None:
+    ps = _ps(PolicyBuilder(default="deny").net_approve(hosts=["api.github.com"]))
+    assert _decide(ps, "api.github.com") == "needs_approval"
+    assert _decide(ps, "evil.com") == "deny"
+
+
+def test_net_allow_without_host_restriction_raises() -> None:
+    with pytest.raises(ValueError, match="host restriction"):
+        PolicyBuilder(default="deny").net_allow()
+    # scheme/port alone is still an error — it would authorize every host.
+    with pytest.raises(ValueError, match="host restriction"):
+        PolicyBuilder(default="deny").net_allow(ports=[443])
+
+
+def test_net_approve_without_host_restriction_raises() -> None:
+    with pytest.raises(ValueError, match="host restriction"):
+        PolicyBuilder(default="deny").net_approve()
+
+
+def test_net_allow_any_host_opt_in() -> None:
+    ps = _ps(PolicyBuilder(default="deny").net_allow(any_host=True))
+    assert _decide(ps, "anything.example.com", scheme="https") == "allow"
+    assert (
+        _decide(ps, "anything.example.com", scheme="http") == "deny"
+    )  # still HTTPS-only
+
+
+# --- pydantic <-> WASM parity -------------------------------------------------
+
+
+@pytest.mark.skipif(not _OPA, reason="opa not on PATH")
+def test_net_allow_pydantic_wasm_parity() -> None:
+    from hexgate.security import WasmPolicy, compile_to_wasm
+    from hexgate.security.rego import compile_to_rego
+
+    policy = (
+        PolicyBuilder(default="deny")
+        .net_allow(hosts=["api.github.com"], subdomains=["githubusercontent.com"])
+        .build()
+    )
+    payload = {"roles": {"default": policy.model_dump(exclude_defaults=True)}}
+    ps = load_policy_set_from_dict(payload)
+    wasm = WasmPolicy.from_bytes(compile_to_wasm(compile_to_rego(payload)).wasm)
+
+    cases = [
+        ("api.github.com", "https"),
+        ("raw.githubusercontent.com", "https"),
+        ("github.com", "https"),  # apex of the exact host — not allowlisted
+        ("api.github.com", "http"),
+        ("evil.com", "https"),
+    ]
+    for host, scheme in cases:
+        args = {"host": host, "scheme": scheme, "port": 443}
+        py = ps.evaluate(role="default", tool=NET_HTTP_REQUEST, args=args).outcome.value
+        rego = wasm.decide(role="default", tool=NET_HTTP_REQUEST, args=args)
+        wo = (
+            "allow"
+            if rego.allow
+            else ("needs_approval" if rego.requires_approval else "deny")
+        )
+        assert py == wo, f"engines disagree on {host}/{scheme}: pydantic={py} wasm={wo}"


### PR DESCRIPTION
## What & why

Today Hexgate authorizes the tool calls a model asks for. It can't see where a tool actually goes on the network. If a tool shells out to `curl`, or an SDK makes its own HTTP request, it can reach any host and policy never notices.

This adds an optional **egress proxy**. Point the agent's process at it and every outbound HTTP(S) request runs through the same policy engine, checked on the destination host. You can say "this agent may only reach `api.github.com`" and the rest is refused before anything leaves the process.

The nice part: egress is treated as one more gated tool, `net.http_request`. It reuses the existing `Decision`, the constraint DSL, and the audit stream. There's no new engine and no change to how policy is evaluated.

## How it works

```
 agent code                 egress proxy                    destination
 httpx / curl / SDK   ──►  decide("net.http_request",  ──┬── allow ──►  api.github.com
   (unchanged)               {host, scheme, port})       │
                                                         └── deny  ──►  403 refused
                                    │
                                    └──►  same audit log as the tool-call decisions
```

For HTTPS the proxy reads the host from the plaintext `CONNECT` line, decides, then tunnels the encrypted bytes without reading them. So it gates the host, not the path or body. Plain HTTP exposes the full URL. No TLS is decrypted.

Routing uses the standard `HTTP_PROXY` / `HTTPS_PROXY` env vars that `egress_guard` sets, so the agent's request code doesn't change.

## Where to look (in order)

| File | What it is | Priority |
|---|---|---|
| `hexgate/egress/gate.py` | the one place egress talks to the enforcer; also identity + approval | start here |
| `hexgate/egress/proxy.py` | the asyncio server + `egress_guard()` env wiring | high |
| `hexgate/egress/transport.py` | CONNECT tunnel (host-level) + plain-HTTP forwarding; the seam a future TLS-intercepting transport slots into | high |
| `hexgate/security/network.py` + `net_allow` in `hexgate/security/builder.py` | the policy sugar (`net_allow` / `net_approve`) | important |
| `hexgate/egress/model.py`, `hexgate/egress/wire.py` | small plumbing (request parsing, byte relay) | skim |
| `docs/concepts/egress.mdx` | the reader-facing explanation | context |

## Using it

```python
policy = PolicyBuilder(default="deny").net_allow(hosts=["api.github.com"]).build()
enforcer = build_enforcer(load_policy_set(policy), agent_name="support-agent")

async with egress_guard(enforcer, User(user_id="alice", role="agent")):
    ...   # every outbound HTTP(S) request here is gated
```

Two runnable demos: `examples/egress_demo.py` (plain script) and `deploy/egress_gate_demo.py` (marimo notebook, code-only, no platform or API key).

## Limits (called out on purpose)

- Env-proxy based, so it's intent-shaping in a plain SDK deployment. A tool that unsets the vars, or sets `trust_env=False`, bypasses it. Making it unbypassable is a sandbox job.
- Host-level only on HTTPS. Seeing the path or body would need TLS interception, which fits a controlled runtime rather than a library.
- One guard per process (it sets global proxy env vars; a nested guard raises instead of clobbering).

## Tests

46 egress + network tests, including a pydantic↔WASM parity check so the sugar behaves the same on the compiled bundle. The full security suite stays green (788 passing).

## Commits

- `feat(sdk)`: the module, the `net_allow` sugar, tests, and the two demos.
- `docs(sdk)`: new `concepts/egress` page, `net_allow` docs under "Define policy in code", and a cross-link from the sandbox page.
