### PR TITLE
feat(sdk): thread ctx.* attributes through both policy engines

### DIFF
--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -178,6 +178,16 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help='Tool arguments as a JSON object (e.g. \'{"amount": 30, "currency": "USD"}\'). Defaults to {}.',
     )
     p_test.add_argument(
+        "--attributes",
+        default="{}",
+        help=(
+            "Caller ABAC attributes as a JSON object, exposed to ctx.* "
+            'constraints (e.g. \'{"department": "finance", "clearance_level": 3}\'). '
+            "JSON (not key=value) so numbers/bools keep their type and match "
+            "production. Defaults to {}."
+        ),
+    )
+    p_test.add_argument(
         "--engine",
         choices=("pydantic", "wasm"),
         default="pydantic",
@@ -507,6 +517,15 @@ def _main_test(args: argparse.Namespace) -> int:
         return 1
 
     try:
+        attributes: dict[str, Any] = json.loads(getattr(args, "attributes", "{}"))
+    except json.JSONDecodeError as exc:
+        print(f"--attributes is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+    if not isinstance(attributes, dict):
+        print("--attributes must be a JSON object (dict).", file=sys.stderr)
+        return 1
+
+    try:
         policy_set = load_policy_set_from_dict(payload)
     except (PolicySetError, ValidationError) as exc:
         print(f"policy schema: {exc}", file=sys.stderr)
@@ -523,8 +542,12 @@ def _main_test(args: argparse.Namespace) -> int:
     engine = getattr(args, "engine", "pydantic")
 
     if engine == "wasm":
-        return _test_via_wasm(payload, args.role, args.tool, tool_args, label)
-    return _test_via_pydantic(policy_set, args.role, args.tool, tool_args, label)
+        return _test_via_wasm(
+            payload, args.role, args.tool, tool_args, attributes, label
+        )
+    return _test_via_pydantic(
+        policy_set, args.role, args.tool, tool_args, attributes, label
+    )
 
 
 def _render_verdict(verdict: Verdict, label: str) -> int:
@@ -551,20 +574,31 @@ def _render_verdict(verdict: Verdict, label: str) -> int:
 
 
 def _test_via_pydantic(
-    policy_set: Any, role: str, tool: str, tool_args: dict, label: str
+    policy_set: Any,
+    role: str,
+    tool: str,
+    tool_args: dict,
+    attributes: dict,
+    label: str,
 ) -> int:
     """Run the decision through the in-process constraint evaluator."""
     policy: AgentPolicy = policy_set.policy_for(role)
-    # Forward role so role-scoped constraints (role == "admin") decide the same
-    # as the wasm path and production — omitting it here made `policy test
-    # --engine pydantic` diverge from --engine wasm on exactly those rules.
+    # Forward role AND attributes so role-scoped (role == "admin") and ctx.*
+    # constraints decide the same as the wasm path and production — omitting
+    # either here made `policy test` fail closed on rules production allows.
     return _render_verdict(
-        evaluate_tool_call(policy, tool, tool_args, role=role), label
+        evaluate_tool_call(policy, tool, tool_args, role=role, attributes=attributes),
+        label,
     )
 
 
 def _test_via_wasm(
-    payload: dict, role: str, tool: str, tool_args: dict, label: str
+    payload: dict,
+    role: str,
+    tool: str,
+    tool_args: dict,
+    attributes: dict,
+    label: str,
 ) -> int:
     """Compile to wasm on the fly + evaluate — matches production semantics."""
     try:
@@ -579,7 +613,9 @@ def _test_via_wasm(
         return 1
     try:
         wasm_policy = WasmPolicy.from_bytes(artifact.wasm)
-        decision = wasm_policy.decide(role=role, tool=tool, args=tool_args)
+        decision = wasm_policy.decide(
+            role=role, tool=tool, args=tool_args, ctx=attributes
+        )
     except WasmEvalError as exc:
         print(f"wasm eval error: {exc}", file=sys.stderr)
         return 1

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -22,9 +22,10 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 from yaml.error import MarkedYAMLError
 
+from hexgate.runtime.context import AttrValue
 from hexgate.security import (
     AgentPolicy,
     DecisionOutcome,
@@ -48,6 +49,13 @@ from hexgate.security import (
     verdict_from_rego,
 )
 from hexgate.security.constraints import ConstraintParseError, parse_constraint
+
+# Same schema ``HexgateContext.attributes`` enforces at runtime, so a bag the
+# simulator accepts is a bag production can actually produce — including the
+# lax coercions (3.0 -> 3), not just the rejections.
+_ATTRIBUTES_ADAPTER: TypeAdapter[dict[str, AttrValue]] = TypeAdapter(
+    dict[str, AttrValue]
+)
 
 
 # ---------------------------------------------------------------------------
@@ -517,12 +525,23 @@ def _main_test(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        attributes: dict[str, Any] = json.loads(getattr(args, "attributes", "{}"))
+        attributes_raw: Any = json.loads(getattr(args, "attributes", "{}"))
     except json.JSONDecodeError as exc:
         print(f"--attributes is not valid JSON: {exc}", file=sys.stderr)
         return 1
-    if not isinstance(attributes, dict):
+    if not isinstance(attributes_raw, dict):
         print("--attributes must be a JSON object (dict).", file=sys.stderr)
+        return 1
+    try:
+        attributes: dict[str, AttrValue] = _ATTRIBUTES_ADAPTER.validate_python(
+            attributes_raw
+        )
+    except ValidationError as exc:
+        print(
+            "--attributes values must be str | int | bool | list[str] "
+            f"(the HexgateContext.attributes schema):\n{exc}",
+            file=sys.stderr,
+        )
         return 1
 
     try:

--- a/hexgate/runtime/context.py
+++ b/hexgate/runtime/context.py
@@ -73,7 +73,10 @@ class HexgateContext(BaseModel):
     * identity / audit    -> ``user_id`` / ``session_id``
     * policy selection     -> ``user_roles`` (only ``primary_role`` used today)
     * token lifetime       -> ``ttl_seconds`` (feeds attenuation, never policy)
-    * ABAC filter surface  -> ``attributes`` (INERT until wired; advisory-only)
+    * ABAC filter surface  -> ``attributes`` (feeds the ``ctx.*`` constraint
+      namespace; untrusted/spoofable — same trust tier as ``user_roles``, since
+      both are read from this contextvar rather than a verified token. A future
+      signed tier will let declared keys be token-verified.)
 
     Two invocation styles, same machinery underneath:
 
@@ -107,7 +110,10 @@ class HexgateContext(BaseModel):
     ttl_seconds: int | None = None
     attributes: dict[str, AttrValue] = Field(
         default_factory=dict,
-        description="Advisory caller attributes for ABAC policy filtering.",
+        description=(
+            "Caller attributes for ABAC ctx.* filtering. Untrusted (spoofable, "
+            "same tier as user_roles) until the signed tier verifies them."
+        ),
     )
 
     # Stack of shadowed values (supports nested scopes). We save/restore via

--- a/hexgate/security/bundle.py
+++ b/hexgate/security/bundle.py
@@ -286,17 +286,23 @@ class PolicyBundle:
         return self._wasm_policy
 
     def evaluate(
-        self, *, role: str | None, tool: str, args: Mapping[str, Any]
+        self,
+        *,
+        role: str | None,
+        tool: str,
+        args: Mapping[str, Any],
+        attributes: Mapping[str, Any] | None = None,
     ) -> Verdict:
         """:class:`~hexgate.security.decision.PolicyEngine` entry point.
 
         Runs the compiled WASM module; ``None`` role falls back to the
-        ``default`` role, matching the pydantic engine."""
+        ``default`` role, matching the pydantic engine. ``attributes`` become
+        the ``input.ctx`` document the compiled ``ctx.*`` conditions read."""
         from hexgate.security.policy import evaluate_tool_call_wasm
         from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 
         return evaluate_tool_call_wasm(
-            self, role or DEFAULT_ROLE_NAME, tool, dict(args)
+            self, role or DEFAULT_ROLE_NAME, tool, dict(args), attributes=attributes
         )
 
     # ---- Metadata ------------------------------------------------------

--- a/hexgate/security/constraints.py
+++ b/hexgate/security/constraints.py
@@ -75,6 +75,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
@@ -835,6 +836,7 @@ def check_constraints(
     *,
     role: str | None = None,
     consts: dict[str, Any] | None = None,
+    attributes: Mapping[str, Any] | None = None,
 ) -> None:
     """Evaluate every constraint; raise on the first failure.
 
@@ -845,6 +847,9 @@ def check_constraints(
     ``role`` and the tool name are exposed to constraints as top-level
     ``role`` / ``tool`` facts, mirroring Rego's ``input.role`` / ``input.tool``.
     ``consts`` supplies the policy's named constants for ``consts.<name>``.
+    ``attributes`` are the caller's ABAC bag, exposed under the ``ctx.<key>``
+    namespace and mirroring Rego's ``input.ctx``. A missing ``ctx.<key>``
+    resolves to ``_MISSING`` and fails closed, exactly like any other ref.
     """
     if not constraints:
         return
@@ -852,6 +857,7 @@ def check_constraints(
         "args": dict(arguments or {}),
         "role": role,
         "tool": tool_name,
+        "ctx": dict(attributes or {}),
         _CONSTS_KEY: consts or {},
     }
     for entry in constraints:

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -86,6 +86,12 @@ class Decision:
     hint: dict[str, Any] | None = None
     violations: tuple[str, ...] = ()
     arguments: dict[str, Any] | None = None
+    # The ABAC attribute snapshot the decision was evaluated against, so an
+    # in-process observer sees the ``ctx.*`` values that drove the outcome.
+    # Deliberately NOT rendered into ``as_error_payload`` (LLM-facing) nor
+    # persisted by the audit sender yet — durable audit + PII/retention policy
+    # lands with the signed tier.
+    attributes: dict[str, Any] | None = None
 
     @classmethod
     def from_verdict(
@@ -96,13 +102,15 @@ class Decision:
         tool_name: str,
         role: str | None = None,
         arguments: dict[str, Any] | None = None,
+        attributes: dict[str, Any] | None = None,
     ) -> "Decision":
         """Lift an engine :class:`Verdict` into a host-facing decision.
 
         The verdict carries the outcome and any structured detail the
         engine produced (reason, file-scope hint); this stamps on the
-        host context the engine doesn't know — agent name, role, and the
-        argument snapshot — and derives the ``error_type`` tag.
+        host context the engine doesn't know — agent name, role, the
+        argument snapshot, and the ABAC attribute snapshot — and derives
+        the ``error_type`` tag.
         """
         return cls(
             outcome=verdict.outcome,
@@ -114,6 +122,7 @@ class Decision:
             hint=verdict.hint,
             violations=verdict.violations,
             arguments=arguments,
+            attributes=attributes,
         )
 
     @property

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -56,7 +56,12 @@ class PolicyEngine(Protocol):
     """
 
     def evaluate(
-        self, *, role: str | None, tool: str, args: Mapping[str, Any]
+        self,
+        *,
+        role: str | None,
+        tool: str,
+        args: Mapping[str, Any],
+        attributes: Mapping[str, Any] | None = None,
     ) -> Verdict: ...
 
 

--- a/hexgate/security/enforcer.py
+++ b/hexgate/security/enforcer.py
@@ -71,9 +71,12 @@ class PolicyEnforcer:
         broken observer never breaks enforcement."""
         context = get_current_context()
         role = context.primary_role if context is not None else None
-        # Advisory ABAC bag read straight off the contextvar — untrusted in this
-        # tier (never token-verified), so it must not gate a production ``deny``
-        # until the signed tier lands.
+        # ABAC bag read off the contextvar, feeding the ``ctx.*`` constraint
+        # namespace. Untrusted/spoofable at the same trust tier as ``role``
+        # above (both contextvar-sourced, not token-verified) — so a ``ctx.*``
+        # rule is exactly as trustworthy as a ``role`` rule today. The signed
+        # tier will let declared keys be verified from ``biscuit_facts``; until
+        # then, don't rely on ``ctx.*`` for security-critical decisions.
         attributes = context.attributes if context is not None else None
         # Deep-copy when audit OR observer is wired: emission/observation
         # may inspect args after ``decide()`` returns, so a shallow copy
@@ -94,6 +97,7 @@ class PolicyEnforcer:
             tool_name=tool_name,
             role=role,
             arguments=args_snapshot,
+            attributes=dict(attributes) if attributes is not None else None,
         )
 
         if self._audit_sender is not None:

--- a/hexgate/security/enforcer.py
+++ b/hexgate/security/enforcer.py
@@ -29,6 +29,16 @@ _log = logging.getLogger(__name__)
 DecisionObserver = Callable[[Decision], None]
 
 
+def _snapshot(values: Mapping[str, Any], *, deep: bool) -> dict[str, Any]:
+    """Copy a mapping for retention on a :class:`Decision`.
+
+    Deep when an audit sender or observer may inspect it after ``decide()``
+    returns: a shallow copy would let the caller mutate a nested value first
+    and make the captured record lie about what was decided.
+    """
+    return copy.deepcopy(dict(values)) if deep else dict(values)
+
+
 class PolicyEnforcer:
     """Evaluate proposed tool calls against a policy engine.
 
@@ -78,18 +88,18 @@ class PolicyEnforcer:
         # tier will let declared keys be verified from ``biscuit_facts``; until
         # then, don't rely on ``ctx.*`` for security-critical decisions.
         attributes = context.attributes if context is not None else None
-        # Deep-copy when audit OR observer is wired: emission/observation
-        # may inspect args after ``decide()`` returns, so a shallow copy
-        # would let the caller mutate nested args first and make the
-        # captured record lie about what was decided.
-        args_snapshot = (
-            copy.deepcopy(dict(arguments))
-            if (self._audit_sender is not None or self._decision_observer is not None)
-            else dict(arguments)
+        # Both snapshots deep-copy on the same condition: ``attributes`` can
+        # hold a ``list[str]`` and lives on a contextvar that outlives the
+        # call, so a shallow copy would alias a mutable value into a retained
+        # Decision exactly like a shallow ``args`` copy would.
+        retained = self._audit_sender is not None or self._decision_observer is not None
+        args_snapshot = _snapshot(arguments, deep=retained)
+        attrs_snapshot = (
+            _snapshot(attributes, deep=retained) if attributes is not None else None
         )
 
         verdict = self.policy.evaluate(
-            role=role, tool=tool_name, args=args_snapshot, attributes=attributes
+            role=role, tool=tool_name, args=args_snapshot, attributes=attrs_snapshot
         )
         decision = Decision.from_verdict(
             verdict,
@@ -97,7 +107,7 @@ class PolicyEnforcer:
             tool_name=tool_name,
             role=role,
             arguments=args_snapshot,
-            attributes=dict(attributes) if attributes is not None else None,
+            attributes=attrs_snapshot,
         )
 
         if self._audit_sender is not None:

--- a/hexgate/security/enforcer.py
+++ b/hexgate/security/enforcer.py
@@ -71,6 +71,10 @@ class PolicyEnforcer:
         broken observer never breaks enforcement."""
         context = get_current_context()
         role = context.primary_role if context is not None else None
+        # Advisory ABAC bag read straight off the contextvar — untrusted in this
+        # tier (never token-verified), so it must not gate a production ``deny``
+        # until the signed tier lands.
+        attributes = context.attributes if context is not None else None
         # Deep-copy when audit OR observer is wired: emission/observation
         # may inspect args after ``decide()`` returns, so a shallow copy
         # would let the caller mutate nested args first and make the
@@ -81,7 +85,9 @@ class PolicyEnforcer:
             else dict(arguments)
         )
 
-        verdict = self.policy.evaluate(role=role, tool=tool_name, args=args_snapshot)
+        verdict = self.policy.evaluate(
+            role=role, tool=tool_name, args=args_snapshot, attributes=attributes
+        )
         decision = Decision.from_verdict(
             verdict,
             agent_name=self.agent_name,

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -45,6 +46,7 @@ def evaluate_tool_call(
     arguments: dict[str, Any] | None = None,
     *,
     role: str | None = None,
+    attributes: Mapping[str, Any] | None = None,
 ) -> Verdict:
     """Return a :class:`Verdict` for a proposed tool call (pydantic engine).
 
@@ -74,6 +76,7 @@ def evaluate_tool_call(
             tool_name,
             role=role,
             consts=policy.consts,
+            attributes=attributes,
         )
     except PolicyDeniedError as exc:
         return Verdict(outcome=DecisionOutcome.DENY, reason=str(exc))
@@ -114,6 +117,7 @@ def authorize_tool_call(
     arguments: dict[str, Any] | None = None,
     *,
     role: str | None = None,
+    attributes: Mapping[str, Any] | None = None,
 ) -> None:
     """Raise when a tool call is denied or requires approval.
 
@@ -121,9 +125,14 @@ def authorize_tool_call(
     callers (the CLI, direct API users) that prefer the exception contract.
     ``role`` is forwarded so ``role``-scoped constraints see the caller's
     role — omitting it here would diverge from the WASM engine, which always
-    receives ``input.role``.
+    receives ``input.role``. ``attributes`` are forwarded for the same reason:
+    ``ctx.*`` constraints must see the caller's ABAC bag.
     """
-    _raise_for_verdict(evaluate_tool_call(policy, tool_name, arguments, role=role))
+    _raise_for_verdict(
+        evaluate_tool_call(
+            policy, tool_name, arguments, role=role, attributes=attributes
+        )
+    )
 
 
 def evaluate_tool_call_wasm(
@@ -131,6 +140,8 @@ def evaluate_tool_call_wasm(
     role: str,
     tool_name: str,
     arguments: dict[str, Any] | None = None,
+    *,
+    attributes: Mapping[str, Any] | None = None,
 ) -> Verdict:
     """WASM-backed counterpart of :func:`evaluate_tool_call`.
 
@@ -144,7 +155,9 @@ def evaluate_tool_call_wasm(
     (deny-by-absence rather than deny-by-constraint), the reason surfaces
     a "no allow rule matched" hint so the message isn't silently empty.
     """
-    decision = bundle.policy().decide(role=role, tool=tool_name, args=arguments or {})
+    decision = bundle.policy().decide(
+        role=role, tool=tool_name, args=arguments or {}, ctx=dict(attributes or {})
+    )
     return verdict_from_rego(decision, tool_name=tool_name, role=role)
 
 
@@ -186,10 +199,16 @@ def authorize_tool_call_wasm(
     role: str,
     tool_name: str,
     arguments: dict[str, Any] | None = None,
+    *,
+    attributes: Mapping[str, Any] | None = None,
 ) -> None:
     """Raise-on-deny wrapper over :func:`evaluate_tool_call_wasm`.
 
     Raises the same exception shape as :func:`authorize_tool_call` so call
     sites don't care which engine produced the decision.
     """
-    _raise_for_verdict(evaluate_tool_call_wasm(bundle, role, tool_name, arguments))
+    _raise_for_verdict(
+        evaluate_tool_call_wasm(
+            bundle, role, tool_name, arguments, attributes=attributes
+        )
+    )

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -71,14 +71,23 @@ class PolicySet:
         return self._policies.get(role, self._policies[DEFAULT_ROLE_NAME])
 
     def evaluate(
-        self, *, role: str | None, tool: str, args: Mapping[str, Any]
+        self,
+        *,
+        role: str | None,
+        tool: str,
+        args: Mapping[str, Any],
+        attributes: Mapping[str, Any] | None = None,
     ) -> Verdict:
         """:class:`~hexgate.security.decision.PolicyEngine` entry point.
 
-        Resolves the role's policy and runs the pydantic engine."""
+        Resolves the role's policy and runs the pydantic engine. ``attributes``
+        feed the ``ctx.*`` constraint namespace; the role still selects the
+        policy bucket (``policy_for``) on its own."""
         from hexgate.security.policy import evaluate_tool_call
 
-        return evaluate_tool_call(self.policy_for(role), tool, dict(args), role=role)
+        return evaluate_tool_call(
+            self.policy_for(role), tool, dict(args), role=role, attributes=attributes
+        )
 
     @property
     def roles(self) -> list[str]:

--- a/hexgate/security/testing.py
+++ b/hexgate/security/testing.py
@@ -26,11 +26,19 @@ Policy = AgentPolicy | PolicySet
 
 
 def _outcome(
-    policy: Policy, tool: str, args: dict[str, Any] | None, role: str | None
+    policy: Policy,
+    tool: str,
+    args: dict[str, Any] | None,
+    role: str | None,
+    attributes: dict[str, Any] | None,
 ) -> DecisionOutcome:
     if isinstance(policy, PolicySet):
-        return policy.evaluate(role=role, tool=tool, args=args or {}).outcome
-    return evaluate_tool_call(policy, tool, args or {}, role=role).outcome
+        return policy.evaluate(
+            role=role, tool=tool, args=args or {}, attributes=attributes
+        ).outcome
+    return evaluate_tool_call(
+        policy, tool, args or {}, role=role, attributes=attributes
+    ).outcome
 
 
 def _check(
@@ -38,9 +46,10 @@ def _check(
     tool: str,
     args: dict[str, Any] | None,
     role: str | None,
+    attributes: dict[str, Any] | None,
     expected: DecisionOutcome,
 ) -> None:
-    actual = _outcome(policy, tool, args, role)
+    actual = _outcome(policy, tool, args, role, attributes)
     if actual is not expected:
         scope = f"role={role!r} " if role is not None else ""
         raise AssertionError(
@@ -55,9 +64,13 @@ def assert_allows(
     args: dict[str, Any] | None = None,
     *,
     role: str | None = None,
+    attributes: dict[str, Any] | None = None,
 ) -> None:
-    """Assert the policy ALLOWS this call."""
-    _check(policy, tool, args, role, DecisionOutcome.ALLOW)
+    """Assert the policy ALLOWS this call.
+
+    ``attributes`` supplies the caller's ABAC bag for ``ctx.*`` constraints,
+    mirroring what :class:`HexgateContext` carries at runtime."""
+    _check(policy, tool, args, role, attributes, DecisionOutcome.ALLOW)
 
 
 def assert_denies(
@@ -66,9 +79,10 @@ def assert_denies(
     args: dict[str, Any] | None = None,
     *,
     role: str | None = None,
+    attributes: dict[str, Any] | None = None,
 ) -> None:
     """Assert the policy DENIES this call."""
-    _check(policy, tool, args, role, DecisionOutcome.DENY)
+    _check(policy, tool, args, role, attributes, DecisionOutcome.DENY)
 
 
 def assert_needs_approval(
@@ -77,6 +91,7 @@ def assert_needs_approval(
     args: dict[str, Any] | None = None,
     *,
     role: str | None = None,
+    attributes: dict[str, Any] | None = None,
 ) -> None:
     """Assert the policy routes this call to approval."""
-    _check(policy, tool, args, role, DecisionOutcome.NEEDS_APPROVAL)
+    _check(policy, tool, args, role, attributes, DecisionOutcome.NEEDS_APPROVAL)

--- a/hexgate/security/wasm_engine.py
+++ b/hexgate/security/wasm_engine.py
@@ -210,14 +210,25 @@ class WasmPolicy:
             raise WasmEvalError(f"no such file: {p}")
         return cls.from_bytes(p.read_bytes(), entrypoint=entrypoint)
 
-    def decide(self, *, role: str, tool: str, args: dict[str, Any]) -> RegoVerdict:
+    def decide(
+        self,
+        *,
+        role: str,
+        tool: str,
+        args: dict[str, Any],
+        ctx: dict[str, Any] | None = None,
+    ) -> RegoVerdict:
         """Evaluate one tool-call decision.
 
-        Composes ``input = {role, tool, args}``, runs the entrypoint, and
-        returns the parsed ``RegoVerdict``. The eval is hermetic — heap is
-        reset before the call so repeated decisions don't accumulate state.
+        Composes ``input = {role, tool, args, ctx}``, runs the entrypoint, and
+        returns the parsed ``RegoVerdict``. ``ctx`` is the caller's ABAC bag,
+        read by compiled ``input.ctx.*`` conditions; it mirrors the pydantic
+        engine's ``ctx`` context key. The eval is hermetic — heap is reset
+        before the call so repeated decisions don't accumulate state.
         """
-        return self.evaluate({"role": role, "tool": tool, "args": args})
+        return self.evaluate(
+            {"role": role, "tool": tool, "args": args, "ctx": ctx or {}}
+        )
 
     def evaluate(self, input_obj: dict[str, Any]) -> RegoVerdict:
         """Lower-level: evaluate with an arbitrary input dict.

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -589,6 +589,80 @@ def test_test_rejects_non_json_attributes(
     assert "--attributes is not valid JSON" in capsys.readouterr().err
 
 
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        '{"clearance_level": 3.5}',  # float — no AttrValue arm accepts it
+        '{"scope": {"nested": 1}}',  # nested object
+        '{"tags": [1, 2]}',  # list of non-strings
+        '{"department": null}',  # null
+    ],
+)
+def test_test_rejects_attributes_outside_attrvalue_schema(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], attributes: str
+) -> None:
+    """Shapes ``HexgateContext.attributes`` can never hold must not reach the
+    engines — the simulator would otherwise decide on a bag production can't
+    produce, defeating the point of the flag."""
+    p = tmp_path / "ctx.yaml"
+    p.write_text(_CTX_GATED_POLICY, encoding="utf-8")
+    rc = _main_test(
+        _ns(
+            source=str(p),
+            role="default",
+            tool="refund",
+            args="{}",
+            attributes=attributes,
+            engine="pydantic",
+        )
+    )
+    assert rc == 1
+    assert "--attributes values must be str | int | bool | list[str]" in (
+        capsys.readouterr().err
+    )
+
+
+def test_test_rejects_non_object_attributes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "ctx.yaml"
+    p.write_text(_CTX_GATED_POLICY, encoding="utf-8")
+    rc = _main_test(
+        _ns(
+            source=str(p),
+            role="default",
+            tool="refund",
+            args="{}",
+            attributes="[1, 2]",
+            engine="pydantic",
+        )
+    )
+    assert rc == 1
+    assert "--attributes must be a JSON object (dict)" in capsys.readouterr().err
+
+
+def test_test_accepts_attributes_hexgate_context_would_coerce(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Validation must not over-reject: HexgateContext coerces a whole float
+    (``3.0`` -> ``3``) rather than raising, so the simulator has to accept it
+    too — only shapes production can't hold are rejected."""
+    p = tmp_path / "ctx.yaml"
+    p.write_text(_CTX_GATED_POLICY, encoding="utf-8")
+    rc = _main_test(
+        _ns(
+            source=str(p),
+            role="default",
+            tool="refund",
+            args="{}",
+            attributes='{"department": "finance", "clearance_level": 3.0}',
+            engine="pydantic",
+        )
+    )
+    assert rc == 0
+    assert "ALLOW" in capsys.readouterr().out
+
+
 def test_test_denies_when_constraint_fails(
     policy_file: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -521,6 +521,74 @@ def test_test_pydantic_role_denies_non_admin(
     assert "DENY" in capsys.readouterr().out
 
 
+_CTX_GATED_POLICY = """\
+version: 1
+roles:
+  default:
+    default_policy:
+      mode: deny
+    tools:
+      refund:
+        mode: allow
+        constraints:
+          - ctx.department == "finance"
+          - ctx.clearance_level >= 3
+"""
+
+
+def test_test_pydantic_forwards_attributes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`policy test --attributes` threads the ABAC bag so ctx.* decides the
+    same as production — without it the simulator would spuriously DENY."""
+    p = tmp_path / "ctx.yaml"
+    p.write_text(_CTX_GATED_POLICY, encoding="utf-8")
+    rc = _main_test(
+        _ns(
+            source=str(p),
+            role="default",
+            tool="refund",
+            args="{}",
+            attributes='{"department": "finance", "clearance_level": 3}',
+            engine="pydantic",
+        )
+    )
+    assert rc == 0
+    assert "ALLOW" in capsys.readouterr().out
+
+
+def test_test_missing_attributes_denies_ctx_policy(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No --attributes → ctx.* refs miss and fail closed (exit 1)."""
+    p = tmp_path / "ctx.yaml"
+    p.write_text(_CTX_GATED_POLICY, encoding="utf-8")
+    rc = _main_test(
+        _ns(source=str(p), role="default", tool="refund", args="{}", engine="pydantic")
+    )
+    assert rc == 1
+    assert "DENY" in capsys.readouterr().out
+
+
+def test_test_rejects_non_json_attributes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    p = tmp_path / "ctx.yaml"
+    p.write_text(_CTX_GATED_POLICY, encoding="utf-8")
+    rc = _main_test(
+        _ns(
+            source=str(p),
+            role="default",
+            tool="refund",
+            args="{}",
+            attributes="not json",
+            engine="pydantic",
+        )
+    )
+    assert rc == 1
+    assert "--attributes is not valid JSON" in capsys.readouterr().err
+
+
 def test_test_denies_when_constraint_fails(
     policy_file: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -640,6 +708,34 @@ def test_test_rejects_non_object_args(
 
 
 # --- engine=wasm path -------------------------------------------------------
+
+
+@needs_opa
+def test_test_engine_wasm_forwards_attributes(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The wasm path threads --attributes into input.ctx, so a ctx.* policy
+    decides identically to the pydantic path (no simulator/runtime drift)."""
+    p = tmp_path / "ctx.yaml"
+    p.write_text(_CTX_GATED_POLICY, encoding="utf-8")
+    allow = _main_test(
+        _ns(
+            source=str(p),
+            role="default",
+            tool="refund",
+            args="{}",
+            attributes='{"department": "finance", "clearance_level": 3}',
+            engine="wasm",
+        )
+    )
+    assert allow == 0
+    assert "ALLOW" in capsys.readouterr().out
+    # Missing bag → fail closed on wasm too.
+    deny = _main_test(
+        _ns(source=str(p), role="default", tool="refund", args="{}", engine="wasm")
+    )
+    assert deny == 1
+    assert "DENY" in capsys.readouterr().out
 
 
 @needs_opa

--- a/tests/runtime/test_context.py
+++ b/tests/runtime/test_context.py
@@ -332,7 +332,7 @@ class _RoleRecordingEngine:
         self.seen_role: str | None = "<unset>"
         self._verdict = Verdict(outcome=DecisionOutcome.ALLOW)
 
-    def evaluate(self, *, role, tool, args):  # type: ignore[no-untyped-def]
+    def evaluate(self, *, role, tool, args, attributes=None):  # type: ignore[no-untyped-def]
         self.seen_role = role
         return self._verdict
 

--- a/tests/security/golden/policy_fixture.rego
+++ b/tests/security/golden/policy_fixture.rego
@@ -51,6 +51,10 @@ allow if {
     input.args.confirmed == true
     is_number(input.args.payment.amount)
     input.args.payment.amount <= 100
+    input.ctx.department == "finance"
+    is_number(input.ctx.clearance_level)
+    input.ctx.clearance_level >= 3
+    input.ctx.region in ["EU", "UK"]
 }
 
 violations contains `args.amount <= 500` if {
@@ -89,6 +93,24 @@ violations contains `args.payment.amount <= 100` if {
     not _p_ee4b81b8b6
 }
 
+violations contains `ctx.department == "finance"` if {
+    input.role == "billing"
+    input.tool == "refund_order"
+    not _p_3420c2e5f0
+}
+
+violations contains `ctx.clearance_level >= 3` if {
+    input.role == "billing"
+    input.tool == "refund_order"
+    not _p_e401e5cd56
+}
+
+violations contains `ctx.region in ["EU", "UK"]` if {
+    input.role == "billing"
+    input.tool == "refund_order"
+    not _p_b7b1e13455
+}
+
 # ---- role: default -----------------------------------------------------
 allow if {
     not input.role in {"billing", "support"}
@@ -123,6 +145,10 @@ _p_066518c099 if {
     input.args.template in ["a", "b"]
 }
 
+_p_3420c2e5f0 if {
+    input.ctx.department == "finance"
+}
+
 _p_8bcb53951e if {
     input.args.currency == "USD"
 }
@@ -132,8 +158,17 @@ _p_b182706c06 if {
     input.args.amount <= 500
 }
 
+_p_b7b1e13455 if {
+    input.ctx.region in ["EU", "UK"]
+}
+
 _p_ce25e566f4 if {
     input.args.confirmed == true
+}
+
+_p_e401e5cd56 if {
+    is_number(input.ctx.clearance_level)
+    input.ctx.clearance_level >= 3
 }
 
 _p_e5bd576175 if {

--- a/tests/security/test_builder.py
+++ b/tests/security/test_builder.py
@@ -165,6 +165,33 @@ def test_assert_helpers_forward_role_on_agent_policy() -> None:
     assert_denies(policy, "deploy")  # no role → fact is None → deny
 
 
+def test_assert_helpers_forward_attributes() -> None:
+    # A ctx.*-scoped constraint: the assert helpers must thread `attributes=`
+    # through, else the ctx.* ref misses and the ABAC allow path is untestable.
+    policy = (
+        PolicyBuilder().allow("refund", when=['ctx.department == "finance"']).build()
+    )
+    assert_allows(policy, "refund", attributes={"department": "finance"})
+    assert_denies(policy, "refund", attributes={"department": "sales"})
+    assert_denies(policy, "refund")  # no attributes → ctx.* misses → deny
+
+
+def test_assert_helpers_forward_attributes_on_policy_set() -> None:
+    ps = (
+        RolePolicyBuilder()
+        .role("default", PolicyBuilder().deny("refund"))
+        .role(
+            "billing",
+            PolicyBuilder().allow("refund", when=["ctx.clearance_level >= 3"]),
+        )
+        .build()
+    )
+    assert_allows(ps, "refund", role="billing", attributes={"clearance_level": 3})
+    assert_denies(ps, "refund", role="billing", attributes={"clearance_level": 2})
+    # str vs numeric gate → cross-type fails closed, same as production.
+    assert_denies(ps, "refund", role="billing", attributes={"clearance_level": "3"})
+
+
 def test_authorize_tool_call_forwards_role() -> None:
     from hexgate.security import PolicyDeniedError, authorize_tool_call
 

--- a/tests/security/test_constraints.py
+++ b/tests/security/test_constraints.py
@@ -754,6 +754,58 @@ def test_check_role_none_denies_role_constraint() -> None:
 
 
 # ---------------------------------------------------------------------------
+# ctx.* — advisory ABAC attributes, mirroring Rego's input.ctx
+# ---------------------------------------------------------------------------
+
+
+def test_check_exposes_attributes_under_ctx_namespace() -> None:
+    """ctx.<key> resolves against the attributes bag, like role/tool facts."""
+    attrs = {"department": "finance", "clearance_level": 3}
+    check_constraints(
+        ['ctx.department == "finance"', "ctx.clearance_level >= 3"],
+        {},
+        "refund",
+        attributes=attrs,
+    )
+    with pytest.raises(PolicyDeniedError, match="ctx.department"):
+        check_constraints(
+            ['ctx.department == "finance"'],
+            {},
+            "refund",
+            attributes={"department": "sales"},
+        )
+
+
+def test_check_missing_ctx_attribute_fails_closed() -> None:
+    """A ctx.* ref with no matching attribute denies, same as any missing ref."""
+    with pytest.raises(PolicyDeniedError, match="ctx.department"):
+        check_constraints(['ctx.department == "finance"'], {}, "refund", attributes={})
+
+
+def test_check_no_attributes_bag_denies_ctx_constraint() -> None:
+    """No attributes at all (None) → ctx.* fails closed."""
+    with pytest.raises(PolicyDeniedError):
+        check_constraints(['ctx.region in ["EU"]'], {}, "t", attributes=None)
+
+
+def test_check_ctx_cross_type_ordered_fails_closed() -> None:
+    """A string attribute against a numeric gate fails closed (no coercion)."""
+    with pytest.raises(PolicyDeniedError):
+        check_constraints(
+            ["ctx.clearance_level >= 3"],
+            {},
+            "t",
+            attributes={"clearance_level": "3"},
+        )
+
+
+def test_bare_ctx_identifier_is_rejected_at_parse() -> None:
+    """``ctx`` alone is not a fact — only the dotted ``ctx.<key>`` form is valid."""
+    with pytest.raises(ConstraintParseError):
+        parse_constraint('ctx == "x"')
+
+
+# ---------------------------------------------------------------------------
 # Named constants (2f) — consts.<name>
 # ---------------------------------------------------------------------------
 

--- a/tests/security/test_decision.py
+++ b/tests/security/test_decision.py
@@ -157,3 +157,28 @@ def test_as_error_payload_does_not_leak_arguments_to_the_llm() -> None:
     payload = _approval_decision().as_error_payload()
 
     assert "arguments" not in payload
+
+
+def test_from_verdict_carries_attribute_snapshot() -> None:
+    """The attribute bag the decision was evaluated against is stamped on the
+    Decision so in-process observers can see what drove a ctx.*-gated outcome."""
+    from hexgate.security.decision import Verdict
+
+    decision = Decision.from_verdict(
+        Verdict(outcome=DecisionOutcome.ALLOW),
+        agent_name="a",
+        tool_name="refund",
+        attributes={"department": "finance"},
+    )
+    assert decision.attributes == {"department": "finance"}
+
+
+def test_as_error_payload_does_not_leak_attributes_to_the_llm() -> None:
+    """``attributes`` is host-side context, never surfaced to the model."""
+    decision = Decision(
+        outcome=DecisionOutcome.DENY,
+        agent_name="a",
+        tool_name="refund",
+        attributes={"department": "finance", "clearance_level": 3},
+    )
+    assert "attributes" not in decision.as_error_payload()

--- a/tests/security/test_enforcer.py
+++ b/tests/security/test_enforcer.py
@@ -32,9 +32,21 @@ class _RecordingEngine:
         self.calls: list[dict[str, Any]] = []
 
     def evaluate(
-        self, *, role: str | None, tool: str, args: Mapping[str, Any]
+        self,
+        *,
+        role: str | None,
+        tool: str,
+        args: Mapping[str, Any],
+        attributes: Mapping[str, Any] | None = None,
     ) -> Verdict:
-        self.calls.append({"role": role, "tool": tool, "args": dict(args)})
+        self.calls.append(
+            {
+                "role": role,
+                "tool": tool,
+                "args": dict(args),
+                "attributes": dict(attributes) if attributes is not None else None,
+            }
+        )
         return self.verdict
 
 
@@ -45,10 +57,39 @@ def test_enforcer_forwards_role_tool_and_args_to_engine() -> None:
     decision = enforcer.decide("read_file", {"file_path": "docs/a.md"})
 
     assert engine.calls == [
-        {"role": None, "tool": "read_file", "args": {"file_path": "docs/a.md"}}
+        {
+            "role": None,
+            "tool": "read_file",
+            "args": {"file_path": "docs/a.md"},
+            "attributes": None,  # no active context → no attributes bag
+        }
     ]
     assert decision.allowed
     assert decision.agent_name == "support"
+
+
+def test_enforcer_forwards_context_attributes_to_engine() -> None:
+    """An active HexgateContext's attributes reach the engine's evaluate()."""
+    from hexgate.runtime.context import HexgateContext
+
+    engine = _RecordingEngine(Verdict(outcome=DecisionOutcome.ALLOW))
+    enforcer = PolicyEnforcer(engine, agent_name="support")
+
+    with HexgateContext(
+        user_id="u",
+        user_roles=["billing"],
+        attributes={"department": "finance", "clearance_level": 3},
+    ).sync_scope():
+        enforcer.decide("refund", {"amount": 10})
+
+    assert engine.calls == [
+        {
+            "role": "billing",  # primary_role
+            "tool": "refund",
+            "args": {"amount": 10},
+            "attributes": {"department": "finance", "clearance_level": 3},
+        }
+    ]
 
 
 def test_enforcer_lifts_deny_verdict_with_structured_detail() -> None:
@@ -117,6 +158,33 @@ def test_policy_set_evaluate_matches_evaluate_tool_call() -> None:
     assert policy_set.evaluate(
         role="anything", tool="fetch", args={}
     ) == evaluate_tool_call(policy, "fetch", {})
+
+
+def test_enforcer_attributes_gate_real_pydantic_engine() -> None:
+    """End-to-end: a ctx.* constraint decides off the context's attributes."""
+    from hexgate.runtime.context import HexgateContext
+
+    policy = AgentPolicy.model_validate(
+        {
+            "default_policy": {"mode": "deny"},
+            "tools": {
+                "refund": {
+                    "mode": "allow",
+                    "constraints": ['ctx.department == "finance"'],
+                }
+            },
+        }
+    )
+    enforcer = PolicyEnforcer(PolicySet({"default": policy}), agent_name="a")
+
+    with HexgateContext(user_id="u", attributes={"department": "finance"}).sync_scope():
+        assert enforcer.decide("refund", {}).allowed
+
+    with HexgateContext(user_id="u", attributes={"department": "sales"}).sync_scope():
+        assert not enforcer.decide("refund", {}).allowed
+
+    # No active context → ctx.* ref misses → fail closed.
+    assert not enforcer.decide("refund", {}).allowed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/security/test_enforcer.py
+++ b/tests/security/test_enforcer.py
@@ -80,7 +80,7 @@ def test_enforcer_forwards_context_attributes_to_engine() -> None:
         user_roles=["billing"],
         attributes={"department": "finance", "clearance_level": 3},
     ).sync_scope():
-        enforcer.decide("refund", {"amount": 10})
+        decision = enforcer.decide("refund", {"amount": 10})
 
     assert engine.calls == [
         {
@@ -90,6 +90,8 @@ def test_enforcer_forwards_context_attributes_to_engine() -> None:
             "attributes": {"department": "finance", "clearance_level": 3},
         }
     ]
+    # The bag is also stamped onto the Decision for in-process observers.
+    assert decision.attributes == {"department": "finance", "clearance_level": 3}
 
 
 def test_enforcer_lifts_deny_verdict_with_structured_detail() -> None:

--- a/tests/security/test_enforcer_audit.py
+++ b/tests/security/test_enforcer_audit.py
@@ -16,7 +16,12 @@ from hexgate.security.enforcer import PolicyEnforcer
 
 class _StubEngine:
     def evaluate(
-        self, *, role: str | None, tool: str, args: Mapping[str, Any]
+        self,
+        *,
+        role: str | None,
+        tool: str,
+        args: Mapping[str, Any],
+        attributes: Mapping[str, Any] | None = None,
     ) -> Verdict:
         return Verdict(outcome=DecisionOutcome.DENY, reason="stub")
 

--- a/tests/security/test_enforcer_observer.py
+++ b/tests/security/test_enforcer_observer.py
@@ -93,6 +93,23 @@ async def test_observer_sees_role_and_args_from_user_scope() -> None:
     assert captured[0].arguments == {"path": "/etc/passwd"}
 
 
+async def test_observer_attribute_snapshot_survives_later_bag_mutation() -> None:
+    """``attributes`` is deep-copied on the same condition as ``args``: a
+    ``list[str]`` value lives on a contextvar that outlives the call, so
+    mutating it afterwards must not rewrite what a retained Decision says
+    was decided."""
+    captured: list[Decision] = []
+    engine = _StubEngine(Verdict(outcome=DecisionOutcome.DENY))
+    enforcer = PolicyEnforcer(engine, agent_name="r", decision_observer=captured.append)
+    async with HexgateContext(user_id="alice", attributes={"tags": ["eu"]}) as ctx:
+        enforcer.decide("read_file", {})
+        tags = ctx.attributes["tags"]
+        assert isinstance(tags, list)  # narrow AttrValue for the mutation below
+        tags.append("us")
+
+    assert captured[0].attributes == {"tags": ["eu"]}
+
+
 # ---------------------------------------------------------------------------
 # Isolation — a broken observer must not break enforcement
 # ---------------------------------------------------------------------------

--- a/tests/security/test_enforcer_observer.py
+++ b/tests/security/test_enforcer_observer.py
@@ -26,7 +26,12 @@ class _StubEngine:
         self._verdict = verdict
 
     def evaluate(
-        self, *, role: str | None, tool: str, args: Mapping[str, Any]
+        self,
+        *,
+        role: str | None,
+        tool: str,
+        args: Mapping[str, Any],
+        attributes: Mapping[str, Any] | None = None,
     ) -> Verdict:
         return self._verdict
 

--- a/tests/security/test_engine_parity.py
+++ b/tests/security/test_engine_parity.py
@@ -476,6 +476,11 @@ _ATTR_POLICY = {
         # negated membership
         ("not_in_list", {"region": "EU"}, "allow"),
         ("not_in_list", {"region": "US"}, "deny"),
+        # missing → pydantic resolves _MISSING to False; Rego's inline
+        # `not <undefined> in [...]` is undefined, so `allow` never fires.
+        # Both deny — the case a change to negated-membership rendering
+        # would silently break.
+        ("not_in_list", {}, "deny"),
         # ordered comparison + cross-type guard
         ("ordered", {"clearance_level": 3}, "allow"),
         ("ordered", {"clearance_level": 2}, "deny"),

--- a/tests/security/test_engine_parity.py
+++ b/tests/security/test_engine_parity.py
@@ -30,11 +30,15 @@ from hexgate.security.rego import compile_to_rego
 pytestmark = pytest.mark.skipif(shutil.which("opa") is None, reason="opa not on PATH")
 
 
-def _py_outcome(policy: dict, role: str | None, tool: str, args: dict) -> str:
+def _py_outcome(
+    policy: dict, role: str | None, tool: str, args: dict, attributes: dict | None
+) -> str:
     ps = load_policy_set_from_dict(policy)
     # Route through PolicySet.evaluate (the real engine entry) so role/tool are
     # threaded into the constraint context, matching what the runtime does.
-    return ps.evaluate(role=role, tool=tool, args=args).outcome.value
+    return ps.evaluate(
+        role=role, tool=tool, args=args, attributes=attributes
+    ).outcome.value
 
 
 @functools.lru_cache(maxsize=None)
@@ -42,9 +46,13 @@ def _wasm_bytes(rego: str) -> bytes:
     return compile_to_wasm(rego).wasm
 
 
-def _wasm_outcome(policy: dict, role: str | None, tool: str, args: dict) -> str:
+def _wasm_outcome(
+    policy: dict, role: str | None, tool: str, args: dict, attributes: dict | None
+) -> str:
     wasm = _wasm_bytes(compile_to_rego(policy))
-    d = WasmPolicy.from_bytes(wasm).decide(role=role, tool=tool, args=args)
+    d = WasmPolicy.from_bytes(wasm).decide(
+        role=role, tool=tool, args=args, ctx=attributes
+    )
     if d.allow:
         return "allow"
     if d.requires_approval:
@@ -53,10 +61,16 @@ def _wasm_outcome(policy: dict, role: str | None, tool: str, args: dict) -> str:
 
 
 def _assert_parity(
-    policy: dict, role: str | None, tool: str, args: dict, expect: str
+    policy: dict,
+    role: str | None,
+    tool: str,
+    args: dict,
+    expect: str,
+    *,
+    attributes: dict | None = None,
 ) -> None:
-    py = _py_outcome(policy, role, tool, args)
-    wasm = _wasm_outcome(policy, role, tool, args)
+    py = _py_outcome(policy, role, tool, args, attributes)
+    wasm = _wasm_outcome(policy, role, tool, args, attributes)
     assert py == wasm, f"engine divergence {role}/{tool}/{args}: py={py} wasm={wasm}"
     assert py == expect, f"wrong outcome {role}/{tool}/{args}: {py} (want {expect})"
 
@@ -412,6 +426,76 @@ def test_role_tool_fact_parity(role: str, tool: str, args: dict, expect: str) ->
 
 
 # ---------------------------------------------------------------------------
+# ctx.* — ABAC attribute filtering. Every operator + the missing-attribute
+# fail-closed case must decide identically on pydantic and opa->wasmtime.
+# ---------------------------------------------------------------------------
+
+_ATTR_POLICY = {
+    "version": 1,
+    "roles": {
+        "default": {
+            "default_policy": {"mode": "deny"},
+            "tools": {
+                "eq": {
+                    "mode": "allow",
+                    "constraints": ['ctx.department == "finance"'],
+                },
+                "in_list": {
+                    "mode": "allow",
+                    "constraints": ['ctx.region in ["EU", "UK"]'],
+                },
+                "not_in_list": {
+                    "mode": "allow",
+                    "constraints": ['ctx.region not in ["US"]'],
+                },
+                "ordered": {
+                    "mode": "allow",
+                    "constraints": ["ctx.clearance_level >= 3"],
+                },
+                "boolean": {
+                    "mode": "allow",
+                    "constraints": ["ctx.confirmed == true"],
+                },
+            },
+        }
+    },
+}
+
+
+@pytest.mark.parametrize(
+    ("tool", "attributes", "expect"),
+    [
+        # string equality
+        ("eq", {"department": "finance"}, "allow"),
+        ("eq", {"department": "sales"}, "deny"),
+        ("eq", {}, "deny"),  # missing attr → fail closed on BOTH engines
+        # membership against a literal list
+        ("in_list", {"region": "EU"}, "allow"),
+        ("in_list", {"region": "US"}, "deny"),
+        ("in_list", {}, "deny"),  # missing → fail closed
+        # negated membership
+        ("not_in_list", {"region": "EU"}, "allow"),
+        ("not_in_list", {"region": "US"}, "deny"),
+        # ordered comparison + cross-type guard
+        ("ordered", {"clearance_level": 3}, "allow"),
+        ("ordered", {"clearance_level": 2}, "deny"),
+        ("ordered", {"clearance_level": "3"}, "deny"),  # str vs num → fail closed
+        ("ordered", {}, "deny"),  # missing → fail closed
+        # boolean equality
+        ("boolean", {"confirmed": True}, "allow"),
+        ("boolean", {"confirmed": False}, "deny"),
+    ],
+)
+def test_ctx_attribute_parity(tool: str, attributes: dict, expect: str) -> None:
+    _assert_parity(_ATTR_POLICY, "default", tool, {}, expect, attributes=attributes)
+
+
+def test_ctx_none_bag_fails_closed_both_engines() -> None:
+    """No attributes at all → every ctx.* ref misses and denies, both engines."""
+    _assert_parity(_ATTR_POLICY, "default", "eq", {}, "deny", attributes=None)
+
+
+# ---------------------------------------------------------------------------
 # Named constants (2f) — consts.<name>, incl. shared via a mixin
 # ---------------------------------------------------------------------------
 
@@ -626,12 +710,14 @@ class _WasmEngine:
     def __init__(self, wasm_bytes: bytes) -> None:
         self._w = WasmPolicy.from_bytes(wasm_bytes)
 
-    def evaluate(self, *, role, tool, args):
+    def evaluate(self, *, role, tool, args, attributes=None):
         from hexgate.security.policy import verdict_from_rego
 
         role_ = role or "default"
         return verdict_from_rego(
-            self._w.decide(role=role_, tool=tool, args=dict(args)),
+            self._w.decide(
+                role=role_, tool=tool, args=dict(args), ctx=dict(attributes or {})
+            ),
             tool_name=tool,
             role=role_,
         )

--- a/tests/security/test_rego_compile.py
+++ b/tests/security/test_rego_compile.py
@@ -254,6 +254,42 @@ def test_not_in_constraint_wraps_with_not() -> None:
     assert 'not input.args.priority in ["urgent"]' in rego
 
 
+def _ctx_rego(constraint: str) -> str:
+    """Compile a single default-role tool carrying one ctx.* constraint."""
+    return compile_to_rego(
+        {
+            "version": 1,
+            "roles": {
+                "default": {
+                    "tools": {
+                        "t": {"mode": "allow", "constraints": [constraint]},
+                    }
+                }
+            },
+        }
+    )
+
+
+def test_ctx_attribute_prefixes_input() -> None:
+    """``ctx.department`` renders as ``input.ctx.department`` — same machinery
+    as ``args.*``, no compiler special-case."""
+    assert 'input.ctx.department == "finance"' in _ctx_rego(
+        'ctx.department == "finance"'
+    )
+
+
+def test_ctx_in_list_constraint() -> None:
+    assert 'input.ctx.region in ["EU", "UK"]' in _ctx_rego('ctx.region in ["EU", "UK"]')
+
+
+def test_ctx_ordered_constraint_emits_type_guard() -> None:
+    """An ordered ctx.* comparison carries the cross-type guard, exactly like
+    ``args.*`` — so a wrong-typed attribute fails closed on WASM too."""
+    rego = _ctx_rego("ctx.clearance_level >= 3")
+    assert "is_number(input.ctx.clearance_level)" in rego
+    assert "input.ctx.clearance_level >= 3" in rego
+
+
 def test_compile_rejects_unparseable_constraint() -> None:
     """An invalid constraint surfaces at load (model grammar validator),
     which compile_to_rego triggers before ever reaching WASM eval."""
@@ -793,6 +829,9 @@ _GOLDEN_PAYLOAD = {
                         'args.priority not in ["urgent"]',
                         "args.confirmed == true",
                         "args.payment.amount <= 100",
+                        'ctx.department == "finance"',
+                        "ctx.clearance_level >= 3",
+                        'ctx.region in ["EU", "UK"]',
                     ],
                 },
                 "delete_user": {"mode": "deny"},


### PR DESCRIPTION
## What

PR 2 of the HexgateContext generalization (follows #106). Threads the
`HexgateContext.attributes` bag — landed inert in #106 — through the engine
contract into **both** policy engines, so a policy constraint can now filter on
caller attributes via a `ctx.<key>` namespace (RBAC → RBAC + ABAC):

```yaml
constraints:
  - ctx.department == "finance"
  - ctx.region in ["EU", "UK"]
  - ctx.clearance_level >= 3
```

Attributes are **advisory / untrusted** in this PR — read straight off the
contextvar, never token-verified. The signed trusted tier (attributes that may
gate a production `deny`) is the next PR.

## Why one PR (P2 + P3 fused)

The pydantic engine (dev / `hexgate chat` / fallback) and the compiled WASM
engine (production bundle) must decide a `ctx.*` constraint **identically**, or a
rule would filter on one engine and no-op on the other. So the contract change,
both engine implementations, the golden fixture, and the parity matrix all ship
together.

## Changes

Every hop takes a keyword-only `attributes` (WASM: `ctx`) arg defaulted to
`None`, so existing callers are source-compatible:

- **`decision.py`** — `PolicyEngine.evaluate` protocol gains `attributes`.
- **`constraints.py`** — `check_constraints` injects `"ctx": dict(attributes or {})`
  into the eval context; `ctx.<key>` resolves via the existing `_walk` with the
  same missing-key → fail-closed semantics as any other ref.
- **`policy.py`** — forwarded through the four evaluators (`evaluate_tool_call`,
  `authorize_tool_call`, and the two `_wasm` variants).
- **`policy_set.py` / `bundle.py`** — both `PolicyEngine.evaluate` entry points forward it.
- **`wasm_engine.py`** — `WasmPolicy.decide` adds `ctx` to the input document
  (`input.ctx`), mirroring the pydantic context dict key-for-key.
- **`enforcer.py`** — reads `context.attributes` off the contextvar and forwards it.

**The Rego compiler is unchanged.** `_render` already prefixes any `Ref` with
`input.`, so `ctx.department → input.ctx.department` for free — including the
ordered-comparison cross-type guard (`is_number(...)`). Proven by tests rather
than edited.

## Tests

- **Parity matrix** (`test_engine_parity.py`) — new `ctx.*` cases across eq /
  `in` / `not in` / ordered / bool, plus fail-closed on missing attribute and on
  cross-type (`"3" >= 3`). Pydantic and real `opa`→`wasmtime` must agree.
- **Constraints unit tests** — `ctx.*` resolution, missing-key deny, bare `ctx`
  rejected at parse (prefix required).
- **Enforcer** — end-to-end through the real pydantic engine + a forwarding
  assertion that context attributes reach the engine.
- **Rego codegen** + regenerated golden fixture (diff is only `input.ctx.*` lines).

## Notes for review

- **Membership against a list-valued attribute** (`"x" in ctx.tags`) is not
  expressible — the grammar restricts `in`'s RHS to a list literal or
  `consts.<name>`. Not a regression; noted as a known ABAC limitation.
- Four hand-rolled fake engines in the test suite gained the `attributes` kwarg
  to satisfy the updated protocol.

## Addressed review feedback

## Checks

`make lint` + `make fmt-check` clean; security + runtime + cli + audit suites
green (**1088 passed / 5 skipped**); full `make coverage` (**1729 passed /
14 skipped**) and the platform-api suite (**441 passed**) green. Parity + CLI
wasm suites run with `opa` on PATH (not skipped).
