### PR TITLE
refactor(dashboard): rename tokens page to API keys, tidy nav and copy

### DIFF
--- a/platform/api/uv.lock
+++ b/platform/api/uv.lock
@@ -994,7 +994,7 @@ wheels = [
 
 [[package]]
 name = "hexgate"
-version = "0.2.8"
+version = "0.2.11"
 source = { editable = "../../" }
 dependencies = [
     { name = "bashlex" },
@@ -1033,15 +1033,15 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "ipykernel", marker = "extra == 'dev'" },
     { name = "jupyter", marker = "extra == 'dev'" },
-    { name = "langchain" },
+    { name = "langchain", specifier = ">=1.2.15" },
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langfuse" },
-    { name = "langgraph", specifier = ">=0.2" },
+    { name = "langgraph", specifier = ">=1.1.10" },
     { name = "litellm", specifier = ">=1.50" },
     { name = "mcp", specifier = ">=1.0" },
     { name = "nest-asyncio", specifier = ">=1.6" },
-    { name = "openai-agents", specifier = ">=0.0.10" },
+    { name = "openai-agents", specifier = ">=0.8.0" },
     { name = "openinference-instrumentation-google-adk", specifier = ">=0.1.11" },
     { name = "openinference-instrumentation-openai-agents", specifier = ">=0.1" },
     { name = "pydantic", specifier = ">=2.12.4" },

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -90,9 +90,9 @@ const workspaceLinks = [
   { to: "/graph", label: "Graph", icon: Network },
   { to: "/playground", label: "Playground", icon: MessageSquareCode },
   { to: "/audit", label: "Audit", icon: ScrollText },
-  { to: "/bans", label: "Bans", icon: Ban },
   { to: "/usage", label: "Usage", icon: BarChart3 },
-  { to: "/tokens", label: "Tokens", icon: KeyRound },
+  { to: "/bans", label: "Bans", icon: Ban },
+  { to: "/tokens", label: "API Keys", icon: KeyRound },
   { to: "/orgs", label: "Organizations", icon: Building2 },
   { to: "/settings", label: "Settings", icon: Settings2 },
 ];

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -92,7 +92,7 @@ const workspaceLinks = [
   { to: "/audit", label: "Audit", icon: ScrollText },
   { to: "/usage", label: "Usage", icon: BarChart3 },
   { to: "/bans", label: "Bans", icon: Ban },
-  { to: "/tokens", label: "API Keys", icon: KeyRound },
+  { to: "/tokens", label: "API keys", icon: KeyRound },
   { to: "/orgs", label: "Organizations", icon: Building2 },
   { to: "/settings", label: "Settings", icon: Settings2 },
 ];

--- a/platform/dashboard/src/routes/Agents.tsx
+++ b/platform/dashboard/src/routes/Agents.tsx
@@ -56,7 +56,7 @@ export function AgentsPage() {
     <div className="-mx-8 -my-6 h-[calc(100vh-56px)] flex flex-col overflow-hidden">
       <header className="flex items-center gap-3 px-6 py-3 border-b border-border bg-card">
         <Bot className="size-4 text-muted-foreground" />
-        <span className="text-sm font-medium">Agent</span>
+        <span className="text-sm font-medium">Agents</span>
         <AgentPicker
           agents={manifests.data ?? []}
           value={selectedName}

--- a/platform/dashboard/src/routes/Graph.tsx
+++ b/platform/dashboard/src/routes/Graph.tsx
@@ -85,7 +85,7 @@ export function GraphPage() {
           </h1>
           <p className="mt-1 text-sm text-muted-foreground">
             Roles, agents, and tools for this project. Read-only — edit in{" "}
-            <span className="font-mono text-foreground">/agents</span>.
+            <span className="font-mono text-foreground">/policies</span>.
           </p>
         </div>
         <div className="flex items-center gap-2 text-xs">

--- a/platform/dashboard/src/routes/Tokens.tsx
+++ b/platform/dashboard/src/routes/Tokens.tsx
@@ -4,10 +4,8 @@ import {
   Check,
   Copy,
   Fingerprint,
-  Filter,
   KeyRound,
   Plus,
-  RefreshCcw,
   Trash2,
   Clock,
   AlertTriangle,
@@ -48,30 +46,6 @@ function formatCreated(iso: string): string {
     month: "short",
     day: "2-digit",
   });
-}
-
-function CopyButton({
-  value,
-  size = "sm",
-}: {
-  value: string;
-  size?: "sm" | "default";
-}) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <Button
-      variant="ghost"
-      size={size === "sm" ? "icon" : "default"}
-      onClick={async () => {
-        await navigator.clipboard.writeText(value);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1200);
-      }}
-      className={size === "sm" ? "size-7" : undefined}
-    >
-      {copied ? <Check className="text-allow" /> : <Copy />}
-    </Button>
-  );
 }
 
 function JustMintedBanner({
@@ -332,16 +306,6 @@ export function TokensPage() {
               · {tokens.data?.length ?? 0}
             </span>
           </div>
-          <div className="flex items-center gap-1 text-xs text-muted-foreground">
-            <Button variant="ghost" size="sm" className="gap-1.5 text-xs">
-              <Filter className="size-3.5" />
-              Filter
-            </Button>
-            <Button variant="ghost" size="sm" className="gap-1.5 text-xs">
-              <Clock className="size-3.5" />
-              Last used
-            </Button>
-          </div>
         </div>
 
         {tokens.isLoading ? (
@@ -421,16 +385,6 @@ export function TokensPage() {
                     </td>
                     <td className="px-5 py-3">
                       <div className="flex items-center justify-end gap-0.5">
-                        <CopyButton value={t.masked} />
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="size-7 text-muted-foreground"
-                          disabled
-                          title="Rotate (coming soon)"
-                        >
-                          <RefreshCcw className="size-3.5" />
-                        </Button>
                         <Button
                           variant="ghost"
                           size="icon"

--- a/platform/dashboard/src/routes/Tokens.tsx
+++ b/platform/dashboard/src/routes/Tokens.tsx
@@ -106,7 +106,7 @@ function JustMintedBanner({
       <div className="flex items-start justify-between">
         <div className="flex items-center gap-2 text-sm">
           <Fingerprint className="size-4 text-primary" />
-          <span className="font-medium">Token minted</span>
+          <span className="font-medium">API key minted</span>
           <span className="text-muted-foreground">·</span>
           <span className="font-mono text-xs">{token.name}</span>
         </div>
@@ -195,15 +195,15 @@ function MintDialog({
       <DialogTrigger asChild>
         <Button className="gap-2">
           <Plus className="size-4" />
-          Mint new token
+          Mint new API key
         </Button>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Mint dev token</DialogTitle>
+          <DialogTitle>Mint API key</DialogTitle>
           <DialogDescription>
-            Tokens authenticate backend services to Hexgate. Use a clear name so
-            you know where it's deployed.
+            API keys authenticate backend services to Hexgate. Use a clear name
+            so you know where it's deployed.
           </DialogDescription>
         </DialogHeader>
 
@@ -261,7 +261,7 @@ function MintDialog({
             onClick={() => mutation.mutate({ name, env })}
             disabled={name.trim().length === 0 || mutation.isPending}
           >
-            {mutation.isPending ? "Minting…" : "Mint token"}
+            {mutation.isPending ? "Minting…" : "Mint API key"}
           </Button>
         </DialogFooter>
       </DialogContent>
@@ -291,8 +291,8 @@ export function TokensPage() {
   if (scope.status === "no-project") {
     return (
       <div className="max-w-[1400px] mx-auto">
-        <h1 className="text-2xl font-semibold tracking-tight">Tokens</h1>
-        <NoProjectEmptyState resource="tokens" />
+        <h1 className="text-2xl font-semibold tracking-tight">API keys</h1>
+        <NoProjectEmptyState resource="API keys" />
       </div>
     );
   }
@@ -301,14 +301,14 @@ export function TokensPage() {
     <div className="max-w-[1400px] mx-auto">
       <div className="flex items-start justify-between">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Tokens</h1>
+          <h1 className="text-2xl font-semibold tracking-tight">API keys</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Long-lived dev tokens for backend services. Never commit to source
+            Long-lived API keys for backend services. Never commit to source
             control.
           </p>
         </div>
         <div className="flex items-center gap-2">
-          <DocsLink path={DOC_PATHS.tokens} label="Token docs" />
+          <DocsLink path={DOC_PATHS.tokens} label="API key docs" />
           {scope.projectId && (
             <MintDialog projectId={scope.projectId} onSuccess={setJustMinted} />
           )}
@@ -327,7 +327,7 @@ export function TokensPage() {
       <div className="mt-6 rounded-lg border border-border bg-card">
         <div className="flex items-center justify-between border-b border-border px-5 py-3">
           <div className="text-sm">
-            Dev tokens{" "}
+            API keys{" "}
             <span className="text-muted-foreground">
               · {tokens.data?.length ?? 0}
             </span>
@@ -351,9 +351,9 @@ export function TokensPage() {
         ) : !tokens.data || tokens.data.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16 text-center">
             <KeyRound className="size-12 text-muted-foreground/50" />
-            <div className="text-sm font-medium">No tokens yet</div>
+            <div className="text-sm font-medium">No API keys yet</div>
             <div className="max-w-xs text-xs text-muted-foreground">
-              Mint your first dev token to let a backend service authenticate to
+              Mint your first API key to let a backend service authenticate to
               Hexgate.
             </div>
           </div>
@@ -362,7 +362,7 @@ export function TokensPage() {
             <thead>
               <tr className="border-b border-border text-[10px] uppercase tracking-wider text-muted-foreground">
                 <th className="px-5 py-2.5 text-left font-medium">Name</th>
-                <th className="px-5 py-2.5 text-left font-medium">Token</th>
+                <th className="px-5 py-2.5 text-left font-medium">API key</th>
                 <th className="px-5 py-2.5 text-left font-medium">Scopes</th>
                 <th className="px-5 py-2.5 text-left font-medium">Created</th>
                 <th className="px-5 py-2.5 text-left font-medium">Last used</th>

--- a/platform/dashboard/src/routes/Tokens.tsx
+++ b/platform/dashboard/src/routes/Tokens.tsx
@@ -55,11 +55,10 @@ function JustMintedBanner({
   token: TokenMintResponse;
   onDismiss: () => void;
 }) {
-  // Brief "Copied!" feedback on successful copy — same pattern as the
-  // inline `CopyButton` above, just with a label since this is the
-  // prominent action on the dialog. 1200ms is long enough to register,
-  // short enough that the operator who clicks twice doesn't see a stale
-  // checkmark.
+  // Brief "Copied!" feedback on successful copy, with a label since this
+  // is the prominent action on the dialog. 1200ms is long enough to
+  // register, short enough that the operator who clicks twice doesn't see
+  // a stale checkmark.
   const [copied, setCopied] = useState(false);
   // Copy-only \u2014 no reveal UI. Matches the show-once + copy-only pattern
   // GitHub / AWS / Stripe / Vercel / Discord use for API tokens. The


### PR DESCRIPTION
## What

Frontend naming/UX cleanup on the dashboard, plus a lockfile sync.

- **Rename Tokens → API keys** — all user-facing copy on the tokens page (page title, table header, dialogs, empty state, docs link) and the sidebar nav label. Route (`/tokens`) and API layer unchanged.
- **Trim the API keys table** — remove the `Filter` / `Last used` toolbar buttons and the per-row copy + rotate actions; **Revoke** remains.
- **Sidebar** — reorder so `Bans` follows `Usage`.
- **Small fixes** — Agents header label `Agent` → `Agents`; Graph subtitle pointer `/agents` → `/policies`.
- **Deps** — sync `platform/api/uv.lock` to the committed `hexgate` 0.2.11 dependency floors.

No behavior or API changes.

<img width="1920" height="1080" alt="Screenshot 2026-07-31 at 15 24 30" src="https://github.com/user-attachments/assets/395cef4b-7095-465b-99e4-5e903063d919" />

