### PR TITLE
test(sdk): add enforcement + policy-pull latency benchmarks

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -51,8 +51,13 @@ Segments:
   compiled bundle (pydantic-fallback shape).
 - `pull_cold_200` — full `fetch()`: round-trip + decode + verify (fresh source
   each sample forces a 200).
-- `pull_warm_304` — conditional `fetch()` with `If-None-Match` → 304. This is
-  the actual per-chat-turn refresh cost.
+- `pull_warm_304` — conditional policy `fetch()` (`If-None-Match` → 304), in
+  isolation.
+- `ban_warm_304` — the same conditional GET against `/v1/bans`, in isolation.
+- `policy+ban_b2b` — both awaited back to back, the way every invoke entrypoint
+  runs them (`_refresh_policy_safely` then `_check_ban`, sequential). **This is
+  the actual per-chat-turn refresh cost** — the two round-trips are additive,
+  not overlapped.
 
 `pull_*` rows carry real network variance — read min vs p99, not p50 alone, as
 the SDK's fixed overhead. `verify_only` is the part that stays constant across
@@ -69,11 +74,13 @@ not a contract**; re-run on the target host:
 | `wasm_cache_hit` | < 1 µs |
 | enforcement `decide()` (per tool call) | ~200–300 µs |
 | `verify_only` (per pull, deterministic) | ~1.8 ms |
-| `pull_warm_304` (per chat turn) | ~50 ms (network-bound) |
+| `pull_warm_304` (policy, per turn) | ~50 ms (network-bound) |
+| `ban_warm_304` (bans, per turn) | ~50 ms (network-bound) |
+| `policy+ban_b2b` (real per-turn refresh) | ~100 ms (network-bound) |
 | `pull_cold_200` (on policy change) | ~76 ms (network-bound) |
 | `key_verify+jwks` (one-off, cold) | ~375 ms (network-bound) |
 
 Takeaway: the deterministic overhead hexgate adds per tool call is
-sub-millisecond (a few hundred µs of WASM eval); the recurring pull cost is a
-~50 ms conditional GET per turn, dominated by network round-trip, not by the
-SDK's crypto (~1.8 ms).
+sub-millisecond (a few hundred µs of WASM eval); the recurring pull cost is two
+sequential conditional GETs per turn (policy + bans, ~100 ms), dominated by
+network round-trip, not by the SDK's crypto (~1.8 ms).

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,79 @@
+# Hexgate latency benchmarks
+
+Measures the latency the SDK adds around an agent's tool calls, split into the
+two deterministic costs plus an optional end-to-end sanity check. Each bench is
+a standalone script (stdlib only — `time.perf_counter_ns` + `statistics`), so
+there's nothing to install beyond the SDK's own env.
+
+All benches print a p50/p95/p99/max table and accept `--json PATH` to dump raw
+nanosecond stats for diffing a later run against this one.
+
+## Bench A — enforcement latency (`bench_enforce.py`)
+
+**Local, no secrets, no network.** The purest signal: once a policy's WASM is
+loaded, what does one `decide()` cost? Needs `opa` on PATH (used once at
+startup to compile `examples/devops_policy.yaml`).
+
+```
+uv run python -m benchmarks.bench_enforce [--iterations N] [--json out.json]
+```
+
+Segments:
+- `wasm_instantiate` — one-off `WasmPolicy.from_bytes` cost.
+- `wasm_cache_hit` — `from_bytes_cached` on a warm hash (the per-turn refresh
+  path when the wasm hasn't changed).
+- `engine:<case>` — raw `PolicyBundle.evaluate` per workload case.
+- `enforcer:<case>` — `PolicyEnforcer.decide` per case; the delta vs the
+  matching `engine:` row is the `Decision`-build + audit/observer wrapper tax.
+
+The workload draws four cases from the devops policy so each branch of the
+compiled decision tree runs: a fast allow, a constrained allow, a
+constraint-violation deny, and a default-policy deny. The bench asserts each
+case's outcome before timing — a policy change that breaks the mix fails loudly
+rather than benchmarking the wrong branch.
+
+## Bench B — policy pull latency (`bench_pull.py`)
+
+**Needs `HEXGATE_API_KEY`** (read from env or `.env`); targets `app.hexgate.ai`
+by default via the SDK's normal URL resolution. Set `HEXGATE_PUBLIC_KEY` to
+skip the JWKS round-trip.
+
+```
+uv run python -m benchmarks.bench_pull [AGENT_NAME] [--samples N] [--json out.json]
+```
+
+Segments:
+- `key_verify+jwks` — one-off: biscuit signature verify + (unless a public key
+  is configured) the JWKS fetch. Dominated by the first-TLS cold start.
+- `verify_only` — **deterministic, no network**: decode + verify a captured
+  bundle payload (base64 + Ed25519 + sha256), looped. The honest "what does
+  bundle verification cost" number. Skipped when the platform served no
+  compiled bundle (pydantic-fallback shape).
+- `pull_cold_200` — full `fetch()`: round-trip + decode + verify (fresh source
+  each sample forces a 200).
+- `pull_warm_304` — conditional `fetch()` with `If-None-Match` → 304. This is
+  the actual per-chat-turn refresh cost.
+
+`pull_*` rows carry real network variance — read min vs p99, not p50 alone, as
+the SDK's fixed overhead. `verify_only` is the part that stays constant across
+runs and machines.
+
+## Indicative numbers
+
+From one dev-machine run (Apple Silicon, `app.hexgate.ai`) — **illustrative,
+not a contract**; re-run on the target host:
+
+| segment | p50 |
+|---|---|
+| `wasm_instantiate` (one-off) | ~135 ms |
+| `wasm_cache_hit` | < 1 µs |
+| enforcement `decide()` (per tool call) | ~200–300 µs |
+| `verify_only` (per pull, deterministic) | ~1.8 ms |
+| `pull_warm_304` (per chat turn) | ~50 ms (network-bound) |
+| `pull_cold_200` (on policy change) | ~76 ms (network-bound) |
+| `key_verify+jwks` (one-off, cold) | ~375 ms (network-bound) |
+
+Takeaway: the deterministic overhead hexgate adds per tool call is
+sub-millisecond (a few hundred µs of WASM eval); the recurring pull cost is a
+~50 ms conditional GET per turn, dominated by network round-trip, not by the
+SDK's crypto (~1.8 ms).

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Latency benchmarks for the hexgate SDK. Not part of the shipped package."""

--- a/benchmarks/_report.py
+++ b/benchmarks/_report.py
@@ -10,6 +10,7 @@ two runs across commits.
 from __future__ import annotations
 
 import json
+import math
 import statistics
 from collections.abc import Callable
 from dataclasses import asdict, dataclass
@@ -50,10 +51,16 @@ class Stats:
 
 
 def _percentile(ordered: list[float], pct: int) -> float:
-    """Nearest-rank percentile over an already-sorted list."""
+    """Nearest-rank percentile over an already-sorted list.
+
+    Uses ``ceil`` (not ``round``): the nearest-rank definition takes the
+    ceil(P/100 · N)-th value, so at small N a ``round``-based index would
+    understate the tail — e.g. p95 over 30 samples must be the 29th, not
+    the banker's-rounded 28th.
+    """
     if not ordered:
         return 0.0
-    rank = max(0, min(len(ordered) - 1, round(pct / 100 * len(ordered)) - 1))
+    rank = max(0, min(len(ordered) - 1, math.ceil(pct / 100 * len(ordered)) - 1))
     return ordered[rank]
 
 

--- a/benchmarks/_report.py
+++ b/benchmarks/_report.py
@@ -1,0 +1,125 @@
+"""Shared timing + reporting for the hexgate latency benchmarks.
+
+Deterministic, dependency-free: ``time.perf_counter_ns`` for wall time and
+``statistics`` for the percentiles. Both real benches (``bench_enforce`` and
+``bench_pull``) import :func:`measure` / :func:`Stats` so a nanosecond is
+timed and reported the same way everywhere — the only honest way to compare
+two runs across commits.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from time import perf_counter_ns
+
+NS_PER_US = 1_000.0
+NS_PER_MS = 1_000_000.0
+
+
+@dataclass(frozen=True)
+class Stats:
+    """Summary of one timed segment. All durations in nanoseconds."""
+
+    label: str
+    n: int
+    mean: float
+    p50: float
+    p95: float
+    p99: float
+    minimum: float
+    maximum: float
+    stdev: float
+
+    @classmethod
+    def from_samples(cls, label: str, samples_ns: list[float]) -> "Stats":
+        ordered = sorted(samples_ns)
+        return cls(
+            label=label,
+            n=len(ordered),
+            mean=statistics.fmean(ordered),
+            p50=_percentile(ordered, 50),
+            p95=_percentile(ordered, 95),
+            p99=_percentile(ordered, 99),
+            minimum=ordered[0],
+            maximum=ordered[-1],
+            stdev=statistics.pstdev(ordered) if len(ordered) > 1 else 0.0,
+        )
+
+
+def _percentile(ordered: list[float], pct: int) -> float:
+    """Nearest-rank percentile over an already-sorted list."""
+    if not ordered:
+        return 0.0
+    rank = max(0, min(len(ordered) - 1, round(pct / 100 * len(ordered)) - 1))
+    return ordered[rank]
+
+
+def measure(
+    label: str,
+    fn: Callable[[], object],
+    *,
+    iterations: int,
+    warmup: int,
+) -> Stats:
+    """Run ``fn`` ``warmup`` times untimed, then ``iterations`` times timed.
+
+    The warmup absorbs one-off costs that would otherwise skew the first
+    sample — JIT paths, wasmtime page-in, cold DNS/TLS on the first HTTP
+    hop — so the reported percentiles describe steady state, not startup.
+    """
+    for _ in range(warmup):
+        fn()
+    samples: list[float] = []
+    for _ in range(iterations):
+        start = perf_counter_ns()
+        fn()
+        samples.append(float(perf_counter_ns() - start))
+    return Stats.from_samples(label, samples)
+
+
+def measure_once(label: str, fn: Callable[[], object]) -> Stats:
+    """Time a single invocation — for one-off costs (WASM instantiation,
+    client key-verify + JWKS fetch) that don't have a steady state to
+    average and would be misleading to loop."""
+    start = perf_counter_ns()
+    fn()
+    elapsed = float(perf_counter_ns() - start)
+    return Stats.from_samples(label, [elapsed])
+
+
+def _fmt(ns: float) -> str:
+    """Human unit: µs under a millisecond, ms above."""
+    if ns < NS_PER_MS:
+        return f"{ns / NS_PER_US:.2f} µs"
+    return f"{ns / NS_PER_MS:.2f} ms"
+
+
+def print_table(title: str, rows: list[Stats]) -> None:
+    label_width = max((len(r.label) for r in rows), default=5)
+    header = (
+        f"{'segment':<{label_width}}  {'n':>6}  {'mean':>11}  "
+        f"{'p50':>11}  {'p95':>11}  {'p99':>11}  {'max':>11}"
+    )
+    print(f"\n{title}")
+    print("=" * len(header))
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(
+            f"{r.label:<{label_width}}  {r.n:>6}  {_fmt(r.mean):>11}  "
+            f"{_fmt(r.p50):>11}  {_fmt(r.p95):>11}  {_fmt(r.p99):>11}  "
+            f"{_fmt(r.maximum):>11}"
+        )
+    print()
+
+
+def emit_json(title: str, rows: list[Stats], path: str) -> None:
+    """Write raw nanosecond stats to ``path`` so a later run can be diffed
+    against this one (the whole point of keeping a benchmark)."""
+    payload = {"title": title, "segments": [asdict(r) for r in rows]}
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2)
+    print(f"wrote {path}")

--- a/benchmarks/_report.py
+++ b/benchmarks/_report.py
@@ -53,10 +53,8 @@ class Stats:
 def _percentile(ordered: list[float], pct: int) -> float:
     """Nearest-rank percentile over an already-sorted list.
 
-    Uses ``ceil`` (not ``round``): the nearest-rank definition takes the
-    ceil(P/100 · N)-th value, so at small N a ``round``-based index would
-    understate the tail — e.g. p95 over 30 samples must be the 29th, not
-    the banker's-rounded 28th.
+    ``ceil``, not ``round``: at small N rounding understates the tail
+    (p95 of 30 samples is the 29th, not the banker's-rounded 28th).
     """
     if not ordered:
         return 0.0

--- a/benchmarks/bench_enforce.py
+++ b/benchmarks/bench_enforce.py
@@ -37,7 +37,7 @@ from benchmarks._report import (
 )
 from hexgate.runtime.context import User
 from hexgate.security.bundle import PolicyBundle, build_signed_bundle
-from hexgate.security.decision import DecisionOutcome
+from hexgate.security.decision import Decision, DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.wasm_engine import WasmPolicy, _wasm_policy_cache
 
@@ -45,6 +45,12 @@ WARMUP = 500
 ITERATIONS = 10_000
 AGENT_NAME = "devops_agent"
 POLICY_PATH = Path(__file__).resolve().parent.parent / "examples" / "devops_policy.yaml"
+
+
+def _noop_observer(_decision: Decision) -> None:
+    """Wired only so ``decide()`` takes the ``copy.deepcopy(args)`` branch
+    every audited production enforcer takes; else the wrapper tax is
+    understated. Local-only, so it adds nothing beyond the copy."""
 
 
 @dataclass(frozen=True)
@@ -146,9 +152,11 @@ def _engine_stats(bundle: PolicyBundle, iterations: int) -> list[Stats]:
 def _enforcer_stats(bundle: PolicyBundle, iterations: int) -> list[Stats]:
     rows: list[Stats] = []
     for case in WORKLOAD:
-        # Audit sender left inert (no api_key wiring) so this measures the
-        # pure Decision-build + copy overhead, not a network emit.
-        enforcer = PolicyEnforcer(bundle, agent_name=AGENT_NAME)
+        # No audit_sender (no network emit), but a no-op observer so
+        # decide() still deep-copies args — the production wrapper tax.
+        enforcer = PolicyEnforcer(
+            bundle, agent_name=AGENT_NAME, decision_observer=_noop_observer
+        )
         user = User(user_id="bench", role=case.role)
         with user.sync_scope():
             rows.append(

--- a/benchmarks/bench_enforce.py
+++ b/benchmarks/bench_enforce.py
@@ -1,0 +1,200 @@
+"""Bench A — policy enforcement latency (local, no secrets, no network).
+
+The purest deterministic signal in the SDK: once a bundle's WASM is loaded,
+what does one ``decide()`` cost? No platform, no LLM, no I/O — just the
+wasmtime evaluation and the enforcer wrapper around it.
+
+Requires ``opa`` on PATH (used once at startup to compile the example policy
+to WASM via ``build_signed_bundle``). Run:
+
+    uv run python -m benchmarks.bench_enforce [--json out.json]
+
+Segments measured:
+  * ``wasm_instantiate``   — one-off ``WasmPolicy.from_bytes`` cost.
+  * ``wasm_cache_hit``     — ``from_bytes_cached`` on a warm hash (refresh path).
+  * ``engine:<case>``      — raw ``PolicyBundle.evaluate`` per workload case.
+  * ``enforcer:<case>``    — ``PolicyEnforcer.decide`` per case (adds the
+                             Decision + audit/observer wrapper). The delta vs
+                             the matching ``engine:`` row is the wrapper tax.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from benchmarks._report import (
+    Stats,
+    emit_json,
+    measure,
+    measure_once,
+    print_table,
+)
+from hexgate.runtime.context import User
+from hexgate.security.bundle import PolicyBundle, build_signed_bundle
+from hexgate.security.decision import DecisionOutcome
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.wasm_engine import WasmPolicy, _wasm_policy_cache
+
+WARMUP = 500
+ITERATIONS = 10_000
+AGENT_NAME = "devops_agent"
+POLICY_PATH = Path(__file__).resolve().parent.parent / "examples" / "devops_policy.yaml"
+
+
+@dataclass(frozen=True)
+class Case:
+    """One workload call plus the outcome the policy is expected to produce,
+    so a silent policy change that breaks the mix is caught, not benchmarked."""
+
+    label: str
+    role: str
+    tool: str
+    args: Mapping[str, Any]
+    expected: DecisionOutcome
+
+
+# Drawn from examples/devops_policy.yaml so each branch of the compiled
+# decision tree is exercised — a fast allow, a constrained allow, and two
+# distinct deny paths (constraint violation vs default_policy).
+WORKLOAD: tuple[Case, ...] = (
+    Case("allow_mixin", "default", "read_logs", {}, DecisionOutcome.ALLOW),
+    Case(
+        "allow_constrained",
+        "operator",
+        "scale_deployment",
+        {"service": "web-api", "env": "staging", "replicas": 5},
+        DecisionOutcome.ALLOW,
+    ),
+    Case(
+        "deny_constraint",
+        "operator",
+        "scale_deployment",
+        {"service": "web-api", "env": "staging", "replicas": 50},
+        DecisionOutcome.DENY,
+    ),
+    Case(
+        "deny_default",
+        "default",
+        "restart_service",
+        {"service": "web-api", "env": "dev"},
+        DecisionOutcome.DENY,
+    ),
+)
+
+
+def _build_bundle() -> PolicyBundle:
+    """Compile the example policy to a real WASM bundle (needs opa)."""
+    policy_yaml = POLICY_PATH.read_text(encoding="utf-8")
+    signed = build_signed_bundle(policy_yaml, source_name=POLICY_PATH.name)
+    if signed.wasm_bytes is None:
+        raise RuntimeError("build_signed_bundle produced no wasm — opa missing?")
+    return PolicyBundle.from_parts(
+        wasm_bytes=signed.wasm_bytes,
+        manifest_bytes=signed.manifest_bytes,
+    )
+
+
+def _verify_workload(bundle: PolicyBundle) -> None:
+    """Fail fast if the policy no longer produces the outcomes the mix
+    assumes — a benchmark over the wrong branches is worse than none."""
+    for case in WORKLOAD:
+        verdict = bundle.evaluate(role=case.role, tool=case.tool, args=case.args)
+        if verdict.outcome is not case.expected:
+            raise RuntimeError(
+                f"workload case {case.label!r} expected {case.expected} but "
+                f"policy returned {verdict.outcome}; update WORKLOAD or policy."
+            )
+
+
+def _instantiation_stats(
+    wasm_bytes: bytes, wasm_hash: str, iterations: int
+) -> list[Stats]:
+    _wasm_policy_cache.clear()
+    cold = measure_once("wasm_instantiate", lambda: WasmPolicy.from_bytes(wasm_bytes))
+    # Prime the content-addressed cache, then time the hit — the per-turn
+    # refresh path when the wasm hasn't changed (the common case).
+    WasmPolicy.from_bytes_cached(wasm_bytes, wasm_hash)
+    warm = measure(
+        "wasm_cache_hit",
+        lambda: WasmPolicy.from_bytes_cached(wasm_bytes, wasm_hash),
+        iterations=iterations,
+        warmup=WARMUP,
+    )
+    return [cold, warm]
+
+
+def _engine_stats(bundle: PolicyBundle, iterations: int) -> list[Stats]:
+    rows: list[Stats] = []
+    for case in WORKLOAD:
+        rows.append(
+            measure(
+                f"engine:{case.label}",
+                lambda c=case: bundle.evaluate(role=c.role, tool=c.tool, args=c.args),
+                iterations=iterations,
+                warmup=WARMUP,
+            )
+        )
+    return rows
+
+
+def _enforcer_stats(bundle: PolicyBundle, iterations: int) -> list[Stats]:
+    rows: list[Stats] = []
+    for case in WORKLOAD:
+        # Audit sender left inert (no api_key wiring) so this measures the
+        # pure Decision-build + copy overhead, not a network emit.
+        enforcer = PolicyEnforcer(bundle, agent_name=AGENT_NAME)
+        user = User(user_id="bench", role=case.role)
+        with user.sync_scope():
+            rows.append(
+                measure(
+                    f"enforcer:{case.label}",
+                    lambda c=case: enforcer.decide(c.tool, c.args),
+                    iterations=iterations,
+                    warmup=WARMUP,
+                )
+            )
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", metavar="PATH", help="write raw stats as JSON")
+    parser.add_argument(
+        "--iterations", type=int, default=ITERATIONS, help="timed iterations per case"
+    )
+    args = parser.parse_args()
+
+    if shutil.which("opa") is None:
+        print(
+            "error: opa not on PATH — install via `brew install opa` to compile "
+            "the policy for this benchmark.",
+            file=sys.stderr,
+        )
+        return 1
+
+    iterations = args.iterations
+
+    print(f"compiling {POLICY_PATH.name} → wasm (opa)…")
+    bundle = _build_bundle()
+    _verify_workload(bundle)
+    assert bundle.wasm_hash is not None
+
+    rows: list[Stats] = []
+    rows += _instantiation_stats(bundle.wasm_bytes, bundle.wasm_hash, iterations)
+    rows += _engine_stats(bundle, iterations)
+    rows += _enforcer_stats(bundle, iterations)
+
+    print_table(f"Bench A — enforcement latency ({iterations:,} iterations/case)", rows)
+    if args.json:
+        emit_json("bench_enforce", rows, args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bench_pull.py
+++ b/benchmarks/bench_pull.py
@@ -1,0 +1,147 @@
+"""Bench B — policy pull latency (network + a real API key).
+
+Measures what the SDK spends pulling a policy from the platform
+(``app.hexgate.ai`` by default via ``resolve_api_url``). The point is to
+separate the *deterministic* crypto cost from the *variable* network cost —
+conflating them yields a number that means nothing.
+
+Requires ``HEXGATE_API_KEY`` in the environment (or ``.env``). Optionally set
+``HEXGATE_PUBLIC_KEY`` to skip the JWKS round-trip. Run:
+
+    uv run python -m benchmarks.bench_pull [AGENT_NAME] [--samples N] [--json out.json]
+
+Segments measured:
+  * ``key_verify+jwks``  — one-off: biscuit signature verify + (unless a
+                           public key is configured) the JWKS fetch.
+  * ``verify_only``      — deterministic, NO network: decode + verify a
+                           captured bundle payload (base64 + Ed25519 + sha256).
+                           Skipped when the platform served no compiled bundle.
+  * ``pull_cold_200``    — full ``fetch()``: round-trip + decode + verify.
+  * ``pull_warm_304``    — conditional ``fetch()`` (If-None-Match → 304): the
+                           per-turn refresh hot path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from benchmarks._report import Stats, emit_json, measure, measure_once, print_table
+from hexgate.bootstrap import bootstrap
+from hexgate.cloud.client import HexgateClient, HexgateError
+from hexgate.config.env import resolve_api_key, resolve_api_url
+from hexgate.security.source import (
+    PlatformPolicySource,
+    decode_and_verify_platform_bundle,
+)
+
+DEFAULT_AGENT_NAME = "devops_agent"
+# Network is slow and the platform may rate-limit; a few dozen samples
+# characterize the spread without hammering prod.
+DEFAULT_SAMPLES = 30
+NETWORK_WARMUP = 2
+
+
+def _one_time_stats(agent_name: str) -> tuple[Stats, HexgateClient]:
+    """Fresh client → first verified touch. Times biscuit verify + (unless a
+    public key is preconfigured) the JWKS fetch. Returns a *warmed* client
+    the later segments reuse, so its key is verified exactly once."""
+    client = HexgateClient.from_env()
+    stats = measure_once("key_verify+jwks", client.biscuit_facts)
+    return stats, client
+
+
+def _verify_only_stats(
+    client: HexgateClient, agent_name: str, iterations: int
+) -> list[Stats]:
+    """Capture one real payload, then loop decode+verify locally — pure
+    crypto, zero network variance. This is the honest 'what does bundle
+    verification cost' number."""
+    payload, _ = client.get_agent(agent_name)
+    if payload is None:
+        raise HexgateError("unconditional get_agent returned no payload")
+    pub = client.public_key_bytes()
+    bundle = decode_and_verify_platform_bundle(payload, pub)
+    if bundle is None:
+        print(
+            f"note: platform served no compiled bundle for {agent_name!r} "
+            "(pydantic-fallback shape) — skipping verify_only.",
+            file=sys.stderr,
+        )
+        return []
+    return [
+        measure(
+            "verify_only",
+            lambda: decode_and_verify_platform_bundle(payload, pub),
+            iterations=iterations,
+            warmup=min(iterations, 50),
+        )
+    ]
+
+
+def _cold_pull_stats(client: HexgateClient, agent_name: str, samples: int) -> Stats:
+    """Force a 200 every sample by using a fresh source (no cached etag),
+    so each call pays the full round-trip + decode + verify."""
+
+    def cold() -> None:
+        PlatformPolicySource(client, agent_name).fetch()
+
+    return measure("pull_cold_200", cold, iterations=samples, warmup=NETWORK_WARMUP)
+
+
+def _warm_refresh_stats(client: HexgateClient, agent_name: str, samples: int) -> Stats:
+    """One source, primed once, then looped — every call sends If-None-Match
+    and the platform answers 304. This is the actual per-turn cost."""
+    source = PlatformPolicySource(client, agent_name)
+    source.fetch()  # prime the cached etag
+    return measure(
+        "pull_warm_304", source.fetch, iterations=samples, warmup=NETWORK_WARMUP
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("agent_name", nargs="?", default=DEFAULT_AGENT_NAME)
+    parser.add_argument("--samples", type=int, default=DEFAULT_SAMPLES)
+    parser.add_argument("--json", metavar="PATH", help="write raw stats as JSON")
+    args = parser.parse_args()
+
+    bootstrap()
+    if not resolve_api_key():
+        print(
+            "error: HEXGATE_API_KEY not set — export it (or add it to .env) to "
+            "run the pull benchmark.",
+            file=sys.stderr,
+        )
+        return 1
+
+    url = resolve_api_url()
+    has_pubkey = bool(os.environ.get("HEXGATE_PUBLIC_KEY"))
+    print(f"target: {url}  agent: {args.agent_name}")
+    print(
+        f"public key preconfigured: {has_pubkey} (JWKS fetch {'skipped' if has_pubkey else 'included in key_verify+jwks'})"
+    )
+
+    try:
+        one_time, client = _one_time_stats(args.agent_name)
+        rows: list[Stats] = [one_time]
+        rows += _verify_only_stats(client, args.agent_name, iterations=1000)
+        rows.append(_cold_pull_stats(client, args.agent_name, args.samples))
+        rows.append(_warm_refresh_stats(client, args.agent_name, args.samples))
+    except HexgateError as exc:
+        print(f"error talking to the platform: {exc}", file=sys.stderr)
+        return 1
+
+    print_table(f"Bench B — policy pull latency ({args.samples} network samples)", rows)
+    print(
+        "note: pull_* rows include real network variance — read min vs p99, "
+        "not p50 alone, as the SDK's fixed overhead."
+    )
+    if args.json:
+        emit_json("bench_pull", rows, args.json)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/bench_pull.py
+++ b/benchmarks/bench_pull.py
@@ -17,9 +17,10 @@ Segments measured:
                            captured bundle payload (base64 + Ed25519 + sha256).
                            Skipped when the platform served no compiled bundle.
   * ``pull_cold_200``    — full ``fetch()``: round-trip + decode + verify.
-  * ``pull_warm_304``    — conditional ``fetch()`` (If-None-Match → 304): the
-                           per-turn refresh hot path. Skipped on the no-bundle
-                           branch, which never returns a 304.
+  * ``pull_warm_304``    — conditional policy ``fetch()`` (If-None-Match → 304),
+                           in isolation. Skipped on the no-bundle branch.
+  * ``ban_warm_304``     — same conditional GET against ``/v1/bans``.
+  * ``policy+ban_b2b``   — both back to back: the real per-turn refresh cost.
 """
 
 from __future__ import annotations
@@ -32,6 +33,7 @@ from benchmarks._report import Stats, emit_json, measure, measure_once, print_ta
 from hexgate.bootstrap import bootstrap
 from hexgate.cloud.client import HexgateClient, HexgateError
 from hexgate.config.env import resolve_api_key, resolve_api_url
+from hexgate.security.bans import PlatformBanSource
 from hexgate.security.source import (
     PlatformPolicySource,
     decode_and_verify_platform_bundle,
@@ -101,24 +103,52 @@ def _cold_pull_stats(client: HexgateClient, agent_name: str, samples: int) -> St
 def _warm_refresh_stats(
     client: HexgateClient, agent_name: str, samples: int, has_bundle: bool
 ) -> list[Stats]:
-    """One source, primed once, then looped: each call sends If-None-Match
-    and gets a 304 — the per-turn cost. The no-bundle branch resets its etag
-    every fetch (never a 304), so skip the row there rather than mislabel a
-    full 200 pull as one."""
+    """Policy 304, ban 304, and both back to back — the real per-turn cost,
+    matching invoke's sequential `_refresh_policy_safely` then `_check_ban`
+    (never gathered, so additive). Sources primed once → every timed call
+    sends If-None-Match. Skipped on the no-bundle branch (never 304s)."""
     if not has_bundle:
         print(
             f"note: no compiled bundle for {agent_name!r} — no 304 hot path, "
-            "skipping pull_warm_304.",
+            "skipping warm-refresh rows.",
             file=sys.stderr,
         )
         return []
-    source = PlatformPolicySource(client, agent_name)
-    source.fetch()  # prime the cached etag
-    return [
+
+    policy = PlatformPolicySource(client, agent_name)
+    policy.fetch()  # prime etag
+    rows = [
         measure(
-            "pull_warm_304", source.fetch, iterations=samples, warmup=NETWORK_WARMUP
+            "pull_warm_304", policy.fetch, iterations=samples, warmup=NETWORK_WARMUP
         )
     ]
+
+    # PlatformBanSource is fail-soft; confirm the feed serves an etag first, or
+    # the ban rows would time a fast empty-return, not a conditional GET.
+    _, ban_etag = client.get_bans()
+    if ban_etag is None:
+        print(
+            "note: /v1/bans served no etag — skipping ban + back-to-back rows.",
+            file=sys.stderr,
+        )
+        return rows
+
+    ban = PlatformBanSource(client)
+    ban.fetch()  # prime etag
+
+    def back_to_back() -> None:
+        policy.fetch()
+        ban.fetch()
+
+    rows.append(
+        measure("ban_warm_304", ban.fetch, iterations=samples, warmup=NETWORK_WARMUP)
+    )
+    rows.append(
+        measure(
+            "policy+ban_b2b", back_to_back, iterations=samples, warmup=NETWORK_WARMUP
+        )
+    )
+    return rows
 
 
 def main() -> int:

--- a/benchmarks/bench_pull.py
+++ b/benchmarks/bench_pull.py
@@ -18,7 +18,10 @@ Segments measured:
                            Skipped when the platform served no compiled bundle.
   * ``pull_cold_200``    — full ``fetch()``: round-trip + decode + verify.
   * ``pull_warm_304``    — conditional ``fetch()`` (If-None-Match → 304): the
-                           per-turn refresh hot path.
+                           per-turn refresh hot path. Only meaningful on the
+                           WASM-bundle path — the no-bundle (pydantic-fallback)
+                           branch never returns a 304, so this row is skipped
+                           there rather than mislabeling a full 200 pull.
 """
 
 from __future__ import annotations
@@ -54,10 +57,14 @@ def _one_time_stats(agent_name: str) -> tuple[Stats, HexgateClient]:
 
 def _verify_only_stats(
     client: HexgateClient, agent_name: str, iterations: int
-) -> list[Stats]:
+) -> tuple[list[Stats], bool]:
     """Capture one real payload, then loop decode+verify locally — pure
     crypto, zero network variance. This is the honest 'what does bundle
-    verification cost' number."""
+    verification cost' number.
+
+    Returns ``(stats, has_bundle)``: ``has_bundle`` is False when the
+    platform served no compiled bundle, which the caller uses to skip the
+    304-only segments that can't happen on that branch."""
     payload, _ = client.get_agent(agent_name)
     if payload is None:
         raise HexgateError("unconditional get_agent returned no payload")
@@ -69,7 +76,7 @@ def _verify_only_stats(
             "(pydantic-fallback shape) — skipping verify_only.",
             file=sys.stderr,
         )
-        return []
+        return [], False
     return [
         measure(
             "verify_only",
@@ -77,7 +84,7 @@ def _verify_only_stats(
             iterations=iterations,
             warmup=min(iterations, 50),
         )
-    ]
+    ], True
 
 
 def _cold_pull_stats(client: HexgateClient, agent_name: str, samples: int) -> Stats:
@@ -90,14 +97,29 @@ def _cold_pull_stats(client: HexgateClient, agent_name: str, samples: int) -> St
     return measure("pull_cold_200", cold, iterations=samples, warmup=NETWORK_WARMUP)
 
 
-def _warm_refresh_stats(client: HexgateClient, agent_name: str, samples: int) -> Stats:
-    """One source, primed once, then looped — every call sends If-None-Match
-    and the platform answers 304. This is the actual per-turn cost."""
+def _warm_refresh_stats(
+    client: HexgateClient, agent_name: str, samples: int, has_bundle: bool
+) -> list[Stats]:
+    """One source, primed once, then looped. On the WASM-bundle path every
+    call sends If-None-Match and the platform answers 304 — the actual
+    per-turn cost. On the no-bundle branch the source resets its etag on
+    every fetch (see ``PlatformPolicySource.fetch``), so no 304 is possible
+    and looping would time a full 200 + YAML parse mislabeled as a 304;
+    skip the row there instead."""
+    if not has_bundle:
+        print(
+            f"note: platform served no compiled bundle for {agent_name!r} "
+            "(pydantic-fallback shape) — no 304 hot path, skipping pull_warm_304.",
+            file=sys.stderr,
+        )
+        return []
     source = PlatformPolicySource(client, agent_name)
     source.fetch()  # prime the cached etag
-    return measure(
-        "pull_warm_304", source.fetch, iterations=samples, warmup=NETWORK_WARMUP
-    )
+    return [
+        measure(
+            "pull_warm_304", source.fetch, iterations=samples, warmup=NETWORK_WARMUP
+        )
+    ]
 
 
 def main() -> int:
@@ -126,10 +148,18 @@ def main() -> int:
     try:
         one_time, client = _one_time_stats(args.agent_name)
         rows: list[Stats] = [one_time]
-        rows += _verify_only_stats(client, args.agent_name, iterations=1000)
+        verify_rows, has_bundle = _verify_only_stats(
+            client, args.agent_name, iterations=1000
+        )
+        rows += verify_rows
         rows.append(_cold_pull_stats(client, args.agent_name, args.samples))
-        rows.append(_warm_refresh_stats(client, args.agent_name, args.samples))
-    except HexgateError as exc:
+        rows += _warm_refresh_stats(client, args.agent_name, args.samples, has_bundle)
+    except (HexgateError, RuntimeError, OSError) as exc:
+        # HexgateError: API/transport errors the client already wraps.
+        # RuntimeError: decode_and_verify_platform_bundle raises this on a
+        #   served-but-invalid bundle (bad base64 / signature / sha256).
+        # OSError: a socket read-timeout during urlopen().read() escapes the
+        #   client unwrapped (TimeoutError is an OSError subclass).
         print(f"error talking to the platform: {exc}", file=sys.stderr)
         return 1
 

--- a/benchmarks/bench_pull.py
+++ b/benchmarks/bench_pull.py
@@ -18,10 +18,8 @@ Segments measured:
                            Skipped when the platform served no compiled bundle.
   * ``pull_cold_200``    — full ``fetch()``: round-trip + decode + verify.
   * ``pull_warm_304``    — conditional ``fetch()`` (If-None-Match → 304): the
-                           per-turn refresh hot path. Only meaningful on the
-                           WASM-bundle path — the no-bundle (pydantic-fallback)
-                           branch never returns a 304, so this row is skipped
-                           there rather than mislabeling a full 200 pull.
+                           per-turn refresh hot path. Skipped on the no-bundle
+                           branch, which never returns a 304.
 """
 
 from __future__ import annotations
@@ -44,6 +42,10 @@ DEFAULT_AGENT_NAME = "devops_agent"
 # characterize the spread without hammering prod.
 DEFAULT_SAMPLES = 30
 NETWORK_WARMUP = 2
+# verify_only is local crypto: loop it hard, but cap warmup so small
+# iteration counts don't warm longer than they measure.
+VERIFY_ONLY_ITERATIONS = 1000
+VERIFY_ONLY_WARMUP_CAP = 50
 
 
 def _one_time_stats(agent_name: str) -> tuple[Stats, HexgateClient]:
@@ -62,9 +64,8 @@ def _verify_only_stats(
     crypto, zero network variance. This is the honest 'what does bundle
     verification cost' number.
 
-    Returns ``(stats, has_bundle)``: ``has_bundle`` is False when the
-    platform served no compiled bundle, which the caller uses to skip the
-    304-only segments that can't happen on that branch."""
+    Returns ``(stats, has_bundle)``; ``has_bundle`` is False when no
+    compiled bundle was served, so the caller can skip the 304-only rows."""
     payload, _ = client.get_agent(agent_name)
     if payload is None:
         raise HexgateError("unconditional get_agent returned no payload")
@@ -82,7 +83,7 @@ def _verify_only_stats(
             "verify_only",
             lambda: decode_and_verify_platform_bundle(payload, pub),
             iterations=iterations,
-            warmup=min(iterations, 50),
+            warmup=min(iterations, VERIFY_ONLY_WARMUP_CAP),
         )
     ], True
 
@@ -100,16 +101,14 @@ def _cold_pull_stats(client: HexgateClient, agent_name: str, samples: int) -> St
 def _warm_refresh_stats(
     client: HexgateClient, agent_name: str, samples: int, has_bundle: bool
 ) -> list[Stats]:
-    """One source, primed once, then looped. On the WASM-bundle path every
-    call sends If-None-Match and the platform answers 304 — the actual
-    per-turn cost. On the no-bundle branch the source resets its etag on
-    every fetch (see ``PlatformPolicySource.fetch``), so no 304 is possible
-    and looping would time a full 200 + YAML parse mislabeled as a 304;
-    skip the row there instead."""
+    """One source, primed once, then looped: each call sends If-None-Match
+    and gets a 304 — the per-turn cost. The no-bundle branch resets its etag
+    every fetch (never a 304), so skip the row there rather than mislabel a
+    full 200 pull as one."""
     if not has_bundle:
         print(
-            f"note: platform served no compiled bundle for {agent_name!r} "
-            "(pydantic-fallback shape) — no 304 hot path, skipping pull_warm_304.",
+            f"note: no compiled bundle for {agent_name!r} — no 304 hot path, "
+            "skipping pull_warm_304.",
             file=sys.stderr,
         )
         return []
@@ -149,17 +148,14 @@ def main() -> int:
         one_time, client = _one_time_stats(args.agent_name)
         rows: list[Stats] = [one_time]
         verify_rows, has_bundle = _verify_only_stats(
-            client, args.agent_name, iterations=1000
+            client, args.agent_name, iterations=VERIFY_ONLY_ITERATIONS
         )
         rows += verify_rows
         rows.append(_cold_pull_stats(client, args.agent_name, args.samples))
         rows += _warm_refresh_stats(client, args.agent_name, args.samples, has_bundle)
     except (HexgateError, RuntimeError, OSError) as exc:
-        # HexgateError: API/transport errors the client already wraps.
-        # RuntimeError: decode_and_verify_platform_bundle raises this on a
-        #   served-but-invalid bundle (bad base64 / signature / sha256).
-        # OSError: a socket read-timeout during urlopen().read() escapes the
-        #   client unwrapped (TimeoutError is an OSError subclass).
+        # RuntimeError: invalid bundle; OSError: read-timeout the client
+        # doesn't wrap. Both would otherwise crash instead of exiting clean.
         print(f"error talking to the platform: {exc}", file=sys.stderr)
         return 1
 


### PR DESCRIPTION
## Summary

Adds `benchmarks/` — a standalone, stdlib-only latency benchmark suite that isolates the deterministic costs the SDK adds around an agent's tool calls, kept separate from LLM and network variance. Not part of the shipped package.

## What's included

- **Bench A — enforcement (`bench_enforce.py`)** — local, no secrets, no network. Compiles `examples/devops_policy.yaml` to WASM via `opa` at startup, then times `wasm_instantiate`, `wasm_cache_hit`, raw `engine:<case>` eval, and full `enforcer:<case>` `decide()`. A four-case workload (fast allow / constrained allow / constraint deny / default deny) exercises every branch of the compiled decision tree, and each case's outcome is asserted before timing so a policy drift fails loudly instead of benchmarking the wrong branch.
- **Bench B — policy pull (`bench_pull.py`)** — targets `app.hexgate.ai` (needs `HEXGATE_API_KEY`). Separates deterministic crypto (`verify_only`) from variable network (`pull_cold_200`, `pull_warm_304`, `key_verify+jwks`).
- **Shared harness (`_report.py`)** — `perf_counter_ns` timing, nearest-rank percentiles, a p50/p95/p99/max table, and `--json PATH` to dump raw stats for diffing later runs.
- **README** with run instructions and per-segment explanations.

## Review hardening

- **Percentile** — nearest-rank now uses `ceil`, not `round`; `round` understated the tail at small N (e.g. p95 over 30 samples).
- **`pull_warm_304`** — skipped on the no-bundle (pydantic-fallback) branch, which never returns a 304, instead of mislabeling a full 200 pull as the 304 hot path.
- **Error handling** — `bench_pull` catches `RuntimeError`/`OSError` (invalid/tampered bundle, socket read-timeout) so it exits cleanly with a message instead of crashing.
- **Enforcer wrapper tax** — benched with a no-op `decision_observer` so `decide()` takes the same `copy.deepcopy(args)` branch every audited production enforcer takes; it was previously understated via the shallow-copy branch.
- Extracted magic literals to named constants.

## Notes

- The README "Indicative numbers" are illustrative from a single dev run — not a contract; re-run on the target host.
- Bench A measures `engine:` and `enforcer:` in separate passes; interleaving them per-case would give a more trustworthy engine-vs-enforcer delta (possible follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
