### PR TITLE
docs(sdk): replace readme decision-flow ascii diagram with svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,10 @@ Hexgate is two things that move together:
 
 You can use the SDK three ways: **local** (YAML/bundle on disk, no platform), **Hexgate Cloud** (remote enforcement + audit — just set `HEXGATE_API_KEY`), or **self-hosted** (run the control plane yourself). `HEXGATE_API_URL` defaults to `https://app.hexgate.ai`, so remote enforcement is one env var away.
 
-```text
-   end user (id + role)          tool call (name + args)
-            └───────────────┬────────────────┘
-                            ▼
-              PolicyEnforcer.decide()  ◄──  policy (local YAML / bundle
-                            ▼                or signed cloud bundle)
-            allow  ·  deny  ·  approval
-                            │
-                            ▼
-      audit log — who called what, and whether it was allowed
-```
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./assets/decision-flow-dark.svg">
+  <img src="./assets/decision-flow-light.svg" alt="End user and tool call merge into PolicyEnforcer.decide(), checked against policy on its right edge, resolving to allow, deny, or approval, always recorded to the audit log." />
+</picture>
 
 ## Quickstart
 

--- a/assets/decision-flow-dark.svg
+++ b/assets/decision-flow-dark.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 370" role="img" aria-label="End user and tool call merge into PolicyEnforcer.decide(), checked against policy on its right edge, resolving to allow, deny, or approval, always recorded to the audit log.">
+  <defs>
+    <marker id="df-arrow-dark" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#8b958d"></path>
+    </marker>
+  </defs>
+
+  <rect x="6" y="6" width="688" height="358" rx="2" fill="#171f1b" stroke="#2b3630"></rect>
+  <path d="M6,20 L6,6 L20,6" fill="none" stroke="#5fb3a9" stroke-width="2"></path>
+  <path d="M694,20 L694,6 L680,6" fill="none" stroke="#5fb3a9" stroke-width="2"></path>
+  <path d="M6,350 L6,364 L20,364" fill="none" stroke="#5fb3a9" stroke-width="2"></path>
+  <path d="M694,350 L694,364 L680,364" fill="none" stroke="#5fb3a9" stroke-width="2"></path>
+
+  <path d="M150,76 V104 H530 V76" fill="none" stroke="#8b958d" stroke-width="1.5"></path>
+  <line x1="340" y1="104" x2="340" y2="132" stroke="#8b958d" stroke-width="1.5" marker-end="url(#df-arrow-dark)"></line>
+  <line x1="340" y1="196" x2="340" y2="214" stroke="#8b958d" stroke-width="1.5" marker-end="url(#df-arrow-dark)"></line>
+  <line x1="340" y1="238" x2="340" y2="260" stroke="#8b958d" stroke-width="1.5" marker-end="url(#df-arrow-dark)"></line>
+  <line x1="470" y1="168" x2="452" y2="168" stroke="#8b958d" stroke-width="1.5" marker-end="url(#df-arrow-dark)"></line>
+
+  <rect x="20" y="20" width="260" height="56" rx="2" fill="#171f1b" stroke="#2b3630"></rect>
+  <text x="150" y="53" text-anchor="middle" dominant-baseline="middle" fill="#e7ece6" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14">end user (id + role)</text>
+
+  <rect x="400" y="20" width="260" height="56" rx="2" fill="#171f1b" stroke="#2b3630"></rect>
+  <text x="530" y="53" text-anchor="middle" dominant-baseline="middle" fill="#e7ece6" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14">tool call (name + args)</text>
+
+  <rect x="230" y="140" width="220" height="56" rx="2" fill="#171f1b" stroke="#5fb3a9" stroke-width="1.5"></rect>
+  <text x="340" y="168" text-anchor="middle" dominant-baseline="middle" fill="#e7ece6" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14" font-weight="600">PolicyEnforcer.decide()</text>
+
+  <text x="480" y="161" fill="#8b958d" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="12.5">policy (local YAML / bundle</text>
+  <text x="480" y="177" fill="#8b958d" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="12.5">or signed cloud bundle)</text>
+
+  <text y="228" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14">
+    <tspan x="290" text-anchor="end" fill="#52c176" font-weight="600">allow</tspan>
+    <tspan x="319" text-anchor="end" fill="#2b3630"> &#183; </tspan>
+    <tspan x="340" text-anchor="middle" fill="#e2685a" font-weight="600">deny</tspan>
+    <tspan x="361" text-anchor="start" fill="#2b3630"> &#183; </tspan>
+    <tspan x="390" text-anchor="start" fill="#e0a83e" font-weight="600">approval</tspan>
+  </text>
+
+  <rect x="140" y="262" width="400" height="80" rx="2" fill="#171f1b" stroke="#5fb3a9" stroke-width="1.5"></rect>
+  <text x="340" y="292" text-anchor="middle" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="15" font-weight="700" fill="#e7ece6">audit log</text>
+  <text x="340" y="314" text-anchor="middle" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="12.5" fill="#8b958d">who called what, and whether it was allowed</text>
+</svg>

--- a/assets/decision-flow-light.svg
+++ b/assets/decision-flow-light.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 700 370" role="img" aria-label="End user and tool call merge into PolicyEnforcer.decide(), checked against policy on its right edge, resolving to allow, deny, or approval, always recorded to the audit log.">
+  <defs>
+    <marker id="df-arrow-light" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#5c6660"></path>
+    </marker>
+  </defs>
+
+  <rect x="6" y="6" width="688" height="358" rx="2" fill="#f7f8f4" stroke="#c9cfc5"></rect>
+  <path d="M6,20 L6,6 L20,6" fill="none" stroke="#235c57" stroke-width="2"></path>
+  <path d="M694,20 L694,6 L680,6" fill="none" stroke="#235c57" stroke-width="2"></path>
+  <path d="M6,350 L6,364 L20,364" fill="none" stroke="#235c57" stroke-width="2"></path>
+  <path d="M694,350 L694,364 L680,364" fill="none" stroke="#235c57" stroke-width="2"></path>
+
+  <path d="M150,76 V104 H530 V76" fill="none" stroke="#5c6660" stroke-width="1.5"></path>
+  <line x1="340" y1="104" x2="340" y2="132" stroke="#5c6660" stroke-width="1.5" marker-end="url(#df-arrow-light)"></line>
+  <line x1="340" y1="196" x2="340" y2="214" stroke="#5c6660" stroke-width="1.5" marker-end="url(#df-arrow-light)"></line>
+  <line x1="340" y1="238" x2="340" y2="260" stroke="#5c6660" stroke-width="1.5" marker-end="url(#df-arrow-light)"></line>
+  <line x1="470" y1="168" x2="452" y2="168" stroke="#5c6660" stroke-width="1.5" marker-end="url(#df-arrow-light)"></line>
+
+  <rect x="20" y="20" width="260" height="56" rx="2" fill="#f7f8f4" stroke="#c9cfc5"></rect>
+  <text x="150" y="53" text-anchor="middle" dominant-baseline="middle" fill="#1b2420" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14">end user (id + role)</text>
+
+  <rect x="400" y="20" width="260" height="56" rx="2" fill="#f7f8f4" stroke="#c9cfc5"></rect>
+  <text x="530" y="53" text-anchor="middle" dominant-baseline="middle" fill="#1b2420" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14">tool call (name + args)</text>
+
+  <rect x="230" y="140" width="220" height="56" rx="2" fill="#f7f8f4" stroke="#235c57" stroke-width="1.5"></rect>
+  <text x="340" y="168" text-anchor="middle" dominant-baseline="middle" fill="#1b2420" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14" font-weight="600">PolicyEnforcer.decide()</text>
+
+  <text x="480" y="161" fill="#5c6660" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="12.5">policy (local YAML / bundle</text>
+  <text x="480" y="177" fill="#5c6660" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="12.5">or signed cloud bundle)</text>
+
+  <text y="228" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="14">
+    <tspan x="290" text-anchor="end" fill="#2f7d46" font-weight="600">allow</tspan>
+    <tspan x="319" text-anchor="end" fill="#c9cfc5"> &#183; </tspan>
+    <tspan x="340" text-anchor="middle" fill="#b23a2e" font-weight="600">deny</tspan>
+    <tspan x="361" text-anchor="start" fill="#c9cfc5"> &#183; </tspan>
+    <tspan x="390" text-anchor="start" fill="#a8710f" font-weight="600">approval</tspan>
+  </text>
+
+  <rect x="140" y="262" width="400" height="80" rx="2" fill="#f7f8f4" stroke="#235c57" stroke-width="1.5"></rect>
+  <text x="340" y="292" text-anchor="middle" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="15" font-weight="700" fill="#1b2420">audit log</text>
+  <text x="340" y="314" text-anchor="middle" font-family="ui-monospace, 'SF Mono', 'Cascadia Code', Menlo, Consolas, monospace" font-size="12.5" fill="#5c6660">who called what, and whether it was allowed</text>
+</svg>


### PR DESCRIPTION
## What is changing?
The ASCII README diagram is replaced with a SVG diagram.

Ships as light/dark variants via <picture> so it renders correctly in both GitHub themes.