### PR TITLE
test(sdk): add live integration tests for all four framework adapters

### DIFF
--- a/hexgate/adapters/_common.py
+++ b/hexgate/adapters/_common.py
@@ -10,20 +10,41 @@ import asyncio
 from typing import Any
 
 from hexgate.runtime import User
+from hexgate.tracing._senders import DEFAULT_DRAIN_TIMEOUT, pending_send_tasks
 
 
-def drain_pending_tasks(loop: asyncio.AbstractEventLoop) -> None:
-    """Give any still-pending tasks on ``loop`` one last chance to finish.
+def drain_pending_tasks(
+    loop: asyncio.AbstractEventLoop, *, drain_timeout: float = DEFAULT_DRAIN_TIMEOUT
+) -> None:
+    """Give hexgate's own still-pending audit-send tasks on ``loop`` one
+    last chance to finish.
 
     A fire-and-forget audit-send (policy decision / LLM usage) from the
     last turn can still be scheduled and pending once the top-level run
     settles, with nothing left to pump the loop for it — silently
-    abandoned otherwise. ``return_exceptions=True`` so a failed send can't
-    raise out of here and crash the caller's run.
+    abandoned otherwise. Scoped to ``pending_send_tasks(loop)`` rather than
+    every task on the loop — ``loop`` is a thread's shared default loop,
+    not one hexgate owns exclusively, and awaiting (or, on timeout,
+    cancelling) a caller's unrelated task would be a surprising, unrelated
+    side effect. ``return_exceptions=True`` so a failed send can't raise
+    out of here and crash the caller's run.
+
+    Bounded by ``drain_timeout``: an unreachable platform can hold a send
+    open for well over 10s (POST timeout, then a 503 jitter sleep, then a
+    retry POST), and this runs synchronously inside the caller's
+    ``run_sync()`` — a dropped audit event beats hanging its return.
     """
-    pending = asyncio.all_tasks(loop)
-    if pending:
-        loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+    pending = pending_send_tasks(loop)
+    if not pending:
+        return
+    try:
+        loop.run_until_complete(
+            asyncio.wait_for(
+                asyncio.gather(*pending, return_exceptions=True), drain_timeout
+            )
+        )
+    except TimeoutError:
+        pass
 
 
 def langfuse_propagate_kwargs(user: User, tag: str) -> dict[str, Any]:

--- a/hexgate/adapters/_common.py
+++ b/hexgate/adapters/_common.py
@@ -1,0 +1,37 @@
+"""Internal helpers shared across all four framework adapters.
+
+Not part of the public API — each adapter's own module is the supported
+import surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from hexgate.runtime import User
+
+
+def drain_pending_tasks(loop: asyncio.AbstractEventLoop) -> None:
+    """Give any still-pending tasks on ``loop`` one last chance to finish.
+
+    A fire-and-forget audit-send (policy decision / LLM usage) from the
+    last turn can still be scheduled and pending once the top-level run
+    settles, with nothing left to pump the loop for it — silently
+    abandoned otherwise. ``return_exceptions=True`` so a failed send can't
+    raise out of here and crash the caller's run.
+    """
+    pending = asyncio.all_tasks(loop)
+    if pending:
+        loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+
+
+def langfuse_propagate_kwargs(user: User, tag: str) -> dict[str, Any]:
+    """Build the ``propagate_attributes(**kwargs)`` mapping for a Langfuse
+    span tagged ``tag``, carrying the active User's identity."""
+    return {
+        "tags": [tag],
+        "user_id": user.user_id,
+        "session_id": user.session_id,
+        "metadata": {"user_role": user.role},
+    }

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -16,6 +16,7 @@ from google.genai import types
 from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
+from hexgate.adapters._common import drain_pending_tasks, langfuse_propagate_kwargs
 from hexgate.adapters.google.usage import HexgateUsagePlugin
 from hexgate.adapters.google.wrapper import wrap_google_agent
 from hexgate.approvals import ApprovalHandler
@@ -80,11 +81,9 @@ class HexgateRunner:
     @contextmanager
     def _propagate(self, user: User):
         """Propagate User identity into Langfuse spans for the block."""
-        kwargs: dict[str, Any] = {"tags": [f"google.runner.run.{self._agent_name}"]}
-        kwargs["user_id"] = user.user_id
-        kwargs["session_id"] = user.session_id
-        kwargs["metadata"] = {"user_role": user.role}
-        with propagate_attributes(**kwargs):
+        with propagate_attributes(
+            **langfuse_propagate_kwargs(user, f"google.runner.run.{self._agent_name}")
+        ):
             yield
 
     def run(
@@ -127,11 +126,7 @@ class HexgateRunner:
                 # background while it completes. Give it one last chance
                 # before tearing the loop down, or its event is silently
                 # dropped.
-                pending = asyncio.all_tasks(loop)
-                if pending:
-                    loop.run_until_complete(
-                        asyncio.gather(*pending, return_exceptions=True)
-                    )
+                drain_pending_tasks(loop)
                 loop.close()
 
     async def run_async(

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -121,6 +121,17 @@ class HexgateRunner:
                         break
             finally:
                 loop.run_until_complete(agen.aclose())
+                # The last turn's fire-and-forget audit-send task (policy
+                # decision / LLM usage) may still be in flight — there's no
+                # further turn left to keep this loop spinning in the
+                # background while it completes. Give it one last chance
+                # before tearing the loop down, or its event is silently
+                # dropped.
+                pending = asyncio.all_tasks(loop)
+                if pending:
+                    loop.run_until_complete(
+                        asyncio.gather(*pending, return_exceptions=True)
+                    )
                 loop.close()
 
     async def run_async(

--- a/hexgate/adapters/langchain/agent.py
+++ b/hexgate/adapters/langchain/agent.py
@@ -9,6 +9,7 @@ from langfuse import get_client, propagate_attributes
 from langfuse.langchain import CallbackHandler
 from langgraph.graph.state import CompiledStateGraph
 
+from hexgate.adapters._common import langfuse_propagate_kwargs
 from hexgate.adapters.langchain.usage import HexgateUsageCallbackHandler
 from hexgate.runtime import User
 
@@ -69,12 +70,7 @@ class HexgateLangchainAgent:
             self._ban_gate.check(user)
 
     def _propagate_kwargs(self, user: User, method: str) -> dict[str, Any]:
-        return {
-            "tags": [f"langchain.agent.{method}"],
-            "user_id": user.user_id,
-            "session_id": user.session_id,
-            "metadata": {"user_role": user.role},
-        }
+        return langfuse_propagate_kwargs(user, f"langchain.agent.{method}")
 
     def _with_callbacks(self, config: RunnableConfig | None) -> RunnableConfig:
         """Append the Hexgate callback handlers to ``config['callbacks']``."""

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -8,6 +8,7 @@ enforcer, so a refresh swap reaches every clone.
 """
 
 import asyncio
+import warnings
 from contextlib import contextmanager
 
 import nest_asyncio
@@ -215,13 +216,38 @@ class HexgateRunner:
         )
         with user.sync_scope():
             with self._propagate(user, agent.name):
-                return Runner.run_sync(
+                result = Runner.run_sync(
                     wrapped_agent,
                     input,
                     run_config=run_config,
                     hooks=self._merge_hooks(hooks),
                     **kwargs,
                 )
+        self._drain_default_loop()
+        return result
+
+    def _drain_default_loop(self) -> None:
+        """``AgentRunner.run_sync`` (the ``agents`` SDK) deliberately keeps
+        its per-thread default loop open across calls rather than closing
+        it, but ``run_until_complete`` only waits for the top-level run —
+        not sibling tasks on the same loop. The last turn's fire-and-forget
+        audit-send (policy decision / LLM usage) can still be scheduled and
+        pending when ``run_sync`` returns, with nothing left to pump the
+        loop for it. Give it one last chance here; don't close the loop —
+        the SDK expects to find the same one open on the next call.
+
+        No-ops when there's no current loop at all — that just means
+        ``Runner.run_sync`` never got to the point of creating/binding one
+        (e.g. it's mocked out in a test), so there's nothing to drain."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            try:
+                loop = asyncio.get_event_loop()
+            except RuntimeError:
+                return
+        pending = asyncio.all_tasks(loop)
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
 
     def run_streamed(
         self,

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -215,15 +215,16 @@ class HexgateRunner:
         )
         with user.sync_scope():
             with self._propagate(user, agent.name):
-                result = Runner.run_sync(
-                    wrapped_agent,
-                    input,
-                    run_config=run_config,
-                    hooks=self._merge_hooks(hooks),
-                    **kwargs,
-                )
-        self._drain_default_loop()
-        return result
+                try:
+                    return Runner.run_sync(
+                        wrapped_agent,
+                        input,
+                        run_config=run_config,
+                        hooks=self._merge_hooks(hooks),
+                        **kwargs,
+                    )
+                finally:
+                    self._drain_default_loop()
 
     def _drain_default_loop(self) -> None:
         """``AgentRunner.run_sync`` (the ``agents`` SDK) deliberately keeps

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -27,6 +27,7 @@ from agents.lifecycle import RunHooksBase
 from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
+from hexgate.adapters._common import drain_pending_tasks, langfuse_propagate_kwargs
 from hexgate.adapters.openai.usage import HexgateUsageHooks
 from hexgate.adapters.openai.wrapper import wrap_openai_agent
 from hexgate.approvals import ApprovalHandler
@@ -147,11 +148,9 @@ class HexgateRunner:
     @contextmanager
     def _propagate(self, user: User, agent_name: str):
         """Propagate User identity into Langfuse spans for the block."""
-        kwargs: dict[str, any] = {"tags": [f"openai.runner.run.{agent_name}"]}
-        kwargs["user_id"] = user.user_id
-        kwargs["session_id"] = user.session_id
-        kwargs["metadata"] = {"user_role": user.role}
-        with propagate_attributes(**kwargs):
+        with propagate_attributes(
+            **langfuse_propagate_kwargs(user, f"openai.runner.run.{agent_name}")
+        ):
             yield
 
     def _merge_hooks(self, hooks: RunHooks | None) -> RunHooks:
@@ -245,9 +244,7 @@ class HexgateRunner:
                 loop = asyncio.get_event_loop()
             except RuntimeError:
                 return
-        pending = asyncio.all_tasks(loop)
-        if pending:
-            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        drain_pending_tasks(loop)
 
     def run_streamed(
         self,

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -236,9 +236,12 @@ class HexgateRunner:
         loop for it. Give it one last chance here; don't close the loop —
         the SDK expects to find the same one open on the next call.
 
-        No-ops when there's no current loop at all — that just means
-        ``Runner.run_sync`` never got to the point of creating/binding one
-        (e.g. it's mocked out in a test), so there's nothing to drain."""
+        If ``Runner.run_sync`` is mocked out and never touches asyncio,
+        ``get_event_loop`` just hands back a freshly created, empty loop —
+        so there's simply nothing pending to drain. The ``RuntimeError``
+        guard instead covers callers with no loop set on the current
+        thread at all (e.g. a background thread, or a test that has
+        explicitly called ``asyncio.set_event_loop(None)``)."""
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             try:

--- a/hexgate/adapters/openai/usage.py
+++ b/hexgate/adapters/openai/usage.py
@@ -27,15 +27,18 @@ class HexgateUsageHooks(RunHooks):
         agent: Agent,
         response: ModelResponse,
     ) -> None:
-        # agent.model is `str | Model | None` — only the str case gives a
-        # clean name; a Model implementation has no guaranteed name field
-        # (agents.models.interface.Model exposes none). Fall back to the
-        # instance's class name rather than "" — the platform rejects an
-        # empty `model` outright (min_length=1), silently dropping the
-        # event.
-        model = (
-            agent.model if isinstance(agent.model, str) else type(agent.model).__name__
-        )
+        # agent.model is `str | Model | None`. None means the agent didn't
+        # set one and the runner/SDK default applies -- that default is
+        # resolved deep in the SDK's run loop and never reaches this hook,
+        # so "default" is an honest placeholder rather than a guess.
+        if isinstance(agent.model, str):
+            model = agent.model
+        elif agent.model is None:
+            model = "default"
+        else:
+            # Standard Model impls expose the real id in .model; class name is a
+            # last resort for an exotic Model that doesn't.
+            model = getattr(agent.model, "model", None) or type(agent.model).__name__
         emit_llm_usage(
             agent.name,
             model,

--- a/hexgate/adapters/openai/usage.py
+++ b/hexgate/adapters/openai/usage.py
@@ -28,8 +28,14 @@ class HexgateUsageHooks(RunHooks):
         response: ModelResponse,
     ) -> None:
         # agent.model is `str | Model | None` — only the str case gives a
-        # clean name; a Model implementation has no guaranteed name field.
-        model = agent.model if isinstance(agent.model, str) else ""
+        # clean name; a Model implementation has no guaranteed name field
+        # (agents.models.interface.Model exposes none). Fall back to the
+        # instance's class name rather than "" — the platform rejects an
+        # empty `model` outright (min_length=1), silently dropping the
+        # event.
+        model = (
+            agent.model if isinstance(agent.model, str) else type(agent.model).__name__
+        )
         emit_llm_usage(
             agent.name,
             model,

--- a/hexgate/adapters/pydantic_ai/agent.py
+++ b/hexgate/adapters/pydantic_ai/agent.py
@@ -10,6 +10,7 @@ from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRun, AgentRunResult
 from pydantic_ai.result import StreamedRunResult
 
+from hexgate.adapters._common import langfuse_propagate_kwargs
 from hexgate.adapters.pydantic_ai.usage import emit_run_usage
 from hexgate.runtime import User
 
@@ -70,12 +71,7 @@ class HexgatePydanticAgent:
         Agent.instrument_all()
 
     def _propagate_kwargs(self, user: User, method: str) -> dict[str, Any]:
-        return {
-            "tags": [f"pydantic_ai.agent.{method}"],
-            "user_id": user.user_id,
-            "session_id": user.session_id,
-            "metadata": {"user_role": user.role},
-        }
+        return langfuse_propagate_kwargs(user, f"pydantic_ai.agent.{method}")
 
     @asynccontextmanager
     async def _abind(self, user: User, method: str) -> AsyncIterator[None]:

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -22,6 +22,12 @@ from hexgate.config.env import resolve_api_key, resolve_api_url
 
 _log = logging.getLogger(__name__)
 
+DEFAULT_DRAIN_TIMEOUT = 5.0
+"""Default bound for waiting on already-scheduled fire-and-forget sends to
+finish — at process shutdown (:meth:`AuditSender.close`) or when an
+adapter's per-call drain (``hexgate.adapters._common.drain_pending_tasks``)
+gives the last turn's send one final chance before giving up on it."""
+
 
 class _PayloadEvent(Protocol):
     """Structural type for anything ``AuditSender`` can emit — a frozen
@@ -292,7 +298,7 @@ class AuditSender:
             with self._sync_lock:
                 self._sync_threads.discard(threading.current_thread())
 
-    async def close(self, drain_timeout: float = 5.0) -> None:
+    async def close(self, drain_timeout: float = DEFAULT_DRAIN_TIMEOUT) -> None:
         """Stop accepting new emits; drain in-flight tasks; close the HTTP clients."""
         # Flip _closing and snapshot _sync_threads as one atomic step, under
         # the same lock _spawn_sync_send uses for its own closing-recheck +
@@ -480,6 +486,28 @@ def get_sender(path: str, api_key: str | None = None) -> AuditSender | None:
     if not resolved_key:
         return None
     return _senders.get((resolved_key, path))
+
+
+def pending_send_tasks(loop: asyncio.AbstractEventLoop) -> set[asyncio.Task[None]]:
+    """Every not-yet-finished fire-and-forget send task, across all senders
+    in the registry, that actually runs on ``loop``.
+
+    Scoped two ways on purpose: to hexgate's own sends (via each sender's
+    own ``_tasks`` bookkeeping, the same set ``close()`` drains) rather than
+    every task on the loop, since a caller's or another library's unrelated
+    task could otherwise get swept up and — worse — cancelled by a draining
+    caller's timeout; and to tasks actually owned by ``loop``, since the
+    registry is process-wide and a concurrent caller's sender may be
+    running on a different thread's loop entirely (e.g. the google adapter
+    builds a fresh loop per call) — awaiting or cancelling a task bound to a
+    loop that isn't the one driving it here is unsafe.
+    """
+    return {
+        task
+        for sender in _senders.values()
+        for task in sender._tasks
+        if not task.done() and task.get_loop() is loop
+    }
 
 
 async def shutdown() -> None:

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -146,13 +146,23 @@ class AuditSender:
             # no loop anywhere in the process (e.g. pydantic_ai's
             # run_sync()). Prefer handing back to the bound loop; only fall
             # to a plain background thread when no loop exists at all.
+            #
+            # is_running(), not is_closed(): self._loop is a singleton
+            # shared across every adapter using this api_key, and it's
+            # rebound to whichever loop last called emit() while running
+            # (_ensure_loop_state). Some adapters (e.g. the openai-agents
+            # SDK's run_sync()) deliberately keep their default loop open
+            # across calls without ever driving it again afterward — open
+            # but idle, so it passes is_closed() yet will never execute a
+            # call_soon_threadsafe callback. is_running() is the only check
+            # that actually reflects whether anyone is still pumping it.
             loop = self._loop
-            if loop is not None and not loop.is_closed():
+            if loop is not None and loop.is_running():
                 try:
                     loop.call_soon_threadsafe(self._spawn_send, event)
                     return
                 except RuntimeError:
-                    pass  # loop torn down between the is_closed() check and the call
+                    pass  # loop torn down between the is_running() check and the call
             self._spawn_sync_send(event)
             return
         self._ensure_loop_state(loop)

--- a/tests/adapters/conftest.py
+++ b/tests/adapters/conftest.py
@@ -1,0 +1,92 @@
+"""Shared fixture for the (opt-in) adapter integration test suite — one
+live platform + ClickHouse backend, common to all four frameworks.
+
+Centralizes what would otherwise be copy-pasted per adapter: reading
+HEXGATE_API_KEY/HEXGATE_API_URL/ClickHouse creds, skipping cleanly when no
+key is configured, and querying the audit tables.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import httpx
+import pytest
+
+
+@dataclass(frozen=True)
+class HexgatePlatformEnv:
+    api_key: str
+    platform_url: str
+    clickhouse_url: str
+    clickhouse_user: str
+    clickhouse_password: str
+
+    def clickhouse_query(self, query: str, **params: str) -> str:
+        """Parameterized query via ClickHouse's HTTP interface — never
+        string-interpolate test-controlled values into SQL."""
+        response = httpx.get(
+            self.clickhouse_url,
+            params={"query": query, **{f"param_{k}": v for k, v in params.items()}},
+            auth=(self.clickhouse_user, self.clickhouse_password),
+            timeout=5,
+        )
+        response.raise_for_status()
+        return response.text.strip()
+
+    def policy_decision_outcome(
+        self, agent_name: str, session_id: str, tool_name: str
+    ) -> str | None:
+        """The most recent policy_decision outcome for this run, or None
+        while the row hasn't landed yet."""
+        text = self.clickhouse_query(
+            "SELECT outcome FROM hexgate_audit.policy_decision "
+            "WHERE agent_name = {agent_name:String} "
+            "AND session_id = {session_id:String} "
+            "AND tool_name = {tool_name:String} "
+            "ORDER BY occurred_at DESC LIMIT 1",
+            agent_name=agent_name,
+            session_id=session_id,
+            tool_name=tool_name,
+        )
+        return text or None
+
+    def llm_invocation_count(self, agent_name: str, session_id: str) -> int:
+        text = self.clickhouse_query(
+            "SELECT count() FROM hexgate_audit.llm_invocation "
+            "WHERE agent_name = {agent_name:String} "
+            "AND session_id = {session_id:String}",
+            agent_name=agent_name,
+            session_id=session_id,
+        )
+        return int(text)
+
+
+@pytest.fixture
+def hexgate_platform_env(monkeypatch: pytest.MonkeyPatch) -> HexgatePlatformEnv:
+    """Skip cleanly if HEXGATE_API_KEY isn't set; otherwise pin
+    HEXGATE_API_KEY/HEXGATE_API_URL in os.environ for this test only —
+    monkeypatch reverts them afterward, so a value set here can't leak
+    into another test the way a bare `os.environ[...] = ...` could — and
+    hand back a small client for polling the audit tables.
+    """
+    api_key = os.environ.get("HEXGATE_API_KEY")
+    if not api_key:
+        pytest.skip("HEXGATE_API_KEY not set; mint a token via the dashboard")
+    platform_url = os.environ.get("HEXGATE_API_URL", "http://localhost:8000").rstrip(
+        "/"
+    )
+    monkeypatch.setenv("HEXGATE_API_KEY", api_key)
+    monkeypatch.setenv("HEXGATE_API_URL", platform_url)
+    return HexgatePlatformEnv(
+        api_key=api_key,
+        platform_url=platform_url,
+        clickhouse_url=os.environ.get(
+            "HEXGATE_CLICKHOUSE_URL", "http://localhost:8124"
+        ),
+        clickhouse_user=os.environ.get("HEXGATE_CLICKHOUSE_USER", "hexgate"),
+        clickhouse_password=os.environ.get(
+            "HEXGATE_CLICKHOUSE_PASSWORD", "hexgate-dev-password"
+        ),
+    )

--- a/tests/adapters/google/test_integration.py
+++ b/tests/adapters/google/test_integration.py
@@ -1,0 +1,135 @@
+"""End-to-end verification that a real (wrapped) google-adk agent, run
+through :class:`HexgateRunner`, actually talks to the live platform for its
+policy and lands both a tool-call decision and an LLM-usage event in
+ClickHouse — the two audit paths ``PolicyEnforcer.decide()`` and
+``HexgateUsagePlugin.after_model_callback`` feed. This is plumbing, not
+model-quality: the "LLM" is a two-turn scripted fake (see ``_ScriptedLlm``
+below) so the run is free and deterministic.
+
+Requires: `make clickhouse-up` and `make platform-api` running, and
+`HEXGATE_API_KEY` set to a token minted via the dashboard (or the
+platform API directly).
+
+Opt in with: `pytest -m integration`.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any, AsyncGenerator
+
+import pytest
+from google.adk.agents import LlmAgent
+from google.adk.models.base_llm import BaseLlm
+from google.adk.models.llm_request import LlmRequest
+from google.adk.models.llm_response import LlmResponse
+from google.adk.sessions import InMemorySessionService
+from google.adk.tools.function_tool import FunctionTool
+from google.genai import types
+from pydantic import PrivateAttr
+
+from hexgate.adapters.google.runner import HexgateRunner
+from hexgate.cli.register.register import register_agent
+from hexgate.runtime import User
+from tests.adapters.conftest import HexgatePlatformEnv
+from tests.adapters.helpers import (
+    AGENT_NAME_PREFIX,
+    USER_ID_PREFIX,
+    assert_policy_and_usage_events_landed,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def get_weather(city: str) -> str:
+    """Return a canned weather report for a city."""
+    return f"It is sunny in {city}."
+
+
+class _ScriptedLlm(BaseLlm):
+    """A deterministic, two-turn fake model — no network call, no API key.
+
+    google-adk 1.32.0 ships no public equivalent to pydantic_ai's
+    ``TestModel`` (the closest thing found, ``_ConformanceTestGemini`` in
+    ``google.adk.cli.conformance``, is a private, Gemini-subclassing replay
+    shim built for the ADK CLI's own conformance-test tooling, not a general
+    unit-test double). ``BaseLlm`` is a small abstract interface
+    (``generate_content_async`` only), so this hand-rolled subclass is the
+    minimal way to drive a real wrapped agent for free: turn 1 always emits
+    a ``get_weather`` function call (forcing a real policy decision through
+    the enforcer), turn 2 emits plain text so the ADK flow's
+    ``Event.is_final_response()`` check ends the run.
+    """
+
+    _call_count: int = PrivateAttr(default=0)
+
+    async def generate_content_async(
+        self, llm_request: LlmRequest, stream: bool = False
+    ) -> AsyncGenerator[LlmResponse, None]:
+        self._call_count += 1
+        usage = types.GenerateContentResponseUsageMetadata(
+            prompt_token_count=5, candidates_token_count=5
+        )
+        if self._call_count == 1:
+            content = types.Content(
+                role="model",
+                parts=[
+                    types.Part.from_function_call(
+                        name="get_weather", args={"city": "Paris"}
+                    )
+                ],
+            )
+        else:
+            content = types.Content(
+                role="model", parts=[types.Part(text="It is sunny in Paris.")]
+            )
+        yield LlmResponse(
+            model_version=self.model, content=content, usage_metadata=usage
+        )
+
+
+def test_wrapped_run_pulls_policy_and_lands_decision_and_usage_events(
+    hexgate_platform_env: HexgatePlatformEnv,
+) -> None:
+    """One wrapped-agent run against the live platform, checked from both
+    ends: the policy that gated ``get_weather`` came from the platform (not
+    an allow-all default), and both audit paths (decision + usage) actually
+    reached ClickHouse.
+
+    ``get_weather`` is deliberately read-shaped: the platform's starter
+    policy classifies tool names by substring heuristic
+    (``platform/api/hexgate_api/features/agents/compiler.py::_classify_tool``)
+    and only read-shaped tools get an explicit ``allow`` for the fallback
+    ``default`` role — every other tool bucket denies by default. That makes
+    the expected outcome deterministic: 'allow', not 'either'.
+    """
+    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
+    session_id = f"s-{uuid.uuid4().hex[:8]}"
+
+    raw_agent = LlmAgent(
+        name=agent_name,
+        model=_ScriptedLlm(model="hexgate-scripted-fake"),
+        tools=[FunctionTool(func=get_weather)],
+    )
+    register_agent(raw_agent)
+
+    runner = HexgateRunner(
+        agent=raw_agent,
+        app_name=agent_name,
+        session_service=InMemorySessionService(),
+        api_key=hexgate_platform_env.api_key,
+        auto_create_session=True,
+    )
+    user = User(user_id=f"{USER_ID_PREFIX}google", session_id=session_id, role="tester")
+    new_message = types.Content(
+        role="user", parts=[types.Part(text="What's the weather in Paris?")]
+    )
+
+    events: list[Any] = list(runner.run(new_message=new_message, user=user))
+    assert events  # the scripted model produced at least the final turn
+
+    # Both sends are fire-and-forget (background thread / task) — poll
+    # rather than assume they've landed the instant run() returns.
+    assert_policy_and_usage_events_landed(
+        hexgate_platform_env, agent_name, session_id, "get_weather"
+    )

--- a/tests/adapters/google/test_integration.py
+++ b/tests/adapters/google/test_integration.py
@@ -103,7 +103,7 @@ def test_wrapped_run_pulls_policy_and_lands_decision_and_usage_events(
     ``default`` role — every other tool bucket denies by default. That makes
     the expected outcome deterministic: 'allow', not 'either'.
     """
-    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
+    agent_name = f"{AGENT_NAME_PREFIX}google_{uuid.uuid4().hex[:8]}"
     session_id = f"s-{uuid.uuid4().hex[:8]}"
 
     raw_agent = LlmAgent(

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any, AsyncIterator
@@ -270,6 +271,50 @@ def test_run_drives_run_async_inline_under_user_scope(
     assert active is user
     # Scope unwound after the call.
     assert get_current_user() is None
+
+
+def test_run_drains_pending_tasks_before_closing_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The last turn's fire-and-forget audit-send task may still be in
+    flight when the generator is exhausted — run()'s finally block must
+    drain it via asyncio.gather before closing the loop, or the send is
+    silently abandoned (the exact scenario runner.py's own comment on
+    this describes)."""
+    _silence_observability(monkeypatch)
+
+    completed: list[bool] = []
+
+    class _RunnerWithPendingTask(_FakeRunner):
+        async def run_async(self, **kwargs: Any) -> AsyncIterator[dict[str, str]]:
+            async def _slow_background_send() -> None:
+                # Long enough that it's still pending once the two yields
+                # below are exhausted and the generator is closed — the
+                # two synchronous __anext__() calls return almost
+                # instantly, nowhere near this sleep's duration.
+                await asyncio.sleep(0.05)
+                completed.append(True)
+
+            asyncio.get_running_loop().create_task(_slow_background_send())
+            async for event in super().run_async(**kwargs):
+                yield event
+
+    _FakeRunner.instances = []
+    monkeypatch.setattr("hexgate.adapters.google.runner.Runner", _RunnerWithPendingTask)
+
+    runner = HexgateRunner(
+        agent=_make_agent(),
+        app_name="my_app",
+        session_service=InMemorySessionService(),
+        api_key="k",
+    )
+
+    events = list(runner.run(new_message="hello", user=_user()))
+
+    assert events == [{"event": "first"}, {"event": "second"}]
+    # If run() had closed the loop without draining pending tasks first,
+    # the background send would never have gotten the chance to finish.
+    assert completed == [True]
 
 
 def test_run_keeps_scope_visible_across_awaits(

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -25,7 +25,23 @@ from hexgate.security import AgentPolicy, BaseToolPolicy, PolicySet, ResolvedPol
 from hexgate.security.bans import BanEntry, BanGate, BanSet
 from hexgate.security.errors import AgentBannedError
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+from hexgate.tracing import _senders as senders_mod
 from hexgate.tracing import usage as tracing_usage_mod
+from hexgate.tracing._senders import AuditSender
+
+
+@contextmanager
+def _registered_sender(key: tuple[str, str] = ("test-key", "/test-path")) -> Any:
+    """Register a real AuditSender in the shared registry for the duration
+    of a test, so drain_pending_tasks' pending_send_tasks() scoping can
+    find a task tracked in it — evicted afterward since the registry is
+    process-global state shared across the whole test session."""
+    sender = AuditSender(endpoint="https://example.invalid/test-path", api_key="k")
+    senders_mod._senders[key] = sender
+    try:
+        yield sender
+    finally:
+        del senders_mod._senders[key]
 
 
 class _StaticBanSource:
@@ -285,36 +301,42 @@ def test_run_drains_pending_tasks_before_closing_loop(
 
     completed: list[bool] = []
 
-    class _RunnerWithPendingTask(_FakeRunner):
-        async def run_async(self, **kwargs: Any) -> AsyncIterator[dict[str, str]]:
-            async def _slow_background_send() -> None:
-                # Long enough that it's still pending once the two yields
-                # below are exhausted and the generator is closed — the
-                # two synchronous __anext__() calls return almost
-                # instantly, nowhere near this sleep's duration.
-                await asyncio.sleep(0.05)
-                completed.append(True)
+    with _registered_sender() as sender:
 
-            asyncio.get_running_loop().create_task(_slow_background_send())
-            async for event in super().run_async(**kwargs):
-                yield event
+        class _RunnerWithPendingTask(_FakeRunner):
+            async def run_async(self, **kwargs: Any) -> AsyncIterator[dict[str, str]]:
+                async def _slow_background_send() -> None:
+                    # Long enough that it's still pending once the two yields
+                    # below are exhausted and the generator is closed — the
+                    # two synchronous __anext__() calls return almost
+                    # instantly, nowhere near this sleep's duration.
+                    await asyncio.sleep(0.05)
+                    completed.append(True)
 
-    _FakeRunner.instances = []
-    monkeypatch.setattr("hexgate.adapters.google.runner.Runner", _RunnerWithPendingTask)
+                task = asyncio.get_running_loop().create_task(_slow_background_send())
+                sender._tasks.add(task)
+                task.add_done_callback(sender._tasks.discard)
+                async for event in super().run_async(**kwargs):
+                    yield event
 
-    runner = HexgateRunner(
-        agent=_make_agent(),
-        app_name="my_app",
-        session_service=InMemorySessionService(),
-        api_key="k",
-    )
+        _FakeRunner.instances = []
+        monkeypatch.setattr(
+            "hexgate.adapters.google.runner.Runner", _RunnerWithPendingTask
+        )
 
-    events = list(runner.run(new_message="hello", user=_user()))
+        runner = HexgateRunner(
+            agent=_make_agent(),
+            app_name="my_app",
+            session_service=InMemorySessionService(),
+            api_key="k",
+        )
 
-    assert events == [{"event": "first"}, {"event": "second"}]
-    # If run() had closed the loop without draining pending tasks first,
-    # the background send would never have gotten the chance to finish.
-    assert completed == [True]
+        events = list(runner.run(new_message="hello", user=_user()))
+
+        assert events == [{"event": "first"}, {"event": "second"}]
+        # If run() had closed the loop without draining pending tasks first,
+        # the background send would never have gotten the chance to finish.
+        assert completed == [True]
 
 
 def test_run_keeps_scope_visible_across_awaits(

--- a/tests/adapters/helpers.py
+++ b/tests/adapters/helpers.py
@@ -1,0 +1,79 @@
+"""Plain (non-fixture) helpers for the adapter integration test suite.
+
+Kept separate from ``conftest.py``: nothing here is a pytest fixture or
+hook, so none of it benefits from pytest's auto-discovery — every symbol
+is imported explicitly wherever it's used, exactly like any other module.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from tests.adapters.conftest import HexgatePlatformEnv
+
+# Shared across all four framework adapters' integration tests, each of
+# which appends its own random suffix to build a unique agent_name per run.
+AGENT_NAME_PREFIX = "integration_test_agent_"
+
+# Shared across all four framework adapters' integration tests, each of
+# which appends its own adapter name to build a per-adapter user_id.
+USER_ID_PREFIX = "u-integration-"
+
+
+def poll_until(
+    fetch: Callable[[], Any],
+    *,
+    timeout: float = 10.0,
+    interval: float = 0.5,
+    message: str,
+) -> Any:
+    """Poll ``fetch()`` every ``interval`` seconds until it returns a
+    truthy value, then return it.
+
+    ``pytest.fail(message)`` if ``timeout`` seconds elapse first. A real
+    wall-clock deadline, not an iteration-count proxy for one — a slow
+    individual ``fetch()`` call eats into the budget instead of silently
+    extending the total wait past ``timeout``.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        value = fetch()
+        if value:
+            return value
+        time.sleep(interval)
+    pytest.fail(message)
+
+
+def assert_policy_and_usage_events_landed(
+    env: "HexgatePlatformEnv",
+    agent_name: str,
+    session_id: str,
+    tool_name: str,
+    *,
+    expected_outcome: str = "allow",
+) -> None:
+    """Poll ClickHouse for the audit row and the usage row a wrapped run produces.
+
+    ``policy_decision`` is the audit trail (the allow/deny outcome);
+    ``llm_invocation`` is usage telemetry (SDK usage ingest), a distinct
+    concept that happens to land in the same ClickHouse database. Both
+    sends run on a background thread — poll rather than assume they've
+    landed the instant the run call returns. Common to all four framework
+    adapters' integration tests, which each wrap one ``tool_name``-calling
+    agent the same way.
+    """
+    outcome = poll_until(
+        lambda: env.policy_decision_outcome(agent_name, session_id, tool_name),
+        message=f"policy_decision row for {tool_name!r} never landed in ClickHouse",
+    )
+    assert outcome == expected_outcome
+
+    poll_until(
+        lambda: env.llm_invocation_count(agent_name, session_id) >= 1,
+        message="llm_invocation row never landed in ClickHouse",
+    )

--- a/tests/adapters/langchain/test_integration.py
+++ b/tests/adapters/langchain/test_integration.py
@@ -1,0 +1,143 @@
+"""End-to-end verification that a real (wrapped) LangGraph agent's policy
+comes from the live platform API and that both its tool-call decision and
+its LLM-usage event land in ClickHouse.
+
+Not a test of answer quality — the model is a scripted fake, never a real
+LLM provider — this only proves Hexgate's own plumbing: policy fetch at
+wrap time, tool-call auditing, and usage ingestion.
+
+Requires: `make clickhouse-up` and `make platform-api` running, and
+`HEXGATE_API_KEY` set to a token minted via the dashboard (or the
+platform API directly).
+
+Opt in with: `pytest -m integration`.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from langchain.agents import create_agent
+from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.tools import tool
+
+from hexgate.adapters.langchain.wrapper import wrap_langchain_agent
+from hexgate.cli.register.register import register_agent
+from hexgate.runtime import User
+from tests.adapters.conftest import HexgatePlatformEnv
+from tests.adapters.helpers import (
+    AGENT_NAME_PREFIX,
+    USER_ID_PREFIX,
+    assert_policy_and_usage_events_landed,
+)
+
+pytestmark = pytest.mark.integration
+
+FAKE_MODEL_NAME = "hexgate-integration-fake-model"
+
+
+class _ScriptedToolCallingModel(FakeMessagesListChatModel):
+    """`FakeMessagesListChatModel` plus a no-op `bind_tools`.
+
+    `create_agent` calls `model.bind_tools(tools)` once at graph-build
+    time; the base `BaseChatModel.bind_tools` raises `NotImplementedError`
+    and the fake never inspects tool schemas anyway (responses are
+    pre-scripted), so identity is enough — no real provider, no network,
+    no API key beyond `HEXGATE_API_KEY` for the platform.
+    """
+
+    def bind_tools(self, tools, *, tool_choice=None, **kwargs):  # type: ignore[no-untyped-def]
+        return self
+
+
+def _make_get_weather_tool():
+    """A `get_weather`-named tool: a "get_" prefix is a read-shape pattern
+    (see `platform/api/hexgate_api/features/agents/compiler.py`'s
+    `_READ_PATTERNS`), so a freshly-registered agent's starter policy puts
+    it in the `read_only` mixin at `mode: allow` for every role — including
+    the `default` role that an unrecognized `User.role` falls back to.
+    That makes the expected `policy_decision` outcome deterministic
+    ('allow'), not something this test needs to special-case per role.
+
+    Defined as an `async def` (not a sync `def`) so LangGraph's ToolNode
+    calls the installed `coroutine` directly on the running event loop
+    instead of via a thread-pool executor — the enforcer's `decide()`
+    reads the active `User` off a contextvar, which a plain
+    `run_in_executor` thread would not see.
+    """
+
+    @tool
+    async def get_weather(city: str) -> str:
+        """Look up the weather for a city."""
+        return f"{city}: sunny, 21C"
+
+    return get_weather
+
+
+def _scripted_responses() -> list[AIMessage]:
+    """One tool-calling turn, then one final answer — deterministically
+    triggers exactly one `get_weather` call and two `on_llm_end` events."""
+    return [
+        AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "name": "get_weather",
+                    "args": {"city": "Paris"},
+                    "id": "call_1",
+                    "type": "tool_call",
+                }
+            ],
+            response_metadata={"model_name": FAKE_MODEL_NAME},
+            usage_metadata={"input_tokens": 12, "output_tokens": 4, "total_tokens": 16},
+        ),
+        AIMessage(
+            content="It's sunny and 21C in Paris.",
+            response_metadata={"model_name": FAKE_MODEL_NAME},
+            usage_metadata={"input_tokens": 20, "output_tokens": 9, "total_tokens": 29},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_agent_run_lands_policy_decision_and_llm_usage_events(
+    hexgate_platform_env: HexgatePlatformEnv,
+) -> None:
+    """Register + wrap a real minimal LangGraph agent, run it through a
+    prompt that deterministically triggers one tool call, then poll
+    ClickHouse for the resulting policy_decision and llm_invocation rows."""
+    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
+    session_id = f"s-{uuid.uuid4().hex[:8]}"
+
+    tools = [_make_get_weather_tool()]
+    model = _ScriptedToolCallingModel(responses=_scripted_responses())
+    raw_agent = create_agent(model=model, tools=tools, name=agent_name)
+
+    # `tools`/`model`/`system_prompt` are only consulted for LangChain
+    # graphs — a compiled graph doesn't reliably expose them post-compile.
+    register_agent(
+        raw_agent,
+        tools=tools,
+        model=FAKE_MODEL_NAME,
+        system_prompt="You are a test agent that exercises Hexgate's plumbing.",
+    )
+    # Policy is resolved from the platform right here, at wrap time
+    # (fail-loud on a 404 if `register_agent` above didn't land first).
+    wrapped = wrap_langchain_agent(
+        agent=raw_agent, tools=tools, api_key=hexgate_platform_env.api_key
+    )
+
+    user = User(
+        user_id=f"{USER_ID_PREFIX}langchain", session_id=session_id, role="tester"
+    )
+    result = await wrapped.ainvoke(
+        {"messages": [{"role": "user", "content": "What's the weather in Paris?"}]},
+        user=user,
+    )
+    assert result["messages"][-1].content
+
+    assert_policy_and_usage_events_landed(
+        hexgate_platform_env, agent_name, session_id, "get_weather"
+    )

--- a/tests/adapters/langchain/test_integration.py
+++ b/tests/adapters/langchain/test_integration.py
@@ -108,7 +108,7 @@ async def test_agent_run_lands_policy_decision_and_llm_usage_events(
     """Register + wrap a real minimal LangGraph agent, run it through a
     prompt that deterministically triggers one tool call, then poll
     ClickHouse for the resulting policy_decision and llm_invocation rows."""
-    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
+    agent_name = f"{AGENT_NAME_PREFIX}langchain_{uuid.uuid4().hex[:8]}"
     session_id = f"s-{uuid.uuid4().hex[:8]}"
 
     tools = [_make_get_weather_tool()]

--- a/tests/adapters/openai/test_integration.py
+++ b/tests/adapters/openai/test_integration.py
@@ -150,7 +150,7 @@ def test_tool_call_records_policy_decision_and_llm_usage(
     `get_weather` matches the read heuristic, so this is a deterministic
     `allow`, not a guess.
     """
-    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
+    agent_name = f"{AGENT_NAME_PREFIX}openai_{uuid.uuid4().hex[:8]}"
     session_id = f"s-{uuid.uuid4().hex[:8]}"
     tool_name = "get_weather"
 

--- a/tests/adapters/openai/test_integration.py
+++ b/tests/adapters/openai/test_integration.py
@@ -1,0 +1,172 @@
+"""End-to-end verification that a real (wrapped) openai-agents-SDK agent's
+run (1) pulls its policy from the live platform API, (2) lands a
+policy_decision row for its tool call, and (3) lands an llm_invocation row
+for its model call. Not a test of answer quality — a test of Hexgate's own
+plumbing (policy fetch + audit ingestion), mirroring
+tests/adapters/pydantic_ai/test_integration.py.
+
+Requires: `make clickhouse-up` and `make platform-api` running, and
+`HEXGATE_API_KEY` set to a token minted via the dashboard (or the
+platform API directly).
+
+Opt in with: `pytest -m integration`.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+from agents import Agent, FunctionTool
+from agents.items import ModelResponse
+from agents.models.interface import Model
+from agents.usage import Usage
+from openai.types.responses import (
+    ResponseFunctionToolCall,
+    ResponseOutputMessage,
+    ResponseOutputText,
+)
+
+from hexgate.adapters.openai.runner import HexgateRunner
+from hexgate.cli.register.register import register_agent
+from hexgate.runtime import User
+from tests.adapters.conftest import HexgatePlatformEnv
+from tests.adapters.helpers import (
+    AGENT_NAME_PREFIX,
+    USER_ID_PREFIX,
+    assert_policy_and_usage_events_landed,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class _ScriptedModel(Model):
+    """Deterministic, $0, no-network fake model.
+
+    openai-agents-sdk ships no TestModel/FakeModel equivalent to
+    pydantic_ai's `pydantic_ai.models.test.TestModel` (verified against
+    `agents/models/interface.py` — only the abstract `Model`/`ModelProvider`
+    contract is exposed). `run_internal/turn_preparation.get_model` returns
+    `agent.model` as-is whenever it's already a `Model` instance, without
+    touching `ModelProvider`/the OpenAI network client — so implementing
+    that public seam directly is the free/deterministic path here. First
+    call scripts a tool call; every call after scripts a final text answer,
+    so the run always terminates regardless of how many turns the loop
+    takes to settle.
+    """
+
+    def __init__(self, *, tool_name: str, tool_args: dict, final_text: str) -> None:
+        self._tool_name = tool_name
+        self._tool_args = tool_args
+        self._final_text = final_text
+        self._calls = 0
+
+    async def get_response(
+        self,
+        system_instructions,
+        input,
+        model_settings,
+        tools,
+        output_schema,
+        handoffs,
+        tracing,
+        *,
+        previous_response_id,
+        conversation_id,
+        prompt,
+    ) -> ModelResponse:
+        self._calls += 1
+        usage = Usage(requests=1, input_tokens=10, output_tokens=5, total_tokens=15)
+        if self._calls == 1:
+            output = [
+                ResponseFunctionToolCall(
+                    id="fc_1",
+                    call_id="call_1",
+                    name=self._tool_name,
+                    arguments=json.dumps(self._tool_args),
+                    type="function_call",
+                    status="completed",
+                )
+            ]
+        else:
+            output = [
+                ResponseOutputMessage(
+                    id="msg_1",
+                    role="assistant",
+                    status="completed",
+                    type="message",
+                    content=[
+                        ResponseOutputText(
+                            type="output_text",
+                            text=self._final_text,
+                            annotations=[],
+                        )
+                    ],
+                )
+            ]
+        return ModelResponse(
+            output=output, usage=usage, response_id=f"resp_{self._calls}"
+        )
+
+    def stream_response(self, *_args, **_kwargs):
+        raise NotImplementedError("_ScriptedModel does not support streaming")
+
+
+def _weather_tool() -> FunctionTool:
+    """A single real tool — needed for a policy_decision row to exist at
+    all. `get_weather` deliberately matches `compiler.py`'s `_READ_PATTERNS`
+    heuristic so a brand-new agent's generated policy allows it under the
+    fallback `default` role (see below)."""
+
+    async def on_invoke(_ctx, _raw_args: str) -> str:
+        return "sunny, 22C"
+
+    return FunctionTool(
+        name="get_weather",
+        description="Get the current weather for a city",
+        params_json_schema={
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+        on_invoke_tool=on_invoke,
+    )
+
+
+def test_tool_call_records_policy_decision_and_llm_usage(
+    hexgate_platform_env: HexgatePlatformEnv,
+) -> None:
+    """Register + run a real wrapped Agent whose scripted turn 1 forces a
+    `get_weather` tool call: proves policy is pulled from the live platform
+    (register_agent fails loud on 404, HexgateRunner._binding_for resolves
+    for real) and that both audit tables get a row for this run.
+
+    Outcome assertion: a just-registered agent's generated policy_yaml
+    (compiler.py's `_default_policy_for_manifest`) gives the `default` role
+    (used because `User(role="tester")` matches no role and PolicySet.get
+    falls back to `default`) an inherited `read_only` mixin with
+    `default_policy: mode: deny` plus an allowlist of read-shape tools.
+    `get_weather` matches the read heuristic, so this is a deterministic
+    `allow`, not a guess.
+    """
+    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
+    session_id = f"s-{uuid.uuid4().hex[:8]}"
+    tool_name = "get_weather"
+
+    model = _ScriptedModel(
+        tool_name=tool_name,
+        tool_args={"city": "Paris"},
+        final_text="It's sunny in Paris.",
+    )
+    raw_agent = Agent(name=agent_name, model=model, tools=[_weather_tool()])
+    register_agent(raw_agent)
+
+    runner = HexgateRunner(api_key=hexgate_platform_env.api_key)
+    user = User(user_id=f"{USER_ID_PREFIX}openai", session_id=session_id, role="tester")
+    result = runner.run_sync(raw_agent, "What's the weather in Paris?", user=user)
+    assert result.final_output
+
+    assert_policy_and_usage_events_landed(
+        hexgate_platform_env, agent_name, session_id, tool_name
+    )

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any, AsyncIterator
 
@@ -20,8 +21,24 @@ from hexgate.security import AgentPolicy, BaseToolPolicy, PolicySet, ResolvedPol
 from hexgate.security.bans import BanEntry, BanGate, BanSet
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.errors import AgentBannedError
+from hexgate.tracing import _senders as senders_mod
 from hexgate.tracing import usage as tracing_usage_mod
+from hexgate.tracing._senders import AuditSender
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+
+
+@contextmanager
+def _registered_sender(key: tuple[str, str] = ("test-key", "/test-path")) -> Any:
+    """Register a real AuditSender in the shared registry for the duration
+    of a test, so drain_pending_tasks' pending_send_tasks() scoping can
+    find a task tracked in it — evicted afterward since the registry is
+    process-global state shared across the whole test session."""
+    sender = AuditSender(endpoint="https://example.invalid/test-path", api_key="k")
+    senders_mod._senders[key] = sender
+    try:
+        yield sender
+    finally:
+        del senders_mod._senders[key]
 
 
 class _StaticBanSource:
@@ -244,35 +261,40 @@ def test_run_sync_drains_pending_tasks_on_the_default_loop(
     completed: list[bool] = []
     loop = asyncio.new_event_loop()
 
-    async def _slow_background_send() -> None:
-        # Long enough that it's still pending once fake_run_sync returns —
-        # nothing here pumps the loop any further for it on its own.
-        await asyncio.sleep(0.05)
-        completed.append(True)
+    with _registered_sender() as sender:
 
-    def fake_run_sync(starting_agent: Agent, input: Any, **kwargs: Any) -> str:
-        # Mirrors the real SDK: set the per-thread default loop and
-        # schedule the fire-and-forget audit-send task on it, then return
-        # immediately without pumping the loop for that task.
-        asyncio.set_event_loop(loop)
-        loop.create_task(_slow_background_send())
-        return "run-sync-result"
+        async def _slow_background_send() -> None:
+            # Long enough that it's still pending once fake_run_sync returns —
+            # nothing here pumps the loop any further for it on its own.
+            await asyncio.sleep(0.05)
+            completed.append(True)
 
-    monkeypatch.setattr(
-        "hexgate.adapters.openai.runner.Runner.run_sync", staticmethod(fake_run_sync)
-    )
+        def fake_run_sync(starting_agent: Agent, input: Any, **kwargs: Any) -> str:
+            # Mirrors the real SDK: set the per-thread default loop and
+            # schedule the fire-and-forget audit-send task on it, then return
+            # immediately without pumping the loop for that task.
+            asyncio.set_event_loop(loop)
+            task = loop.create_task(_slow_background_send())
+            sender._tasks.add(task)
+            task.add_done_callback(sender._tasks.discard)
+            return "run-sync-result"
 
-    try:
-        runner = HexgateRunner(api_key="k")
-        result = runner.run_sync(_make_agent(), "hello", user=_user())
+        monkeypatch.setattr(
+            "hexgate.adapters.openai.runner.Runner.run_sync",
+            staticmethod(fake_run_sync),
+        )
 
-        assert result == "run-sync-result"
-        # If run_sync() had returned without draining the default loop,
-        # the background send would never have gotten the chance to finish.
-        assert completed == [True]
-    finally:
-        loop.close()
-        asyncio.set_event_loop(None)
+        try:
+            runner = HexgateRunner(api_key="k")
+            result = runner.run_sync(_make_agent(), "hello", user=_user())
+
+            assert result == "run-sync-result"
+            # If run_sync() had returned without draining the default loop,
+            # the background send would never have gotten the chance to finish.
+            assert completed == [True]
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import Any, AsyncIterator
 
@@ -227,6 +228,51 @@ def test_run_sync_opens_user_scope_and_calls_runner_run_sync(
     assert captured["input"] == "hello"
     assert captured["active_user"] is user
     assert get_current_user() is None
+
+
+def test_run_sync_drains_pending_tasks_on_the_default_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The last turn's fire-and-forget audit-send task can still be
+    pending on the per-thread default loop when Runner.run_sync returns —
+    the ``agents`` SDK deliberately keeps that loop open across calls, and
+    nothing else pumps it for a sibling task once the top-level run
+    settles. run_sync() must drain it via _drain_default_loop before
+    returning, or the send is silently abandoned (the exact scenario
+    _drain_default_loop's own docstring describes)."""
+    _silence_observability(monkeypatch)
+    completed: list[bool] = []
+    loop = asyncio.new_event_loop()
+
+    async def _slow_background_send() -> None:
+        # Long enough that it's still pending once fake_run_sync returns —
+        # nothing here pumps the loop any further for it on its own.
+        await asyncio.sleep(0.05)
+        completed.append(True)
+
+    def fake_run_sync(starting_agent: Agent, input: Any, **kwargs: Any) -> str:
+        # Mirrors the real SDK: set the per-thread default loop and
+        # schedule the fire-and-forget audit-send task on it, then return
+        # immediately without pumping the loop for that task.
+        asyncio.set_event_loop(loop)
+        loop.create_task(_slow_background_send())
+        return "run-sync-result"
+
+    monkeypatch.setattr(
+        "hexgate.adapters.openai.runner.Runner.run_sync", staticmethod(fake_run_sync)
+    )
+
+    try:
+        runner = HexgateRunner(api_key="k")
+        result = runner.run_sync(_make_agent(), "hello", user=_user())
+
+        assert result == "run-sync-result"
+        # If run_sync() had returned without draining the default loop,
+        # the background send would never have gotten the chance to finish.
+        assert completed == [True]
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/openai/test_usage.py
+++ b/tests/adapters/openai/test_usage.py
@@ -68,16 +68,17 @@ async def test_on_llm_end_emits_usage_from_response(
 
 
 @pytest.mark.asyncio
-async def test_on_llm_end_when_model_is_not_a_string_then_model_is_empty(
+async def test_on_llm_end_when_model_is_not_a_string_then_model_is_class_name(
     emitted: list[dict[str, Any]],
 ) -> None:
     """agent.model is `str | Model | None` — a Model instance (or None) has
-    no guaranteed name field, so it's reported as an empty string rather
-    than guessed at."""
+    no guaranteed name field, so it's reported as the instance's class name
+    rather than guessed at. Not "" — the platform rejects an empty `model`
+    outright (min_length=1), which would silently drop the event."""
     hooks = HexgateUsageHooks(api_key="k")
     agent = Agent(name="my-agent")  # model defaults to None
 
     await hooks.on_llm_end(context=object(), agent=agent, response=_response())
 
     [call] = emitted
-    assert call["model"] == ""
+    assert call["model"] == "NoneType"

--- a/tests/adapters/openai/test_usage.py
+++ b/tests/adapters/openai/test_usage.py
@@ -7,10 +7,26 @@ from typing import Any
 import pytest
 from agents import Agent
 from agents.items import ModelResponse
+from agents.models.interface import Model
 from agents.usage import Usage
 
 from hexgate.adapters.openai import usage as usage_mod
 from hexgate.adapters.openai.usage import HexgateUsageHooks
+
+
+class _StubModel(Model):
+    """Minimal concrete Model for testing agent.model resolution."""
+
+    async def get_response(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+    def stream_response(self, *args: object, **kwargs: object) -> object:
+        raise NotImplementedError
+
+
+class _ModelWithId(_StubModel):
+    def __init__(self, model_id: str) -> None:
+        self.model = model_id
 
 
 def _response(input_tokens: int = 10, output_tokens: int = 20) -> ModelResponse:
@@ -68,17 +84,49 @@ async def test_on_llm_end_emits_usage_from_response(
 
 
 @pytest.mark.asyncio
-async def test_on_llm_end_when_model_is_not_a_string_then_model_is_class_name(
+async def test_on_llm_end_when_model_is_none_then_model_is_default(
     emitted: list[dict[str, Any]],
 ) -> None:
-    """agent.model is `str | Model | None` — a Model instance (or None) has
-    no guaranteed name field, so it's reported as the instance's class name
-    rather than guessed at. Not "" — the platform rejects an empty `model`
-    outright (min_length=1), which would silently drop the event."""
+    """agent.model defaults to None when unset -- the agent uses whatever
+    model the runner/SDK resolves at call time, which this hook never sees.
+    "default" is an honest placeholder rather than a guess. Not "" -- the
+    platform rejects an empty `model` outright (min_length=1), which would
+    silently drop the event."""
     hooks = HexgateUsageHooks(api_key="k")
     agent = Agent(name="my-agent")  # model defaults to None
 
     await hooks.on_llm_end(context=object(), agent=agent, response=_response())
 
     [call] = emitted
-    assert call["model"] == "NoneType"
+    assert call["model"] == "default"
+
+
+@pytest.mark.asyncio
+async def test_on_llm_end_when_model_is_a_model_instance_then_model_is_its_id(
+    emitted: list[dict[str, Any]],
+) -> None:
+    """Standard Model impls (e.g. OpenAIResponsesModel) expose the real
+    model id via .model -- that should be reported, not the class name."""
+    hooks = HexgateUsageHooks(api_key="k")
+    agent = Agent(name="my-agent", model=_ModelWithId("gpt-4o"))
+
+    await hooks.on_llm_end(context=object(), agent=agent, response=_response())
+
+    [call] = emitted
+    assert call["model"] == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_on_llm_end_when_model_is_an_exotic_model_then_model_is_class_name(
+    emitted: list[dict[str, Any]],
+) -> None:
+    """A Model implementation with no .model attribute has no guaranteed
+    name field (agents.models.interface.Model exposes none), so it falls
+    back to the instance's class name."""
+    hooks = HexgateUsageHooks(api_key="k")
+    agent = Agent(name="my-agent", model=_StubModel())
+
+    await hooks.on_llm_end(context=object(), agent=agent, response=_response())
+
+    [call] = emitted
+    assert call["model"] == "_StubModel"

--- a/tests/adapters/pydantic_ai/test_integration.py
+++ b/tests/adapters/pydantic_ai/test_integration.py
@@ -56,7 +56,7 @@ def test_run_sync_with_no_event_loop_delivers_llm_usage_event(
     The agent carries one tool (`get_weather`) so the run also produces a
     policy_decision row — TestModel's default `call_tools='all'` calls
     every registered tool automatically, no scripted response needed."""
-    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
+    agent_name = f"{AGENT_NAME_PREFIX}pydantic_ai_{uuid.uuid4().hex[:8]}"
     session_id = f"s-{uuid.uuid4().hex[:8]}"
 
     raw_agent = Agent(

--- a/tests/adapters/pydantic_ai/test_integration.py
+++ b/tests/adapters/pydantic_ai/test_integration.py
@@ -1,7 +1,8 @@
-"""End-to-end verification that HexgatePydanticAgent.run_sync() delivers
-its LLM-usage event even with no asyncio event loop anywhere in the
-process — the exact condition AuditSender.emit()'s no-loop fallback
-exists for.
+"""End-to-end verification that HexgatePydanticAgent.run_sync() (1) pulls
+its policy from the live platform, (2) delivers its LLM-usage event even
+with no asyncio event loop anywhere in the process — the exact condition
+AuditSender.emit()'s no-loop fallback exists for — and (3) lands a
+policy_decision row for its tool call.
 
 Requires: `make clickhouse-up` and `make platform-api` running, and
 `HEXGATE_API_KEY` set to a token minted via the dashboard (or the
@@ -12,80 +13,66 @@ Opt in with: `pytest -m integration`.
 
 from __future__ import annotations
 
-import os
-import time
 import uuid
 
-import httpx
 import pytest
 from pydantic_ai import Agent
 from pydantic_ai.models.test import TestModel
+from pydantic_ai.tools import Tool
 
 from hexgate.adapters.pydantic_ai.wrapper import wrap_pydantic_agent
 from hexgate.cli.register.register import register_agent
 from hexgate.runtime import User
+from tests.adapters.conftest import HexgatePlatformEnv
+from tests.adapters.helpers import (
+    AGENT_NAME_PREFIX,
+    USER_ID_PREFIX,
+    assert_policy_and_usage_events_landed,
+)
 
 pytestmark = pytest.mark.integration
 
-PLATFORM_URL = os.environ.get("HEXGATE_API_URL", "http://localhost:8000").rstrip("/")
-CLICKHOUSE_URL = os.environ.get("HEXGATE_CLICKHOUSE_URL", "http://localhost:8124")
-CLICKHOUSE_USER = os.environ.get("HEXGATE_CLICKHOUSE_USER", "hexgate")
-CLICKHOUSE_PASSWORD = os.environ.get(
-    "HEXGATE_CLICKHOUSE_PASSWORD", "hexgate-dev-password"
-)
-TOKEN = os.environ.get("HEXGATE_API_KEY")
+
+def _get_weather(city: str) -> str:
+    """A `get_weather`-named tool: a "get_" prefix is a read-shape pattern
+    (see `platform/api/hexgate_api/features/agents/compiler.py`'s
+    `_READ_PATTERNS`), so a freshly-registered agent's starter policy puts
+    it in the `read_only` mixin at `mode: allow` for every role — including
+    the `default` role that an unrecognized `User.role` falls back to.
+    That makes the expected `policy_decision` outcome deterministic
+    ('allow'), not something this test needs to special-case per role.
+    """
+    return f"{city}: sunny, 21C"
 
 
-def _need_token() -> None:
-    if not TOKEN:
-        pytest.skip("HEXGATE_API_KEY not set; mint a token via the dashboard")
-
-
-def _clickhouse_count(agent_name: str, session_id: str) -> int:
-    """Parameterized query via ClickHouse's HTTP interface — no string
-    interpolation of test-controlled values into SQL."""
-    response = httpx.get(
-        CLICKHOUSE_URL,
-        params={
-            "query": (
-                "SELECT count() FROM hexgate_audit.llm_invocation "
-                "WHERE agent_name = {agent_name:String} "
-                "AND session_id = {session_id:String}"
-            ),
-            "param_agent_name": agent_name,
-            "param_session_id": session_id,
-        },
-        auth=(CLICKHOUSE_USER, CLICKHOUSE_PASSWORD),
-        timeout=5,
-    )
-    response.raise_for_status()
-    return int(response.text.strip())
-
-
-def test_run_sync_with_no_event_loop_delivers_llm_usage_event() -> None:
+def test_run_sync_with_no_event_loop_delivers_llm_usage_event(
+    hexgate_platform_env: HexgatePlatformEnv,
+) -> None:
     """Regression: run_sync(), called from a plain synchronous test with no
     asyncio.run() anywhere, used to silently drop its usage event —
     AuditSender.emit() had no loop to fall back to and just warned once.
-    It now delivers via a bounded, non-daemon background thread instead."""
-    _need_token()
-    os.environ["HEXGATE_API_KEY"] = TOKEN
-    os.environ["HEXGATE_API_URL"] = PLATFORM_URL
+    It now delivers via a bounded, non-daemon background thread instead.
 
-    agent_name = f"integration_test_agent_{uuid.uuid4().hex[:8]}"
+    The agent carries one tool (`get_weather`) so the run also produces a
+    policy_decision row — TestModel's default `call_tools='all'` calls
+    every registered tool automatically, no scripted response needed."""
+    agent_name = f"{AGENT_NAME_PREFIX}{uuid.uuid4().hex[:8]}"
     session_id = f"s-{uuid.uuid4().hex[:8]}"
 
-    raw_agent = Agent(model=TestModel(), name=agent_name)
+    raw_agent = Agent(
+        model=TestModel(),
+        name=agent_name,
+        tools=[Tool(_get_weather, name="get_weather")],
+    )
     register_agent(raw_agent)
-    wrapped = wrap_pydantic_agent(agent=raw_agent, api_key=TOKEN)
+    wrapped = wrap_pydantic_agent(agent=raw_agent, api_key=hexgate_platform_env.api_key)
 
-    user = User(user_id="u-integration", session_id=session_id, role="tester")
-    result = wrapped.run_sync("Say hello", user=user)
+    user = User(
+        user_id=f"{USER_ID_PREFIX}pydantic_ai", session_id=session_id, role="tester"
+    )
+    result = wrapped.run_sync("What's the weather in Paris?", user=user)
     assert result.output
 
-    # The send runs on a background thread — poll briefly rather than
-    # assuming it's landed the instant run_sync() returns.
-    for _ in range(20):
-        if _clickhouse_count(agent_name, session_id) == 1:
-            return
-        time.sleep(0.5)
-    pytest.fail("LLM-usage event never landed in ClickHouse")
+    assert_policy_and_usage_events_landed(
+        hexgate_platform_env, agent_name, session_id, "get_weather"
+    )

--- a/tests/adapters/test_common.py
+++ b/tests/adapters/test_common.py
@@ -1,0 +1,139 @@
+"""Tests for hexgate.adapters._common's shared drain helper."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+import pytest
+
+from hexgate.adapters._common import drain_pending_tasks
+from hexgate.tracing import _senders as senders_mod
+from hexgate.tracing._senders import AuditSender
+
+
+@contextmanager
+def _registered_sender(
+    key: tuple[str, str] = ("test-key", "/test-path"),
+) -> Iterator[AuditSender]:
+    """Register a real AuditSender in the shared registry for the duration
+    of the test, so pending_send_tasks() can find it — and always evict it
+    afterward, since _senders is process-global state shared across the
+    whole test session."""
+    sender = AuditSender(endpoint="https://example.invalid/test-path", api_key="k")
+    senders_mod._senders[key] = sender
+    try:
+        yield sender
+    finally:
+        del senders_mod._senders[key]
+
+
+def _track(sender: AuditSender, loop: asyncio.AbstractEventLoop, coro) -> asyncio.Task:
+    """Schedule coro on loop and register it in sender._tasks, mirroring
+    what _spawn_send does for a real audit POST."""
+    task = loop.create_task(coro)
+    sender._tasks.add(task)
+    task.add_done_callback(sender._tasks.discard)
+    return task
+
+
+def test_drain_pending_tasks_happy_path() -> None:
+    """A sender-tracked task that finishes well within drain_timeout is
+    awaited to completion."""
+    loop = asyncio.new_event_loop()
+    completed: list[bool] = []
+
+    async def _quick() -> None:
+        await asyncio.sleep(0.01)
+        completed.append(True)
+
+    try:
+        with _registered_sender() as sender:
+            task = _track(sender, loop, _quick())
+            drain_pending_tasks(loop, drain_timeout=5.0)
+            assert completed == [True]
+            assert task.done()
+    finally:
+        loop.close()
+
+
+def test_drain_pending_tasks_when_task_exceeds_timeout_then_it_gives_up() -> None:
+    """An unreachable platform can hold a send open well past drain_timeout —
+    drain_pending_tasks must return anyway rather than hang the caller's
+    run_sync() for the full retry/backoff duration."""
+    loop = asyncio.new_event_loop()
+    completed: list[bool] = []
+
+    async def _slow() -> None:
+        await asyncio.sleep(5.0)
+        completed.append(True)
+
+    try:
+        with _registered_sender() as sender:
+            _track(sender, loop, _slow())
+            drain_pending_tasks(loop, drain_timeout=0.05)
+            assert completed == []
+    finally:
+        loop.close()
+
+
+def test_drain_pending_tasks_when_nothing_pending_then_it_is_a_no_op() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        with _registered_sender() as sender:
+            assert not sender._tasks
+            drain_pending_tasks(loop, drain_timeout=5.0)
+    finally:
+        loop.close()
+
+
+def test_drain_pending_tasks_ignores_tasks_not_tracked_by_a_sender() -> None:
+    """`loop` is a thread's shared default loop, not one hexgate owns
+    exclusively — a caller's own unrelated task can be scheduled on it too.
+    drain_pending_tasks must not await (or, on timeout, cancel) it."""
+    loop = asyncio.new_event_loop()
+    completed: list[bool] = []
+
+    async def _unrelated() -> None:
+        await asyncio.sleep(5.0)
+        completed.append(True)
+
+    try:
+        unrelated_task = loop.create_task(_unrelated())
+        drain_pending_tasks(loop, drain_timeout=0.05)
+        assert not unrelated_task.done()
+        assert not unrelated_task.cancelled()
+    finally:
+        unrelated_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            loop.run_until_complete(unrelated_task)
+        loop.close()
+
+
+def test_drain_pending_tasks_ignores_a_sender_tasks_bound_to_a_different_loop() -> None:
+    """The sender registry is process-wide; a concurrently running adapter
+    on another thread can own a sender with tasks on its own, different
+    loop. Draining must not reach across into that other loop."""
+    this_loop = asyncio.new_event_loop()
+    other_loop = asyncio.new_event_loop()
+    completed: list[bool] = []
+
+    async def _slow() -> None:
+        await asyncio.sleep(5.0)
+        completed.append(True)
+
+    try:
+        with _registered_sender() as sender:
+            _track(sender, other_loop, _slow())
+            drain_pending_tasks(this_loop, drain_timeout=0.05)
+            assert completed == []
+            assert sender._tasks  # untouched: still pending on other_loop
+    finally:
+        this_loop.close()
+        for task in list(sender._tasks):
+            task.cancel()
+        other_loop.run_until_complete(
+            asyncio.gather(*sender._tasks, return_exceptions=True)
+        )
+        other_loop.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,34 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from hexgate.runtime.srt import SrtUnavailableError, ensure_srt_available
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Silence Langfuse's background span export when no real project
+    credentials are configured.
+
+    ``Langfuse()`` defaults ``tracing_enabled=True`` even with no/empty
+    public+secret key, so any ``@observe``-wrapped ``@agent_tool`` call in a
+    unit test still queues spans and tries to flush them against the real
+    Langfuse host — failing with a 401 that has nothing to do with the test
+    itself. Must run in ``pytest_configure`` (before collection), not a
+    per-test fixture: whatever first constructs the client during this suite
+    does so early enough that a function-scoped ``monkeypatch.setenv`` in an
+    autouse fixture is already too late to gate it. Leaves tracing untouched
+    when a real key is already in the environment (e.g. `pytest -m
+    integration` with `.env` sourced), so that path still exercises the real
+    client.
+    """
+    _ = config
+    if not (
+        os.environ.get("LANGFUSE_PUBLIC_KEY") and os.environ.get("LANGFUSE_SECRET_KEY")
+    ):
+        os.environ["LANGFUSE_TRACING_ENABLED"] = "false"
 
 
 @pytest.fixture


### PR DESCRIPTION
## What is changing

Adds an opt-in (`-m integration`) live test for each of the four SDK framework adapters (openai, google, langchain, pydantic_ai), extending the existing pydantic_ai sync/no-loop regression test into full coverage across all four.

Running these live surfaced three real bugs in the adapters themselves (not the tests), all fixed here:
- **google**: the last turn's fire-and-forget audit-send task could still be pending when the run's event loop closed, silently dropping it.
- **openai**: same class of bug on its persistent per-thread default loop, plus a case where an empty model name reached the audit payload.
- **audit sender**: cached loop reuse checked `is_closed()` instead of `is_running()`, which could hand back a loop mid-teardown.

Also silences Langfuse's background span export in tests when no real key is configured (`pytest_configure` sets `LANGFUSE_TRACING_ENABLED=false`) — `Langfuse()` defaults `tracing_enabled=True` even with empty keys, so any `@observe`-wrapped call was failing with an unrelated 401 during the openai integration test.

Once both loop-drain fixes existed independently, the duplication between them (and the near-identical Langfuse tag-building across all four adapters) became obvious — `hexgate/adapters/_common.py` now holds `drain_pending_tasks`/`langfuse_propagate_kwargs`, used by all four adapters. No behavior change there.

`tests/adapters/conftest.py` (the `hexgate_platform_env` fixture) and `tests/adapters/helpers.py` (`poll_until`, `assert_policy_and_usage_events_landed`) let the four adapter integration tests share one implementation instead of four copies.

## Why is this change necessary

Each adapter's wrapper mechanics were already covered by mocked unit tests, but nothing proved the actual live plumbing works: that policy is really pulled from the platform API at wrap time, and that a real tool-call decision and its LLM-usage event actually reach ClickHouse. That gap is exactly what let the three loop/draining bugs above ship unnoticed — they only show up when a real agent is wrapped and run against a live platform + ClickHouse, not against mocks.

## Tests

- Four new opt-in integration tests (one per adapter), each wrapping a real minimal agent with one real tool, driven by a free/deterministic fake model (no real paid LLM calls), asserting a `policy_decision` row and an `llm_invocation` row land correctly in ClickHouse.
- Two new regression tests for the loop-drain fixes (`test_run_drains_pending_tasks_before_closing_loop` for google, `test_run_sync_drains_pending_tasks_on_the_default_loop` for openai) — each verified by temporarily reverting its fix, confirming the test fails, then restoring the real code.
- Confirmed live: `pytest -m integration` against a real local platform-api + ClickHouse now passes all 6 selected tests (all four adapters + both `tests/audit/test_integration.py` cases) — this was the failing state a few iterations ago before the fixes above landed.
- Each adapter test's `agent_name` now embeds the framework (`integration_test_agent_openai_...`, `..._google_...`, etc.) so the audit dashboard's Decisions view shows which framework produced which row at a glance, instead of an indistinguishable random suffix.
- Full existing SDK test suite (1656 tests) still passes after the `_common.py` refactor — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)