### PR TITLE
feat(sdk): multi-module policy — modules + linker (1/3)

### DIFF
--- a/deploy/demo_policies/policies/boundaries/org_core.yaml
+++ b/deploy/demo_policies/policies/boundaries/org_core.yaml
@@ -1,4 +1,4 @@
-# Org guardrail (security-owned). Floor posture: default_policy allow means it
+# Org boundary (security-owned). Floor posture: default_policy allow means it
 # only SUBTRACTS what it names — unlisted tools pass through to capabilities.
 # Its `allow` on refund_order is a CEILING (a cap), not a grant.
 default_policy: { mode: allow }

--- a/deploy/demo_policies/policies/capabilities/payments.yaml
+++ b/deploy/demo_policies/policies/capabilities/payments.yaml
@@ -1,0 +1,4 @@
+# Payments capability pack (team-owned). Grants only.
+tools:
+  refund_order: { mode: allow, constraints: ['args.currency in ["USD", "EUR"]'] }
+  lookup_order: { mode: allow }

--- a/deploy/demo_policies/policies/capabilities/support_leaf.yaml
+++ b/deploy/demo_policies/policies/capabilities/support_leaf.yaml
@@ -1,0 +1,4 @@
+# The support agent's own inline leaf (capability). Grants only.
+tools:
+  send_email: { mode: allow }
+  escalate: { mode: approval_required }

--- a/deploy/demo_policies/policies/guardrails/org_core.yaml
+++ b/deploy/demo_policies/policies/guardrails/org_core.yaml
@@ -1,0 +1,7 @@
+# Org guardrail (security-owned). Floor posture: default_policy allow means it
+# only SUBTRACTS what it names — unlisted tools pass through to capabilities.
+# Its `allow` on refund_order is a CEILING (a cap), not a grant.
+default_policy: { mode: allow }
+tools:
+  delete_database: { mode: deny }                       # absolute — no layer can undo
+  refund_order: { mode: allow, constraints: ["args.amount <= 1000"] }   # cap

--- a/deploy/policy_modules_demo.py
+++ b/deploy/policy_modules_demo.py
@@ -5,7 +5,7 @@ local — no platform, no API key):
 
   many module .yaml files  →  link()  →  one effective policy  →  (rego → wasm)
 
-You'll see the two tiers compose — **guardrails** (caps + hard denies) over
+You'll see the two tiers compose — **boundaries** (caps + hard denies) over
 **capabilities** (grants) — under the rule *fences intersect, grants union,
 denies win*. Edit a decision's args and watch allow / deny / approval resolve
 live. If `opa` is on PATH, each decision is also checked against the compiled
@@ -79,7 +79,7 @@ def _(mo):
         Instead of one policy file per agent, an agent's policy is a **stack of
         modules** composed into one effective policy:
 
-        - **Guardrails** (security-owned) — caps + hard denies. A guardrail
+        - **Boundaries** (security-owned) — caps + hard denies. A boundary
           `allow` is a *ceiling*, not a grant.
         - **Capabilities** (team-owned) — additive grants only.
 
@@ -100,7 +100,7 @@ def _(mo):
 def _(dedent):
     # Three modules — the same files that live in deploy/demo_policies/. Edit
     # them here and the whole notebook re-resolves.
-    GUARDRAILS = {
+    BOUNDARIES = {
         "org_core": dedent(
             """
             # floor: only subtracts what it names; unlisted tools pass through.
@@ -127,26 +127,26 @@ def _(dedent):
             """
         ),
     }
-    return CAPABILITIES, GUARDRAILS
+    return CAPABILITIES, BOUNDARIES
 
 
 @app.cell
-def _(CAPABILITIES, GUARDRAILS, Path, load_local_modules, tempfile):
+def _(CAPABILITIES, BOUNDARIES, Path, load_local_modules, tempfile):
     # Write the modules to a temp policies/ tree and load them through the real
     # local-files loader — exactly what `hexgate policy resolve --dir` does.
     _root = Path(tempfile.mkdtemp(prefix="hexgate-demo-"))
-    for _kind, _mods in (("guardrails", GUARDRAILS), ("capabilities", CAPABILITIES)):
+    for _kind, _mods in (("boundaries", BOUNDARIES), ("capabilities", CAPABILITIES)):
         _dir = _root / "policies" / _kind
         _dir.mkdir(parents=True, exist_ok=True)
         for _name, _body in _mods.items():
             (_dir / f"{_name}.yaml").write_text(_body, encoding="utf-8")
 
-    guardrails, capabilities = load_local_modules(_root)
-    return capabilities, guardrails
+    boundaries, capabilities = load_local_modules(_root)
+    return capabilities, boundaries
 
 
 @app.cell
-def _(capabilities, guardrails, mo):
+def _(capabilities, boundaries, mo):
     def _row(m):
         tools = ", ".join(sorted(m.policy.tools)) or "—"
         return {
@@ -157,7 +157,7 @@ def _(capabilities, guardrails, mo):
         }
 
     mo.ui.table(
-        [_row(m) for m in (*guardrails, *capabilities)],
+        [_row(m) for m in (*boundaries, *capabilities)],
         selection=None,
     )
     return
@@ -178,8 +178,8 @@ def _(mo):
 
 
 @app.cell
-def _(capabilities, guardrails, link_policy_set):
-    result = link_policy_set(guardrails, capabilities)
+def _(capabilities, boundaries, link_policy_set):
+    result = link_policy_set(boundaries, capabilities)
     effective = result.effective["default"]
     return effective, result
 
@@ -214,7 +214,7 @@ def _(mo, result):
         "\n\n**Shadowed (ineligible under a ceiling):** "
         + ", ".join(f"`{t}` ← {p.module}" for t, p in result.trace.shadowed.items())
         if result.trace.shadowed
-        else "\n\n**Shadowed:** none (floor guardrail — nothing gated out)."
+        else "\n\n**Shadowed:** none (floor boundary — nothing gated out)."
     )
     mo.md(
         "**Provenance** — every rule traces to its source layers\n\n"
@@ -238,7 +238,9 @@ def _(OPA, WasmPolicy, compile_to_rego, compile_to_wasm, effective):
 def _(result, verdict_from_rego, wasm_engine):
     def decide(tool, args):
         """Return (pydantic_outcome, wasm_outcome) for a tool call."""
-        py = result.policy_set.evaluate(role="default", tool=tool, args=args).outcome.value
+        py = result.policy_set.evaluate(
+            role="default", tool=tool, args=args
+        ).outcome.value
         if wasm_engine is None:
             return py, None
         wo = verdict_from_rego(
@@ -258,7 +260,7 @@ def _(mo):
         ## 3 · Try a decision
 
         Pick a tool and edit the args, then **▶ Check**. `refund_order` shows the
-        interesting cases: over the $1000 cap → deny (guardrail), wrong currency →
+        interesting cases: over the $1000 cap → deny (boundary), wrong currency →
         deny (no grant), `delete_database` → always deny, unlisted tool → deny.
         """
     )
@@ -280,7 +282,9 @@ def _(effective, mo):
         )
         .batch(
             tool=mo.ui.dropdown(_tools, value="refund_order"),
-            args=mo.ui.text_area(value='{"amount": 800, "currency": "USD"}', full_width=True),
+            args=mo.ui.text_area(
+                value='{"amount": 800, "currency": "USD"}', full_width=True
+            ),
         )
         .form(submit_button_label="▶ Check decision")
     )
@@ -299,7 +303,9 @@ def _(OPA, decide, json, mo, try_it):
         return mo.callout(mo.md(f"**{engine}**\n\n### {label}"), kind=kind)
 
     if try_it.value is None:
-        _out = mo.callout(mo.md("Pick a tool + args, then **▶ Check decision**."), kind="info")
+        _out = mo.callout(
+            mo.md("Pick a tool + args, then **▶ Check decision**."), kind="info"
+        )
     else:
         _v = try_it.value
         try:
@@ -368,14 +374,14 @@ def _(A, D, M, evaluate_outcomes, link, mo):
     _eur = M("eur", "capability", {"refund": A(['args.currency == "EUR"'])})
     _union, _ = link([], [_usd, _eur])
 
-    # fences INTERSECT — two guardrail caps → the stricter wins
-    _g1 = M("cap1000", "guardrail", {"refund": A(["args.amount <= 1000"])})
-    _g2 = M("cap500", "guardrail", {"refund": A(["args.amount <= 500"])})
+    # fences INTERSECT — two boundary caps → the stricter wins
+    _g1 = M("cap1000", "boundary", {"refund": A(["args.amount <= 1000"])})
+    _g2 = M("cap500", "boundary", {"refund": A(["args.amount <= 500"])})
     _intersect, _ = link([_g1, _g2], [M("c", "capability", {"refund": A()})])
 
-    # deny WINS — guardrail deny beats a capability grant
+    # deny WINS — boundary deny beats a capability grant
     _dw, _ = link(
-        [M("g", "guardrail", {"wire": D()})], [M("c", "capability", {"wire": A()})]
+        [M("g", "boundary", {"wire": D()})], [M("c", "capability", {"wire": A()})]
     )
 
     mo.vstack(
@@ -389,7 +395,7 @@ def _(A, D, M, evaluate_outcomes, link, mo):
             evaluate_outcomes(
                 _intersect, [("refund", {"amount": 400}), ("refund", {"amount": 700})]
             ),
-            mo.md("**deny wins** — guardrail deny beats the grant"),
+            mo.md("**deny wins** — boundary deny beats the grant"),
             evaluate_outcomes(_dw, [("wire", {})]),
         ]
     )
@@ -414,15 +420,13 @@ def _(mo):
 @app.cell
 def _(A, D, LinkError, M, link, mo):
     # Capabilities may only grant — a capability that tries to deny is a hard
-    # LinkError, so a team can never silently punch a hole in a guardrail.
+    # LinkError, so a team can never silently punch a hole in a boundary.
     try:
         link([], [M("rogue", "capability", {"refund": D()})])
         _msg = "no error (unexpected)"
     except LinkError as exc:
         _msg = str(exc)
-    mo.callout(
-        mo.md(f"**capabilities can't deny**\n\n```\n{_msg}\n```"), kind="danger"
-    )
+    mo.callout(mo.md(f"**capabilities can't deny**\n\n```\n{_msg}\n```"), kind="danger")
     return
 
 
@@ -432,8 +436,8 @@ def _(mo):
         """
         ## 5 · Ceiling vs floor
 
-        A guardrail's `default_policy` sets its posture. Same capabilities below,
-        two guardrails:
+        A boundary's `default_policy` sets its posture. Same capabilities below,
+        two boundaries:
 
         - **floor** (`default_policy: allow`) — only subtracts named tools;
           `lookup_order` / `send_email` pass through.
@@ -449,11 +453,15 @@ def _(A, D, M, link, mo):
     from hexgate.security import evaluate_tool_call
 
     _caps = [
-        M("payments", "capability", {"refund": A(["args.amount <= 1000"]), "lookup_order": A()}),
+        M(
+            "payments",
+            "capability",
+            {"refund": A(["args.amount <= 1000"]), "lookup_order": A()},
+        ),
         M("leaf", "capability", {"send_email": A()}),
     ]
-    _floor = M("g", "guardrail", {"refund": A(), "delete": D()}, default="allow")
-    _ceiling = M("g", "guardrail", {"refund": A(), "delete": D()}, default="deny")
+    _floor = M("g", "boundary", {"refund": A(), "delete": D()}, default="allow")
+    _ceiling = M("g", "boundary", {"refund": A(), "delete": D()}, default="deny")
 
     _eff_floor, _ = link([_floor], _caps)
     _eff_ceiling, _ = link([_ceiling], _caps)
@@ -465,10 +473,7 @@ def _(A, D, M, link, mo):
     _rows = "\n".join(
         f"| `{t}` | {_o(_eff_floor, t)} | {_o(_eff_ceiling, t)} |" for t in _tools
     )
-    mo.md(
-        "| tool | floor guardrail | ceiling guardrail |\n"
-        "| --- | --- | --- |\n" + _rows
-    )
+    mo.md("| tool | floor boundary | ceiling boundary |\n| --- | --- | --- |\n" + _rows)
     return
 
 

--- a/deploy/policy_modules_demo.py
+++ b/deploy/policy_modules_demo.py
@@ -1,0 +1,492 @@
+"""Hexgate stacked-policy demo (marimo) — many module files, one signed decision.
+
+A read-top-to-bottom tour of the policy **modules + linker** (SDK-side, fully
+local — no platform, no API key):
+
+  many module .yaml files  →  link()  →  one effective policy  →  (rego → wasm)
+
+You'll see the two tiers compose — **guardrails** (caps + hard denies) over
+**capabilities** (grants) — under the rule *fences intersect, grants union,
+denies win*. Edit a decision's args and watch allow / deny / approval resolve
+live. If `opa` is on PATH, each decision is also checked against the compiled
+WASM engine so you can watch the two engines agree.
+
+The same rules power `hexgate policy resolve --dir deploy/demo_policies`.
+
+Run with `marimo edit deploy/policy_modules_demo.py`.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import json
+    import shutil
+    import tempfile
+    from pathlib import Path
+    from textwrap import dedent
+
+    import marimo as mo
+
+    from hexgate.security import (
+        AgentPolicy,
+        BaseToolPolicy,
+        DecisionOutcome,
+        LinkError,
+        ModuleContent,
+        compile_to_rego,
+        compile_to_wasm,
+        link,
+        link_policy_set,
+        load_local_modules,
+        verdict_from_rego,
+    )
+    from hexgate.security.wasm_engine import WasmPolicy
+
+    OPA = shutil.which("opa") is not None
+    return (
+        AgentPolicy,
+        BaseToolPolicy,
+        DecisionOutcome,
+        LinkError,
+        ModuleContent,
+        OPA,
+        Path,
+        WasmPolicy,
+        compile_to_rego,
+        compile_to_wasm,
+        dedent,
+        json,
+        link,
+        link_policy_set,
+        load_local_modules,
+        mo,
+        tempfile,
+        verdict_from_rego,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # 🛡️ Hexgate — stacked policy
+
+        Instead of one policy file per agent, an agent's policy is a **stack of
+        modules** composed into one effective policy:
+
+        - **Guardrails** (security-owned) — caps + hard denies. A guardrail
+          `allow` is a *ceiling*, not a grant.
+        - **Capabilities** (team-owned) — additive grants only.
+
+        Composition rule: **fences intersect · grants union · denies win.**
+        Everything below is local SDK code — no platform, no key.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 1 · The module bundle""")
+    return
+
+
+@app.cell
+def _(dedent):
+    # Three modules — the same files that live in deploy/demo_policies/. Edit
+    # them here and the whole notebook re-resolves.
+    GUARDRAILS = {
+        "org_core": dedent(
+            """
+            # floor: only subtracts what it names; unlisted tools pass through.
+            default_policy: { mode: allow }
+            tools:
+              delete_database: { mode: deny }                                 # absolute
+              refund_order: { mode: allow, constraints: ["args.amount <= 1000"] }  # cap
+            """
+        ),
+    }
+    CAPABILITIES = {
+        "payments": dedent(
+            """
+            tools:
+              refund_order: { mode: allow, constraints: ['args.currency in ["USD", "EUR"]'] }
+              lookup_order: { mode: allow }
+            """
+        ),
+        "support_leaf": dedent(
+            """
+            tools:
+              send_email: { mode: allow }
+              escalate: { mode: approval_required }
+            """
+        ),
+    }
+    return CAPABILITIES, GUARDRAILS
+
+
+@app.cell
+def _(CAPABILITIES, GUARDRAILS, Path, load_local_modules, tempfile):
+    # Write the modules to a temp policies/ tree and load them through the real
+    # local-files loader — exactly what `hexgate policy resolve --dir` does.
+    _root = Path(tempfile.mkdtemp(prefix="hexgate-demo-"))
+    for _kind, _mods in (("guardrails", GUARDRAILS), ("capabilities", CAPABILITIES)):
+        _dir = _root / "policies" / _kind
+        _dir.mkdir(parents=True, exist_ok=True)
+        for _name, _body in _mods.items():
+            (_dir / f"{_name}.yaml").write_text(_body, encoding="utf-8")
+
+    guardrails, capabilities = load_local_modules(_root)
+    return capabilities, guardrails
+
+
+@app.cell
+def _(capabilities, guardrails, mo):
+    def _row(m):
+        tools = ", ".join(sorted(m.policy.tools)) or "—"
+        return {
+            "module": m.name,
+            "tier": m.kind,
+            "tools": tools,
+            "hash": m.content_hash[:12],
+        }
+
+    mo.ui.table(
+        [_row(m) for m in (*guardrails, *capabilities)],
+        selection=None,
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 2 · Link → one effective policy
+
+        The **linker** folds the stack into a single `AgentPolicy`. That's the
+        only thing that compiles — Rego/WASM never see the stack, so the
+        pydantic-vs-WASM parity gate is untouched.
+        """
+    )
+    return
+
+
+@app.cell
+def _(capabilities, guardrails, link_policy_set):
+    result = link_policy_set(guardrails, capabilities)
+    effective = result.effective["default"]
+    return effective, result
+
+
+@app.cell
+def _(effective, mo):
+    def _fmt(tp):
+        line = f"**{tp.mode}**"
+        if tp.constraints:
+            line += "  ·  " + "  ∧  ".join(f"`{c}`" for c in tp.constraints)
+        return line
+
+    _rows = "\n".join(
+        f"| `{name}` | {_fmt(tp)} |" for name, tp in sorted(effective.tools.items())
+    )
+    mo.md(
+        "**Effective policy** (default_policy: `deny` — fail-closed)\n\n"
+        "| tool | resolved rule |\n| --- | --- |\n" + _rows
+    )
+    return
+
+
+@app.cell
+def _(mo, result):
+    # Provenance: which layers fed each rule, and which grants got shadowed by a
+    # ceiling. This is what powers the analyzer + editor's file-attributed errors.
+    _contrib = "\n".join(
+        f"| `{tool}` | {', '.join(sorted({p.module for p in provs}))} |"
+        for tool, provs in sorted(result.trace.contributors.items())
+    )
+    _shadow = (
+        "\n\n**Shadowed (ineligible under a ceiling):** "
+        + ", ".join(f"`{t}` ← {p.module}" for t, p in result.trace.shadowed.items())
+        if result.trace.shadowed
+        else "\n\n**Shadowed:** none (floor guardrail — nothing gated out)."
+    )
+    mo.md(
+        "**Provenance** — every rule traces to its source layers\n\n"
+        "| tool | contributing layers |\n| --- | --- |\n" + _contrib + _shadow
+    )
+    return
+
+
+@app.cell
+def _(OPA, WasmPolicy, compile_to_rego, compile_to_wasm, effective):
+    # Build the WASM engine once (if opa is available) so decisions can be
+    # cross-checked against the compiled production bundle.
+    wasm_engine = None
+    if OPA:
+        _rego = compile_to_rego(effective.model_dump(mode="json"))
+        wasm_engine = WasmPolicy.from_bytes(compile_to_wasm(_rego).wasm)
+    return (wasm_engine,)
+
+
+@app.cell
+def _(result, verdict_from_rego, wasm_engine):
+    def decide(tool, args):
+        """Return (pydantic_outcome, wasm_outcome) for a tool call."""
+        py = result.policy_set.evaluate(role="default", tool=tool, args=args).outcome.value
+        if wasm_engine is None:
+            return py, None
+        wo = verdict_from_rego(
+            wasm_engine.decide(role="default", tool=tool, args=args),
+            tool_name=tool,
+            role="default",
+        ).outcome.value
+        return py, wo
+
+    return (decide,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 3 · Try a decision
+
+        Pick a tool and edit the args, then **▶ Check**. `refund_order` shows the
+        interesting cases: over the $1000 cap → deny (guardrail), wrong currency →
+        deny (no grant), `delete_database` → always deny, unlisted tool → deny.
+        """
+    )
+    return
+
+
+@app.cell
+def _(effective, mo):
+    _tools = sorted(effective.tools) + ["unlisted_tool"]
+    try_it = (
+        mo.md(
+            """
+            **tool** {tool}
+
+            **args** (JSON)
+
+            {args}
+            """
+        )
+        .batch(
+            tool=mo.ui.dropdown(_tools, value="refund_order"),
+            args=mo.ui.text_area(value='{"amount": 800, "currency": "USD"}', full_width=True),
+        )
+        .form(submit_button_label="▶ Check decision")
+    )
+    try_it
+    return (try_it,)
+
+
+@app.cell
+def _(OPA, decide, json, mo, try_it):
+    def _box(engine, outcome):
+        label, kind = {
+            "allow": ("✅ allow", "success"),
+            "deny": ("❌ deny", "danger"),
+            "needs_approval": ("🔶 needs approval", "warn"),
+        }.get(outcome, (f"— {outcome}", "neutral"))
+        return mo.callout(mo.md(f"**{engine}**\n\n### {label}"), kind=kind)
+
+    if try_it.value is None:
+        _out = mo.callout(mo.md("Pick a tool + args, then **▶ Check decision**."), kind="info")
+    else:
+        _v = try_it.value
+        try:
+            _args = json.loads(_v["args"] or "{}")
+            _py, _wo = decide(_v["tool"], _args)
+            _boxes = [_box("pydantic · dev", _py)]
+            if OPA:
+                _boxes.append(_box("wasm · prod bundle", _wo))
+            _footer = (
+                ("### ✅ engines agree" if _py == _wo else "### ❌ engines DISAGREE")
+                if OPA
+                else "_(install `opa` to also check the WASM bundle)_"
+            )
+            _out = mo.vstack(
+                [
+                    mo.md(f"`{_v['tool']}({_args})`"),
+                    mo.hstack(_boxes, widths="equal"),
+                    mo.md(_footer),
+                ]
+            )
+        except json.JSONDecodeError as _exc:
+            _out = mo.callout(mo.md(f"Invalid JSON in args: {_exc}"), kind="warn")
+    _out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 4 · The combining rules
+
+        Small self-contained bundles showing each rule. `M(...)` builds a module
+        in-code so the rule is visible in one place.
+        """
+    )
+    return
+
+
+@app.cell
+def _(AgentPolicy, BaseToolPolicy, ModuleContent):
+    def M(name, kind, tools, default="allow"):
+        return ModuleContent(
+            name=name,
+            kind=kind,
+            policy=AgentPolicy(
+                default_policy=BaseToolPolicy(mode=default), tools=tools
+            ),
+            source=f"{name}.yaml",
+            content_hash=name,
+        )
+
+    def A(constraints=None):
+        return BaseToolPolicy(mode="allow", constraints=constraints or [])
+
+    def D(constraints=None):
+        return BaseToolPolicy(mode="deny", constraints=constraints or [])
+
+    return A, D, M
+
+
+@app.cell
+def _(A, D, M, evaluate_outcomes, link, mo):
+    # grants UNION — allowed if EITHER capability's condition holds
+    _usd = M("usd", "capability", {"refund": A(['args.currency == "USD"'])})
+    _eur = M("eur", "capability", {"refund": A(['args.currency == "EUR"'])})
+    _union, _ = link([], [_usd, _eur])
+
+    # fences INTERSECT — two guardrail caps → the stricter wins
+    _g1 = M("cap1000", "guardrail", {"refund": A(["args.amount <= 1000"])})
+    _g2 = M("cap500", "guardrail", {"refund": A(["args.amount <= 500"])})
+    _intersect, _ = link([_g1, _g2], [M("c", "capability", {"refund": A()})])
+
+    # deny WINS — guardrail deny beats a capability grant
+    _dw, _ = link(
+        [M("g", "guardrail", {"wire": D()})], [M("c", "capability", {"wire": A()})]
+    )
+
+    mo.vstack(
+        [
+            mo.md("**grants union** — `refund` allowed for USD **or** EUR"),
+            evaluate_outcomes(
+                _union,
+                [("refund", {"currency": "USD"}), ("refund", {"currency": "GBP"})],
+            ),
+            mo.md("**fences intersect** — caps 1000 ∧ 500 → stricter 500 wins"),
+            evaluate_outcomes(
+                _intersect, [("refund", {"amount": 400}), ("refund", {"amount": 700})]
+            ),
+            mo.md("**deny wins** — guardrail deny beats the grant"),
+            evaluate_outcomes(_dw, [("wire", {})]),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    def evaluate_outcomes(policy, cases):
+        from hexgate.security import evaluate_tool_call
+
+        emoji = {"allow": "✅", "deny": "❌", "needs_approval": "🔶"}
+        parts = []
+        for tool, args in cases:
+            o = evaluate_tool_call(policy, tool, args).outcome.value
+            parts.append(f"`{tool}({args})` → {emoji.get(o, '')} **{o}**")
+        return mo.md("&nbsp;&nbsp;·&nbsp;&nbsp;".join(parts))
+
+    return (evaluate_outcomes,)
+
+
+@app.cell
+def _(A, D, LinkError, M, link, mo):
+    # Capabilities may only grant — a capability that tries to deny is a hard
+    # LinkError, so a team can never silently punch a hole in a guardrail.
+    try:
+        link([], [M("rogue", "capability", {"refund": D()})])
+        _msg = "no error (unexpected)"
+    except LinkError as exc:
+        _msg = str(exc)
+    mo.callout(
+        mo.md(f"**capabilities can't deny**\n\n```\n{_msg}\n```"), kind="danger"
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 5 · Ceiling vs floor
+
+        A guardrail's `default_policy` sets its posture. Same capabilities below,
+        two guardrails:
+
+        - **floor** (`default_policy: allow`) — only subtracts named tools;
+          `lookup_order` / `send_email` pass through.
+        - **ceiling** (`default_policy: deny`) — a tool it doesn't list is
+          *ineligible*, so those same grants are shadowed → deny.
+        """
+    )
+    return
+
+
+@app.cell
+def _(A, D, M, link, mo):
+    from hexgate.security import evaluate_tool_call
+
+    _caps = [
+        M("payments", "capability", {"refund": A(["args.amount <= 1000"]), "lookup_order": A()}),
+        M("leaf", "capability", {"send_email": A()}),
+    ]
+    _floor = M("g", "guardrail", {"refund": A(), "delete": D()}, default="allow")
+    _ceiling = M("g", "guardrail", {"refund": A(), "delete": D()}, default="deny")
+
+    _eff_floor, _ = link([_floor], _caps)
+    _eff_ceiling, _ = link([_ceiling], _caps)
+
+    def _o(policy, tool):
+        return evaluate_tool_call(policy, tool, {"amount": 500}).outcome.value
+
+    _tools = ["refund", "lookup_order", "send_email", "delete"]
+    _rows = "\n".join(
+        f"| `{t}` | {_o(_eff_floor, t)} | {_o(_eff_ceiling, t)} |" for t in _tools
+    )
+    mo.md(
+        "| tool | floor guardrail | ceiling guardrail |\n"
+        "| --- | --- | --- |\n" + _rows
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ---
+        **Try it yourself:** edit the module YAML in cell 1 and the whole notebook
+        re-resolves. Or run the same thing from the CLI:
+
+        ```
+        hexgate policy resolve --dir deploy/demo_policies
+        ```
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/docs/internals/policy-modules.md
+++ b/docs/internals/policy-modules.md
@@ -17,7 +17,7 @@ Rego → WASM → a signed bundle exactly as a single file did:
 
 ```
 many *.yaml modules            link()                 one effective policy
-  guardrails  (caps + denies) ──────▶  fold  ──────▶  AgentPolicy  ──▶ rego ──▶ wasm ──▶ signed bundle
+  boundaries  (caps + denies) ──────▶  fold  ──────▶  AgentPolicy  ──▶ rego ──▶ wasm ──▶ signed bundle
   capabilities (grants)          (the new step)                        (all unchanged)
 ```
 
@@ -29,22 +29,22 @@ This is the load-bearing invariant: *resolve, then compile.*
 
 Every module is one of two kinds, and the kind decides what it is allowed to say.
 
-- **Guardrail** — caps and hard denies. Security-owned. Its `allow` is a
+- **Boundary** — caps and hard denies. Security-owned. Its `allow` is a
   *ceiling* (permit up to a constraint), **not** a grant.
 - **Capability** — additive grants. Team-owned. It may only `allow` /
   `approval_required`; a capability that tries to `deny` is a hard error.
 
-| Mode | Guardrail | Capability |
+| Mode | Boundary | Capability |
 | --- | --- | --- |
 | `deny` | ✓ absolute (or a conditional region) | ✗ `LinkError` |
 | `allow` | ✓ — a ceiling (permits, does **not** grant) | ✓ — a grant |
 | `approval_required` | ✓ | ✓ |
 | `default_policy: deny` (a fence) | ✓ (ceiling posture) | ignored |
 
-The one subtlety worth internalising: **a guardrail `allow` never turns a tool
+The one subtlety worth internalising: **a boundary `allow` never turns a tool
 on.** It only says "if this tool is granted, it may not exceed this constraint."
-A tool becomes usable only when a **capability** grants it. So a guardrail alone
-grants nothing; a capability alone is bounded by whatever guardrails permit.
+A tool becomes usable only when a **capability** grants it. So a boundary alone
+grants nothing; a capability alone is bounded by whatever boundaries permit.
 
 ## Reconciliation rules
 
@@ -58,8 +58,8 @@ DENY  >  APPROVAL_REQUIRED  >  ALLOW  >  implicit-deny
 The per-tool algorithm (`_fold_tool` in `hexgate/security/linker.py`):
 
 1. A capability that denies the tool → **`LinkError`** (capabilities may only grant).
-2. An **unconditional** guardrail deny → **DENY**, absolute. Nothing below can undo it.
-3. A **ceiling** guardrail (`default_policy: deny`) that does not list the tool →
+2. An **unconditional** boundary deny → **DENY**, absolute. Nothing below can undo it.
+3. A **ceiling** boundary (`default_policy: deny`) that does not list the tool →
    **implicit deny** (the tool is ineligible); the exclusion is recorded so the
    analyzer can later flag any capability grant for it as shadowed.
 4. No capability grants the tool → **implicit deny** (eligible but ungranted).
@@ -71,15 +71,15 @@ Summarised in one line:
 
 > **Fences intersect. Grants union. Denies win.**
 
-- **guardrail + guardrail** on one tool → intersection (all caps bind; the
+- **boundary + boundary** on one tool → intersection (all caps bind; the
   stricter wins; any deny wins).
 - **capability + capability** on one tool → union (either grant's condition
   suffices).
-- **guardrail ∩ capability** → the ceiling constraint AND the grant condition.
+- **boundary ∩ capability** → the ceiling constraint AND the grant condition.
 
 ### Ceiling vs floor
 
-A guardrail's `default_policy` sets its posture:
+A boundary's `default_policy` sets its posture:
 
 - **Ceiling** (`default_policy: deny`) — an allowlist. A tool it does not name is
   ineligible, so a capability grant for it has no effect.
@@ -97,7 +97,7 @@ and only builds trees over its nodes — no new grammar:
   `list[str]` that is already implicit-AND, so combining ceilings + a grant is
   just appending strings.
 - **Union** is a top-level `or` expression: `(A) or (B)`.
-- **Deny-region subtraction** (a *conditional* guardrail deny) becomes
+- **Deny-region subtraction** (a *conditional* boundary deny) becomes
   `and not (region)` appended to the grant.
 
 Every assembled expression is re-parsed with `parse_constraint` to validate it
@@ -107,15 +107,15 @@ not at evaluation.
 ### Constants
 
 `consts` (referenced from constraints as `consts.<name>`) are merged across
-layers with **guardrails winning**. A capability that redefines a guardrail's
+layers with **boundaries winning**. A capability that redefines a boundary's
 constant to a *different* value is a `LinkError` — otherwise a lower-authority
-layer could loosen a guardrail cap expressed as `args.amount <= consts.max` by
-shadowing `max`. A capability-only constant, or one that matches the guardrail's
+layer could loosen a boundary cap expressed as `args.amount <= consts.max` by
+shadowing `max`. A capability-only constant, or one that matches the boundary's
 value, merges normally.
 
 ## Worked example
 
-Guardrail `org_core` (floor): `deny delete_database`, `allow refund_order`
+Boundary `org_core` (floor): `deny delete_database`, `allow refund_order`
 capped at `args.amount <= 1000`. Capability `payments`:
 `allow refund_order when currency in [USD, EUR]`, `allow lookup_order`.
 Capability leaf: `allow send_email`, `approval_required escalate`.
@@ -123,11 +123,11 @@ Capability leaf: `allow send_email`, `approval_required escalate`.
 | Call | Outcome | Why |
 | --- | --- | --- |
 | `refund_order(800, USD)` | allow | in ceiling (≤1000) ∧ granted (USD) |
-| `refund_order(1200, USD)` | deny | over the guardrail cap |
+| `refund_order(1200, USD)` | deny | over the boundary cap |
 | `refund_order(800, GBP)` | deny | inside the ceiling, but no grant for GBP |
-| `delete_database()` | deny | absolute guardrail deny |
+| `delete_database()` | deny | absolute boundary deny |
 | `lookup_order()` | allow | floor lets it through; capability grants |
-| `send_email()` | allow (floor) / deny (ceiling) | eligible only if the guardrail is a floor |
+| `send_email()` | allow (floor) / deny (ceiling) | eligible only if the boundary is a floor |
 | `escalate()` | approval | granted, gated on a human |
 
 If `org_core` were a **ceiling** instead of a floor, `lookup_order` and
@@ -137,14 +137,14 @@ recorded as shadowed.
 ## Attachment & authority
 
 - **Capabilities** are opted into by the agent (imported).
-- **Guardrails** are inherited from the agent's scope (org → project), so an
-  agent cannot opt out of them. Rule of thumb: *it's a guardrail if the agent
+- **Boundaries** are inherited from the agent's scope (org → project), so an
+  agent cannot opt out of them. Rule of thumb: *it's a boundary if the agent
   didn't get to choose it.*
 - Authority is not a field in the file. It is enforced by **where the file lives**
   (a protected path + review) and, ultimately, by **signing** — the platform
-  enforces a layer as a guardrail only if its content hash is signed by the
+  enforces a layer as a boundary only if its content hash is signed by the
   security key. *(Signing + scope-attachment are platform-side and not in this
-  first slice; the SDK loads guardrail and capability modules from local
+  first slice; the SDK loads boundary and capability modules from local
   directories.)*
 
 ## Invariants
@@ -152,7 +152,7 @@ recorded as shadowed.
 - **Parity untouched.** The linker emits one `AgentPolicy`; both engines evaluate
   the resolved policy, and the existing parity suite runs over it.
 - **Capabilities can only tighten.** Enforced structurally: capabilities cannot
-  deny, cannot set a fence, and cannot override a guardrail constant.
+  deny, cannot set a fence, and cannot override a boundary constant.
 - **Fail-closed.** The effective `default_policy` is `deny`; a tool no layer
   grants is denied.
 - **Provenance is preserved.** Every resolved rule records the layers that fed it
@@ -169,7 +169,7 @@ recorded as shadowed.
 
 ## Not built yet
 
-- **Signing + scope-attached guardrails + a platform module store** — the loader
+- **Signing + scope-attached boundaries + a platform module store** — the loader
   is local-files only; the platform-store loader is a later PR.
 - **Durable versioning** — modules carry a content hash (identity) today, but
   there is no version history, pinning, or fan-out yet.

--- a/docs/internals/policy-modules.md
+++ b/docs/internals/policy-modules.md
@@ -1,0 +1,183 @@
+# Multi-module policy — composition and reconciliation
+
+*How a stack of policy files becomes one enforced policy, and the exact rules
+that reconcile them when they overlap.*
+
+> Status: reflects the first slice (modules + linker, `hexgate/security/`).
+> The analyzer (lints) and dashboard editor are later PRs; durable versioning
+> and the platform-side module store are deferred. This doc describes what the
+> linker does today, and flags what is not built yet.
+
+## The shift
+
+An agent's policy used to be a single `policy.yaml`. It now composes from a
+**stack of modules** — independently-authored fragments — folded into one
+effective `AgentPolicy` by the **linker**. The effective policy then compiles to
+Rego → WASM → a signed bundle exactly as a single file did:
+
+```
+many *.yaml modules            link()                 one effective policy
+  guardrails  (caps + denies) ──────▶  fold  ──────▶  AgentPolicy  ──▶ rego ──▶ wasm ──▶ signed bundle
+  capabilities (grants)          (the new step)                        (all unchanged)
+```
+
+Composition happens at the **model layer**, not in Rego. The engines only ever
+see one resolved `AgentPolicy`, so the pydantic-vs-WASM parity gate is untouched.
+This is the load-bearing invariant: *resolve, then compile.*
+
+## Two tiers
+
+Every module is one of two kinds, and the kind decides what it is allowed to say.
+
+- **Guardrail** — caps and hard denies. Security-owned. Its `allow` is a
+  *ceiling* (permit up to a constraint), **not** a grant.
+- **Capability** — additive grants. Team-owned. It may only `allow` /
+  `approval_required`; a capability that tries to `deny` is a hard error.
+
+| Mode | Guardrail | Capability |
+| --- | --- | --- |
+| `deny` | ✓ absolute (or a conditional region) | ✗ `LinkError` |
+| `allow` | ✓ — a ceiling (permits, does **not** grant) | ✓ — a grant |
+| `approval_required` | ✓ | ✓ |
+| `default_policy: deny` (a fence) | ✓ (ceiling posture) | ignored |
+
+The one subtlety worth internalising: **a guardrail `allow` never turns a tool
+on.** It only says "if this tool is granted, it may not exceed this constraint."
+A tool becomes usable only when a **capability** grants it. So a guardrail alone
+grants nothing; a capability alone is bounded by whatever guardrails permit.
+
+## Reconciliation rules
+
+For a single `(tool, arguments)`, every layer votes an outcome and the resolver
+takes the **most restrictive**:
+
+```
+DENY  >  APPROVAL_REQUIRED  >  ALLOW  >  implicit-deny
+```
+
+The per-tool algorithm (`_fold_tool` in `hexgate/security/linker.py`):
+
+1. A capability that denies the tool → **`LinkError`** (capabilities may only grant).
+2. An **unconditional** guardrail deny → **DENY**, absolute. Nothing below can undo it.
+3. A **ceiling** guardrail (`default_policy: deny`) that does not list the tool →
+   **implicit deny** (the tool is ineligible); the exclusion is recorded so the
+   analyzer can later flag any capability grant for it as shadowed.
+4. No capability grants the tool → **implicit deny** (eligible but ungranted).
+5. Otherwise → **ALLOW** (or **APPROVAL_REQUIRED** if any contributing grant or
+   ceiling requires approval), with the effective constraint being *every
+   contributing layer's constraint combined*.
+
+Summarised in one line:
+
+> **Fences intersect. Grants union. Denies win.**
+
+- **guardrail + guardrail** on one tool → intersection (all caps bind; the
+  stricter wins; any deny wins).
+- **capability + capability** on one tool → union (either grant's condition
+  suffices).
+- **guardrail ∩ capability** → the ceiling constraint AND the grant condition.
+
+### Ceiling vs floor
+
+A guardrail's `default_policy` sets its posture:
+
+- **Ceiling** (`default_policy: deny`) — an allowlist. A tool it does not name is
+  ineligible, so a capability grant for it has no effect.
+- **Floor** (`default_policy: allow`, the less-surprising default today) — only
+  subtracts what it names; unlisted tools pass through to the capabilities.
+
+Both use the same machinery; only step 3 above differs.
+
+### Constraint algebra
+
+The linker reuses the existing constraint DSL (`hexgate/security/constraints.py`)
+and only builds trees over its nodes — no new grammar:
+
+- **Intersection** is list concatenation. `AgentPolicy.tools[t].constraints` is a
+  `list[str]` that is already implicit-AND, so combining ceilings + a grant is
+  just appending strings.
+- **Union** is a top-level `or` expression: `(A) or (B)`.
+- **Deny-region subtraction** (a *conditional* guardrail deny) becomes
+  `and not (region)` appended to the grant.
+
+Every assembled expression is re-parsed with `parse_constraint` to validate it
+against the live grammar, so an unrenderable combination fails loud at link time,
+not at evaluation.
+
+### Constants
+
+`consts` (referenced from constraints as `consts.<name>`) are merged across
+layers with **guardrails winning**. A capability that redefines a guardrail's
+constant to a *different* value is a `LinkError` — otherwise a lower-authority
+layer could loosen a guardrail cap expressed as `args.amount <= consts.max` by
+shadowing `max`. A capability-only constant, or one that matches the guardrail's
+value, merges normally.
+
+## Worked example
+
+Guardrail `org_core` (floor): `deny delete_database`, `allow refund_order`
+capped at `args.amount <= 1000`. Capability `payments`:
+`allow refund_order when currency in [USD, EUR]`, `allow lookup_order`.
+Capability leaf: `allow send_email`, `approval_required escalate`.
+
+| Call | Outcome | Why |
+| --- | --- | --- |
+| `refund_order(800, USD)` | allow | in ceiling (≤1000) ∧ granted (USD) |
+| `refund_order(1200, USD)` | deny | over the guardrail cap |
+| `refund_order(800, GBP)` | deny | inside the ceiling, but no grant for GBP |
+| `delete_database()` | deny | absolute guardrail deny |
+| `lookup_order()` | allow | floor lets it through; capability grants |
+| `send_email()` | allow (floor) / deny (ceiling) | eligible only if the guardrail is a floor |
+| `escalate()` | approval | granted, gated on a human |
+
+If `org_core` were a **ceiling** instead of a floor, `lookup_order` and
+`send_email` would be denied (ineligible — not named by the ceiling), and both
+recorded as shadowed.
+
+## Attachment & authority
+
+- **Capabilities** are opted into by the agent (imported).
+- **Guardrails** are inherited from the agent's scope (org → project), so an
+  agent cannot opt out of them. Rule of thumb: *it's a guardrail if the agent
+  didn't get to choose it.*
+- Authority is not a field in the file. It is enforced by **where the file lives**
+  (a protected path + review) and, ultimately, by **signing** — the platform
+  enforces a layer as a guardrail only if its content hash is signed by the
+  security key. *(Signing + scope-attachment are platform-side and not in this
+  first slice; the SDK loads guardrail and capability modules from local
+  directories.)*
+
+## Invariants
+
+- **Parity untouched.** The linker emits one `AgentPolicy`; both engines evaluate
+  the resolved policy, and the existing parity suite runs over it.
+- **Capabilities can only tighten.** Enforced structurally: capabilities cannot
+  deny, cannot set a fence, and cannot override a guardrail constant.
+- **Fail-closed.** The effective `default_policy` is `deny`; a tool no layer
+  grants is denied.
+- **Provenance is preserved.** Every resolved rule records the layers that fed it
+  and any shadowing ceiling (`RuleTrace`), so errors can be attributed to a file.
+
+## Where it lives
+
+| Concern | Code |
+| --- | --- |
+| Data model (`ModuleContent`, `Provenance`, `RuleTrace`, `LinkResult`) | `hexgate/security/modules.py` |
+| The fold | `hexgate/security/linker.py` (`link`, `link_policy_set`, `_fold_tool`) |
+| Local-files loader (the seam a platform store swaps later) | `hexgate/security/module_loader.py` |
+| Inspection | `hexgate policy resolve --dir <root>` |
+
+## Not built yet
+
+- **Signing + scope-attached guardrails + a platform module store** — the loader
+  is local-files only; the platform-store loader is a later PR.
+- **Durable versioning** — modules carry a content hash (identity) today, but
+  there is no version history, pinning, or fan-out yet.
+- **Per-role module scoping** — the linker folds into the single `default` role.
+- **`file_scope` in modules** — a module tool using `file_scope` is a `LinkError`
+  rather than being silently dropped; composing it is a later addition.
+- **Agent-level rules** (`agents:` — can A invoke B) — reuses this same linker;
+  a later PR.
+- **The analyzer + editor** — lints (dead / shadowed / conflicting) and the
+  dashboard view are the next two PRs; the `RuleTrace` provenance here is what
+  they consume.

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -189,6 +189,30 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     p_test.set_defaults(func=_main_test)
 
+    # ---- resolve ----
+    p_resolve = sub.add_parser(
+        "resolve",
+        help="Link a bundle of policy modules into one effective policy.",
+        description=(
+            "Loads guardrail + capability modules from <dir>/policies/, composes "
+            "them (fences intersect, grants union, denies win) into a single "
+            "effective policy, and prints it. The intermediate artifact between "
+            "many module files and the signed WASM bundle — inspect it to see "
+            "exactly what the engines will enforce."
+        ),
+    )
+    p_resolve.add_argument(
+        "--dir",
+        default=".",
+        help="Repo root containing a policies/ tree (default: current dir).",
+    )
+    p_resolve.add_argument(
+        "-o",
+        "--output",
+        help="Write the effective policy YAML here (default: stdout).",
+    )
+    p_resolve.set_defaults(func=_main_resolve)
+
 
 def main(args: argparse.Namespace) -> int:
     """Entry point used by the top-level dispatcher in hexgate/cli/__init__.py."""
@@ -414,6 +438,50 @@ def _main_show_rego(args: argparse.Namespace) -> int:
         print(f"compile error: {exc}", file=sys.stderr)
         return 1
     sys.stdout.write(rego)
+    return 0
+
+
+def _main_resolve(args: argparse.Namespace) -> int:
+    """Link the local module bundle into one effective policy and print it."""
+    from hexgate.security import (
+        LinkError,
+        link_policy_set,
+        load_local_modules,
+    )
+
+    guardrails, capabilities = load_local_modules(args.dir)
+    if not guardrails and not capabilities:
+        print(
+            f"no modules found under {args.dir}/policies/"
+            " (expected policies/guardrails/ and/or policies/capabilities/)",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        result = link_policy_set(guardrails, capabilities)
+    except (LinkError, PolicySetError, ConstraintParseError, ValidationError) as exc:
+        print(f"link error: {exc}", file=sys.stderr)
+        return 1
+
+    effective = result.effective[DEFAULT_ROLE_NAME]
+    # Full dump (not exclude_defaults): a tool set to the default `deny` mode
+    # would otherwise render as `{}`, hiding the outcome in an inspection view.
+    text = yaml.safe_dump(effective.model_dump(mode="json"), sort_keys=False)
+    if args.output:
+        Path(args.output).write_text(text, encoding="utf-8")
+        print(f"✓ wrote effective policy to {args.output}")
+    else:
+        sys.stdout.write(text)
+
+    # Provenance to stderr so stdout stays a clean policy document.
+    print("\nlayers (resolution order):", file=sys.stderr)
+    for prov in result.layers:
+        print(f"  [{prov.kind:10}] {prov.module}  ({prov.source})", file=sys.stderr)
+    if result.trace.shadowed:
+        print("shadowed (ineligible under a ceiling):", file=sys.stderr)
+        for tool, by in sorted(result.trace.shadowed.items()):
+            print(f"  {tool}  ← {by.module} ({by.source})", file=sys.stderr)
     return 0
 
 

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -194,7 +194,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         "resolve",
         help="Link a bundle of policy modules into one effective policy.",
         description=(
-            "Loads guardrail + capability modules from <dir>/policies/, composes "
+            "Loads boundary + capability modules from <dir>/policies/, composes "
             "them (fences intersect, grants union, denies win) into a single "
             "effective policy, and prints it. The intermediate artifact between "
             "many module files and the signed WASM bundle — inspect it to see "
@@ -450,20 +450,20 @@ def _main_resolve(args: argparse.Namespace) -> int:
     )
 
     try:
-        guardrails, capabilities = load_local_modules(args.dir)
+        boundaries, capabilities = load_local_modules(args.dir)
     except (ValueError, OSError) as exc:
         print(f"load error: {exc}", file=sys.stderr)
         return 1
-    if not guardrails and not capabilities:
+    if not boundaries and not capabilities:
         print(
             f"no modules found under {args.dir}/policies/"
-            " (expected policies/guardrails/ and/or policies/capabilities/)",
+            " (expected policies/boundaries/ and/or policies/capabilities/)",
             file=sys.stderr,
         )
         return 1
 
     try:
-        result = link_policy_set(guardrails, capabilities)
+        result = link_policy_set(boundaries, capabilities)
     except (LinkError, PolicySetError, ConstraintParseError, ValidationError) as exc:
         print(f"link error: {exc}", file=sys.stderr)
         return 1

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -449,7 +449,11 @@ def _main_resolve(args: argparse.Namespace) -> int:
         load_local_modules,
     )
 
-    guardrails, capabilities = load_local_modules(args.dir)
+    try:
+        guardrails, capabilities = load_local_modules(args.dir)
+    except (ValueError, OSError) as exc:
+        print(f"load error: {exc}", file=sys.stderr)
+        return 1
     if not guardrails and not capabilities:
         print(
             f"no modules found under {args.dir}/policies/"

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -81,6 +81,16 @@ from hexgate.security.policy_set import (
     load_policy_set,
     load_policy_set_from_dict,
 )
+from hexgate.security.modules import (
+    LayerKind,
+    LinkError,
+    LinkResult,
+    ModuleContent,
+    Provenance,
+    RuleTrace,
+)
+from hexgate.security.linker import link, link_policy_set
+from hexgate.security.module_loader import ModuleLoader, load_local_modules
 from hexgate.security.rego import compile_default_only, compile_to_rego
 from hexgate.security.rego_wasm import (
     DEFAULT_ENTRYPOINTS,
@@ -112,6 +122,16 @@ from hexgate.security.testing import (
 __all__ = [
     "AgentBannedError",
     "AgentPolicy",
+    "LayerKind",
+    "LinkError",
+    "LinkResult",
+    "ModuleContent",
+    "ModuleLoader",
+    "Provenance",
+    "RuleTrace",
+    "link",
+    "link_policy_set",
+    "load_local_modules",
     "EMPTY_BAN_SET",
     "BanContentError",
     "BanEnforcementEvent",

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -13,8 +13,8 @@ Rules (see ``policy-modules-plan.md``): **fences intersect, grants union, denies
 win.** Per ``(tool, args)`` the most restrictive layer wins:
 ``deny > approval_required > allow > implicit-deny``.
 
-- **Guardrail** — caps + hard denies. An unconditional deny is absolute. A
-  ``default_policy: deny`` guardrail is a *ceiling*: a tool it doesn't list is
+- **Boundary** — caps + hard denies. An unconditional deny is absolute. A
+  ``default_policy: deny`` boundary is a *ceiling*: a tool it doesn't list is
   ineligible. Its ``allow`` entries are ceilings (permit up to a constraint),
   not grants.
 - **Capability** — grants only (``allow`` / ``approval_required``). A capability
@@ -23,7 +23,7 @@ win.** Per ``(tool, args)`` the most restrictive layer wins:
 
 Constraint algebra reuses the existing DSL nodes: intersection is list
 concatenation (``constraints: list[str]`` is implicit-AND), union is a top-level
-``or`` expression, and a conditional guardrail deny subtracts via ``and not(…)``.
+``or`` expression, and a conditional boundary deny subtracts via ``and not(…)``.
 Every assembled expression is re-parsed with :func:`parse_constraint` to validate
 against the live grammar.
 """
@@ -50,18 +50,18 @@ _GRANT_MODES = ("allow", "approval_required")
 
 
 def link_policy_set(
-    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+    boundaries: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> LinkResult:
     """Fold a bundle into one effective :class:`PolicySet` + provenance.
 
-    ``guardrails`` are the scope-inherited layers (caps/denies); ``capabilities``
+    ``boundaries`` are the scope-inherited layers (caps/denies); ``capabilities``
     are the imported packs + the agent's inline leaf, in resolution order. This
     iteration folds into the single ``default`` role; per-role scoping is a
     follow-up.
     """
-    effective, trace = link(guardrails, capabilities)
+    effective, trace = link(boundaries, capabilities)
     policy_set = PolicySet({DEFAULT_ROLE_NAME: effective})
-    layers = [_prov(m) for m in (*guardrails, *capabilities)]
+    layers = [_prov(m) for m in (*boundaries, *capabilities)]
     return LinkResult(
         policy_set=policy_set,
         effective={DEFAULT_ROLE_NAME: effective},
@@ -71,16 +71,16 @@ def link_policy_set(
 
 
 def link(
-    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+    boundaries: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> tuple[AgentPolicy, RuleTrace]:
     """Fold one role's layers into a single :class:`AgentPolicy`. Pure; no I/O."""
-    _reject_file_scope(guardrails, capabilities)
-    consts = _merge_consts(guardrails, capabilities)
+    _reject_file_scope(boundaries, capabilities)
+    consts = _merge_consts(boundaries, capabilities)
 
     trace = RuleTrace()
     tools: dict[str, ToolPolicy] = {}
-    for name in _tool_names(guardrails, capabilities):
-        rule = _fold_tool(name, guardrails, capabilities, trace)
+    for name in _tool_names(boundaries, capabilities):
+        rule = _fold_tool(name, boundaries, capabilities, trace)
         if rule is not None:
             tools[name] = rule
 
@@ -92,29 +92,29 @@ def link(
 
 
 def _merge_consts(
-    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+    boundaries: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> dict[str, object]:
     """Merge consts across layers. A constant defined twice with **different**
     values is a hard :class:`LinkError`, never a silent last-wins.
 
-    Two collisions matter: a capability redefining a guardrail's constant would
+    Two collisions matter: a capability redefining a boundary's constant would
     let a lower-authority layer loosen a cap like ``args.amount <= consts.max``;
-    and two guardrails disagreeing on a value would silently pick one. Both are
+    and two boundaries disagreeing on a value would silently pick one. Both are
     rejected. Equal values (or a name unique to one module) merge normally.
     """
     merged: dict[str, object] = {}
     owner: dict[str, ModuleContent] = {}
-    owner_is_guardrail: dict[str, bool] = {}
+    owner_is_boundary: dict[str, bool] = {}
 
-    def _put(module: ModuleContent, is_guardrail: bool) -> None:
+    def _put(module: ModuleContent, is_boundary: bool) -> None:
         for name, value in module.policy.consts.items():
             if name in merged and merged[name] != value:
                 prev = owner[name]
-                if owner_is_guardrail[name] and not is_guardrail:
+                if owner_is_boundary[name] and not is_boundary:
                     raise LinkError(
-                        f"capability {module.name!r} redefines guardrail constant "
+                        f"capability {module.name!r} redefines boundary constant "
                         f"consts.{name} ({value!r} vs {merged[name]!r} from "
-                        f"{prev.name!r}); capabilities may not override guardrail "
+                        f"{prev.name!r}); capabilities may not override boundary "
                         f"constants ({module.source})"
                     )
                 raise LinkError(
@@ -124,17 +124,17 @@ def _merge_consts(
                 )
             merged[name] = value
             owner[name] = module
-            owner_is_guardrail[name] = is_guardrail
+            owner_is_boundary[name] = is_boundary
 
-    for module in guardrails:
-        _put(module, is_guardrail=True)
+    for module in boundaries:
+        _put(module, is_boundary=True)
     for module in capabilities:
-        _put(module, is_guardrail=False)
+        _put(module, is_boundary=False)
     return merged
 
 
 def _reject_file_scope(
-    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+    boundaries: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> None:
     """Reject ``file_scope`` in a module — composing it isn't supported yet.
 
@@ -142,7 +142,7 @@ def _reject_file_scope(
     enforced by the pydantic engine), so fail loud instead. Keep file-scoped
     tools in a single-file policy until module composition supports them.
     """
-    for module in (*guardrails, *capabilities):
+    for module in (*boundaries, *capabilities):
         for tool_name, tp in module.policy.tools.items():
             if isinstance(tp, FileToolPolicy) and tp.file_scope is not None:
                 raise LinkError(
@@ -154,7 +154,7 @@ def _reject_file_scope(
 
 def _fold_tool(
     tool: str,
-    guardrails: list[ModuleContent],
+    boundaries: list[ModuleContent],
     capabilities: list[ModuleContent],
     trace: RuleTrace,
 ) -> ToolPolicy | None:
@@ -165,13 +165,13 @@ def _fold_tool(
         if tp is not None and tp.mode == "deny":
             raise LinkError(
                 f"capability {cap.name!r} denies {tool!r}; capabilities may only "
-                f"grant — move the deny to a guardrail ({cap.source})"
+                f"grant — move the deny to a boundary ({cap.source})"
             )
 
-    # 1. Unconditional guardrail deny wins absolutely. A *conditional* deny
+    # 1. Unconditional boundary deny wins absolutely. A *conditional* deny
     #    (has constraints) instead subtracts its region from the grant (step 5).
     conditional_denies: list[tuple[ModuleContent, list[str]]] = []
-    for g in guardrails:
+    for g in boundaries:
         tp = g.policy.tools.get(tool)
         if tp is not None and tp.mode == "deny":
             if tp.constraints:
@@ -180,11 +180,11 @@ def _fold_tool(
                 trace.record(tool, [_prov(g)])
                 return BaseToolPolicy(mode="deny")
 
-    # 2. Ceiling eligibility + ceiling constraints. A ceiling guardrail
+    # 2. Ceiling eligibility + ceiling constraints. A ceiling boundary
     #    (default_policy: deny) that doesn't list the tool makes it ineligible.
     contributors: list[Provenance] = []
     ceiling_constraints: list[str] = []
-    for g in guardrails:
+    for g in boundaries:
         tp = g.policy.tools.get(tool)
         is_ceiling = g.policy.default_policy.mode == "deny"
         if tp is not None and tp.mode in _GRANT_MODES:
@@ -209,7 +209,7 @@ def _fold_tool(
 
     mode = (
         "approval_required"
-        if _any_approval([tp for _, tp in grants], guardrails, tool)
+        if _any_approval([tp for _, tp in grants], boundaries, tool)
         else "allow"
     )
 
@@ -252,14 +252,14 @@ def _and_expr(constraints: list[str]) -> str:
 
 
 def _any_approval(
-    grants: list[ToolPolicy], guardrails: list[ModuleContent], tool: str
+    grants: list[ToolPolicy], boundaries: list[ModuleContent], tool: str
 ) -> bool:
     """Approval is stricter than allow: any approval among grants/ceilings wins."""
     if any(tp.mode == "approval_required" for tp in grants):
         return True
     return any(
         (tp := g.policy.tools.get(tool)) is not None and tp.mode == "approval_required"
-        for g in guardrails
+        for g in boundaries
     )
 
 

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -1,0 +1,212 @@
+"""The linker — compose a bundle of policy modules into one effective policy.
+
+The intermediate step between *many policy files* and *one signed WASM bundle*:
+
+    [modules]  --link()-->  one AgentPolicy  --compile_to_rego-->  rego  -->  wasm
+
+Composition lives here, at the model layer. The output is an ordinary
+:class:`~hexgate.security.models.AgentPolicy` whose ``constraints`` are the same
+strings the DSL already parses, so the pydantic-vs-WASM **parity gate applies to
+the resolved policy for free** — the engines never see the stack.
+
+Rules (see ``policy-modules-plan.md``): **fences intersect, grants union, denies
+win.** Per ``(tool, args)`` the most restrictive layer wins:
+``deny > approval_required > allow > implicit-deny``.
+
+- **Guardrail** — caps + hard denies. An unconditional deny is absolute. A
+  ``default_policy: deny`` guardrail is a *ceiling*: a tool it doesn't list is
+  ineligible. Its ``allow`` entries are ceilings (permit up to a constraint),
+  not grants.
+- **Capability** — grants only (``allow`` / ``approval_required``). A capability
+  ``deny`` is a :class:`LinkError`. Multiple capabilities granting one tool
+  *union* (either condition suffices).
+
+Constraint algebra reuses the existing DSL nodes: intersection is list
+concatenation (``constraints: list[str]`` is implicit-AND), union is a top-level
+``or`` expression, and a conditional guardrail deny subtracts via ``and not(…)``.
+Every assembled expression is re-parsed with :func:`parse_constraint` to validate
+against the live grammar.
+"""
+
+from __future__ import annotations
+
+from hexgate.security.constraints import parse_constraint
+from hexgate.security.models import AgentPolicy, BaseToolPolicy, ToolPolicy
+from hexgate.security.modules import (
+    LinkError,
+    LinkResult,
+    ModuleContent,
+    Provenance,
+    RuleTrace,
+)
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySet
+
+_GRANT_MODES = ("allow", "approval_required")
+
+
+def link_policy_set(
+    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+) -> LinkResult:
+    """Fold a bundle into one effective :class:`PolicySet` + provenance.
+
+    ``guardrails`` are the scope-inherited layers (caps/denies); ``capabilities``
+    are the imported packs + the agent's inline leaf, in resolution order. This
+    iteration folds into the single ``default`` role; per-role scoping is a
+    follow-up.
+    """
+    effective, trace = link(guardrails, capabilities)
+    policy_set = PolicySet({DEFAULT_ROLE_NAME: effective})
+    layers = [_prov(m) for m in (*guardrails, *capabilities)]
+    return LinkResult(
+        policy_set=policy_set,
+        effective={DEFAULT_ROLE_NAME: effective},
+        layers=layers,
+        trace=trace,
+    )
+
+
+def link(
+    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+) -> tuple[AgentPolicy, RuleTrace]:
+    """Fold one role's layers into a single :class:`AgentPolicy`. Pure; no I/O."""
+    trace = RuleTrace()
+    tools: dict[str, ToolPolicy] = {}
+    for name in _tool_names(guardrails, capabilities):
+        rule = _fold_tool(name, guardrails, capabilities, trace)
+        if rule is not None:
+            tools[name] = rule
+
+    # consts from every layer are merged so const refs resolve + compile.
+    consts: dict[str, object] = {}
+    for module in (*guardrails, *capabilities):
+        consts.update(module.policy.consts)
+
+    # Effective default is fail-closed: a tool no layer grants is denied.
+    effective = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"), tools=tools, consts=consts
+    )
+    return effective, trace
+
+
+def _fold_tool(
+    tool: str,
+    guardrails: list[ModuleContent],
+    capabilities: list[ModuleContent],
+    trace: RuleTrace,
+) -> ToolPolicy | None:
+    """Resolve one tool across all layers. ``None`` means implicit-deny (omit)."""
+    # Capabilities may only grant. A capability deny is a config error.
+    for cap in capabilities:
+        tp = cap.policy.tools.get(tool)
+        if tp is not None and tp.mode == "deny":
+            raise LinkError(
+                f"capability {cap.name!r} denies {tool!r}; capabilities may only "
+                f"grant — move the deny to a guardrail ({cap.source})"
+            )
+
+    # 1. Unconditional guardrail deny wins absolutely. A *conditional* deny
+    #    (has constraints) instead subtracts its region from the grant (step 5).
+    conditional_denies: list[tuple[ModuleContent, list[str]]] = []
+    for g in guardrails:
+        tp = g.policy.tools.get(tool)
+        if tp is not None and tp.mode == "deny":
+            if tp.constraints:
+                conditional_denies.append((g, list(tp.constraints)))
+            else:
+                trace.record(tool, [_prov(g)])
+                return BaseToolPolicy(mode="deny")
+
+    # 2. Ceiling eligibility + ceiling constraints. A ceiling guardrail
+    #    (default_policy: deny) that doesn't list the tool makes it ineligible.
+    contributors: list[Provenance] = []
+    ceiling_constraints: list[str] = []
+    for g in guardrails:
+        tp = g.policy.tools.get(tool)
+        is_ceiling = g.policy.default_policy.mode == "deny"
+        if tp is not None and tp.mode in _GRANT_MODES:
+            ceiling_constraints.extend(tp.constraints)  # fences intersect (AND)
+            contributors.append(_prov(g))
+        elif tp is None and is_ceiling:
+            trace.shadow(tool, _prov(g))
+            return None
+
+    # 3+4. Capability grants. No grant → eligible but ungranted → implicit deny.
+    grants: list[tuple[ModuleContent, ToolPolicy]] = []
+    for cap in capabilities:
+        tp = cap.policy.tools.get(tool)
+        if tp is not None and tp.mode in _GRANT_MODES:
+            grants.append((cap, tp))
+    if not grants:
+        return None
+    contributors.extend(_prov(cap) for cap, _ in grants)
+
+    mode = (
+        "approval_required"
+        if _any_approval([tp for _, tp in grants], guardrails, tool)
+        else "allow"
+    )
+
+    # 5. effective = ceiling(AND) ∧ union(grants) ∧ not(conditional denies)
+    constraints: list[str] = list(ceiling_constraints)
+    union = _union([tp for _, tp in grants])
+    if union is not None:
+        constraints.append(union)
+    for g, region in conditional_denies:
+        constraints.append(f"not ({_and_expr(region)})")
+        contributors.append(_prov(g))
+
+    for expr in constraints:  # validate the assembled grammar on both engines
+        parse_constraint(expr)
+    trace.record(tool, contributors)
+    return BaseToolPolicy(mode=mode, constraints=constraints)
+
+
+def _union(grants: list[ToolPolicy]) -> str | None:
+    """OR the capability grants into one expression.
+
+    Returns ``None`` when any grant is unconditional (empty constraints) — an
+    unconditional grant makes the whole union unconditional, so no constraint is
+    emitted for it.
+    """
+    exprs: list[str] = []
+    for tp in grants:
+        if not tp.constraints:
+            return None
+        exprs.append(f"({_and_expr(tp.constraints)})")
+    joined = " or ".join(exprs)
+    parse_constraint(joined)  # fail loud on assembled grammar we can't parse
+    return joined
+
+
+def _and_expr(constraints: list[str]) -> str:
+    """A tool's constraint list → one parenthesised AND-expression."""
+    return " and ".join(f"({c})" for c in constraints)
+
+
+def _any_approval(
+    grants: list[ToolPolicy], guardrails: list[ModuleContent], tool: str
+) -> bool:
+    """Approval is stricter than allow: any approval among grants/ceilings wins."""
+    if any(tp.mode == "approval_required" for tp in grants):
+        return True
+    return any(
+        (tp := g.policy.tools.get(tool)) is not None and tp.mode == "approval_required"
+        for g in guardrails
+    )
+
+
+def _tool_names(*groups: list[ModuleContent]) -> list[str]:
+    names: set[str] = set()
+    for group in groups:
+        for module in group:
+            names.update(module.policy.tools)
+    return sorted(names)
+
+
+def _prov(module: ModuleContent) -> Provenance:
+    return Provenance(
+        module=module.name,
+        kind=module.kind,
+        source=module.source,
+        content_hash=module.content_hash,
+    )

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -94,26 +94,42 @@ def link(
 def _merge_consts(
     guardrails: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> dict[str, object]:
-    """Merge consts across layers, **guardrails win**.
+    """Merge consts across layers. A constant defined twice with **different**
+    values is a hard :class:`LinkError`, never a silent last-wins.
 
-    A capability may not redefine a guardrail's constant to a different value —
-    that would let a lower-authority layer loosen a guardrail cap expressed as
-    ``args.amount <= consts.max`` by shadowing ``max``. Such a collision is a
-    hard :class:`LinkError`; a capability-only const is merged normally.
+    Two collisions matter: a capability redefining a guardrail's constant would
+    let a lower-authority layer loosen a cap like ``args.amount <= consts.max``;
+    and two guardrails disagreeing on a value would silently pick one. Both are
+    rejected. Equal values (or a name unique to one module) merge normally.
     """
-    guard_consts: dict[str, object] = {}
-    for module in guardrails:
-        guard_consts.update(module.policy.consts)
-    merged = dict(guard_consts)
-    for cap in capabilities:
-        for name, value in cap.policy.consts.items():
-            if name in guard_consts and guard_consts[name] != value:
+    merged: dict[str, object] = {}
+    owner: dict[str, ModuleContent] = {}
+    owner_is_guardrail: dict[str, bool] = {}
+
+    def _put(module: ModuleContent, is_guardrail: bool) -> None:
+        for name, value in module.policy.consts.items():
+            if name in merged and merged[name] != value:
+                prev = owner[name]
+                if owner_is_guardrail[name] and not is_guardrail:
+                    raise LinkError(
+                        f"capability {module.name!r} redefines guardrail constant "
+                        f"consts.{name} ({value!r} vs {merged[name]!r} from "
+                        f"{prev.name!r}); capabilities may not override guardrail "
+                        f"constants ({module.source})"
+                    )
                 raise LinkError(
-                    f"capability {cap.name!r} redefines guardrail constant "
-                    f"consts.{name} ({value!r} vs guardrail {guard_consts[name]!r}); "
-                    f"capabilities may not override guardrail constants ({cap.source})"
+                    f"consts.{name} defined twice with conflicting values: "
+                    f"{merged[name]!r} in {prev.name!r} vs {value!r} in "
+                    f"{module.name!r} ({module.source})"
                 )
             merged[name] = value
+            owner[name] = module
+            owner_is_guardrail[name] = is_guardrail
+
+    for module in guardrails:
+        _put(module, is_guardrail=True)
+    for module in capabilities:
+        _put(module, is_guardrail=False)
     return merged
 
 
@@ -174,7 +190,10 @@ def _fold_tool(
         if tp is not None and tp.mode in _GRANT_MODES:
             ceiling_constraints.extend(tp.constraints)  # fences intersect (AND)
             contributors.append(_prov(g))
-        elif tp is None and is_ceiling:
+        elif is_ceiling and (tp is None or tp.mode not in _GRANT_MODES):
+            # A ceiling only permits tools it explicitly allows/approves. If it
+            # doesn't (unlisted, or mentioned only via a conditional deny), the
+            # tool is ineligible — a capability grant can't make it eligible.
             trace.shadow(tool, _prov(g))
             return None
 

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -31,7 +31,12 @@ against the live grammar.
 from __future__ import annotations
 
 from hexgate.security.constraints import parse_constraint
-from hexgate.security.models import AgentPolicy, BaseToolPolicy, ToolPolicy
+from hexgate.security.models import (
+    AgentPolicy,
+    BaseToolPolicy,
+    FileToolPolicy,
+    ToolPolicy,
+)
 from hexgate.security.modules import (
     LinkError,
     LinkResult,
@@ -69,6 +74,9 @@ def link(
     guardrails: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> tuple[AgentPolicy, RuleTrace]:
     """Fold one role's layers into a single :class:`AgentPolicy`. Pure; no I/O."""
+    _reject_file_scope(guardrails, capabilities)
+    consts = _merge_consts(guardrails, capabilities)
+
     trace = RuleTrace()
     tools: dict[str, ToolPolicy] = {}
     for name in _tool_names(guardrails, capabilities):
@@ -76,16 +84,56 @@ def link(
         if rule is not None:
             tools[name] = rule
 
-    # consts from every layer are merged so const refs resolve + compile.
-    consts: dict[str, object] = {}
-    for module in (*guardrails, *capabilities):
-        consts.update(module.policy.consts)
-
     # Effective default is fail-closed: a tool no layer grants is denied.
     effective = AgentPolicy(
         default_policy=BaseToolPolicy(mode="deny"), tools=tools, consts=consts
     )
     return effective, trace
+
+
+def _merge_consts(
+    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+) -> dict[str, object]:
+    """Merge consts across layers, **guardrails win**.
+
+    A capability may not redefine a guardrail's constant to a different value —
+    that would let a lower-authority layer loosen a guardrail cap expressed as
+    ``args.amount <= consts.max`` by shadowing ``max``. Such a collision is a
+    hard :class:`LinkError`; a capability-only const is merged normally.
+    """
+    guard_consts: dict[str, object] = {}
+    for module in guardrails:
+        guard_consts.update(module.policy.consts)
+    merged = dict(guard_consts)
+    for cap in capabilities:
+        for name, value in cap.policy.consts.items():
+            if name in guard_consts and guard_consts[name] != value:
+                raise LinkError(
+                    f"capability {cap.name!r} redefines guardrail constant "
+                    f"consts.{name} ({value!r} vs guardrail {guard_consts[name]!r}); "
+                    f"capabilities may not override guardrail constants ({cap.source})"
+                )
+            merged[name] = value
+    return merged
+
+
+def _reject_file_scope(
+    guardrails: list[ModuleContent], capabilities: list[ModuleContent]
+) -> None:
+    """Reject ``file_scope`` in a module — composing it isn't supported yet.
+
+    Silently dropping it in the fold would erase a path fence (``file_scope`` is
+    enforced by the pydantic engine), so fail loud instead. Keep file-scoped
+    tools in a single-file policy until module composition supports them.
+    """
+    for module in (*guardrails, *capabilities):
+        for tool_name, tp in module.policy.tools.items():
+            if isinstance(tp, FileToolPolicy) and tp.file_scope is not None:
+                raise LinkError(
+                    f"module {module.name!r} tool {tool_name!r} uses file_scope, "
+                    f"which module composition does not support yet — keep it in a "
+                    f"single-file policy or drop file_scope ({module.source})"
+                )
 
 
 def _fold_tool(
@@ -172,8 +220,9 @@ def _union(grants: list[ToolPolicy]) -> str | None:
     for tp in grants:
         if not tp.constraints:
             return None
-        exprs.append(f"({_and_expr(tp.constraints)})")
-    joined = " or ".join(exprs)
+        exprs.append(_and_expr(tp.constraints))
+    # One grant needs no OR wrapper; multiple are parenthesised and OR-joined.
+    joined = exprs[0] if len(exprs) == 1 else " or ".join(f"({e})" for e in exprs)
     parse_constraint(joined)  # fail loud on assembled grammar we can't parse
     return joined
 

--- a/hexgate/security/module_loader.py
+++ b/hexgate/security/module_loader.py
@@ -43,10 +43,11 @@ def load_local_modules(
 ) -> tuple[list[ModuleContent], list[ModuleContent]]:
     """Load ``(guardrails, capabilities)`` from a repo root's ``policies/`` tree.
 
-    Guardrails come from ``<root>/policies/guardrails/**.yaml``, capabilities
-    from ``<root>/policies/capabilities/**.yaml``. Missing directories yield an
-    empty list (a repo may ship only one tier). Each file's stem is the module
-    name; its content hash is the sha256 of its canonical JSON.
+    Guardrails come from ``<root>/policies/guardrails/`` (``*.yaml`` / ``*.yml``,
+    recursively), capabilities from ``<root>/policies/capabilities/``. Missing
+    directories yield an empty list (a repo may ship only one tier). A module's
+    name is its path under the tier dir without suffix (so nested files with the
+    same stem stay distinct); its content hash is the sha256 of its canonical JSON.
     """
     root = Path(root)
     guardrails = _read_dir(root.joinpath(*GUARDRAIL_SUBDIR), "guardrail")
@@ -57,16 +58,23 @@ def load_local_modules(
 def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:
     if not directory.is_dir():
         return []
+    files = sorted({*directory.glob("**/*.yaml"), *directory.glob("**/*.yml")})
     modules: list[ModuleContent] = []
-    for file in sorted(directory.glob("**/*.yaml")):
-        payload = yaml.safe_load(file.read_text(encoding="utf-8")) or {}
+    for file in files:
+        # Parse + validate inside the try so a malformed-YAML file names itself
+        # in the error too, not just a schema-invalid one.
         try:
+            payload = yaml.safe_load(file.read_text(encoding="utf-8")) or {}
             policy = AgentPolicy.model_validate(payload)
         except Exception as exc:  # noqa: BLE001 — surface the offending file
-            raise ValueError(f"module {file.name!r} is invalid: {exc}") from exc
+            raise ValueError(
+                f"module {file.relative_to(directory).as_posix()!r} is invalid: {exc}"
+            ) from exc
         modules.append(
             ModuleContent(
-                name=file.stem,
+                # Path-relative name (no suffix) so nested files with the same
+                # stem stay distinct, e.g. "team/refunds" vs "refunds".
+                name=file.relative_to(directory).with_suffix("").as_posix(),
                 kind=kind,
                 policy=policy,
                 source=str(file),

--- a/hexgate/security/module_loader.py
+++ b/hexgate/security/module_loader.py
@@ -63,9 +63,12 @@ def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:
     for file in files:
         # Parse + validate inside the try so a malformed-YAML file names itself
         # in the error too, not just a schema-invalid one.
+        # Everything that can fail on a bad file — parse, validate, hash — runs
+        # inside the try so the error always names the offending file.
         try:
             payload = yaml.safe_load(file.read_text(encoding="utf-8")) or {}
             policy = AgentPolicy.model_validate(payload)
+            content_hash = _canonical_hash(payload)
         except Exception as exc:  # noqa: BLE001 — surface the offending file
             raise ValueError(
                 f"module {file.relative_to(directory).as_posix()!r} is invalid: {exc}"
@@ -78,13 +81,17 @@ def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:
                 kind=kind,
                 policy=policy,
                 source=str(file),
-                content_hash=_canonical_hash(payload),
+                content_hash=content_hash,
             )
         )
     return modules
 
 
 def _canonical_hash(payload: object) -> str:
-    """sha256 of the module's canonical JSON — stable across dict ordering."""
-    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    """sha256 of the module's canonical JSON — stable across dict ordering.
+
+    ``default=str`` so non-JSON scalars YAML can produce (e.g. an unquoted date
+    becomes ``datetime.date``) serialize deterministically instead of raising.
+    """
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/hexgate/security/module_loader.py
+++ b/hexgate/security/module_loader.py
@@ -1,6 +1,6 @@
 """Load policy modules from local files — the SDK / dev path.
 
-Reads a repo's ``policies/guardrails/`` and ``policies/capabilities/``
+Reads a repo's ``policies/boundaries/`` and ``policies/capabilities/``
 directories into :class:`~hexgate.security.modules.ModuleContent`, hashing each
 for content identity. Devs point the linker + analyzer at this with no platform.
 
@@ -21,16 +21,16 @@ import yaml
 from hexgate.security.models import AgentPolicy
 from hexgate.security.modules import LayerKind, ModuleContent
 
-GUARDRAIL_SUBDIR = ("policies", "guardrails")
+BOUNDARY_SUBDIR = ("policies", "boundaries")
 CAPABILITY_SUBDIR = ("policies", "capabilities")
 
 
 class ModuleLoader(Protocol):
     """Resolve the modules that apply to an agent.
 
-    Returns ``(guardrails, capabilities)`` in resolution order. The local-files
+    Returns ``(boundaries, capabilities)`` in resolution order. The local-files
     loader ignores ``agent_name`` (it returns the repo's whole bundle); the
-    platform loader will use it to scope-attach org guardrails + imports.
+    platform loader will use it to scope-attach org boundaries + imports.
     """
 
     def load(
@@ -41,18 +41,18 @@ class ModuleLoader(Protocol):
 def load_local_modules(
     root: str | Path,
 ) -> tuple[list[ModuleContent], list[ModuleContent]]:
-    """Load ``(guardrails, capabilities)`` from a repo root's ``policies/`` tree.
+    """Load ``(boundaries, capabilities)`` from a repo root's ``policies/`` tree.
 
-    Guardrails come from ``<root>/policies/guardrails/`` (``*.yaml`` / ``*.yml``,
+    Boundaries come from ``<root>/policies/boundaries/`` (``*.yaml`` / ``*.yml``,
     recursively), capabilities from ``<root>/policies/capabilities/``. Missing
     directories yield an empty list (a repo may ship only one tier). A module's
     name is its path under the tier dir without suffix (so nested files with the
     same stem stay distinct); its content hash is the sha256 of its canonical JSON.
     """
     root = Path(root)
-    guardrails = _read_dir(root.joinpath(*GUARDRAIL_SUBDIR), "guardrail")
+    boundaries = _read_dir(root.joinpath(*BOUNDARY_SUBDIR), "boundary")
     capabilities = _read_dir(root.joinpath(*CAPABILITY_SUBDIR), "capability")
-    return guardrails, capabilities
+    return boundaries, capabilities
 
 
 def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:

--- a/hexgate/security/module_loader.py
+++ b/hexgate/security/module_loader.py
@@ -1,0 +1,82 @@
+"""Load policy modules from local files — the SDK / dev path.
+
+Reads a repo's ``policies/guardrails/`` and ``policies/capabilities/``
+directories into :class:`~hexgate.security.modules.ModuleContent`, hashing each
+for content identity. Devs point the linker + analyzer at this with no platform.
+
+This is the **loader seam**: the platform swaps :class:`ModuleLoader` for a
+store-backed (and, later, version-pinned) implementation. Everything downstream
+of the seam — link, analyze, compile — is shared.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Protocol
+
+import yaml
+
+from hexgate.security.models import AgentPolicy
+from hexgate.security.modules import LayerKind, ModuleContent
+
+GUARDRAIL_SUBDIR = ("policies", "guardrails")
+CAPABILITY_SUBDIR = ("policies", "capabilities")
+
+
+class ModuleLoader(Protocol):
+    """Resolve the modules that apply to an agent.
+
+    Returns ``(guardrails, capabilities)`` in resolution order. The local-files
+    loader ignores ``agent_name`` (it returns the repo's whole bundle); the
+    platform loader will use it to scope-attach org guardrails + imports.
+    """
+
+    def load(
+        self, agent_name: str
+    ) -> tuple[list[ModuleContent], list[ModuleContent]]: ...
+
+
+def load_local_modules(
+    root: str | Path,
+) -> tuple[list[ModuleContent], list[ModuleContent]]:
+    """Load ``(guardrails, capabilities)`` from a repo root's ``policies/`` tree.
+
+    Guardrails come from ``<root>/policies/guardrails/**.yaml``, capabilities
+    from ``<root>/policies/capabilities/**.yaml``. Missing directories yield an
+    empty list (a repo may ship only one tier). Each file's stem is the module
+    name; its content hash is the sha256 of its canonical JSON.
+    """
+    root = Path(root)
+    guardrails = _read_dir(root.joinpath(*GUARDRAIL_SUBDIR), "guardrail")
+    capabilities = _read_dir(root.joinpath(*CAPABILITY_SUBDIR), "capability")
+    return guardrails, capabilities
+
+
+def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:
+    if not directory.is_dir():
+        return []
+    modules: list[ModuleContent] = []
+    for file in sorted(directory.glob("**/*.yaml")):
+        payload = yaml.safe_load(file.read_text(encoding="utf-8")) or {}
+        try:
+            policy = AgentPolicy.model_validate(payload)
+        except Exception as exc:  # noqa: BLE001 — surface the offending file
+            raise ValueError(f"module {file.name!r} is invalid: {exc}") from exc
+        modules.append(
+            ModuleContent(
+                name=file.stem,
+                kind=kind,
+                policy=policy,
+                source=str(file),
+                content_hash=_canonical_hash(payload),
+            )
+        )
+    return modules
+
+
+def _canonical_hash(payload: object) -> str:
+    """sha256 of the module's canonical JSON — stable across dict ordering."""
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()

--- a/hexgate/security/modules.py
+++ b/hexgate/security/modules.py
@@ -21,14 +21,14 @@ from hexgate.security.models import AgentPolicy
 if TYPE_CHECKING:  # avoid an import cycle — policy_set imports models, not this
     from hexgate.security.policy_set import PolicySet
 
-LayerKind = Literal["guardrail", "capability"]
+LayerKind = Literal["boundary", "capability"]
 
 
 class LinkError(ValueError):
     """Raised when a bundle of modules can't be composed.
 
     The common case is a capability that tries to ``deny`` — capabilities may
-    only grant; a deny belongs to a guardrail.
+    only grant; a deny belongs to a boundary.
     """
 
 
@@ -69,7 +69,7 @@ class RuleTrace:
     """Per-tool provenance the analyzer + editor consume.
 
     ``contributors[tool]`` — the layers that fed the effective rule for ``tool``.
-    ``shadowed[tool]`` — a higher-tier layer (a guardrail ceiling) that made a
+    ``shadowed[tool]`` — a higher-tier layer (a boundary ceiling) that made a
     tool ineligible, so any lower grant for it is inert. This is the raw material
     the analyzer turns into ``dead`` / ``shadowed`` lints.
     """

--- a/hexgate/security/modules.py
+++ b/hexgate/security/modules.py
@@ -1,0 +1,102 @@
+"""Data model for stacked policy modules and the linker's output.
+
+A *module* is an :class:`~hexgate.security.models.AgentPolicy` fragment given an
+identity (``name``), a tier (``kind``), an origin (``source``), and a content
+hash. Modules compose — via :mod:`hexgate.security.linker` — into one effective
+policy per agent, which then compiles to Rego/WASM exactly as a single policy
+does today. See ``policy-modules-plan.md``.
+
+Everything here is SDK-side: devs load, link, and lint modules locally with no
+platform. ``content_hash`` is the content-identity half of versioning (cheap, no
+DB) — present now so durable version history can clip on later without rework.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from hexgate.security.models import AgentPolicy
+
+if TYPE_CHECKING:  # avoid an import cycle — policy_set imports models, not this
+    from hexgate.security.policy_set import PolicySet
+
+LayerKind = Literal["guardrail", "capability"]
+
+
+class LinkError(ValueError):
+    """Raised when a bundle of modules can't be composed.
+
+    The common case is a capability that tries to ``deny`` — capabilities may
+    only grant; a deny belongs to a guardrail.
+    """
+
+
+@dataclass(frozen=True)
+class ModuleContent:
+    """One policy fragment in a bundle, with identity + provenance.
+
+    ``policy`` is the fragment itself (``default_policy`` + ``tools`` + ``consts``).
+    ``kind`` fixes its tier. ``source`` is where it came from (a file path for the
+    local loader) and ``content_hash`` is its stable identity.
+    """
+
+    name: str
+    kind: LayerKind
+    policy: AgentPolicy
+    source: str
+    content_hash: str
+
+
+@dataclass(frozen=True)
+class Provenance:
+    """Where a resolved rule — or a contributing layer — came from.
+
+    Threaded through the linker so the analyzer and editor can attribute every
+    effective rule (and every shadowed one) back to its source file. ``line`` is
+    populated later; file-level attribution is what the linker guarantees now.
+    """
+
+    module: str
+    kind: LayerKind
+    source: str
+    content_hash: str
+    line: int | None = None
+
+
+@dataclass
+class RuleTrace:
+    """Per-tool provenance the analyzer + editor consume.
+
+    ``contributors[tool]`` — the layers that fed the effective rule for ``tool``.
+    ``shadowed[tool]`` — a higher-tier layer (a guardrail ceiling) that made a
+    tool ineligible, so any lower grant for it is inert. This is the raw material
+    the analyzer turns into ``dead`` / ``shadowed`` lints.
+    """
+
+    contributors: dict[str, list[Provenance]] = field(default_factory=dict)
+    shadowed: dict[str, Provenance] = field(default_factory=dict)
+
+    def record(self, tool: str, provs: list[Provenance]) -> None:
+        if provs:
+            self.contributors.setdefault(tool, []).extend(provs)
+
+    def shadow(self, tool: str, by: Provenance) -> None:
+        self.shadowed[tool] = by
+
+
+@dataclass(frozen=True)
+class LinkResult:
+    """The linker's output: one effective policy + full provenance.
+
+    ``policy_set`` feeds ``compile_to_rego`` unchanged. ``effective`` is the
+    folded policy per role (single ``default`` role in this iteration).
+    ``layers`` lists every input module in resolution order — the provenance the
+    signed bundle records and audit will later pin. ``trace`` carries per-tool
+    attribution for the analyzer/editor.
+    """
+
+    policy_set: "PolicySet"
+    effective: dict[str, AgentPolicy]
+    layers: list[Provenance]
+    trace: RuleTrace

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -1,0 +1,283 @@
+"""Tests for the policy linker — composing a module bundle into one policy.
+
+The fold is the crown jewel, so these are pure (no opa needed) except the final
+parity test. Fixtures mirror ``policy-modules-plan.md``'s worked example, with
+the two guardrail postures kept internally consistent:
+
+- **floor** guardrail (``default_policy: allow``) — only subtracts what it names;
+  unlisted tools pass through to capabilities.
+- **ceiling** guardrail (``default_policy: deny``) — a tool it doesn't list is
+  ineligible, so a capability grant for it is inert (shadowed).
+"""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from hexgate.security import (
+    AgentPolicy,
+    BaseToolPolicy,
+    DecisionOutcome,
+    LinkError,
+    ModuleContent,
+    evaluate_tool_call,
+    link,
+    link_policy_set,
+)
+
+_OPA_AVAILABLE = shutil.which("opa") is not None
+needs_opa = pytest.mark.skipif(not _OPA_AVAILABLE, reason="opa not on PATH")
+
+
+def _mod(name, kind, tools, *, default_mode="allow", consts=None):
+    return ModuleContent(
+        name=name,
+        kind=kind,
+        policy=AgentPolicy(
+            default_policy=BaseToolPolicy(mode=default_mode),
+            tools=tools,
+            consts=consts or {},
+        ),
+        source=f"{name}.yaml",
+        content_hash=f"hash-{name}",
+    )
+
+
+def _allow(constraints=None):
+    return BaseToolPolicy(mode="allow", constraints=constraints or [])
+
+
+def _deny(constraints=None):
+    return BaseToolPolicy(mode="deny", constraints=constraints or [])
+
+
+def _approval():
+    return BaseToolPolicy(mode="approval_required")
+
+
+# --- floor guardrail: the worked-example table (unlisted tools pass through) ---
+
+
+@pytest.fixture
+def floor_bundle():
+    guardrail = _mod(
+        "org.core",
+        "guardrail",
+        {
+            "delete_database": _deny(),
+            "refund_order": _allow(["args.amount <= 1000"]),
+        },
+        default_mode="allow",  # floor
+    )
+    payments = _mod(
+        "payments",
+        "capability",
+        {
+            "refund_order": _allow(['args.currency in ["USD", "EUR"]']),
+            "lookup_order": _allow(),
+        },
+    )
+    leaf = _mod(
+        "leaf",
+        "capability",
+        {"send_email": _allow(), "escalate": _approval()},
+    )
+    return [guardrail], [payments, leaf]
+
+
+@pytest.mark.parametrize(
+    "tool,args,expected",
+    [
+        ("refund_order", {"amount": 800, "currency": "USD"}, DecisionOutcome.ALLOW),
+        ("refund_order", {"amount": 1200, "currency": "USD"}, DecisionOutcome.DENY),
+        ("refund_order", {"amount": 800, "currency": "GBP"}, DecisionOutcome.DENY),
+        ("delete_database", {}, DecisionOutcome.DENY),
+        ("lookup_order", {}, DecisionOutcome.ALLOW),
+        ("send_email", {}, DecisionOutcome.ALLOW),
+        ("escalate", {}, DecisionOutcome.NEEDS_APPROVAL),
+    ],
+)
+def test_floor_worked_example(floor_bundle, tool, args, expected):
+    effective, _ = link(*floor_bundle)
+    assert evaluate_tool_call(effective, tool, args).outcome is expected
+
+
+def test_floor_refund_intersects_ceiling_and_grant(floor_bundle):
+    effective, _ = link(*floor_bundle)
+    # ceiling constraint (amount<=1000) AND the capability grant (currency).
+    cons = effective.tools["refund_order"].constraints
+    assert any("amount <= 1000" in c for c in cons)
+    assert any("currency" in c for c in cons)
+
+
+# --- ceiling guardrail: a tool it doesn't list is ineligible ---
+
+
+def test_ceiling_gates_eligibility_and_records_shadow():
+    ceiling = _mod(
+        "org.ceiling",
+        "guardrail",
+        {
+            "delete_database": _deny(),
+            "refund_order": _allow(["args.amount <= 1000"]),
+        },
+        default_mode="deny",  # ceiling
+    )
+    # payments grants refund_order (in the ceiling) + lookup_order (not in it).
+    payments = _mod(
+        "payments", "capability", {"refund_order": _allow(), "lookup_order": _allow()}
+    )
+    leaf = _mod("leaf", "capability", {"send_email": _allow()})
+
+    effective, trace = link([ceiling], [payments, leaf])
+
+    # refund_order is in the ceiling AND granted → allowed (capped).
+    assert evaluate_tool_call(effective, "refund_order", {"amount": 500}).outcome is (
+        DecisionOutcome.ALLOW
+    )
+    assert evaluate_tool_call(effective, "lookup_order", {}).outcome is (
+        DecisionOutcome.DENY
+    )
+    assert evaluate_tool_call(effective, "send_email", {}).outcome is (
+        DecisionOutcome.DENY
+    )
+    # and the shadowing is attributed to the ceiling for the analyzer.
+    assert "lookup_order" in trace.shadowed
+    assert trace.shadowed["lookup_order"].module == "org.ceiling"
+
+
+# --- combining rules ---
+
+
+def test_two_capabilities_union():
+    """Two grants for one tool union: allowed if EITHER condition holds."""
+    usd = _mod("usd", "capability", {"refund": _allow(['args.currency == "USD"'])})
+    eur = _mod("eur", "capability", {"refund": _allow(['args.currency == "EUR"'])})
+    effective, _ = link([], [usd, eur])
+
+    assert evaluate_tool_call(effective, "refund", {"currency": "USD"}).outcome is (
+        DecisionOutcome.ALLOW
+    )
+    assert evaluate_tool_call(effective, "refund", {"currency": "EUR"}).outcome is (
+        DecisionOutcome.ALLOW
+    )
+    assert evaluate_tool_call(effective, "refund", {"currency": "GBP"}).outcome is (
+        DecisionOutcome.DENY
+    )
+
+
+def test_two_guardrails_intersect_stricter_cap():
+    """Two ceilings on one tool intersect: the stricter bound wins."""
+    g1 = _mod("g1", "guardrail", {"refund": _allow(["args.amount <= 1000"])})
+    g2 = _mod("g2", "guardrail", {"refund": _allow(["args.amount <= 500"])})
+    grant = _mod("cap", "capability", {"refund": _allow()})
+    effective, _ = link([g1, g2], [grant])
+
+    assert evaluate_tool_call(effective, "refund", {"amount": 400}).outcome is (
+        DecisionOutcome.ALLOW
+    )
+    assert evaluate_tool_call(effective, "refund", {"amount": 700}).outcome is (
+        DecisionOutcome.DENY  # over the stricter 500 cap
+    )
+
+
+def test_unconditional_guardrail_deny_is_absolute():
+    """A guardrail deny beats any capability grant."""
+    guard = _mod("g", "guardrail", {"wire": _deny()}, default_mode="allow")
+    grant = _mod("c", "capability", {"wire": _allow()})
+    effective, _ = link([guard], [grant])
+    assert evaluate_tool_call(effective, "wire", {}).outcome is DecisionOutcome.DENY
+
+
+def test_conditional_guardrail_deny_subtracts_region():
+    """A guardrail deny WITH constraints subtracts that region from the grant."""
+    guard = _mod(
+        "g",
+        "guardrail",
+        {"refund": _deny(["args.amount > 1000"])},
+        default_mode="allow",
+    )
+    grant = _mod("c", "capability", {"refund": _allow()})
+    effective, _ = link([guard], [grant])
+    assert evaluate_tool_call(effective, "refund", {"amount": 500}).outcome is (
+        DecisionOutcome.ALLOW
+    )
+    assert evaluate_tool_call(effective, "refund", {"amount": 2000}).outcome is (
+        DecisionOutcome.DENY
+    )
+
+
+def test_capability_deny_raises():
+    """Capabilities may only grant — a deny is a config error, not a silent tighten."""
+    bad = _mod("bad", "capability", {"refund": _deny()})
+    with pytest.raises(LinkError, match="capabilities may only grant"):
+        link([], [bad])
+
+
+# --- provenance + policy-set wiring ---
+
+
+def test_provenance_records_contributing_layers(floor_bundle):
+    _, trace = link(*floor_bundle)
+    contributors = {p.module for p in trace.contributors["refund_order"]}
+    assert contributors == {"org.core", "payments"}
+
+
+def test_link_policy_set_merges_consts_and_builds_default_role():
+    guard = _mod(
+        "g",
+        "guardrail",
+        {"refund": _allow(["args.amount <= consts.cap"])},
+        consts={"cap": 1000},
+    )
+    grant = _mod("c", "capability", {"refund": _allow()})
+    result = link_policy_set([guard], [grant])
+    assert "default" in result.policy_set.roles
+    assert result.effective["default"].consts == {"cap": 1000}
+    # const-ref validation (PolicySet construction) didn't reject it.
+    assert (
+        result.policy_set.evaluate(
+            role="default", tool="refund", args={"amount": 500}
+        ).outcome
+        is DecisionOutcome.ALLOW
+    )
+
+
+# --- parity: the resolved policy evaluates identically on both engines ---
+
+
+@needs_opa
+def test_resolved_policy_parity_pydantic_vs_wasm(floor_bundle):
+    """Resolve → compile → wasm must agree with the pydantic engine, so the
+    linker's assembled constraints (nested parens, top-level OR, `not(...)`)
+    survive the Rego/WASM round-trip."""
+    from hexgate.security import (
+        compile_to_rego,
+        compile_to_wasm,
+        verdict_from_rego,
+    )
+    from hexgate.security.wasm_engine import WasmPolicy
+
+    result = link_policy_set(*floor_bundle)
+    payload = result.effective["default"].model_dump(mode="json")
+    wasm = compile_to_wasm(compile_to_rego(payload)).wasm
+    engine = WasmPolicy.from_bytes(wasm)
+
+    cases = [
+        ("refund_order", {"amount": 800, "currency": "USD"}),
+        ("refund_order", {"amount": 1200, "currency": "USD"}),
+        ("refund_order", {"amount": 800, "currency": "GBP"}),
+        ("delete_database", {}),
+        ("lookup_order", {}),
+        ("send_email", {}),
+    ]
+    for tool, args in cases:
+        pyd = result.policy_set.evaluate(role="default", tool=tool, args=args)
+        wsm = verdict_from_rego(
+            engine.decide(role="default", tool=tool, args=args),
+            tool_name=tool,
+            role="default",
+        )
+        assert pyd.outcome is wsm.outcome, (tool, args)

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -229,6 +229,37 @@ def test_capability_cannot_override_guardrail_const():
         link([guard], [cap])
 
 
+def test_ceiling_conditional_deny_only_does_not_grant_eligibility():
+    """A ceiling that mentions a tool ONLY via a conditional deny must not let a
+    capability grant slip through — the tool isn't in the ceiling's allow set."""
+    ceiling = _mod(
+        "org",
+        "guardrail",
+        {"refund": _deny(["args.amount > 10000"])},  # conditional deny, no allow
+        default_mode="deny",  # ceiling
+    )
+    cap = _mod("c", "capability", {"refund": _allow()})
+    effective, trace = link([ceiling], [cap])
+    # ineligible: the ceiling never granted refund, so a $5000 refund is denied.
+    assert evaluate_tool_call(effective, "refund", {"amount": 5000}).outcome is (
+        DecisionOutcome.DENY
+    )
+    assert "refund" in trace.shadowed
+
+
+def test_two_guardrails_conflicting_const_raises():
+    """Two guardrails disagreeing on a const value must not silently last-win."""
+    g1 = _mod(
+        "org",
+        "guardrail",
+        {"refund": _allow(["args.amount <= consts.cap"])},
+        consts={"cap": 100},
+    )
+    g2 = _mod("team", "guardrail", {"lookup": _allow()}, consts={"cap": 100000})
+    with pytest.raises(LinkError, match="conflicting values"):
+        link([g1, g2], [])
+
+
 def test_matching_const_across_tiers_is_allowed():
     """Same const value in both tiers is harmless — only a differing value errors."""
     guard = _mod(

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -2,11 +2,11 @@
 
 The fold is the crown jewel, so these are pure (no opa needed) except the final
 parity test. Fixtures mirror ``policy-modules-plan.md``'s worked example, with
-the two guardrail postures kept internally consistent:
+the two boundary postures kept internally consistent:
 
-- **floor** guardrail (``default_policy: allow``) — only subtracts what it names;
+- **floor** boundary (``default_policy: allow``) — only subtracts what it names;
   unlisted tools pass through to capabilities.
-- **ceiling** guardrail (``default_policy: deny``) — a tool it doesn't list is
+- **ceiling** boundary (``default_policy: deny``) — a tool it doesn't list is
   ineligible, so a capability grant for it is inert (shadowed).
 """
 
@@ -57,14 +57,14 @@ def _approval():
     return BaseToolPolicy(mode="approval_required")
 
 
-# --- floor guardrail: the worked-example table (unlisted tools pass through) ---
+# --- floor boundary: the worked-example table (unlisted tools pass through) ---
 
 
 @pytest.fixture
 def floor_bundle():
-    guardrail = _mod(
+    boundary = _mod(
         "org.core",
-        "guardrail",
+        "boundary",
         {
             "delete_database": _deny(),
             "refund_order": _allow(["args.amount <= 1000"]),
@@ -84,7 +84,7 @@ def floor_bundle():
         "capability",
         {"send_email": _allow(), "escalate": _approval()},
     )
-    return [guardrail], [payments, leaf]
+    return [boundary], [payments, leaf]
 
 
 @pytest.mark.parametrize(
@@ -112,13 +112,13 @@ def test_floor_refund_intersects_ceiling_and_grant(floor_bundle):
     assert any("currency" in c for c in cons)
 
 
-# --- ceiling guardrail: a tool it doesn't list is ineligible ---
+# --- ceiling boundary: a tool it doesn't list is ineligible ---
 
 
 def test_ceiling_gates_eligibility_and_records_shadow():
     ceiling = _mod(
         "org.ceiling",
-        "guardrail",
+        "boundary",
         {
             "delete_database": _deny(),
             "refund_order": _allow(["args.amount <= 1000"]),
@@ -168,10 +168,10 @@ def test_two_capabilities_union():
     )
 
 
-def test_two_guardrails_intersect_stricter_cap():
+def test_two_boundaries_intersect_stricter_cap():
     """Two ceilings on one tool intersect: the stricter bound wins."""
-    g1 = _mod("g1", "guardrail", {"refund": _allow(["args.amount <= 1000"])})
-    g2 = _mod("g2", "guardrail", {"refund": _allow(["args.amount <= 500"])})
+    g1 = _mod("g1", "boundary", {"refund": _allow(["args.amount <= 1000"])})
+    g2 = _mod("g2", "boundary", {"refund": _allow(["args.amount <= 500"])})
     grant = _mod("cap", "capability", {"refund": _allow()})
     effective, _ = link([g1, g2], [grant])
 
@@ -183,19 +183,19 @@ def test_two_guardrails_intersect_stricter_cap():
     )
 
 
-def test_unconditional_guardrail_deny_is_absolute():
-    """A guardrail deny beats any capability grant."""
-    guard = _mod("g", "guardrail", {"wire": _deny()}, default_mode="allow")
+def test_unconditional_boundary_deny_is_absolute():
+    """A boundary deny beats any capability grant."""
+    guard = _mod("g", "boundary", {"wire": _deny()}, default_mode="allow")
     grant = _mod("c", "capability", {"wire": _allow()})
     effective, _ = link([guard], [grant])
     assert evaluate_tool_call(effective, "wire", {}).outcome is DecisionOutcome.DENY
 
 
-def test_conditional_guardrail_deny_subtracts_region():
-    """A guardrail deny WITH constraints subtracts that region from the grant."""
+def test_conditional_boundary_deny_subtracts_region():
+    """A boundary deny WITH constraints subtracts that region from the grant."""
     guard = _mod(
         "g",
-        "guardrail",
+        "boundary",
         {"refund": _deny(["args.amount > 1000"])},
         default_mode="allow",
     )
@@ -216,16 +216,16 @@ def test_capability_deny_raises():
         link([], [bad])
 
 
-def test_capability_cannot_override_guardrail_const():
-    """A capability redefining a guardrail const would loosen a cap — reject it."""
+def test_capability_cannot_override_boundary_const():
+    """A capability redefining a boundary const would loosen a cap — reject it."""
     guard = _mod(
         "g",
-        "guardrail",
+        "boundary",
         {"refund": _allow(["args.amount <= consts.cap"])},
         consts={"cap": 1000},
     )
     cap = _mod("c", "capability", {"refund": _allow()}, consts={"cap": 1_000_000})
-    with pytest.raises(LinkError, match="may not override guardrail constants"):
+    with pytest.raises(LinkError, match="may not override boundary constants"):
         link([guard], [cap])
 
 
@@ -234,7 +234,7 @@ def test_ceiling_conditional_deny_only_does_not_grant_eligibility():
     capability grant slip through — the tool isn't in the ceiling's allow set."""
     ceiling = _mod(
         "org",
-        "guardrail",
+        "boundary",
         {"refund": _deny(["args.amount > 10000"])},  # conditional deny, no allow
         default_mode="deny",  # ceiling
     )
@@ -247,15 +247,15 @@ def test_ceiling_conditional_deny_only_does_not_grant_eligibility():
     assert "refund" in trace.shadowed
 
 
-def test_two_guardrails_conflicting_const_raises():
-    """Two guardrails disagreeing on a const value must not silently last-win."""
+def test_two_boundaries_conflicting_const_raises():
+    """Two boundaries disagreeing on a const value must not silently last-win."""
     g1 = _mod(
         "org",
-        "guardrail",
+        "boundary",
         {"refund": _allow(["args.amount <= consts.cap"])},
         consts={"cap": 100},
     )
-    g2 = _mod("team", "guardrail", {"lookup": _allow()}, consts={"cap": 100000})
+    g2 = _mod("team", "boundary", {"lookup": _allow()}, consts={"cap": 100000})
     with pytest.raises(LinkError, match="conflicting values"):
         link([g1, g2], [])
 
@@ -264,7 +264,7 @@ def test_matching_const_across_tiers_is_allowed():
     """Same const value in both tiers is harmless — only a differing value errors."""
     guard = _mod(
         "g",
-        "guardrail",
+        "boundary",
         {"refund": _allow(["args.amount <= consts.cap"])},
         consts={"cap": 1000},
     )
@@ -279,7 +279,7 @@ def test_file_scope_in_module_raises():
 
     guard = _mod(
         "g",
-        "guardrail",
+        "boundary",
         {
             "write_file": FileToolPolicy(
                 mode="allow", file_scope=FileScope(allowed_paths=["/tmp/**"])
@@ -302,7 +302,7 @@ def test_provenance_records_contributing_layers(floor_bundle):
 def test_link_policy_set_merges_consts_and_builds_default_role():
     guard = _mod(
         "g",
-        "guardrail",
+        "boundary",
         {"refund": _allow(["args.amount <= consts.cap"])},
         consts={"cap": 1000},
     )

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -216,6 +216,49 @@ def test_capability_deny_raises():
         link([], [bad])
 
 
+def test_capability_cannot_override_guardrail_const():
+    """A capability redefining a guardrail const would loosen a cap — reject it."""
+    guard = _mod(
+        "g",
+        "guardrail",
+        {"refund": _allow(["args.amount <= consts.cap"])},
+        consts={"cap": 1000},
+    )
+    cap = _mod("c", "capability", {"refund": _allow()}, consts={"cap": 1_000_000})
+    with pytest.raises(LinkError, match="may not override guardrail constants"):
+        link([guard], [cap])
+
+
+def test_matching_const_across_tiers_is_allowed():
+    """Same const value in both tiers is harmless — only a differing value errors."""
+    guard = _mod(
+        "g",
+        "guardrail",
+        {"refund": _allow(["args.amount <= consts.cap"])},
+        consts={"cap": 1000},
+    )
+    cap = _mod("c", "capability", {"refund": _allow()}, consts={"cap": 1000})
+    effective, _ = link([guard], [cap])
+    assert effective.consts["cap"] == 1000
+
+
+def test_file_scope_in_module_raises():
+    """file_scope can't survive composition yet — fail loud, don't silently drop."""
+    from hexgate.security import FileScope, FileToolPolicy
+
+    guard = _mod(
+        "g",
+        "guardrail",
+        {
+            "write_file": FileToolPolicy(
+                mode="allow", file_scope=FileScope(allowed_paths=["/tmp/**"])
+            )
+        },
+    )
+    with pytest.raises(LinkError, match="file_scope"):
+        link([guard], [])
+
+
 # --- provenance + policy-set wiring ---
 
 

--- a/tests/security/test_module_loader.py
+++ b/tests/security/test_module_loader.py
@@ -15,10 +15,10 @@ def _write(root: Path, rel: str, body: str) -> None:
     path.write_text(body, encoding="utf-8")
 
 
-def test_loads_guardrails_and_capabilities_with_correct_kinds(tmp_path):
+def test_loads_boundaries_and_capabilities_with_correct_kinds(tmp_path):
     _write(
         tmp_path,
-        "policies/guardrails/org.yaml",
+        "policies/boundaries/org.yaml",
         "default_policy: { mode: deny }\ntools:\n  delete_database: { mode: deny }\n",
     )
     _write(
@@ -27,13 +27,13 @@ def test_loads_guardrails_and_capabilities_with_correct_kinds(tmp_path):
         "tools:\n  refund_order: { mode: allow }\n",
     )
 
-    guardrails, capabilities = load_local_modules(tmp_path)
+    boundaries, capabilities = load_local_modules(tmp_path)
 
-    assert [g.name for g in guardrails] == ["org"]
-    assert guardrails[0].kind == "guardrail"
+    assert [g.name for g in boundaries] == ["org"]
+    assert boundaries[0].kind == "boundary"
     assert [c.name for c in capabilities] == ["payments"]
     assert capabilities[0].kind == "capability"
-    assert "delete_database" in guardrails[0].policy.tools
+    assert "delete_database" in boundaries[0].policy.tools
 
 
 def test_content_hash_is_stable_and_distinct(tmp_path):
@@ -49,15 +49,15 @@ def test_content_hash_is_stable_and_distinct(tmp_path):
 
 
 def test_missing_directories_return_empty(tmp_path):
-    guardrails, capabilities = load_local_modules(tmp_path)
-    assert guardrails == []
+    boundaries, capabilities = load_local_modules(tmp_path)
+    assert boundaries == []
     assert capabilities == []
 
 
 def test_only_one_tier_present(tmp_path):
-    _write(tmp_path, "policies/guardrails/g.yaml", "tools:\n  t: { mode: deny }\n")
-    guardrails, capabilities = load_local_modules(tmp_path)
-    assert len(guardrails) == 1
+    _write(tmp_path, "policies/boundaries/g.yaml", "tools:\n  t: { mode: deny }\n")
+    boundaries, capabilities = load_local_modules(tmp_path)
+    assert len(boundaries) == 1
     assert capabilities == []
 
 
@@ -78,9 +78,9 @@ def test_malformed_yaml_names_the_offending_file(tmp_path):
 
 
 def test_yml_extension_is_loaded(tmp_path):
-    _write(tmp_path, "policies/guardrails/org.yml", "tools:\n  t: { mode: deny }\n")
-    guardrails, _ = load_local_modules(tmp_path)
-    assert [g.name for g in guardrails] == ["org"]
+    _write(tmp_path, "policies/boundaries/org.yml", "tools:\n  t: { mode: deny }\n")
+    boundaries, _ = load_local_modules(tmp_path)
+    assert [g.name for g in boundaries] == ["org"]
 
 
 def test_unquoted_yaml_date_does_not_crash_hashing(tmp_path):

--- a/tests/security/test_module_loader.py
+++ b/tests/security/test_module_loader.py
@@ -69,3 +69,30 @@ def test_invalid_module_names_the_offending_file(tmp_path):
     )
     with pytest.raises(ValueError, match="broken.yaml"):
         load_local_modules(tmp_path)
+
+
+def test_malformed_yaml_names_the_offending_file(tmp_path):
+    _write(tmp_path, "policies/capabilities/bad.yaml", "tools: [unclosed\n")
+    with pytest.raises(ValueError, match="bad.yaml"):
+        load_local_modules(tmp_path)
+
+
+def test_yml_extension_is_loaded(tmp_path):
+    _write(tmp_path, "policies/guardrails/org.yml", "tools:\n  t: { mode: deny }\n")
+    guardrails, _ = load_local_modules(tmp_path)
+    assert [g.name for g in guardrails] == ["org"]
+
+
+def test_nested_same_stem_modules_stay_distinct(tmp_path):
+    _write(
+        tmp_path,
+        "policies/capabilities/team_a/refunds.yaml",
+        "tools:\n  r: { mode: allow }\n",
+    )
+    _write(
+        tmp_path,
+        "policies/capabilities/team_b/refunds.yaml",
+        "tools:\n  s: { mode: allow }\n",
+    )
+    _, capabilities = load_local_modules(tmp_path)
+    assert sorted(c.name for c in capabilities) == ["team_a/refunds", "team_b/refunds"]

--- a/tests/security/test_module_loader.py
+++ b/tests/security/test_module_loader.py
@@ -1,0 +1,71 @@
+"""Tests for the local-files module loader (the SDK / dev seam)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hexgate.security import load_local_modules
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_loads_guardrails_and_capabilities_with_correct_kinds(tmp_path):
+    _write(
+        tmp_path,
+        "policies/guardrails/org.yaml",
+        "default_policy: { mode: deny }\ntools:\n  delete_database: { mode: deny }\n",
+    )
+    _write(
+        tmp_path,
+        "policies/capabilities/payments.yaml",
+        "tools:\n  refund_order: { mode: allow }\n",
+    )
+
+    guardrails, capabilities = load_local_modules(tmp_path)
+
+    assert [g.name for g in guardrails] == ["org"]
+    assert guardrails[0].kind == "guardrail"
+    assert [c.name for c in capabilities] == ["payments"]
+    assert capabilities[0].kind == "capability"
+    assert "delete_database" in guardrails[0].policy.tools
+
+
+def test_content_hash_is_stable_and_distinct(tmp_path):
+    _write(tmp_path, "policies/capabilities/a.yaml", "tools:\n  x: { mode: allow }\n")
+    _write(tmp_path, "policies/capabilities/b.yaml", "tools:\n  y: { mode: allow }\n")
+
+    first = load_local_modules(tmp_path)[1]
+    second = load_local_modules(tmp_path)[1]
+
+    by_name = {m.name: m.content_hash for m in first}
+    assert by_name == {m.name: m.content_hash for m in second}  # stable across runs
+    assert by_name["a"] != by_name["b"]  # distinct content → distinct hash
+
+
+def test_missing_directories_return_empty(tmp_path):
+    guardrails, capabilities = load_local_modules(tmp_path)
+    assert guardrails == []
+    assert capabilities == []
+
+
+def test_only_one_tier_present(tmp_path):
+    _write(tmp_path, "policies/guardrails/g.yaml", "tools:\n  t: { mode: deny }\n")
+    guardrails, capabilities = load_local_modules(tmp_path)
+    assert len(guardrails) == 1
+    assert capabilities == []
+
+
+def test_invalid_module_names_the_offending_file(tmp_path):
+    _write(
+        tmp_path,
+        "policies/capabilities/broken.yaml",
+        "tools:\n  refund: { mode: allow, constraints: ['args.amount =< 1'] }\n",
+    )
+    with pytest.raises(ValueError, match="broken.yaml"):
+        load_local_modules(tmp_path)

--- a/tests/security/test_module_loader.py
+++ b/tests/security/test_module_loader.py
@@ -83,6 +83,18 @@ def test_yml_extension_is_loaded(tmp_path):
     assert [g.name for g in guardrails] == ["org"]
 
 
+def test_unquoted_yaml_date_does_not_crash_hashing(tmp_path):
+    """A YAML date scalar becomes datetime.date; hashing it must not raise."""
+    _write(
+        tmp_path,
+        "policies/capabilities/dated.yaml",
+        "consts: { window_start: 2026-01-01 }\ntools:\n  t: { mode: allow }\n",
+    )
+    _, capabilities = load_local_modules(tmp_path)
+    assert len(capabilities) == 1
+    assert capabilities[0].content_hash  # computed, no TypeError
+
+
 def test_nested_same_stem_modules_stay_distinct(tmp_path):
     _write(
         tmp_path,


### PR DESCRIPTION
First of 3 PRs adding **multi-module policy**: instead of one policy file per agent, an agent's policy becomes a stack of independently-authored modules that compose into one effective policy.

- **PR 1 (this one)** — SDK core: the module model + the linker.
- **PR 2** — analyzer: lints (dead / shadowed / conflicting rules), all file-attributed.
- **PR 3** — dashboard editor + resolved-policy view.

Everything here is SDK-side and fully local (no platform, no key).

## What it does

A bundle of boundary + capability modules is folded into a single `AgentPolicy`, which then compiles to Rego → WASM exactly as today. The composition happens at the model layer, so the engines only ever see one policy and the pydantic-vs-WASM parity gate is untouched.

```
many *.yaml modules            link()              one effective policy
  boundaries  (caps + denies) ──────▶  fold  ──────▶  AgentPolicy  ──▶ rego ──▶ wasm ──▶ signed bundle
  capabilities (grants)          (the new step)                        (all unchanged)
```

Two tiers, one rule set: **fences intersect, grants union, denies win.**

- **Boundaries** cap and hard-deny (cf. AWS permissions boundary). A boundary `allow` is a ceiling (a cap), not a grant.
- **Capabilities** only grant. A capability that tries to `deny` is a hard error, so a lower-authority layer can never loosen a boundary.

You can drive it end to end:

```
hexgate policy resolve --dir deploy/demo_policies    # prints the effective policy + provenance
marimo edit deploy/policy_modules_demo.py            # interactive tour
```

## Important files (suggested review order)

| File | What to look at |
| --- | --- |
| `hexgate/security/linker.py` | The fold. Start here — `_fold_tool` is the whole thing. |
| `hexgate/security/modules.py` | Data model: `ModuleContent`, provenance, `LinkResult`. |
| `hexgate/security/module_loader.py` | Local-files loader (the seam the platform swaps later). |
| `hexgate/cli/policy/main.py` | `hexgate policy resolve` — the inspection command. |
| `tests/security/test_linker.py` | Fold behavior, ceiling/floor, and the pydantic-vs-WASM parity check. |
| `docs/internals/policy-modules.md` | Architecture + reconciliation rules. |
| `deploy/policy_modules_demo.py` | Runnable marimo demo + sample bundle. |

## Notes

- "boundary" (not "guardrail") for the security-owned tier, to avoid collision with LLM content/safety guardrails and with the ceiling/floor posture.
- Not wired into the platform or versioning yet — that's later. `default_policy` "floor" is expressed as `mode: allow` for now (no dedicated sentinel).
- Full security suite green (909 tests, incl. an opa-gated parity test on resolved policies).
