### PR TITLE
feat(sdk): policy analyzer + hexgate policy check (2/3)

### DIFF
--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -1,10 +1,11 @@
 """`hexgate policy` subcommand — author + inspect + dry-run policy documents.
 
-Wraps the compiler library and both enforcement engines in a five-verb
-CLI: ``build``, ``validate``, ``show-rego``, ``test``, ``keygen``. Every
-verb is a thin wrapper — the heavy lifting lives in
-:mod:`hexgate.security`. That symmetry lets the platform's save flow use
-the same code without duplication.
+Wraps the compiler library and both enforcement engines in a set of thin
+verbs: ``build``, ``validate``, ``show-rego``, ``test``, ``keygen``,
+``resolve`` (compose a module bundle into one effective policy), and
+``check`` (lint that bundle). Every verb is a thin wrapper — the heavy
+lifting lives in :mod:`hexgate.security`. That symmetry lets the platform's
+save flow use the same code without duplication.
 
 ``build`` compiles the policy to a signed WASM bundle (yaml + rego +
 wasm + manifest, ``--sign-key`` to sign); ``test`` evaluates a decision
@@ -554,30 +555,34 @@ def _main_check(args: argparse.Namespace) -> int:
             print(f"manifest error: {exc}", file=sys.stderr)
             return 1
 
+    from hexgate.security.analyzer import SEVERITY_RANK
+
     lints = check_bundle(boundaries, capabilities, manifest=manifest)
 
-    if not lints:
-        print("✓ No policy lints.")
-        if manifest is None:
+    # A link error short-circuits before drift/soft lints run, so the
+    # "supply a manifest" hint only makes sense when linking succeeded.
+    linked = not (len(lints) == 1 and lints[0].code == "link-error")
+
+    def _drift_hint() -> None:
+        if manifest is None and linked:
             print(
                 "  (drift checks skipped — pass --manifest to enable them)",
                 file=sys.stderr,
             )
+
+    if not lints:
+        print("✓ No policy lints.")
+        _drift_hint()
         return 0
 
     icon = {"error": "✗", "warning": "!", "info": "·"}
-    rank = {"error": 0, "warning": 1, "info": 2}
     for lint in lints:
         where = f" ({lint.source})" if lint.source else ""
         print(f"{icon.get(lint.severity, '·')} [{lint.code}] {lint.message}{where}")
-    if manifest is None:
-        print(
-            "  (drift checks skipped — pass --manifest to enable them)",
-            file=sys.stderr,
-        )
+    _drift_hint()
 
-    threshold = rank[args.max_severity]
-    worst = min(rank[lint.severity] for lint in lints)
+    threshold = SEVERITY_RANK[args.max_severity]
+    worst = min(SEVERITY_RANK[lint.severity] for lint in lints)
     return 1 if worst <= threshold else 0
 
 

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -213,6 +213,41 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
     )
     p_resolve.set_defaults(func=_main_resolve)
 
+    # ---- check ----
+    p_check = sub.add_parser(
+        "check",
+        help="Lint a bundle of policy modules (dead / redundant / drift).",
+        description=(
+            "Links the boundary + capability modules under <dir>/policies/ and "
+            "reports authoring problems that don't stop composition but are "
+            "almost always mistakes: a capability grant a boundary ceiling makes "
+            "dead, a duplicate grant, or (with --manifest) a rule referencing a "
+            "tool/arg the agent's code doesn't have. Exits non-zero when any lint "
+            "is at or above --max-severity, so CI can gate on it."
+        ),
+    )
+    p_check.add_argument(
+        "--dir",
+        default=".",
+        help="Repo root containing a policies/ tree (default: current dir).",
+    )
+    p_check.add_argument(
+        "--manifest",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Optional AgentManifest JSON. Enables drift checks (unknown tool / "
+            "arg); without it those are skipped."
+        ),
+    )
+    p_check.add_argument(
+        "--max-severity",
+        choices=("error", "warning", "info"),
+        default="error",
+        help="Exit non-zero if any lint is at or above this severity (default error).",
+    )
+    p_check.set_defaults(func=_main_check)
+
 
 def main(args: argparse.Namespace) -> int:
     """Entry point used by the top-level dispatcher in hexgate/cli/__init__.py."""
@@ -487,6 +522,63 @@ def _main_resolve(args: argparse.Namespace) -> int:
         for tool, by in sorted(result.trace.shadowed.items()):
             print(f"  {tool}  ← {by.module} ({by.source})", file=sys.stderr)
     return 0
+
+
+def _main_check(args: argparse.Namespace) -> int:
+    """Lint the local module bundle; exit non-zero at/above --max-severity."""
+    from hexgate.security import check as check_bundle
+    from hexgate.security import load_local_modules
+
+    try:
+        boundaries, capabilities = load_local_modules(args.dir)
+    except (ValueError, OSError) as exc:
+        print(f"load error: {exc}", file=sys.stderr)
+        return 1
+    if not boundaries and not capabilities:
+        print(
+            f"no modules found under {args.dir}/policies/"
+            " (expected policies/boundaries/ and/or policies/capabilities/)",
+            file=sys.stderr,
+        )
+        return 1
+
+    manifest = None
+    if args.manifest:
+        from hexgate.manifest.models import AgentManifest
+
+        try:
+            manifest = AgentManifest.model_validate_json(
+                Path(args.manifest).read_text(encoding="utf-8")
+            )
+        except (OSError, ValidationError, ValueError) as exc:
+            print(f"manifest error: {exc}", file=sys.stderr)
+            return 1
+
+    lints = check_bundle(boundaries, capabilities, manifest=manifest)
+
+    if not lints:
+        print("✓ No policy lints.")
+        if manifest is None:
+            print(
+                "  (drift checks skipped — pass --manifest to enable them)",
+                file=sys.stderr,
+            )
+        return 0
+
+    icon = {"error": "✗", "warning": "!", "info": "·"}
+    rank = {"error": 0, "warning": 1, "info": 2}
+    for lint in lints:
+        where = f" ({lint.source})" if lint.source else ""
+        print(f"{icon.get(lint.severity, '·')} [{lint.code}] {lint.message}{where}")
+    if manifest is None:
+        print(
+            "  (drift checks skipped — pass --manifest to enable them)",
+            file=sys.stderr,
+        )
+
+    threshold = rank[args.max_severity]
+    worst = min(rank[lint.severity] for lint in lints)
+    return 1 if worst <= threshold else 0
 
 
 def _main_test(args: argparse.Namespace) -> int:

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -90,6 +90,7 @@ from hexgate.security.modules import (
     RuleTrace,
 )
 from hexgate.security.linker import link, link_policy_set
+from hexgate.security.analyzer import PolicyLint, analyze, check
 from hexgate.security.module_loader import ModuleLoader, load_local_modules
 from hexgate.security.rego import compile_default_only, compile_to_rego
 from hexgate.security.rego_wasm import (
@@ -127,8 +128,11 @@ __all__ = [
     "LinkResult",
     "ModuleContent",
     "ModuleLoader",
+    "PolicyLint",
     "Provenance",
     "RuleTrace",
+    "analyze",
+    "check",
     "link",
     "link_policy_set",
     "load_local_modules",

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -1,0 +1,226 @@
+"""Analyze a linked policy bundle for authoring problems — the lint layer.
+
+The linker (:mod:`hexgate.security.linker`) *raises* :class:`LinkError` for the
+unfixable cases (a capability that denies, a conflicting const, ``file_scope`` in
+a module). This module runs over a **successfully linked** bundle and reports the
+*soft* problems that don't stop composition but are almost always mistakes:
+
+- **dead-grant** — a capability grants a tool a boundary ceiling excludes, so the
+  grant never fires.
+- **redundant-grant** — two capabilities grant the same tool identically.
+- **unknown-tool** / **unknown-arg** — a rule references a tool or arg absent from
+  the agent's manifest (drift between policy and code). Only checked when a
+  manifest is supplied; boundary drift is fail-open, so it's an error.
+
+Every :class:`PolicyLint` carries the ``source`` file it attributes to — the same
+contract the CLI (`hexgate policy check`) and the dashboard editor both consume.
+Deferred (needs a solver): semantic conflicts — empty intersection, always-true /
+always-false, subsumption.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from hexgate.security.constraints import iter_arg_refs, parse_constraint
+from hexgate.security.linker import link_policy_set
+from hexgate.security.modules import (
+    LayerKind,
+    LinkError,
+    LinkResult,
+    ModuleContent,
+)
+
+if TYPE_CHECKING:  # avoid importing the manifest package eagerly
+    from hexgate.manifest.models import AgentManifest
+
+Severity = Literal["error", "warning", "info"]
+_GRANT_MODES = ("allow", "approval_required")
+_SEVERITY_RANK = {"error": 0, "warning": 1, "info": 2}
+
+
+@dataclass(frozen=True)
+class PolicyLint:
+    """One authoring problem, attributed to the file that caused it.
+
+    ``line`` is ``None`` for now (file-level attribution); line-level lands with
+    YAML position tracking in the loader. ``tier`` / ``tool`` are set when known.
+    """
+
+    code: str
+    severity: Severity
+    message: str
+    source: str | None = None
+    line: int | None = None
+    tier: LayerKind | None = None
+    tool: str | None = None
+
+
+def check(
+    boundaries: list[ModuleContent],
+    capabilities: list[ModuleContent],
+    *,
+    manifest: AgentManifest | None = None,
+) -> list[PolicyLint]:
+    """Link + analyze in one call.
+
+    A :class:`LinkError` (the hard cases) becomes a single ``error`` lint so a
+    caller reports hard failures and soft lints through one uniform list.
+    """
+    try:
+        result = link_policy_set(boundaries, capabilities)
+    except LinkError as exc:
+        return [PolicyLint("link-error", "error", str(exc))]
+    return analyze(result, boundaries, capabilities, manifest=manifest)
+
+
+def analyze(
+    result: LinkResult,
+    boundaries: list[ModuleContent],
+    capabilities: list[ModuleContent],
+    *,
+    manifest: AgentManifest | None = None,
+) -> list[PolicyLint]:
+    """Soft lints over a successfully-linked bundle, most-severe first.
+
+    Needs the input modules (not just ``result``) to know what each layer
+    *declared* versus what survived the fold.
+    """
+    lints: list[PolicyLint] = []
+    lints += _dead_grants(result, capabilities)
+    lints += _redundant_grants(capabilities)
+    if manifest is not None:
+        lints += _drift(boundaries, capabilities, manifest)
+    return sorted(lints, key=lambda lint: _SEVERITY_RANK[lint.severity])
+
+
+def _dead_grants(
+    result: LinkResult, capabilities: list[ModuleContent]
+) -> list[PolicyLint]:
+    """A capability grant for a tool a ceiling made ineligible never fires."""
+    out: list[PolicyLint] = []
+    for tool, shadowed_by in result.trace.shadowed.items():
+        for cap in capabilities:
+            tp = cap.policy.tools.get(tool)
+            if tp is not None and tp.mode in _GRANT_MODES:
+                out.append(
+                    PolicyLint(
+                        code="dead-grant",
+                        severity="warning",
+                        message=(
+                            f"{cap.name!r} grants {tool!r} but boundary "
+                            f"{shadowed_by.module!r} (a ceiling) never permits it "
+                            f"— this grant never fires"
+                        ),
+                        source=cap.source,
+                        tier="capability",
+                        tool=tool,
+                    )
+                )
+    return out
+
+
+def _redundant_grants(capabilities: list[ModuleContent]) -> list[PolicyLint]:
+    """Two capabilities granting the same tool with the same mode + constraints."""
+    out: list[PolicyLint] = []
+    seen: dict[tuple[str, str, tuple[str, ...]], ModuleContent] = {}
+    for cap in capabilities:
+        for tool, tp in cap.policy.tools.items():
+            if tp.mode not in _GRANT_MODES:
+                continue
+            key = (tool, tp.mode, tuple(sorted(tp.constraints)))
+            first = seen.get(key)
+            if first is not None:
+                out.append(
+                    PolicyLint(
+                        code="redundant-grant",
+                        severity="info",
+                        message=(
+                            f"{cap.name!r} repeats the {tool!r} grant already in "
+                            f"{first.name!r}"
+                        ),
+                        source=cap.source,
+                        tier="capability",
+                        tool=tool,
+                    )
+                )
+            else:
+                seen[key] = cap
+    return out
+
+
+def _drift(
+    boundaries: list[ModuleContent],
+    capabilities: list[ModuleContent],
+    manifest: AgentManifest,
+) -> list[PolicyLint]:
+    """Rules referencing tools / args the agent's code doesn't have.
+
+    Boundary drift is fail-open (a stale deny protects nothing) → error;
+    capability drift is fail-safe (a dead grant) → warning.
+    """
+    tool_props: dict[str, set[str]] = {
+        t.name: set(t.input_schema.properties) for t in manifest.tools
+    }
+    known_tools = set(tool_props)
+
+    out: list[PolicyLint] = []
+    tiers: list[tuple[list[ModuleContent], LayerKind]] = [
+        (boundaries, "boundary"),
+        (capabilities, "capability"),
+    ]
+    for modules, tier in tiers:
+        severity: Severity = "error" if tier == "boundary" else "warning"
+        for module in modules:
+            for tool, tp in module.policy.tools.items():
+                if tool not in known_tools:
+                    out.append(
+                        PolicyLint(
+                            code="unknown-tool",
+                            severity=severity,
+                            message=(
+                                f"{module.name!r} references tool {tool!r}, which "
+                                f"the agent's manifest doesn't declare"
+                            ),
+                            source=module.source,
+                            tier=tier,
+                            tool=tool,
+                        )
+                    )
+                    continue
+                out += _unknown_args(module, tier, tool, tp, tool_props[tool])
+    return out
+
+
+def _unknown_args(
+    module: ModuleContent,
+    tier: LayerKind,
+    tool: str,
+    tool_policy: Any,
+    valid_args: set[str],
+) -> list[PolicyLint]:
+    """Constraint ``args.<x>`` paths where ``<x>`` isn't a parameter of the tool."""
+    out: list[PolicyLint] = []
+    flagged: set[str] = set()
+    for raw in tool_policy.constraints:
+        for path in iter_arg_refs(parse_constraint(raw)):
+            if len(path) >= 2 and path[0] == "args" and path[1] not in valid_args:
+                arg = path[1]
+                if arg in flagged:
+                    continue
+                flagged.add(arg)
+                out.append(
+                    PolicyLint(
+                        code="unknown-arg",
+                        severity="warning",
+                        message=(
+                            f"{module.name!r} constrains {tool!r} on args.{arg}, "
+                            f"which the tool doesn't accept"
+                        ),
+                        source=module.source,
+                        tier=tier,
+                        tool=tool,
+                    )
+                )
+    return out

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -26,18 +26,19 @@ from typing import TYPE_CHECKING, Any, Literal
 from hexgate.security.constraints import iter_arg_refs, parse_constraint
 from hexgate.security.linker import link_policy_set
 from hexgate.security.modules import (
+    GRANT_MODES,
     LayerKind,
     LinkError,
     LinkResult,
     ModuleContent,
 )
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 
 if TYPE_CHECKING:  # avoid importing the manifest package eagerly
     from hexgate.manifest.models import AgentManifest
 
 Severity = Literal["error", "warning", "info"]
-_GRANT_MODES = ("allow", "approval_required")
-_SEVERITY_RANK = {"error": 0, "warning": 1, "info": 2}
+SEVERITY_RANK: dict[Severity, int] = {"error": 0, "warning": 1, "info": 2}
 
 
 @dataclass(frozen=True)
@@ -92,33 +93,51 @@ def analyze(
     lints += _redundant_grants(capabilities)
     if manifest is not None:
         lints += _drift(boundaries, capabilities, manifest)
-    return sorted(lints, key=lambda lint: _SEVERITY_RANK[lint.severity])
+    return sorted(lints, key=lambda lint: SEVERITY_RANK[lint.severity])
 
 
 def _dead_grants(
     result: LinkResult, capabilities: list[ModuleContent]
 ) -> list[PolicyLint]:
-    """A capability grant for a tool a ceiling made ineligible never fires."""
+    """A capability grant that the effective policy doesn't allow never fires.
+
+    Keyed off the *resolved* policy, not just ``trace.shadowed``, so it catches
+    every dead grant: a ceiling that excludes the tool AND a boundary that
+    hard-denies it (the latter never enters ``shadowed`` — it takes the
+    absolute-deny path in the fold). A grant survives iff the effective tool is
+    still allow/approval.
+    """
+    effective = result.effective[DEFAULT_ROLE_NAME]
     out: list[PolicyLint] = []
-    for tool, shadowed_by in result.trace.shadowed.items():
-        for cap in capabilities:
-            tp = cap.policy.tools.get(tool)
-            if tp is not None and tp.mode in _GRANT_MODES:
-                out.append(
-                    PolicyLint(
-                        code="dead-grant",
-                        severity="warning",
-                        message=(
-                            f"{cap.name!r} grants {tool!r} but boundary "
-                            f"{shadowed_by.module!r} (a ceiling) never permits it "
-                            f"— this grant never fires"
-                        ),
-                        source=cap.source,
-                        tier="capability",
-                        tool=tool,
-                    )
+    for cap in capabilities:
+        for tool, tp in cap.policy.tools.items():
+            if tp.mode not in GRANT_MODES:
+                continue
+            eff = effective.tools.get(tool)
+            if eff is not None and eff.mode in GRANT_MODES:
+                continue  # the grant contributes to the effective allow — alive
+            out.append(
+                PolicyLint(
+                    code="dead-grant",
+                    severity="warning",
+                    message=(
+                        f"{cap.name!r} grants {tool!r} but {_dead_reason(tool, result)}"
+                        f" — this grant never fires"
+                    ),
+                    source=cap.source,
+                    tier="capability",
+                    tool=tool,
                 )
+            )
     return out
+
+
+def _dead_reason(tool: str, result: LinkResult) -> str:
+    """Why a grant is dead: a ceiling that excludes it, or a boundary deny."""
+    shadowed_by = result.trace.shadowed.get(tool)
+    if shadowed_by is not None:
+        return f"boundary {shadowed_by.module!r} (a ceiling) never permits it"
+    return "a boundary denies it"
 
 
 def _redundant_grants(capabilities: list[ModuleContent]) -> list[PolicyLint]:
@@ -127,7 +146,7 @@ def _redundant_grants(capabilities: list[ModuleContent]) -> list[PolicyLint]:
     seen: dict[tuple[str, str, tuple[str, ...]], ModuleContent] = {}
     for cap in capabilities:
         for tool, tp in cap.policy.tools.items():
-            if tp.mode not in _GRANT_MODES:
+            if tp.mode not in GRANT_MODES:
                 continue
             key = (tool, tp.mode, tuple(sorted(tp.constraints)))
             first = seen.get(key)

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -23,7 +23,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
-from hexgate.security.constraints import iter_arg_refs, parse_constraint
+from hexgate.security.constraints import (
+    ConstraintParseError,
+    iter_arg_refs,
+    parse_constraint,
+)
 from hexgate.security.linker import link_policy_set
 from hexgate.security.modules import (
     GRANT_MODES,
@@ -32,7 +36,7 @@ from hexgate.security.modules import (
     LinkResult,
     ModuleContent,
 )
-from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySetError
 
 if TYPE_CHECKING:  # avoid importing the manifest package eagerly
     from hexgate.manifest.models import AgentManifest
@@ -66,12 +70,16 @@ def check(
 ) -> list[PolicyLint]:
     """Link + analyze in one call.
 
-    A :class:`LinkError` (the hard cases) becomes a single ``error`` lint so a
-    caller reports hard failures and soft lints through one uniform list.
+    A hard failure (the linker rejecting the bundle, or an invalid resolved
+    policy) becomes a single ``error`` lint so a caller reports hard failures
+    and soft lints through one uniform list. The except tuple matches what
+    ``link_policy_set`` can raise: ``LinkError`` from the fold, and
+    ``PolicySetError`` / ``ConstraintParseError`` from validating the resolved
+    policy (e.g. an undefined ``consts`` reference).
     """
     try:
         result = link_policy_set(boundaries, capabilities)
-    except LinkError as exc:
+    except (LinkError, PolicySetError, ConstraintParseError) as exc:
         return [PolicyLint("link-error", "error", str(exc))]
     return analyze(result, boundaries, capabilities, manifest=manifest)
 
@@ -91,6 +99,7 @@ def analyze(
     lints: list[PolicyLint] = []
     lints += _dead_grants(result, capabilities)
     lints += _redundant_grants(capabilities)
+    lints += _constraint_erased(capabilities)
     if manifest is not None:
         lints += _drift(boundaries, capabilities, manifest)
     return sorted(lints, key=lambda lint: SEVERITY_RANK[lint.severity])
@@ -169,6 +178,44 @@ def _redundant_grants(capabilities: list[ModuleContent]) -> list[PolicyLint]:
     return out
 
 
+def _constraint_erased(capabilities: list[ModuleContent]) -> list[PolicyLint]:
+    """A constrained grant nullified by an unconditional sibling grant.
+
+    Capability grants for one tool union, so an unconditional grant (no
+    constraints) widens the tool to everything and drops every sibling's
+    condition. That is intended union semantics, but it is the security-relevant
+    direction (a tight rule silently erased), so it warrants a warning.
+    """
+    grants: dict[str, list[tuple[ModuleContent, Any]]] = {}
+    for cap in capabilities:
+        for tool, tp in cap.policy.tools.items():
+            if tp.mode in GRANT_MODES:
+                grants.setdefault(tool, []).append((cap, tp))
+
+    out: list[PolicyLint] = []
+    for tool, entries in grants.items():
+        unconditional = [cap for cap, tp in entries if not tp.constraints]
+        if not unconditional:
+            continue
+        for cap, tp in entries:
+            if tp.constraints:
+                out.append(
+                    PolicyLint(
+                        code="constraint-erased",
+                        severity="warning",
+                        message=(
+                            f"{cap.name!r} constrains {tool!r}, but "
+                            f"{unconditional[0].name!r} grants it unconditionally, "
+                            f"so the constraint is dropped from the effective policy"
+                        ),
+                        source=cap.source,
+                        tier="capability",
+                        tool=tool,
+                    )
+                )
+    return out
+
+
 def _drift(
     boundaries: list[ModuleContent],
     capabilities: list[ModuleContent],
@@ -176,8 +223,14 @@ def _drift(
 ) -> list[PolicyLint]:
     """Rules referencing tools / args the agent's code doesn't have.
 
-    Boundary drift is fail-open (a stale deny protects nothing) → error;
-    capability drift is fail-safe (a dead grant) → warning.
+    Severity follows the failure direction, not just the tier:
+      * boundary allow/approval (a ceiling) naming a missing tool leaves the real
+        tool uncapped -> fail-open -> error.
+      * boundary deny naming a missing tool protects nothing and breaks nothing
+        -> info.
+      * capability drift is a dead grant -> warning.
+      * a boundary deny's arg typo inverts (``not(<missing> ...)`` folds to allow)
+        -> fail-open -> error; other arg drift -> warning.
     """
     tool_props: dict[str, set[str]] = {
         t.name: set(t.input_schema.properties) for t in manifest.tools
@@ -190,14 +243,13 @@ def _drift(
         (capabilities, "capability"),
     ]
     for modules, tier in tiers:
-        severity: Severity = "error" if tier == "boundary" else "warning"
         for module in modules:
             for tool, tp in module.policy.tools.items():
                 if tool not in known_tools:
                     out.append(
                         PolicyLint(
                             code="unknown-tool",
-                            severity=severity,
+                            severity=_unknown_tool_severity(tier, tp.mode),
                             message=(
                                 f"{module.name!r} references tool {tool!r}, which "
                                 f"the agent's manifest doesn't declare"
@@ -208,8 +260,21 @@ def _drift(
                         )
                     )
                     continue
-                out += _unknown_args(module, tier, tool, tp, tool_props[tool])
+                arg_severity: Severity = (
+                    "error" if (tier == "boundary" and tp.mode == "deny") else "warning"
+                )
+                out += _unknown_args(
+                    module, tier, tool, tp, tool_props[tool], arg_severity
+                )
     return out
+
+
+def _unknown_tool_severity(tier: LayerKind, mode: str) -> Severity:
+    """A boundary deny on a missing tool is harmless; a boundary ceiling that
+    names a missing tool leaves the real tool uncapped (fail-open)."""
+    if tier == "capability":
+        return "warning"
+    return "info" if mode == "deny" else "error"
 
 
 def _unknown_args(
@@ -218,6 +283,7 @@ def _unknown_args(
     tool: str,
     tool_policy: Any,
     valid_args: set[str],
+    severity: Severity,
 ) -> list[PolicyLint]:
     """Constraint ``args.<x>`` paths where ``<x>`` isn't a parameter of the tool."""
     out: list[PolicyLint] = []
@@ -232,7 +298,7 @@ def _unknown_args(
                 out.append(
                     PolicyLint(
                         code="unknown-arg",
-                        severity="warning",
+                        severity=severity,
                         message=(
                             f"{module.name!r} constrains {tool!r} on args.{arg}, "
                             f"which the tool doesn't accept"

--- a/hexgate/security/constraints.py
+++ b/hexgate/security/constraints.py
@@ -535,6 +535,39 @@ def iter_const_refs(node: Node):
         yield from iter_const_refs(node.inner)
 
 
+def iter_arg_refs(node: Node):
+    """Yield every field-reference path (a :class:`Ref`'s dotted tuple) in a node.
+
+    Mirrors :func:`iter_const_refs` but for field paths (``args.amount`` →
+    ``("args", "amount")``, ``role`` → ``("role",)``). Used by the analyzer to
+    check a constraint's ``args.*`` paths against a tool's input schema. Element
+    refs (``.`` inside a quantifier) bind to a collection element, not a named
+    field, so they're skipped.
+    """
+
+    def _operand(op):
+        if isinstance(op, Ref):
+            yield op.path
+        elif isinstance(op, Count) and isinstance(op.ref, Ref):
+            yield op.ref.path
+
+    if isinstance(node, Cmp):
+        yield from _operand(node.left)
+        yield from _operand(node.right)
+    elif isinstance(node, Call):
+        if isinstance(node.arg, Ref):
+            yield node.arg.path
+    elif isinstance(node, Quant):
+        if isinstance(node.ref, Ref):
+            yield node.ref.path
+        yield from iter_arg_refs(node.body)
+    elif isinstance(node, (And, Or)):
+        for part in node.parts:
+            yield from iter_arg_refs(part)
+    elif isinstance(node, Not):
+        yield from iter_arg_refs(node.inner)
+
+
 def _reject_unscoped_elem(node: Node, source: str, *, in_quant: bool) -> None:
     """Raise if an element ref (``.`` / ``.field``) appears outside a quantifier.
 

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -74,6 +74,7 @@ def link(
 ) -> tuple[AgentPolicy, RuleTrace]:
     """Fold one role's layers into a single :class:`AgentPolicy`. Pure; no I/O."""
     _reject_file_scope(boundaries, capabilities)
+    _reject_default_policy_constraints(boundaries, capabilities)
     consts = _merge_consts(boundaries, capabilities)
 
     trace = RuleTrace()
@@ -130,6 +131,28 @@ def _merge_consts(
     for module in capabilities:
         _put(module, is_boundary=False)
     return merged
+
+
+def _reject_default_policy_constraints(
+    boundaries: list[ModuleContent], capabilities: list[ModuleContent]
+) -> None:
+    """Reject ``default_policy.constraints`` in a module.
+
+    The fold reads a boundary's ``default_policy.mode`` (to tell a ceiling from a
+    floor) but the effective default is always fail-closed ``deny``, so any
+    constraints on a module's ``default_policy`` would be silently dropped. The
+    pydantic engine does enforce them in a single-file policy, so dropping them
+    on a migration would quietly lose a fence. Fail loud instead; put the rule on
+    a named tool.
+    """
+    for module in (*boundaries, *capabilities):
+        if module.policy.default_policy.constraints:
+            raise LinkError(
+                f"module {module.name!r} sets default_policy constraints, which "
+                f"module composition does not support (the effective default is "
+                f"fail-closed deny); move the rule onto a named tool "
+                f"({module.source})"
+            )
 
 
 def _reject_file_scope(

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -38,6 +38,7 @@ from hexgate.security.models import (
     ToolPolicy,
 )
 from hexgate.security.modules import (
+    GRANT_MODES,
     LinkError,
     LinkResult,
     ModuleContent,
@@ -45,8 +46,6 @@ from hexgate.security.modules import (
     RuleTrace,
 )
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySet
-
-_GRANT_MODES = ("allow", "approval_required")
 
 
 def link_policy_set(
@@ -187,10 +186,10 @@ def _fold_tool(
     for g in boundaries:
         tp = g.policy.tools.get(tool)
         is_ceiling = g.policy.default_policy.mode == "deny"
-        if tp is not None and tp.mode in _GRANT_MODES:
+        if tp is not None and tp.mode in GRANT_MODES:
             ceiling_constraints.extend(tp.constraints)  # fences intersect (AND)
             contributors.append(_prov(g))
-        elif is_ceiling and (tp is None or tp.mode not in _GRANT_MODES):
+        elif is_ceiling and (tp is None or tp.mode not in GRANT_MODES):
             # A ceiling only permits tools it explicitly allows/approves. If it
             # doesn't (unlisted, or mentioned only via a conditional deny), the
             # tool is ineligible — a capability grant can't make it eligible.
@@ -201,7 +200,7 @@ def _fold_tool(
     grants: list[tuple[ModuleContent, ToolPolicy]] = []
     for cap in capabilities:
         tp = cap.policy.tools.get(tool)
-        if tp is not None and tp.mode in _GRANT_MODES:
+        if tp is not None and tp.mode in GRANT_MODES:
             grants.append((cap, tp))
     if not grants:
         return None

--- a/hexgate/security/modules.py
+++ b/hexgate/security/modules.py
@@ -23,6 +23,10 @@ if TYPE_CHECKING:  # avoid an import cycle — policy_set imports models, not th
 
 LayerKind = Literal["boundary", "capability"]
 
+# The modes that grant a tool (as opposed to deny). Shared by the linker's fold
+# and the analyzer's lints so they can't drift out of lockstep.
+GRANT_MODES: tuple[str, ...] = ("allow", "approval_required")
+
 
 class LinkError(ValueError):
     """Raised when a bundle of modules can't be composed.

--- a/tests/cli/test_policy_check.py
+++ b/tests/cli/test_policy_check.py
@@ -1,0 +1,72 @@
+"""CLI tests for `hexgate policy check`."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from hexgate.cli import run
+
+
+def _write(root: Path, rel: str, body: str) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def _run(*argv: str) -> int:
+    """Invoke the CLI and return its exit code (run() calls sys.exit)."""
+    saved = sys.argv
+    sys.argv = ["hexgate", *argv]
+    try:
+        run()
+        return 0
+    except SystemExit as exc:
+        return exc.code if isinstance(exc.code, int) else 0
+    finally:
+        sys.argv = saved
+
+
+def test_check_clean_bundle_exits_zero(tmp_path):
+    _write(
+        tmp_path,
+        "policies/boundaries/org.yaml",
+        "default_policy: { mode: allow }\ntools:\n  refund: { mode: allow }\n",
+    )
+    _write(
+        tmp_path,
+        "policies/capabilities/pay.yaml",
+        "tools:\n  refund: { mode: allow }\n",
+    )
+    assert _run("policy", "check", "--dir", str(tmp_path)) == 0
+
+
+def test_check_dead_grant_is_a_warning_below_default_threshold(tmp_path):
+    # ceiling boundary lists only refund; the capability also grants send_email,
+    # which the ceiling excludes -> dead-grant (warning).
+    _write(
+        tmp_path,
+        "policies/boundaries/org.yaml",
+        "default_policy: { mode: deny }\ntools:\n  refund: { mode: allow }\n",
+    )
+    _write(
+        tmp_path,
+        "policies/capabilities/pay.yaml",
+        "tools:\n  refund: { mode: allow }\n  send_email: { mode: allow }\n",
+    )
+    # default --max-severity is error, so a warning does not fail the run.
+    assert _run("policy", "check", "--dir", str(tmp_path)) == 0
+    # but gating on warning does.
+    assert (
+        _run("policy", "check", "--dir", str(tmp_path), "--max-severity", "warning")
+        == 1
+    )
+
+
+def test_check_link_error_exits_one(tmp_path):
+    _write(
+        tmp_path,
+        "policies/capabilities/bad.yaml",
+        "tools:\n  refund: { mode: deny }\n",  # capabilities may not deny
+    )
+    assert _run("policy", "check", "--dir", str(tmp_path)) == 1

--- a/tests/security/test_analyzer.py
+++ b/tests/security/test_analyzer.py
@@ -78,6 +78,21 @@ def test_dead_grant_when_ceiling_excludes_a_capability_grant():
     assert "org" in dead[0].message  # names the shadowing boundary
 
 
+def test_dead_grant_when_a_boundary_hard_denies_the_tool():
+    # The most clear-cut dead grant: an unconditional boundary deny beats the
+    # grant. This never enters trace.shadowed, so keying off the effective
+    # policy (not shadowed) is what catches it.
+    boundary = _mod("org", "boundary", {"wire": _deny()})  # floor, unconditional deny
+    cap = _mod("c", "capability", {"wire": _allow()})
+
+    lints = check([boundary], [cap])
+
+    dead = [lint for lint in lints if lint.code == "dead-grant"]
+    assert len(dead) == 1
+    assert dead[0].tool == "wire"
+    assert "denies" in dead[0].message
+
+
 # --- redundant-grant ---
 
 
@@ -155,9 +170,9 @@ def test_analyze_sorts_errors_first():
     result = link_policy_set([boundary], [c1, c2])
     lints = analyze(result, [boundary], [c1, c2], manifest=manifest)
 
+    from hexgate.security.analyzer import SEVERITY_RANK
+
     severities = [lint.severity for lint in lints]
-    assert severities == sorted(
-        severities, key={"error": 0, "warning": 1, "info": 2}.get
-    )
+    assert severities == sorted(severities, key=SEVERITY_RANK.get)
     assert ("unknown-tool", "ghost") in _codes(lints)  # error present
     assert ("redundant-grant", "refund") in _codes(lints)  # info present

--- a/tests/security/test_analyzer.py
+++ b/tests/security/test_analyzer.py
@@ -123,17 +123,24 @@ def test_link_error_becomes_an_error_lint():
 # --- drift (needs a manifest) ---
 
 
-def test_unknown_tool_boundary_is_error_capability_is_warning():
-    boundary = _mod("b", "boundary", {"delete_db": _deny()})
+def test_unknown_tool_severity_follows_failure_direction():
+    # boundary ceiling naming a missing tool = fail-open (real tool uncapped) = error;
+    # boundary deny on a missing tool = harmless = info;
+    # capability drift = dead grant = warning.
+    boundary = _mod(
+        "b",
+        "boundary",
+        {"ghost_cap": _allow(), "ghost_deny": _deny()},
+    )
     cap = _mod("c", "capability", {"ghost_tool": _allow()})
-    manifest = _manifest(("refund", ["amount"]))  # neither tool is declared
+    manifest = _manifest(("refund", ["amount"]))  # none of these tools declared
 
     lints = check([boundary], [cap], manifest=manifest)
-    by = {(lint.tool): lint for lint in lints if lint.code == "unknown-tool"}
+    by = {lint.tool: lint for lint in lints if lint.code == "unknown-tool"}
 
-    assert by["delete_db"].severity == "error"
-    assert by["delete_db"].tier == "boundary"
-    assert by["ghost_tool"].severity == "warning"
+    assert by["ghost_cap"].severity == "error"  # boundary ceiling allow
+    assert by["ghost_deny"].severity == "info"  # boundary deny, harmless
+    assert by["ghost_tool"].severity == "warning"  # capability grant
     assert by["ghost_tool"].tier == "capability"
 
 
@@ -162,7 +169,7 @@ def test_unknown_arg_flags_a_constraint_on_a_missing_parameter():
 
 
 def test_analyze_sorts_errors_first():
-    boundary = _mod("b", "boundary", {"ghost": _deny()})
+    boundary = _mod("b", "boundary", {"ghost": _allow()})  # ceiling drift = error
     c1 = _mod("c1", "capability", {"refund": _allow(["args.amount <= 1"])})
     c2 = _mod("c2", "capability", {"refund": _allow(["args.amount <= 1"])})
     manifest = _manifest(("refund", ["amount"]))
@@ -176,3 +183,56 @@ def test_analyze_sorts_errors_first():
     assert severities == sorted(severities, key=SEVERITY_RANK.get)
     assert ("unknown-tool", "ghost") in _codes(lints)  # error present
     assert ("redundant-grant", "refund") in _codes(lints)  # info present
+
+
+def test_undefined_const_becomes_link_error_lint_not_traceback():
+    # link_policy_set raises PolicySetError (undefined const) — check() must fold
+    # it into a lint, not let it escape as a traceback.
+    cap = _mod(
+        "c", "capability", {"refund": _allow(["args.amount <= consts.max_refund"])}
+    )
+    lints = check([], [cap])
+    assert [lint.code for lint in lints] == ["link-error"]
+    assert lints[0].severity == "error"
+
+
+def test_boundary_deny_arg_typo_is_error():
+    # A boundary conditional deny with a typo'd arg inverts to an allow
+    # (fail-open), so its arg drift must be an error, not a warning.
+    boundary = _mod("org", "boundary", {"refund": _deny(["args.amoun > 1000"])})
+    cap = _mod("c", "capability", {"refund": _allow()})
+    manifest = _manifest(("refund", ["amount"]))
+
+    lints = check([boundary], [cap], manifest=manifest)
+    arg = [lint for lint in lints if lint.code == "unknown-arg"]
+    assert len(arg) == 1
+    assert arg[0].severity == "error"
+    assert arg[0].tier == "boundary"
+
+
+def test_constraint_erased_when_a_sibling_grant_is_unconditional():
+    tight = _mod("tight", "capability", {"refund": _allow(["args.amount <= 100"])})
+    loose = _mod("loose", "capability", {"refund": _allow()})  # unconditional
+    lints = check([], [tight, loose])
+    erased = [lint for lint in lints if lint.code == "constraint-erased"]
+    assert len(erased) == 1
+    assert erased[0].tool == "refund"
+    assert erased[0].source == "tight.yaml"  # the constrained one is flagged
+    assert "loose" in erased[0].message
+
+
+def test_default_policy_constraints_rejected_as_link_error():
+    from hexgate.security import AgentPolicy, BaseToolPolicy
+
+    module = ModuleContent(
+        name="b",
+        kind="boundary",
+        policy=AgentPolicy(
+            default_policy=BaseToolPolicy(mode="allow", constraints=["args.x <= 1"])
+        ),
+        source="b.yaml",
+        content_hash="h",
+    )
+    lints = check([module], [])
+    assert [lint.code for lint in lints] == ["link-error"]
+    assert "default_policy constraints" in lints[0].message

--- a/tests/security/test_analyzer.py
+++ b/tests/security/test_analyzer.py
@@ -1,0 +1,163 @@
+"""Tests for the policy analyzer — soft lints over a linked bundle."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from hexgate.security import (
+    AgentPolicy,
+    BaseToolPolicy,
+    ModuleContent,
+    analyze,
+    check,
+    link_policy_set,
+)
+
+
+def _mod(name, kind, tools, *, default_mode="allow"):
+    return ModuleContent(
+        name=name,
+        kind=kind,
+        policy=AgentPolicy(
+            default_policy=BaseToolPolicy(mode=default_mode), tools=tools
+        ),
+        source=f"{name}.yaml",
+        content_hash=f"hash-{name}",
+    )
+
+
+def _allow(constraints=None):
+    return BaseToolPolicy(mode="allow", constraints=constraints or [])
+
+
+def _deny(constraints=None):
+    return BaseToolPolicy(mode="deny", constraints=constraints or [])
+
+
+def _manifest(*tools):
+    """Duck-typed AgentManifest: tools=[(name, [arg, ...]), ...]."""
+    return SimpleNamespace(
+        tools=[
+            SimpleNamespace(
+                name=name,
+                input_schema=SimpleNamespace(properties={a: None for a in args}),
+            )
+            for name, args in tools
+        ]
+    )
+
+
+def _codes(lints):
+    return {(lint.code, lint.tool) for lint in lints}
+
+
+# --- clean ---
+
+
+def test_clean_bundle_has_no_lints():
+    boundary = _mod("b", "boundary", {"refund": _allow(["args.amount <= 100"])})
+    cap = _mod("c", "capability", {"refund": _allow()})
+    manifest = _manifest(("refund", ["amount"]))
+    assert check([boundary], [cap], manifest=manifest) == []
+
+
+# --- dead-grant (provenance only, no manifest) ---
+
+
+def test_dead_grant_when_ceiling_excludes_a_capability_grant():
+    ceiling = _mod("org", "boundary", {"refund": _allow()}, default_mode="deny")
+    cap = _mod("c", "capability", {"refund": _allow(), "send_email": _allow()})
+
+    lints = check([ceiling], [cap])
+
+    dead = [lint for lint in lints if lint.code == "dead-grant"]
+    assert len(dead) == 1
+    assert dead[0].tool == "send_email"
+    assert dead[0].severity == "warning"
+    assert dead[0].source == "c.yaml"
+    assert "org" in dead[0].message  # names the shadowing boundary
+
+
+# --- redundant-grant ---
+
+
+def test_redundant_grant_across_two_capabilities():
+    c1 = _mod("c1", "capability", {"refund": _allow(["args.amount <= 100"])})
+    c2 = _mod("c2", "capability", {"refund": _allow(["args.amount <= 100"])})
+
+    lints = check([], [c1, c2])
+
+    red = [lint for lint in lints if lint.code == "redundant-grant"]
+    assert len(red) == 1
+    assert red[0].tool == "refund"
+    assert red[0].severity == "info"
+    assert red[0].source == "c2.yaml"  # the later one is flagged
+
+
+# --- link errors surface as an error lint, not an exception ---
+
+
+def test_link_error_becomes_an_error_lint():
+    bad = _mod("bad", "capability", {"refund": _deny()})
+    lints = check([], [bad])
+    assert len(lints) == 1
+    assert lints[0].code == "link-error"
+    assert lints[0].severity == "error"
+
+
+# --- drift (needs a manifest) ---
+
+
+def test_unknown_tool_boundary_is_error_capability_is_warning():
+    boundary = _mod("b", "boundary", {"delete_db": _deny()})
+    cap = _mod("c", "capability", {"ghost_tool": _allow()})
+    manifest = _manifest(("refund", ["amount"]))  # neither tool is declared
+
+    lints = check([boundary], [cap], manifest=manifest)
+    by = {(lint.tool): lint for lint in lints if lint.code == "unknown-tool"}
+
+    assert by["delete_db"].severity == "error"
+    assert by["delete_db"].tier == "boundary"
+    assert by["ghost_tool"].severity == "warning"
+    assert by["ghost_tool"].tier == "capability"
+
+
+def test_drift_skipped_without_a_manifest():
+    boundary = _mod("b", "boundary", {"delete_db": _deny()})
+    cap = _mod("c", "capability", {"ghost_tool": _allow()})
+    lints = check([boundary], [cap])  # no manifest
+    assert not any(lint.code == "unknown-tool" for lint in lints)
+
+
+def test_unknown_arg_flags_a_constraint_on_a_missing_parameter():
+    boundary = _mod("b", "boundary", {"refund": _allow(['args.currency == "USD"'])})
+    cap = _mod("c", "capability", {"refund": _allow()})
+    manifest = _manifest(("refund", ["amount"]))  # accepts amount, not currency
+
+    lints = check([boundary], [cap], manifest=manifest)
+
+    arg = [lint for lint in lints if lint.code == "unknown-arg"]
+    assert len(arg) == 1
+    assert arg[0].tool == "refund"
+    assert arg[0].source == "b.yaml"
+    assert "currency" in arg[0].message
+
+
+# --- analyze() over an existing result, and severity ordering ---
+
+
+def test_analyze_sorts_errors_first():
+    boundary = _mod("b", "boundary", {"ghost": _deny()})
+    c1 = _mod("c1", "capability", {"refund": _allow(["args.amount <= 1"])})
+    c2 = _mod("c2", "capability", {"refund": _allow(["args.amount <= 1"])})
+    manifest = _manifest(("refund", ["amount"]))
+
+    result = link_policy_set([boundary], [c1, c2])
+    lints = analyze(result, [boundary], [c1, c2], manifest=manifest)
+
+    severities = [lint.severity for lint in lints]
+    assert severities == sorted(
+        severities, key={"error": 0, "warning": 1, "info": 2}.get
+    )
+    assert ("unknown-tool", "ghost") in _codes(lints)  # error present
+    assert ("redundant-grant", "refund") in _codes(lints)  # info present


### PR DESCRIPTION
Second of the 3 multi-module policy PRs (after #97, modules + linker). This one is the **analyzer**: it turns the linker's provenance into file-attributed lints a dev sees in the terminal / CI, and that the PR-3 editor will render inline.

Pure SDK, fully local, no platform. Mostly *surfacing* the provenance PR 1 already produces (`RuleTrace.contributors` / `shadowed`), not new engine work.

## What it does

The link step already *raises* `LinkError` for the unfixable cases (a capability that denies, a conflicting const, `file_scope`). The analyzer runs over a successfully-linked bundle and reports the soft problems that don't stop composition but are almost always mistakes:

| Lint | Severity | From |
| --- | --- | --- |
| `dead-grant` | warning | a capability grants a tool a boundary ceiling excludes (never fires) |
| `redundant-grant` | info | two capabilities grant the same tool identically |
| `unknown-tool` | boundary → error, capability → warning | a rule references a tool the agent's manifest doesn't declare (drift) |
| `unknown-arg` | warning | a constraint `args.x` the tool doesn't accept |

`PolicyLint(code, severity, message, source, tier, tool)` is the shared contract the CLI and the PR-3 editor both consume.

Drift (`unknown-tool` / `unknown-arg`) needs the agent's `AgentManifest`, so it only runs when one is supplied; the two provenance-only lints always run. Boundary drift is an **error** because a stale deny is fail-open (protects nothing); capability drift is a warning (fail-safe dead grant).

**Deferred (needs a solver):** semantic conflicts - empty intersection, always-true/false, subsumption.

## Try it

```
hexgate policy check --dir deploy/demo_policies                 # provenance lints
hexgate policy check --dir . --manifest agent.json             # + drift
hexgate policy check --dir . --max-severity warning            # gate CI harder
```

Exits non-zero at or above `--max-severity` (default `error`).

## Important files

| File | What to look at |
| --- | --- |
| `hexgate/security/analyzer.py` | `PolicyLint`, `analyze()`, `check()`, and the four detectors. |
| `hexgate/security/constraints.py` | `iter_arg_refs` (mirrors `iter_const_refs`), for the arg-drift check. |
| `hexgate/cli/policy/main.py` | the `check` subcommand + exit-code gating. |
| `tests/security/test_analyzer.py` | one fixture per lint class + link-error-as-lint + severity order. |
| `tests/cli/test_policy_check.py` | CLI exit codes (clean / warning threshold / link error). |

## Notes

- No `platform/api` changes. Full suite green (937 tests).
- `line` on `PolicyLint` is `None` for now (file-level attribution); line-level lands with YAML position tracking in the loader.
- Design: `policy-modules-plan.md` (Phase 3) and `policy-modules-implementation.md` (PR 2 section).
