### PR TITLE
feat(sdk): tcp_egress_guard env passthrough (redirect a client's DB endpoint at the proxy)

### DIFF
--- a/hexgate/egress/tcp.py
+++ b/hexgate/egress/tcp.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
-from collections.abc import AsyncIterator
+import os
+from collections.abc import AsyncIterator, Mapping
 
 from hexgate.approvals import ApprovalHandler
 from hexgate.egress.gate import Gate
@@ -102,17 +103,34 @@ async def tcp_egress_guard(
     host: str = "127.0.0.1",
     port: int = 0,
     approval_handler: ApprovalHandler | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> AsyncIterator[TcpEgressProxy]:
     """Start a :class:`TcpEgressProxy` for ``target`` and stop it on exit.
 
-    Unlike :func:`~hexgate.egress.proxy.egress_guard`, there is no env-var hook
-    to set (TCP clients don't read ``HTTP_PROXY``). The caller reads
-    ``proxy.host`` / ``proxy.port`` from the yielded proxy and points its
-    connection string there.
+    A database driver has no equivalent of ``HTTP_PROXY`` to read on its own, so
+    redirection is explicit. Two shapes, depending on who opens the connection.
+
+    Wrap an agent from the outside (the usual SDK model). Pass ``env`` to point
+    the driver's own endpoint variables at the proxy, so an agent that reads its
+    endpoint from the environment connects through the gate with no code change::
+
+        async with tcp_egress_guard(
+            enforcer, user, target=("db.internal", 5432),
+            env={"PGHOST": "{host}", "PGPORT": "{port}"},
+        ):
+            run_agent(...)  # its PGHOST/PGPORT-configured client is now gated
+
+    Each ``env`` value is a template with ``{host}`` / ``{port}`` placeholders (a
+    single ``DATABASE_URL`` works too:
+    ``env={"DATABASE_URL": "postgresql://app@{host}:{port}/db"}``). The variables
+    are set for the duration of the block and restored on exit. An agent that
+    hardcodes host and port inside a DSN cannot be redirected this way.
+
+    Build the connection yourself. Read ``proxy.host`` / ``proxy.port`` from the
+    yielded proxy and put them in your own connection string::
 
         async with tcp_egress_guard(enforcer, user, target=("db.internal", 5432)) as p:
             dsn = f"postgresql://user@{p.host}:{p.port}/app"
-            ...
     """
     proxy = TcpEgressProxy(
         enforcer,
@@ -123,7 +141,16 @@ async def tcp_egress_guard(
         approval_handler=approval_handler,
     )
     await proxy.start()
+    env = env or {}
+    saved = {name: os.environ.get(name) for name in env}
+    for name, template in env.items():
+        os.environ[name] = template.format(host=proxy.host, port=proxy.port)
     try:
         yield proxy
     finally:
+        for name, previous in saved.items():
+            if previous is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = previous
         await proxy.stop()

--- a/tests/egress/test_tcp.py
+++ b/tests/egress/test_tcp.py
@@ -7,6 +7,7 @@ proxy runs on the test's own event loop, so every client is async.
 from __future__ import annotations
 
 import asyncio
+import os
 
 import pytest
 
@@ -226,6 +227,53 @@ async def test_tcp_egress_guard_yields_running_proxy() -> None:
             assert await asyncio.wait_for(reader.readexactly(2), timeout=5) == b"yo"
             writer.close()
     finally:
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_guard_redirects_env_to_proxy_and_removes_after() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    enforcer = _enforcer(constraints=['args.host == "127.0.0.1"'])
+    for var in ("PGHOST", "PGPORT"):
+        os.environ.pop(var, None)  # start from a clean slate
+    try:
+        async with tcp_egress_guard(
+            enforcer,
+            User(user_id="u", role="agent"),
+            target=("127.0.0.1", echo_port),
+            env={"PGHOST": "{host}", "PGPORT": "{port}"},
+        ) as proxy:
+            assert os.environ["PGHOST"] == proxy.host
+            assert os.environ["PGPORT"] == str(proxy.port)
+        # Not set before the guard, so removed on exit.
+        assert "PGHOST" not in os.environ
+        assert "PGPORT" not in os.environ
+    finally:
+        for var in ("PGHOST", "PGPORT"):
+            os.environ.pop(var, None)
+        echo.close()
+        await echo.wait_closed()
+
+
+async def test_guard_restores_preexisting_env() -> None:
+    echo, echo_port = await _start_tcp_echo()
+    enforcer = _enforcer(constraints=['args.host == "127.0.0.1"'])
+    os.environ["DATABASE_URL"] = "postgresql://real/db"
+    try:
+        async with tcp_egress_guard(
+            enforcer,
+            User(user_id="u", role="agent"),
+            target=("127.0.0.1", echo_port),
+            env={"DATABASE_URL": "postgresql://app@{host}:{port}/db"},
+        ) as proxy:
+            assert (
+                os.environ["DATABASE_URL"]
+                == f"postgresql://app@{proxy.host}:{proxy.port}/db"
+            )
+        # Restored to the prior value, not removed.
+        assert os.environ["DATABASE_URL"] == "postgresql://real/db"
+    finally:
+        os.environ.pop("DATABASE_URL", None)
         echo.close()
         await echo.wait_closed()
 


### PR DESCRIPTION
## What & why

Hexgate is used by wrapping an agent from the outside (`enforce_policy(agent, ...)`), not by editing the code that opens each connection. HTTP egress already fits that: `egress_guard` sets `HTTP_PROXY`, and the agent's clients route through the proxy on their own.

`tcp_egress_guard` didn't fit it. It only handed back `proxy.host` / `proxy.port` for you to thread into a DSN by hand, which assumes you own the line that opens the database connection. In real usage that line is buried inside the agent or a tool.

This loosens that. `tcp_egress_guard` takes an `env` passthrough: templates with `{host}` / `{port}` placeholders that get pointed at the running proxy and restored on exit. An agent that reads its endpoint from the environment (`PGHOST`/`PGPORT`, or a `DATABASE_URL`) is now gated by wrapping it, no change to its connection code.

```python
async with tcp_egress_guard(enforcer, user, target=("db.internal", 5432),
                            env={"PGHOST": "{host}", "PGPORT": "{port}"}):
    run_agent(...)   # its PGHOST/PGPORT-configured client is now gated
```

## Where to look

| File | What |
|---|---|
| `hexgate/egress/tcp.py` | `tcp_egress_guard` gains `env`; sets each templated var to the proxy address, restores on exit. Docstring now leads with the wrap-from-outside shape. |
| `tests/egress/test_tcp.py` | env is set to the proxy inside the block and removed after; a pre-existing value is restored, not clobbered. |

## Honest limit (unchanged)

An agent that hardcodes host and port inside a DSN can't be redirected from the outside, the same class as an HTTP client with `trust_env=False`. Catching that case needs a transparent-redirect sandbox, which is out of scope for the library.

Full egress + TCP suites pass.
