### PR TITLE
feat(sdk): raw-TCP egress reachability gate (gate DB connections by host:port)

### DIFF
--- a/deploy/egress_gate_demo.py
+++ b/deploy/egress_gate_demo.py
@@ -17,13 +17,14 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _():
+    import asyncio
     import inspect
 
     import httpx
     import marimo as mo
 
     from hexgate import PolicyBuilder, User
-    from hexgate.egress import NET_TOOL, egress_guard
+    from hexgate.egress import NET_TOOL, egress_guard, tcp_egress_guard
     from hexgate.security.enforcer import build_enforcer
     from hexgate.security.policy_set import load_policy_set
 
@@ -31,12 +32,14 @@ def _():
         NET_TOOL,
         PolicyBuilder,
         User,
+        asyncio,
         build_enforcer,
         egress_guard,
         httpx,
         inspect,
         load_policy_set,
         mo,
+        tcp_egress_guard,
     )
 
 
@@ -53,6 +56,10 @@ def _(mo):
         The **egress proxy** closes that gap: it routes the process's outbound
         HTTP(S) through the *same* policy engine, mapped to a synthetic
         `net.http_request` tool. Network egress becomes **just another gated tool**.
+
+        The same plane reaches beyond HTTP. A raw-TCP **reachability gate**
+        (`net.tcp_connect`) decides database and broker connections by host and
+        port before TLS starts. That's section 4.
 
         This demo is **code-only** — no platform, no API key, no YAML file. The
         policy is written in Python and drives a live in-process proxy.
@@ -234,6 +241,97 @@ async def _(mo, probe, url_form):
             )
         _out = mo.vstack([mo.md(f"`GET {_url}`"), _result, _decision_md])
     _out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 4 · Beyond HTTP: the raw-TCP reachability gate
+
+        A database driver opens a raw TCP socket and ignores `HTTP_PROXY`, so the
+        HTTP proxy above never sees it. `net_tcp_allow` + `tcp_egress_guard` gate
+        that connection by host and port, decided before any bytes flow (so before
+        TLS), then tunnel it or drop it. Below, a local echo server stands in for a
+        database: one policy allows its port, the other only allows `5432`.
+        """
+    )
+    return
+
+
+@app.cell
+async def _(
+    PolicyBuilder,
+    User,
+    asyncio,
+    build_enforcer,
+    load_policy_set,
+    mo,
+    tcp_egress_guard,
+):
+    async def _mock_db():
+        async def _handle(reader, writer):
+            while data := await reader.read(1024):
+                writer.write(b"reply:" + data)
+                await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(_handle, "127.0.0.1", 0)
+        return server, server.sockets[0].getsockname()[1]
+
+    async def _probe(policy, target):
+        decisions = []
+        enforcer = build_enforcer(
+            load_policy_set(policy),
+            agent_name="tcp-demo",
+            decision_observer=decisions.append,
+        )
+        async with tcp_egress_guard(
+            enforcer, User(user_id="notebook", role="agent"), target=target
+        ) as proxy:
+            try:
+                reader, writer = await asyncio.open_connection(proxy.host, proxy.port)
+                writer.write(b"SELECT 1")
+                await writer.drain()
+                data = await asyncio.wait_for(reader.read(100), timeout=3)
+                writer.close()
+                outcome = data.decode() if data else "connection dropped"
+            except (OSError, asyncio.TimeoutError):
+                outcome = "connection refused"
+        return (decisions[0] if decisions else None), outcome
+
+    _db, _port = await _mock_db()
+    try:
+        _allow = (
+            PolicyBuilder(default="deny")
+            .net_tcp_allow(hosts=["127.0.0.1"], ports=[_port])
+            .build()
+        )
+        _deny = (
+            PolicyBuilder(default="deny")
+            .net_tcp_allow(hosts=["127.0.0.1"], ports=[5432])
+            .build()
+        )
+        _da, _ra = await _probe(_allow, ("127.0.0.1", _port))
+        _dd, _rd = await _probe(_deny, ("127.0.0.1", _port))
+    finally:
+        _db.close()
+        await _db.wait_closed()
+
+    _mark = {"allow": "✅ allow", "deny": "❌ deny", "needs_approval": "🔶 approval"}
+    mo.md(
+        "\n".join(
+            [
+                f"| policy | decision on `127.0.0.1:{_port}` | result |",
+                "|---|---|---|",
+                f"| `net_tcp_allow(ports=[{_port}])` | "
+                f"{_mark.get(_da.outcome.value) if _da else '?'} | `{_ra}` |",
+                "| `net_tcp_allow(ports=[5432])` | "
+                f"{_mark.get(_dd.outcome.value) if _dd else '?'} | `{_rd}` |",
+            ]
+        )
+    )
     return
 
 

--- a/examples/tcp_egress_demo.py
+++ b/examples/tcp_egress_demo.py
@@ -1,0 +1,91 @@
+"""TCP egress reachability-gate demo — gate a DB-style connection by host/port.
+
+No real database required: a local echo server stands in for the "database".
+The first policy allows a raw TCP connection to it and the proxy tunnels the
+bytes; the second policy only allows a different port, so the connection is
+refused. Each decision is printed as it happens.
+
+    python examples/tcp_egress_demo.py
+
+The reachability gate decides host + port before any bytes flow, so it covers a
+TLS'd database connection without inspecting it. It does not see the SQL sent
+over the connection.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from hexgate import PolicyBuilder, User
+from hexgate.egress import tcp_egress_guard
+from hexgate.security.decision import Decision
+from hexgate.security.enforcer import build_enforcer
+from hexgate.security.policy_set import load_policy_set
+
+
+def _print_decision(decision: Decision) -> None:
+    mark = "✓" if decision.allowed else "✗"
+    args = decision.arguments or {}
+    print(
+        f"  {mark} {decision.outcome.value:15} tcp {args.get('host')}:{args.get('port')}"
+    )
+    if not decision.allowed and decision.reason:
+        print(f"      reason: {decision.reason}")
+
+
+async def _start_mock_db() -> tuple[asyncio.AbstractServer, int]:
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        while data := await reader.read(1024):
+            writer.write(b"reply:" + data)
+            await writer.drain()
+        writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1]
+
+
+async def _probe(policy, target: tuple[str, int]) -> None:
+    enforcer = build_enforcer(
+        load_policy_set(policy),
+        agent_name="tcp-demo",
+        decision_observer=_print_decision,
+    )
+    user = User(user_id="demo", role="agent")
+    async with tcp_egress_guard(enforcer, user, target=target) as proxy:
+        try:
+            reader, writer = await asyncio.open_connection(proxy.host, proxy.port)
+            writer.write(b"SELECT 1")
+            await writer.drain()
+            data = await asyncio.wait_for(reader.read(100), timeout=3)
+            writer.close()
+            print(f"  -> {data.decode() if data else 'connection dropped'}")
+        except (OSError, asyncio.TimeoutError) as exc:
+            print(f"  -> blocked: {type(exc).__name__}")
+
+
+async def main() -> None:
+    db, db_port = await _start_mock_db()
+    try:
+        print(f"\nallow tcp -> 127.0.0.1:{db_port}")
+        await _probe(
+            PolicyBuilder(default="deny")
+            .net_tcp_allow(hosts=["127.0.0.1"], ports=[db_port])
+            .build(),
+            ("127.0.0.1", db_port),
+        )
+        print(f"\ndeny tcp -> 127.0.0.1:{db_port}  (policy only allows port 5432)")
+        await _probe(
+            PolicyBuilder(default="deny")
+            .net_tcp_allow(hosts=["127.0.0.1"], ports=[5432])
+            .build(),
+            ("127.0.0.1", db_port),
+        )
+    finally:
+        db.close()
+        await db.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/hexgate/egress/__init__.py
+++ b/hexgate/egress/__init__.py
@@ -1,9 +1,12 @@
 """Optional network-egress enforcement plane for Hexgate.
 
-Routes an agent's outbound HTTP(S) through the same ``PolicyEnforcer`` that
-gates tool calls, mapped to the synthetic ``net.http_request`` tool. A second
-enforcement plane alongside the declared-tool-call one: it gates the *actual*
-destination a process reaches, not just the tool the model asked for.
+Routes an agent's outbound traffic through the same ``PolicyEnforcer`` that
+gates tool calls. HTTP(S) egress maps to the synthetic ``net.http_request``
+tool (``EgressProxy``); a raw-TCP connection maps to ``net.tcp_connect``
+(``TcpEgressProxy``, the reachability gate for databases and other non-HTTP
+services). A second enforcement plane alongside the declared-tool-call one: it
+gates the *actual* destination a process reaches, not just the tool the model
+asked for.
 
 Framework-agnostic and base-install: stdlib ``asyncio`` plus the
 framework-agnostic ``hexgate.security``, ``hexgate.runtime``, and
@@ -26,6 +29,7 @@ from hexgate.egress.model import (
     split_authority,
 )
 from hexgate.egress.proxy import EgressProxy, egress_guard
+from hexgate.egress.tcp import TcpEgressProxy, tcp_egress_guard
 from hexgate.egress.transport import Transport, TunnelTransport
 
 __all__ = [
@@ -33,10 +37,12 @@ __all__ = [
     "EgressProxy",
     "Gate",
     "GateResult",
+    "TcpEgressProxy",
     "Transport",
     "TunnelTransport",
     "connect_to_args",
     "egress_guard",
     "http_to_args",
     "split_authority",
+    "tcp_egress_guard",
 ]

--- a/hexgate/egress/gate.py
+++ b/hexgate/egress/gate.py
@@ -52,10 +52,12 @@ class Gate:
         enforcer: PolicyEnforcer,
         user: User,
         *,
+        tool: str = NET_TOOL,
         approval_handler: ApprovalHandler | None = None,
     ) -> None:
         self._enforcer = enforcer
         self._user = user
+        self._tool = tool
         self._approval_handler = approval_handler
 
     async def check(self, args: dict[str, Any]) -> GateResult:
@@ -68,7 +70,7 @@ class Gate:
         duration of the synchronous decide call.
         """
         with self._user.sync_scope():
-            decision = self._enforcer.decide(NET_TOOL, args)
+            decision = self._enforcer.decide(self._tool, args)
 
         if decision.allowed:
             return GateResult(True, decision)

--- a/hexgate/egress/proxy.py
+++ b/hexgate/egress/proxy.py
@@ -25,6 +25,7 @@ from collections.abc import AsyncIterator, Sequence
 from hexgate.approvals import ApprovalHandler
 from hexgate.egress.gate import Gate
 from hexgate.egress.model import split_authority
+from hexgate.egress.server import ProxyServer
 from hexgate.egress.transport import Transport, TunnelTransport
 from hexgate.egress.wire import close_writer, parse_request_line, read_headers, refuse
 from hexgate.runtime.context import User
@@ -47,12 +48,13 @@ _PROXY_ENV_VARS = (
 _guard_active = False
 
 
-class EgressProxy:
+class EgressProxy(ProxyServer):
     """An asyncio forward proxy that authorizes each request via ``Gate``.
 
     One proxy serves one agent run: the ``user`` fixes the identity every
     egress decision is attributed to. Start it, point the process's HTTP
-    clients at ``http://{host}:{port}``, and every request is gated.
+    clients at ``http://{host}:{port}``, and every request is gated. Socket
+    lifecycle (bind / accept / teardown) is inherited from :class:`ProxyServer`.
     """
 
     def __init__(
@@ -65,63 +67,20 @@ class EgressProxy:
         approval_handler: ApprovalHandler | None = None,
         transport: Transport | None = None,
     ) -> None:
+        super().__init__(host=host, port=port)
         self._gate = Gate(enforcer, user, approval_handler=approval_handler)
         self._transport: Transport = (
             transport if transport is not None else TunnelTransport()
         )
-        self._host = host
-        self._requested_port = port
-        self._server: asyncio.AbstractServer | None = None
-        self._port: int | None = None
-        # In-flight connection-handler tasks, so stop() can cancel open tunnels
-        # instead of leaving them relaying after the guard restores env vars.
-        self._conns: set[asyncio.Task[None]] = set()
 
-    @property
-    def host(self) -> str:
-        return self._host
-
-    @property
-    def port(self) -> int:
-        """The bound port. Raises if the proxy has not been started."""
-        if self._port is None:
-            raise RuntimeError("EgressProxy is not started; call start() first")
-        return self._port
-
-    async def start(self) -> None:
-        """Bind and begin accepting connections. Idempotent."""
-        if self._server is not None:
-            return
-        self._server = await asyncio.start_server(
-            self._handle_client, self._host, self._requested_port
-        )
-        self._port = self._server.sockets[0].getsockname()[1]
+    def _log_listening(self) -> None:
         _log.info("egress proxy listening on %s:%s", self._host, self._port)
 
-    async def stop(self) -> None:
-        """Stop accepting, cancel open connections, close the socket. Idempotent."""
-        if self._server is None:
-            return
-        self._server.close()
-        # Cancel handlers still relaying (e.g. an open CONNECT tunnel) BEFORE
-        # wait_closed(): on Python 3.12+ wait_closed() blocks until active
-        # connections finish, so an open tunnel would otherwise deadlock it.
-        for task in list(self._conns):
-            task.cancel()
-        if self._conns:
-            await asyncio.gather(*self._conns, return_exceptions=True)
-            self._conns.clear()
-        with contextlib.suppress(Exception):
-            await self._server.wait_closed()
-        self._server = None
-        self._port = None
-
-    async def _handle_client(
+    async def _handle(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
-        task = asyncio.current_task()
-        if task is not None:
-            self._conns.add(task)
+        # Task tracking and the generic error-close are handled by ProxyServer;
+        # here we only parse the proxied request and dispatch to the transport.
         try:
             request_line = await reader.readline()
             if not request_line:
@@ -142,12 +101,6 @@ class EgressProxy:
         except ValueError:
             # Malformed request line / CONNECT target / oversized headers.
             await refuse(writer, 400, "Bad Request", "malformed request")
-        except Exception:
-            _log.exception("egress proxy connection handler failed")
-            close_writer(writer)
-        finally:
-            if task is not None:
-                self._conns.discard(task)
 
 
 @contextlib.asynccontextmanager

--- a/hexgate/egress/server.py
+++ b/hexgate/egress/server.py
@@ -1,0 +1,104 @@
+"""Shared asyncio server lifecycle for the egress proxies.
+
+Both the HTTP (:class:`~hexgate.egress.proxy.EgressProxy`) and raw-TCP
+(:class:`~hexgate.egress.tcp.TcpEgressProxy`) proxies bind a local socket, track
+in-flight connection handlers, and tear them down on ``stop()`` in a specific
+order: cancel the handlers *before* ``wait_closed()``, because on Python 3.12+
+``wait_closed()`` blocks until active connections finish, so an open tunnel would
+otherwise deadlock it. That lifecycle lives here once; a subclass implements only
+:meth:`_handle` for the per-connection logic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+
+from hexgate.egress.wire import close_writer
+
+_log = logging.getLogger(__name__)
+
+
+class ProxyServer:
+    """Bind / accept / teardown for a local forwarding proxy.
+
+    Subclass and implement :meth:`_handle`. The base owns the socket lifecycle
+    and in-flight-connection bookkeeping so the tricky teardown exists once.
+    """
+
+    def __init__(self, *, host: str = "127.0.0.1", port: int = 0) -> None:
+        self._host = host
+        self._requested_port = port
+        self._server: asyncio.AbstractServer | None = None
+        self._port: int | None = None
+        # In-flight connection-handler tasks, so stop() can cancel open tunnels
+        # instead of leaving them relaying after the caller has moved on.
+        self._conns: set[asyncio.Task[None]] = set()
+
+    @property
+    def host(self) -> str:
+        return self._host
+
+    @property
+    def port(self) -> int:
+        """The bound port. Raises if the proxy has not been started."""
+        if self._port is None:
+            raise RuntimeError(
+                f"{type(self).__name__} is not started; call start() first"
+            )
+        return self._port
+
+    async def start(self) -> None:
+        """Bind and begin accepting connections. Idempotent."""
+        if self._server is not None:
+            return
+        self._server = await asyncio.start_server(
+            self._serve, self._host, self._requested_port
+        )
+        self._port = self._server.sockets[0].getsockname()[1]
+        self._log_listening()
+
+    async def stop(self) -> None:
+        """Stop accepting, cancel open connections, close the socket. Idempotent."""
+        if self._server is None:
+            return
+        self._server.close()
+        # Cancel in-flight handlers (e.g. an open tunnel) BEFORE wait_closed():
+        # on Python 3.12+ wait_closed() blocks until active connections finish,
+        # so an open tunnel would otherwise deadlock it.
+        for task in list(self._conns):
+            task.cancel()
+        if self._conns:
+            await asyncio.gather(*self._conns, return_exceptions=True)
+            self._conns.clear()
+        with contextlib.suppress(Exception):
+            await self._server.wait_closed()
+        self._server = None
+        self._port = None
+
+    async def _serve(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Register the handler task, run :meth:`_handle`, always tear down."""
+        task = asyncio.current_task()
+        if task is not None:
+            self._conns.add(task)
+        try:
+            await self._handle(reader, writer)
+        except Exception:
+            _log.exception("%s connection handler failed", type(self).__name__)
+            close_writer(writer)
+        finally:
+            if task is not None:
+                self._conns.discard(task)
+
+    def _log_listening(self) -> None:
+        """Log where the proxy bound. Override to add detail (e.g. the target)."""
+        _log.info("%s listening on %s:%s", type(self).__name__, self._host, self._port)
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Handle one accepted connection. Implemented by the subclass."""
+        raise NotImplementedError

--- a/hexgate/egress/tcp.py
+++ b/hexgate/egress/tcp.py
@@ -1,0 +1,129 @@
+"""Raw-TCP reachability gate — decide whether the agent may open a connection.
+
+``TcpEgressProxy`` is the non-HTTP counterpart of :class:`~hexgate.egress.proxy.EgressProxy`.
+It forwards one TCP target (a database, cache, broker, anything) and asks the
+same :class:`~hexgate.egress.gate.Gate` — via the ``net.tcp_connect`` tool —
+whether *this* caller may open the connection, before any bytes flow. On allow
+it opens a raw tunnel and relays bytes untouched (TLS included, never decrypted);
+on deny it drops the socket.
+
+Routing differs from the HTTP proxy: a database driver speaks its own binary
+protocol and ignores ``HTTP_PROXY``, so there is no env-var hook. The caller
+points its connection string at ``proxy.host:proxy.port`` (or an OS-level
+redirect forces traffic here). Like the HTTP proxy, that makes it intent-shaping
+unless a sandbox forces all egress through it.
+
+Scope: reachability only. It gates the destination host/port, not the SQL or
+commands sent over the connection. Inspecting those would need a
+protocol-aware, connection-terminating proxy per database, which this is not.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import AsyncIterator
+
+from hexgate.approvals import ApprovalHandler
+from hexgate.egress.gate import Gate
+from hexgate.egress.server import ProxyServer
+from hexgate.egress.wire import close_writer, open_upstream, pipe
+from hexgate.runtime.context import User
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.network import NET_TCP_CONNECT
+
+_log = logging.getLogger(__name__)
+
+
+class TcpEgressProxy(ProxyServer):
+    """An asyncio TCP proxy that authorizes each connection to one target.
+
+    One proxy forwards one ``(host, port)`` target; the ``user`` fixes the
+    identity every decision is attributed to. Start it, point a client at
+    ``proxy.host:proxy.port``, and each accepted connection is gated on
+    ``net.tcp_connect`` before it is tunnelled to the target. Socket lifecycle
+    (bind / accept / teardown) is inherited from :class:`ProxyServer`.
+    """
+
+    def __init__(
+        self,
+        enforcer: PolicyEnforcer,
+        user: User,
+        *,
+        target: tuple[str, int],
+        host: str = "127.0.0.1",
+        port: int = 0,
+        approval_handler: ApprovalHandler | None = None,
+    ) -> None:
+        super().__init__(host=host, port=port)
+        self._gate = Gate(
+            enforcer, user, tool=NET_TCP_CONNECT, approval_handler=approval_handler
+        )
+        self._target = target
+
+    def _log_listening(self) -> None:
+        _log.info(
+            "tcp egress proxy on %s:%s -> %s:%s",
+            self._host,
+            self._port,
+            *self._target,
+        )
+
+    async def _handle(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        # Task tracking and the generic error-close are handled by ProxyServer.
+        host, port = self._target
+        result = await self._gate.check({"host": host, "port": port, "protocol": "tcp"})
+        if not result.allowed:
+            _log.info("tcp egress DENY %s:%s — %s", host, port, result.decision.reason)
+            # Raw TCP has no error frame to send; drop the socket. The client
+            # sees a closed connection, which its driver surfaces as an error.
+            close_writer(writer)
+            return
+        try:
+            upstream_reader, upstream_writer = await open_upstream(host, port)
+        except (OSError, TimeoutError) as exc:
+            _log.info(
+                "tcp egress upstream connect failed for %s:%s: %s", host, port, exc
+            )
+            close_writer(writer)
+            return
+        await pipe(reader, writer, upstream_reader, upstream_writer)
+
+
+@contextlib.asynccontextmanager
+async def tcp_egress_guard(
+    enforcer: PolicyEnforcer,
+    user: User,
+    *,
+    target: tuple[str, int],
+    host: str = "127.0.0.1",
+    port: int = 0,
+    approval_handler: ApprovalHandler | None = None,
+) -> AsyncIterator[TcpEgressProxy]:
+    """Start a :class:`TcpEgressProxy` for ``target`` and stop it on exit.
+
+    Unlike :func:`~hexgate.egress.proxy.egress_guard`, there is no env-var hook
+    to set (TCP clients don't read ``HTTP_PROXY``). The caller reads
+    ``proxy.host`` / ``proxy.port`` from the yielded proxy and points its
+    connection string there.
+
+        async with tcp_egress_guard(enforcer, user, target=("db.internal", 5432)) as p:
+            dsn = f"postgresql://user@{p.host}:{p.port}/app"
+            ...
+    """
+    proxy = TcpEgressProxy(
+        enforcer,
+        user,
+        target=target,
+        host=host,
+        port=port,
+        approval_handler=approval_handler,
+    )
+    await proxy.start()
+    try:
+        yield proxy
+    finally:
+        await proxy.stop()

--- a/hexgate/egress/transport.py
+++ b/hexgate/egress/transport.py
@@ -19,7 +19,7 @@ from typing import Protocol
 
 from hexgate.egress.gate import Gate
 from hexgate.egress.model import connect_to_args, http_to_args
-from hexgate.egress.wire import pipe, refuse, strip_proxy_headers
+from hexgate.egress.wire import open_upstream, pipe, refuse, strip_proxy_headers
 
 _log = logging.getLogger(__name__)
 
@@ -122,8 +122,8 @@ async def _open(
 ) -> tuple[asyncio.StreamReader, asyncio.StreamWriter] | None:
     """Open an upstream connection, or write a 502 and return ``None``."""
     try:
-        return await asyncio.open_connection(host, port)
-    except OSError as exc:
+        return await open_upstream(host, port)
+    except (OSError, TimeoutError) as exc:
         _log.info("egress upstream connect failed for %s:%s: %s", host, port, exc)
         await refuse(writer, 502, "Bad Gateway", f"cannot reach {host}:{port}")
         return None

--- a/hexgate/egress/wire.py
+++ b/hexgate/egress/wire.py
@@ -125,6 +125,22 @@ def strip_proxy_headers(header_block: bytes) -> bytes:
     return b"\r\n".join(kept)
 
 
+_UPSTREAM_CONNECT_TIMEOUT = 10.0
+
+
+async def open_upstream(
+    host: str, port: int, *, timeout: float = _UPSTREAM_CONNECT_TIMEOUT
+) -> tuple[asyncio.StreamReader, asyncio.StreamWriter]:
+    """Open a TCP connection to an upstream, bounded by a connect timeout.
+
+    Wraps :func:`asyncio.open_connection` in ``wait_for`` so a black-holed
+    target (SYN dropped, no RST) can't hang the handler indefinitely. Raises
+    ``OSError`` (refused / unreachable) or ``TimeoutError`` (no response within
+    ``timeout``); callers treat both as "cannot reach upstream".
+    """
+    return await asyncio.wait_for(asyncio.open_connection(host, port), timeout)
+
+
 def close_writer(writer: asyncio.StreamWriter) -> None:
     """Close a stream writer, swallowing the error if it's already gone."""
     with contextlib.suppress(OSError):

--- a/hexgate/security/builder.py
+++ b/hexgate/security/builder.py
@@ -29,7 +29,11 @@ from hexgate.security.models import (
     PolicyMode,
     ToolPolicy,
 )
-from hexgate.security.network import NET_HTTP_REQUEST, net_constraints
+from hexgate.security.network import (
+    NET_HTTP_REQUEST,
+    NET_TCP_CONNECT,
+    net_constraints,
+)
 from hexgate.security.policy_set import PolicySet, load_policy_map
 
 
@@ -190,7 +194,9 @@ class PolicyBuilder:
         ``ValueError`` — a scheme/port filter alone would silently authorize
         egress to *every* host, which is almost never intended.
         """
-        return self._net("allow", hosts, subdomains, schemes, ports, when, any_host)
+        return self._net_rule(
+            NET_HTTP_REQUEST, "allow", hosts, subdomains, schemes, ports, when, any_host
+        )
 
     def net_approve(
         self,
@@ -203,12 +209,62 @@ class PolicyBuilder:
         any_host: bool = False,
     ) -> PolicyBuilder:
         """Require approval for egress to matching hosts (see :meth:`net_allow`)."""
-        return self._net(
-            "approval_required", hosts, subdomains, schemes, ports, when, any_host
+        return self._net_rule(
+            NET_HTTP_REQUEST,
+            "approval_required",
+            hosts,
+            subdomains,
+            schemes,
+            ports,
+            when,
+            any_host,
         )
 
-    def _net(
+    def net_tcp_allow(
         self,
+        *,
+        hosts: Iterable[str] = (),
+        subdomains: Iterable[str] = (),
+        ports: Iterable[int] = (),
+        when: WhenArg = (),
+        any_host: bool = False,
+    ) -> PolicyBuilder:
+        """Allow a raw-TCP egress connection (the ``net.tcp_connect`` tool).
+
+        The reachability gate for non-HTTP services (databases, caches, message
+        brokers). Renders a host / port allowlist into ``net.tcp_connect``
+        constraints, decided before any bytes flow, so it covers TLS'd
+        connections without inspecting them. A host restriction is required:
+        pass ``hosts=``, ``subdomains=``, or ``any_host=True``.
+        """
+        return self._net_rule(
+            NET_TCP_CONNECT, "allow", hosts, subdomains, (), ports, when, any_host
+        )
+
+    def net_tcp_approve(
+        self,
+        *,
+        hosts: Iterable[str] = (),
+        subdomains: Iterable[str] = (),
+        ports: Iterable[int] = (),
+        when: WhenArg = (),
+        any_host: bool = False,
+    ) -> PolicyBuilder:
+        """Require approval for a raw-TCP connection (see :meth:`net_tcp_allow`)."""
+        return self._net_rule(
+            NET_TCP_CONNECT,
+            "approval_required",
+            hosts,
+            subdomains,
+            (),
+            ports,
+            when,
+            any_host,
+        )
+
+    def _net_rule(
+        self,
+        tool: str,
         mode: PolicyMode,
         hosts: Iterable[str],
         subdomains: Iterable[str],
@@ -217,20 +273,20 @@ class PolicyBuilder:
         when: WhenArg,
         any_host: bool,
     ) -> PolicyBuilder:
+        """Shared assembly for the HTTP (``net_allow``) and TCP (``net_tcp_allow``)
+        egress rules. TCP passes ``schemes=()`` (no scheme before a raw connect)."""
         hosts, subdomains = list(hosts), list(subdomains)
         if not any_host and not hosts and not subdomains:
             raise ValueError(
-                "net_allow/net_approve requires a host restriction: pass hosts=, "
-                "subdomains=, or any_host=True to deliberately allow every host. "
-                "A scheme/port filter alone would authorize egress to ALL hosts."
+                "a host restriction is required: pass hosts=, subdomains=, or "
+                "any_host=True. A scheme/port filter alone would authorize egress "
+                "to every host."
             )
         constraints = net_constraints(
             hosts=hosts, subdomains=subdomains, schemes=schemes, ports=ports
         )
         constraints.extend(_normalize(when))
-        self._tools[NET_HTTP_REQUEST] = BaseToolPolicy(
-            mode=mode, constraints=constraints
-        )
+        self._tools[tool] = BaseToolPolicy(mode=mode, constraints=constraints)
         return self
 
     def build(self) -> AgentPolicy:

--- a/hexgate/security/network.py
+++ b/hexgate/security/network.py
@@ -16,10 +16,16 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable
 
-# The synthetic tool every egress request is attributed to. Defined here (not in
-# hexgate.egress) so the policy layer (PolicyBuilder.net_allow) and the proxy
-# share one definition — egress depends downward on security, never the reverse.
+# The synthetic tool every HTTP(S) egress request is attributed to. Defined here
+# (not in hexgate.egress) so the policy layer (PolicyBuilder.net_allow) and the
+# proxy share one definition — egress depends downward on security, never the
+# reverse.
 NET_HTTP_REQUEST = "net.http_request"
+
+# The synthetic tool a raw-TCP egress connection (e.g. a database driver opening
+# a socket) is attributed to. Gated on host + port before any bytes flow, so it
+# works for any TCP service regardless of the wire protocol on top.
+NET_TCP_CONNECT = "net.tcp_connect"
 
 
 def host_match_constraint(

--- a/tests/egress/test_tcp.py
+++ b/tests/egress/test_tcp.py
@@ -1,0 +1,236 @@
+"""End-to-end tests for the raw-TCP reachability gate over loopback sockets.
+
+A TCP echo server stands in for the upstream service (a database, say). The
+proxy runs on the test's own event loop, so every client is async.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hexgate.egress.tcp import TcpEgressProxy, tcp_egress_guard
+from hexgate.runtime.context import User
+from hexgate.security.decision import Decision
+from hexgate.security.enforcer import build_enforcer
+from hexgate.security.policy_set import load_policy_set_from_dict
+
+
+def _enforcer(*, mode="allow", constraints=(), observer=None):
+    policy = load_policy_set_from_dict(
+        {
+            "roles": {
+                "agent": {
+                    "default_policy": {"mode": "deny"},
+                    "tools": {
+                        "net.tcp_connect": {
+                            "mode": mode,
+                            "constraints": list(constraints),
+                        }
+                    },
+                }
+            }
+        }
+    )
+    return build_enforcer(policy, agent_name="test-tcp", decision_observer=observer)
+
+
+async def _start_tcp_echo() -> tuple[asyncio.AbstractServer, int]:
+    async def handle(
+        reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        try:
+            while data := await reader.read(1024):
+                writer.write(data)
+                await writer.drain()
+        except OSError:
+            pass
+        finally:
+            writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    return server, server.sockets[0].getsockname()[1]
+
+
+def _proxy(enforcer, target, **kw) -> TcpEgressProxy:
+    return TcpEgressProxy(
+        enforcer, User(user_id="u", role="agent"), target=target, **kw
+    )
+
+
+async def test_allow_tunnels_bytes() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy(
+        _enforcer(constraints=['args.host == "127.0.0.1"']), ("127.0.0.1", echo_port)
+    )
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        writer.write(b"ping")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readexactly(4), timeout=5) == b"ping"
+        writer.close()
+    finally:
+        await proxy.stop()
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_deny_host_drops_connection() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    # Policy allows a different host, so this target is denied.
+    proxy = _proxy(
+        _enforcer(constraints=['args.host == "db.internal"']), ("127.0.0.1", echo_port)
+    )
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        # Accepted, then dropped on deny -> the client sees EOF, no echo.
+        assert await asyncio.wait_for(reader.read(100), timeout=5) == b""
+        writer.close()
+    finally:
+        await proxy.stop()
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_deny_port_drops_connection() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy(
+        _enforcer(constraints=['args.host == "127.0.0.1"', "args.port in [5432]"]),
+        ("127.0.0.1", echo_port),  # echo_port is not 5432 -> deny
+    )
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        assert await asyncio.wait_for(reader.read(100), timeout=5) == b""
+        writer.close()
+    finally:
+        await proxy.stop()
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_approval_bool_true_allows() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy(
+        _enforcer(mode="approval_required"),
+        ("127.0.0.1", echo_port),
+        approval_handler=True,
+    )
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        writer.write(b"hi")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readexactly(2), timeout=5) == b"hi"
+        writer.close()
+    finally:
+        await proxy.stop()
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_approval_bool_false_denies() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy(
+        _enforcer(mode="approval_required"),
+        ("127.0.0.1", echo_port),
+        approval_handler=False,
+    )
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        assert await asyncio.wait_for(reader.read(100), timeout=5) == b""
+        writer.close()
+    finally:
+        await proxy.stop()
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_binds_identity_and_records_tcp_tool() -> None:
+    seen: list[Decision] = []
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy(
+        _enforcer(constraints=['args.host == "127.0.0.1"'], observer=seen.append),
+        ("127.0.0.1", echo_port),
+    )
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        writer.write(b"x")
+        await writer.drain()
+        await asyncio.wait_for(reader.readexactly(1), timeout=5)
+        writer.close()
+    finally:
+        await proxy.stop()
+        echo.close()
+        await echo.wait_closed()
+    assert len(seen) == 1
+    assert seen[0].tool_name == "net.tcp_connect"
+    assert seen[0].role == "agent"
+    assert seen[0].arguments == {
+        "host": "127.0.0.1",
+        "port": echo_port,
+        "protocol": "tcp",
+    }
+
+
+async def test_upstream_unreachable_drops_connection() -> None:
+    dead, dead_port = await _start_tcp_echo()
+    dead.close()
+    await dead.wait_closed()
+    proxy = _proxy(
+        _enforcer(constraints=['args.host == "127.0.0.1"']), ("127.0.0.1", dead_port)
+    )
+    await proxy.start()
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+        assert await asyncio.wait_for(reader.read(100), timeout=5) == b""
+        writer.close()
+    finally:
+        await proxy.stop()
+
+
+async def test_stop_cancels_inflight_tunnel() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    proxy = _proxy(
+        _enforcer(constraints=['args.host == "127.0.0.1"']), ("127.0.0.1", echo_port)
+    )
+    await proxy.start()
+    reader, writer = await asyncio.open_connection("127.0.0.1", proxy.port)
+    writer.write(b"hello")
+    await writer.drain()
+    assert await asyncio.wait_for(reader.readexactly(5), timeout=5) == b"hello"
+    try:
+        await proxy.stop()  # must cancel the open tunnel, not leave it relaying
+        assert await asyncio.wait_for(reader.read(100), timeout=5) == b""
+        writer.close()
+    finally:
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_tcp_egress_guard_yields_running_proxy() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    enforcer = _enforcer(constraints=['args.host == "127.0.0.1"'])
+    try:
+        async with tcp_egress_guard(
+            enforcer, User(user_id="u", role="agent"), target=("127.0.0.1", echo_port)
+        ) as proxy:
+            reader, writer = await asyncio.open_connection(proxy.host, proxy.port)
+            writer.write(b"yo")
+            await writer.drain()
+            assert await asyncio.wait_for(reader.readexactly(2), timeout=5) == b"yo"
+            writer.close()
+    finally:
+        echo.close()
+        await echo.wait_closed()
+
+
+def test_port_before_start_raises() -> None:
+    proxy = _proxy(_enforcer(constraints=['args.host == "x"']), ("x", 1))
+    with pytest.raises(RuntimeError):
+        _ = proxy.port

--- a/tests/egress/test_wire.py
+++ b/tests/egress/test_wire.py
@@ -6,7 +6,12 @@ import asyncio
 
 import pytest
 
-from hexgate.egress.wire import parse_request_line, read_headers, strip_proxy_headers
+from hexgate.egress.wire import (
+    open_upstream,
+    parse_request_line,
+    read_headers,
+    strip_proxy_headers,
+)
 
 
 def test_parse_request_line() -> None:
@@ -53,3 +58,10 @@ async def test_read_headers_raises_on_truncated_block() -> None:
     reader.feed_eof()
     with pytest.raises(ValueError):
         await read_headers(reader)
+
+
+async def test_open_upstream_bounded_by_timeout() -> None:
+    # 192.0.2.1 is TEST-NET-1 (RFC 5737): non-routable, so the connect either
+    # times out or is refused — never hangs. Either way open_upstream raises.
+    with pytest.raises((TimeoutError, OSError)):
+        await open_upstream("192.0.2.1", 9, timeout=0.2)

--- a/tests/security/test_network_builder.py
+++ b/tests/security/test_network_builder.py
@@ -14,6 +14,7 @@ import pytest
 from hexgate import C, PolicyBuilder
 from hexgate.security.network import (
     NET_HTTP_REQUEST,
+    NET_TCP_CONNECT,
     host_match_constraint,
     net_constraints,
 )
@@ -143,6 +144,37 @@ def test_net_allow_any_host_opt_in() -> None:
     )  # still HTTPS-only
 
 
+# --- net_tcp_allow (raw-TCP reachability gate) --------------------------------
+
+
+def _tcp_decide(ps, host, port):
+    return ps.evaluate(
+        role="default",
+        tool=NET_TCP_CONNECT,
+        args={"host": host, "port": port, "protocol": "tcp"},
+    ).outcome.value
+
+
+def test_net_tcp_allow_host_and_port() -> None:
+    ps = _ps(
+        PolicyBuilder(default="deny").net_tcp_allow(hosts=["db.internal"], ports=[5432])
+    )
+    assert _tcp_decide(ps, "db.internal", 5432) == "allow"
+    assert _tcp_decide(ps, "db.internal", 6379) == "deny"  # wrong port
+    assert _tcp_decide(ps, "evil.internal", 5432) == "deny"  # wrong host
+
+
+def test_net_tcp_allow_requires_host_restriction() -> None:
+    with pytest.raises(ValueError, match="host restriction"):
+        PolicyBuilder(default="deny").net_tcp_allow(ports=[5432])
+
+
+def test_net_tcp_approve_mode() -> None:
+    ps = _ps(PolicyBuilder(default="deny").net_tcp_approve(hosts=["db.internal"]))
+    assert _tcp_decide(ps, "db.internal", 5432) == "needs_approval"
+    assert _tcp_decide(ps, "evil.internal", 5432) == "deny"
+
+
 # --- pydantic <-> WASM parity -------------------------------------------------
 
 
@@ -177,3 +209,30 @@ def test_net_allow_pydantic_wasm_parity() -> None:
             else ("needs_approval" if rego.requires_approval else "deny")
         )
         assert py == wo, f"engines disagree on {host}/{scheme}: pydantic={py} wasm={wo}"
+
+
+@pytest.mark.skipif(not _OPA, reason="opa not on PATH")
+def test_net_tcp_allow_pydantic_wasm_parity() -> None:
+    from hexgate.security import WasmPolicy, compile_to_wasm
+    from hexgate.security.rego import compile_to_rego
+
+    policy = (
+        PolicyBuilder(default="deny")
+        .net_tcp_allow(hosts=["db.internal"], ports=[5432])
+        .build()
+    )
+    payload = {"roles": {"default": policy.model_dump(exclude_defaults=True)}}
+    ps = load_policy_set_from_dict(payload)
+    wasm = WasmPolicy.from_bytes(compile_to_wasm(compile_to_rego(payload)).wasm)
+
+    cases = [("db.internal", 5432), ("db.internal", 6379), ("evil.internal", 5432)]
+    for host, port in cases:
+        args = {"host": host, "port": port, "protocol": "tcp"}
+        py = ps.evaluate(role="default", tool=NET_TCP_CONNECT, args=args).outcome.value
+        rego = wasm.decide(role="default", tool=NET_TCP_CONNECT, args=args)
+        wo = (
+            "allow"
+            if rego.allow
+            else ("needs_approval" if rego.requires_approval else "deny")
+        )
+        assert py == wo, f"engines disagree on {host}:{port}: pydantic={py} wasm={wo}"


### PR DESCRIPTION
## What & why

The egress proxy (#95) gates HTTP(S) by host. But a database driver opens a raw TCP socket and ignores `HTTP_PROXY`, so DB traffic isn't covered by it at all.

This adds a raw-TCP **reachability gate**. Point a connection string at the proxy and it decides `net.tcp_connect{host, port}` before any bytes flow (so before TLS), then tunnels the connection or drops it. Same `PolicyEnforcer`, same `Decision`, same audit stream as tool calls and HTTP egress.

Scope worth stating up front: it gates the *destination* ("may this agent reach `db.internal:5432`"), not the SQL sent over the connection. Query-level inspection would need a protocol-aware, connection-terminating proxy per database, which this is not.

## How it works

```
 db driver / client           tcp egress proxy               target
 conn string -> proxy   ──►  decide("net.tcp_connect",  ──┬── allow ──►  db.internal:5432
   (proxy host:port)           {host, port})              │              (raw tunnel, TLS untouched)
                                                          └── deny  ──►  socket dropped
                                    │
                                    └──►  same audit log as the tool + HTTP decisions
```

Because the decision happens before the TLS handshake, a TLS'd database connection is gated without being decrypted.

## Where to look (in order)

| File | What it is | Priority |
|---|---|---|
| `hexgate/egress/tcp.py` | `TcpEgressProxy` + `tcp_egress_guard(target=(host,port))`: gate then tunnel-or-drop | start here |
| `hexgate/egress/server.py` | **New** shared `ProxyServer` base for the socket lifecycle. The cancel-in-flight-before-`wait_closed()` `stop()` now lives once; both proxies subclass it | high — this refactor also touches the HTTP proxy |
| `hexgate/security/builder.py` + `network.py` | `net_tcp_allow` / `net_tcp_approve` and the `net.tcp_connect` tool | important |
| `hexgate/egress/gate.py`, `wire.py` | `Gate` gains a `tool` param (one seam, two planes); `open_upstream` bounds the upstream connect with a timeout | skim |
| `examples/tcp_egress_demo.py` | mock-DB demo, no real database needed | context |

## Using it

```python
policy = PolicyBuilder(default="deny").net_tcp_allow(hosts=["db.internal"], ports=[5432]).build()

async with tcp_egress_guard(enforcer, User(user_id="alice", role="agent"),
                            target=("db.internal", 5432)) as proxy:
    dsn = f"postgresql://app@{proxy.host}:{proxy.port}/db"
    ...   # connections opened through this DSN are gated
```

## Notes and limits

- **Routing is opt-in.** DB drivers don't read `HTTP_PROXY`, so the app points its connection string at `proxy.host:proxy.port` (or a sandbox redirect forces traffic through it). Intent-shaping unless a sandbox enforces it, same as the HTTP proxy.
- **Reachability only.** Gates host + port, not the SQL/commands on the connection.
- Builds on #95, and refactors the shared server lifecycle out of `EgressProxy` into `ProxyServer` so the deadlock-prone teardown isn't duplicated.

## Tests

TCP allow / deny (host and port) / approval / identity / upstream-unreachable / stop-cancels-open-tunnel / guard, a pydantic↔WASM parity check for `net.tcp_connect`, an `open_upstream` timeout test, and the full HTTP-egress + security suites still pass.
