### PR TITLE
build(redpanda): stand up local Redpanda infra for OTLP ingestion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,5 +21,5 @@ tests/                # hexgate package tests (agents, cli, security, tracing, s
 
 ## Rules & Constants
 - **Branches:** `{initials}/{type}/{short_description}` (e.g., `vl/feat/web_search`)
-- **Commits:** `type(scope): description` (lowercase, imperative, no period). Scopes: `platform-api`, `dashboard`, `sdk`, `cli`, `clickhouse`. Types: `feat`, `fix`, `docs`, `build`, `refactor`, `test`.
+- **Commits:** `type(scope): description` (lowercase, imperative, no period). Scopes: `platform-api`, `dashboard`, `sdk`, `cli`, `clickhouse`, `kafka`. Types: `feat`, `fix`, `docs`, `build`, `refactor`, `test`.
 - **Envs:** All prefixed with `HEXGATE_`. Never commit private keys.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Hexgate — Claude Code Instructions
 
 ## Tech Stack
-- Python ≥ 3.13 (`uv`), FastAPI (`platform/api/`), ClickHouse (Docker), Kafka (Docker, dev-infra only for now — see `platform/docker-compose.yml`)
+- Python ≥ 3.13 (`uv`), FastAPI (`platform/api/`), ClickHouse (Docker), Redpanda (Docker, Kafka-protocol-compatible, dev-infra only for now — see `platform/docker-compose.yml`)
 - React, Vite, pnpm (`platform/dashboard/`)
 - Ruff (Python). WASM via `wasmtime`.
 
@@ -21,5 +21,5 @@ tests/                # hexgate package tests (agents, cli, security, tracing, s
 
 ## Rules & Constants
 - **Branches:** `{initials}/{type}/{short_description}` (e.g., `vl/feat/web_search`)
-- **Commits:** `type(scope): description` (lowercase, imperative, no period). Scopes: `platform-api`, `dashboard`, `sdk`, `cli`, `clickhouse`, `kafka`. Types: `feat`, `fix`, `docs`, `build`, `refactor`, `test`.
+- **Commits:** `type(scope): description` (lowercase, imperative, no period). Scopes: `platform-api`, `dashboard`, `sdk`, `cli`, `clickhouse`, `redpanda`. Types: `feat`, `fix`, `docs`, `build`, `refactor`, `test`.
 - **Envs:** All prefixed with `HEXGATE_`. Never commit private keys.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Hexgate — Claude Code Instructions
 
 ## Tech Stack
-- Python ≥ 3.13 (`uv`), FastAPI (`platform/api/`), ClickHouse (Docker)
+- Python ≥ 3.13 (`uv`), FastAPI (`platform/api/`), ClickHouse (Docker), Kafka (Docker, dev-infra only for now — see `platform/docker-compose.yml`)
 - React, Vite, pnpm (`platform/dashboard/`)
 - Ruff (Python). WASM via `wasmtime`.
 

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,36 @@ postgres-reset: ## Wipe ONLY the Postgres data volume and restart
 	-docker volume rm platform_postgres-data
 	$(COMPOSE) up -d --wait postgres
 
+# -------- Platform infra (Kafka — OTLP ingestion buffer) --------
+#
+# Single-node KRaft dev broker (no ZooKeeper). Topics aren't auto-created
+# on first boot (Kafka has no docker-entrypoint-initdb.d equivalent) — run
+# `make kafka-topics` once after `make kafka-up`.
+
+.PHONY: kafka-up
+kafka-up: ## Start local Kafka and wait until healthy
+	$(COMPOSE) up -d --wait kafka
+
+.PHONY: kafka-stop
+kafka-stop: ## Stop Kafka (keeps the data volume)
+	$(COMPOSE) stop kafka
+
+.PHONY: kafka-topics
+kafka-topics: kafka-up ## Create the hexgate.otlp.raw / hexgate.otlp.dlq topics (idempotent)
+	docker exec hexgate-kafka /opt/kafka/bin/kafka-topics.sh --version >/dev/null
+	docker cp platform/kafka/init/create-topics.sh hexgate-kafka:/tmp/create-topics.sh
+	docker exec hexgate-kafka bash /tmp/create-topics.sh
+
+.PHONY: kafka-list-topics
+kafka-list-topics: ## List topics on the local Kafka broker
+	docker exec hexgate-kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+
+.PHONY: kafka-reset
+kafka-reset: ## Wipe ONLY the Kafka data volume and restart
+	$(COMPOSE) rm -sf kafka
+	-docker volume rm platform_kafka-data
+	$(COMPOSE) up -d --wait kafka
+
 # -------- Platform API (FastAPI control plane) --------
 #
 # The platform API is a separate uv project under platform/api/ with its

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,6 @@ kafka-stop: ## Stop Kafka (keeps the data volume)
 
 .PHONY: kafka-topics
 kafka-topics: kafka-up ## Create the hexgate.otlp.raw / hexgate.otlp.dlq topics (idempotent)
-	docker exec hexgate-kafka /opt/kafka/bin/kafka-topics.sh --version >/dev/null
 	docker cp platform/kafka/init/create-topics.sh hexgate-kafka:/tmp/create-topics.sh
 	docker exec hexgate-kafka bash /tmp/create-topics.sh
 

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ clickhouse-up: ## Start the local ClickHouse server (creates schema on first run
 
 .PHONY: clickhouse-down
 clickhouse-down: ## Stop ClickHouse (keeps the data volume)
-	$(COMPOSE) down
+	$(COMPOSE) stop clickhouse
 
 .PHONY: clickhouse-logs
 clickhouse-logs: ## Tail ClickHouse server logs
@@ -161,15 +161,14 @@ clickhouse-cli: ## Open an interactive SQL shell against the local ClickHouse
 	    --user hexgate --password hexgate-dev-password --database hexgate_audit
 
 .PHONY: clickhouse-reset
-clickhouse-reset: ## Wipe the data volume and re-run init scripts
-	$(COMPOSE) down -v
+clickhouse-reset: ## Wipe ONLY the ClickHouse data volume and re-run init scripts
+	$(COMPOSE) rm -sf clickhouse
+	-docker volume rm platform_clickhouse-data
 	$(COMPOSE) up -d clickhouse
 
 # -------- Platform infra (Postgres control-plane DB) --------
 #
-# Control-plane DB (service in platform/docker-compose.yml). NOTE:
-# `clickhouse-down`/`clickhouse-reset` run `down` on the whole compose and so
-# also stop Postgres — use the `postgres-*` targets below to avoid that.
+# Control-plane DB (service in platform/docker-compose.yml).
 
 # DSN matching the postgres service (host port 5433, committed dev creds).
 POSTGRES_DSN ?= postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433/hexgate
@@ -216,10 +215,11 @@ redpanda-list-topics: ## List topics on the local Redpanda broker
 	docker exec hexgate-redpanda rpk topic list --brokers localhost:9092
 
 .PHONY: redpanda-reset
-redpanda-reset: ## Wipe ONLY the Redpanda data volume and restart
+redpanda-reset: ## Wipe ONLY the Redpanda data volume, restart, and recreate topics
 	$(COMPOSE) rm -sf redpanda
 	-docker volume rm platform_redpanda-data
 	$(COMPOSE) up -d --wait redpanda
+	$(MAKE) redpanda-topics
 
 # -------- Platform API (FastAPI control plane) --------
 #

--- a/Makefile
+++ b/Makefile
@@ -192,34 +192,34 @@ postgres-reset: ## Wipe ONLY the Postgres data volume and restart
 	-docker volume rm platform_postgres-data
 	$(COMPOSE) up -d --wait postgres
 
-# -------- Platform infra (Kafka — OTLP ingestion buffer) --------
+# -------- Platform infra (Redpanda — OTLP ingestion buffer) --------
 #
-# Single-node KRaft dev broker (no ZooKeeper). Topics aren't auto-created
-# on first boot (Kafka has no docker-entrypoint-initdb.d equivalent) — run
-# `make kafka-topics` once after `make kafka-up`.
+# Single-node dev broker, Kafka-wire-protocol-compatible. Topics aren't
+# auto-created on first boot — run `make redpanda-topics` once after
+# `make redpanda-up`.
 
-.PHONY: kafka-up
-kafka-up: ## Start local Kafka and wait until healthy
-	$(COMPOSE) up -d --wait kafka
+.PHONY: redpanda-up
+redpanda-up: ## Start local Redpanda and wait until healthy
+	$(COMPOSE) up -d --wait redpanda
 
-.PHONY: kafka-stop
-kafka-stop: ## Stop Kafka (keeps the data volume)
-	$(COMPOSE) stop kafka
+.PHONY: redpanda-stop
+redpanda-stop: ## Stop Redpanda (keeps the data volume)
+	$(COMPOSE) stop redpanda
 
-.PHONY: kafka-topics
-kafka-topics: kafka-up ## Create the hexgate.otlp.raw / hexgate.otlp.dlq topics (idempotent)
-	docker cp platform/kafka/init/create-topics.sh hexgate-kafka:/tmp/create-topics.sh
-	docker exec hexgate-kafka bash /tmp/create-topics.sh
+.PHONY: redpanda-topics
+redpanda-topics: redpanda-up ## Create the hexgate.otlp.raw / hexgate.otlp.dlq topics (idempotent)
+	docker cp platform/redpanda/init/create-topics.sh hexgate-redpanda:/tmp/create-topics.sh
+	docker exec hexgate-redpanda bash /tmp/create-topics.sh
 
-.PHONY: kafka-list-topics
-kafka-list-topics: ## List topics on the local Kafka broker
-	docker exec hexgate-kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list
+.PHONY: redpanda-list-topics
+redpanda-list-topics: ## List topics on the local Redpanda broker
+	docker exec hexgate-redpanda rpk topic list --brokers localhost:9092
 
-.PHONY: kafka-reset
-kafka-reset: ## Wipe ONLY the Kafka data volume and restart
-	$(COMPOSE) rm -sf kafka
-	-docker volume rm platform_kafka-data
-	$(COMPOSE) up -d --wait kafka
+.PHONY: redpanda-reset
+redpanda-reset: ## Wipe ONLY the Redpanda data volume and restart
+	$(COMPOSE) rm -sf redpanda
+	-docker volume rm platform_redpanda-data
+	$(COMPOSE) up -d --wait redpanda
 
 # -------- Platform API (FastAPI control plane) --------
 #

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -56,22 +56,39 @@ services:
     container_name: hexgate-kafka
     ports:
       # Not offset like postgres/clickhouse above — nothing commonly binds
-      # 9092 locally, and advertised.listeners below must match this port
-      # exactly or clients get redirected to the wrong port on reconnect.
+      # 9092 locally, and the PLAINTEXT advertised listener below must
+      # match this port exactly or host-side clients get redirected to
+      # the wrong port on reconnect.
       - "127.0.0.1:9092:9092"
     environment:
       # Single-node KRaft mode (broker + controller combined) — no
-      # ZooKeeper. LOCAL DEV ONLY: PLAINTEXT, no auth, fixed cluster id
-      # (not a secret, just an identity for this dev cluster's storage —
-      # same "committed dev creds" pattern as postgres/clickhouse above).
+      # ZooKeeper. LOCAL DEV ONLY: no auth, fixed cluster id (not a
+      # secret, just an identity for this dev cluster's storage — same
+      # "committed dev creds" pattern as postgres/clickhouse above).
+      #
+      # Two client-facing listeners, both PLAINTEXT, for two different
+      # audiences — same reason docker-compose.deploy.yml points
+      # HEXGATE_CLICKHOUSE_HOST at the service name "clickhouse" rather
+      # than localhost: a hostname only means "this container" from
+      # inside that same container.
+      #   - PLAINTEXT (9092, published above): for host-machine clients
+      #     (this repo's own CLI tools, a dev running the future
+      #     Collector natively). Advertised as localhost:9092.
+      #   - DOCKER (29092, NOT published): for other containers on this
+      #     compose network. Advertised as kafka:29092 — the compose
+      #     service name, resolvable from any sibling container.
+      # A client that bootstraps via one and gets advertised the other
+      # would try to reconnect to an address that doesn't reach the
+      # broker from where it's sitting, so both must stay in sync with
+      # how each audience actually connects.
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://:9092,DOCKER://:29092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,DOCKER://kafka:29092
       KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
       KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: DOCKER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,DOCKER:PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_LOG_DIRS: /var/lib/kafka/data
       CLUSTER_ID: Y53xctxPRGixoc3BnBGhkQ
@@ -79,9 +96,12 @@ services:
       - kafka-data:/var/lib/kafka/data
     healthcheck:
       test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      # Widened past the ~6s cold-start (fresh volume, KRaft storage
+      # format included) observed on a fast dev machine — headroom for
+      # a slower one or a busy CI runner.
       interval: 5s
       timeout: 5s
-      retries: 10
+      retries: 20
 
 volumes:
   clickhouse-data:

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -51,6 +51,39 @@ services:
       timeout: 3s
       retries: 10
 
+  kafka:
+    image: apache/kafka:3.9.0
+    container_name: hexgate-kafka
+    ports:
+      # Not offset like postgres/clickhouse above — nothing commonly binds
+      # 9092 locally, and advertised.listeners below must match this port
+      # exactly or clients get redirected to the wrong port on reconnect.
+      - "127.0.0.1:9092:9092"
+    environment:
+      # Single-node KRaft mode (broker + controller combined) — no
+      # ZooKeeper. LOCAL DEV ONLY: PLAINTEXT, no auth, fixed cluster id
+      # (not a secret, just an identity for this dev cluster's storage —
+      # same "committed dev creds" pattern as postgres/clickhouse above).
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: Y53xctxPRGixoc3BnBGhkQ
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
 volumes:
   clickhouse-data:
   postgres-data:
+  kafka-data:

--- a/platform/docker-compose.yml
+++ b/platform/docker-compose.yml
@@ -51,21 +51,23 @@ services:
       timeout: 3s
       retries: 10
 
-  kafka:
-    image: apache/kafka:3.9.0
-    container_name: hexgate-kafka
+  redpanda:
+    image: redpandadata/redpanda:latest
+    container_name: hexgate-redpanda
     ports:
       # Not offset like postgres/clickhouse above — nothing commonly binds
-      # 9092 locally, and the PLAINTEXT advertised listener below must
+      # 9092 locally, and the PLAINTEXT advertised address below must
       # match this port exactly or host-side clients get redirected to
       # the wrong port on reconnect.
       - "127.0.0.1:9092:9092"
-    environment:
-      # Single-node KRaft mode (broker + controller combined) — no
-      # ZooKeeper. LOCAL DEV ONLY: no auth, fixed cluster id (not a
-      # secret, just an identity for this dev cluster's storage — same
-      # "committed dev creds" pattern as postgres/clickhouse above).
-      #
+    command:
+      - redpanda
+      - start
+      # dev-container bundles --overprovisioned, --reserve-memory 0M,
+      # --check=false, --unsafe-bypass-fsync — the single-node local-dev
+      # tuning Kafka needed several separate flags for.
+      - --mode
+      - dev-container
       # Two client-facing listeners, both PLAINTEXT, for two different
       # audiences — same reason docker-compose.deploy.yml points
       # HEXGATE_CLICKHOUSE_HOST at the service name "clickhouse" rather
@@ -75,30 +77,20 @@ services:
       #     (this repo's own CLI tools, a dev running the future
       #     Collector natively). Advertised as localhost:9092.
       #   - DOCKER (29092, NOT published): for other containers on this
-      #     compose network. Advertised as kafka:29092 — the compose
+      #     compose network. Advertised as redpanda:29092 — the compose
       #     service name, resolvable from any sibling container.
       # A client that bootstraps via one and gets advertised the other
       # would try to reconnect to an address that doesn't reach the
       # broker from where it's sitting, so both must stay in sync with
       # how each audience actually connects.
-      KAFKA_NODE_ID: 1
-      KAFKA_PROCESS_ROLES: broker,controller
-      KAFKA_LISTENERS: PLAINTEXT://:9092,DOCKER://:29092,CONTROLLER://:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,DOCKER://kafka:29092
-      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@localhost:9093
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_INTER_BROKER_LISTENER_NAME: DOCKER
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,DOCKER:PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_LOG_DIRS: /var/lib/kafka/data
-      CLUSTER_ID: Y53xctxPRGixoc3BnBGhkQ
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:9092,DOCKER://0.0.0.0:29092
+      - --advertise-kafka-addr
+      - PLAINTEXT://localhost:9092,DOCKER://redpanda:29092
     volumes:
-      - kafka-data:/var/lib/kafka/data
+      - redpanda-data:/var/lib/redpanda/data
     healthcheck:
-      test: ["CMD-SHELL", "/opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1"]
-      # Widened past the ~6s cold-start (fresh volume, KRaft storage
-      # format included) observed on a fast dev machine — headroom for
-      # a slower one or a busy CI runner.
+      test: ["CMD-SHELL", "rpk cluster health >/dev/null 2>&1"]
       interval: 5s
       timeout: 5s
       retries: 20
@@ -106,4 +98,4 @@ services:
 volumes:
   clickhouse-data:
   postgres-data:
-  kafka-data:
+  redpanda-data:

--- a/platform/kafka/init/create-topics.sh
+++ b/platform/kafka/init/create-topics.sh
@@ -20,10 +20,13 @@ TOPICS_SH=/opt/kafka/bin/kafka-topics.sh
   --partitions 3 --replication-factor 1 \
   --config retention.ms=259200000 # 3 days
 
-# Permanently-rejected events (unfixable validation, unresolvable
-# agent_version_id) reaching the enrichment job. Auth rejections never
-# land here — the ingestion Collector rejects those directly back to the
-# SDK, before anything reaches Kafka.
+# Intended for permanently-rejected events (unfixable validation,
+# unresolvable agent_version_id) reaching the enrichment job — once that
+# job and the ingestion Collector exist. Neither does yet, and this
+# broker has no auth in front of it at all (PLAINTEXT, no ACLs): today,
+# anything that can reach it can write here directly. Nothing currently
+# enforces "auth rejections never reach this topic" as an actual
+# guarantee — that's a property the Collector work still has to build.
 "$TOPICS_SH" --bootstrap-server "$BOOTSTRAP" \
   --create --if-not-exists --topic hexgate.otlp.dlq \
   --partitions 3 --replication-factor 1 \

--- a/platform/kafka/init/create-topics.sh
+++ b/platform/kafka/init/create-topics.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Creates the topics that buffer OTLP spans between the ingestion
+# Collector and the enrichment job that writes them to ClickHouse. Not
+# auto-run on container start (Kafka has no docker-entrypoint-initdb.d
+# equivalent) — invoked via `make kafka-topics` once the broker is up.
+# Idempotent (--if-not-exists), safe to re-run.
+#
+# Partition count (3) is a local-dev placeholder for parallelism, not a
+# load-tested figure — revisit once real throughput numbers exist.
+set -euo pipefail
+
+BOOTSTRAP="${KAFKA_BOOTSTRAP_SERVER:-localhost:9092}"
+TOPICS_SH=/opt/kafka/bin/kafka-topics.sh
+
+# Buffer, not the system of record — ClickHouse is. Short retention is
+# fine: the enrichment job is expected to keep up, this only needs to
+# survive a brief consumer outage/redeploy.
+"$TOPICS_SH" --bootstrap-server "$BOOTSTRAP" \
+  --create --if-not-exists --topic hexgate.otlp.raw \
+  --partitions 3 --replication-factor 1 \
+  --config retention.ms=259200000 # 3 days
+
+# Permanently-rejected events (unfixable validation, unresolvable
+# agent_version_id) reaching the enrichment job. Auth rejections never
+# land here — the ingestion Collector rejects those directly back to the
+# SDK, before anything reaches Kafka.
+"$TOPICS_SH" --bootstrap-server "$BOOTSTRAP" \
+  --create --if-not-exists --topic hexgate.otlp.dlq \
+  --partitions 3 --replication-factor 1 \
+  --config retention.ms=2592000000 # 30 days
+
+"$TOPICS_SH" --bootstrap-server "$BOOTSTRAP" --list

--- a/platform/redpanda/init/create-topics.sh
+++ b/platform/redpanda/init/create-topics.sh
@@ -2,7 +2,7 @@
 # Creates the topics that buffer OTLP spans between the ingestion
 # Collector and the enrichment job that writes them to ClickHouse. Not
 # auto-run on container start — invoked via `make redpanda-topics` once
-# the broker is up. Idempotent (--if-not-exists), safe to re-run.
+# the broker is up. Safe to re-run.
 #
 # Partition count (3) is a local-dev placeholder for parallelism, not a
 # load-tested figure — revisit once real throughput numbers exist.
@@ -10,13 +10,46 @@ set -euo pipefail
 
 BOOTSTRAP="${HEXGATE_REDPANDA_BOOTSTRAP_SERVER:-localhost:9092}"
 
+# rpk auto-detects a container environment and applies dev-container
+# cluster defaults (including this) regardless of whether --mode
+# dev-container was actually passed — confirmed the image's own shipped
+# config has no such key, so this isn't something the compose command
+# controls. Left enabled, a producer using a wrong/stale topic name (or
+# hitting the broker before this script has ever run) gets the topic
+# silently fabricated with cluster defaults — 1 partition, 7-day
+# retention — instead of a clear error. Applies live, no restart.
+rpk cluster config set auto_create_topics_enabled false --no-confirm
+
+# `create --if-not-exists` only applies -c/--partitions on the branch
+# where it actually creates the topic — on a topic that already exists
+# (e.g. created earlier with different settings, or left over from a
+# retention value this script used to set before a config change), it's
+# a pure no-op: still exits 0, still prints "OK (topic already exists)",
+# but the existing config is untouched. So retention is reconciled
+# separately below, every run, regardless of whether create just made
+# the topic or found it already there.
+#
+# Partition count is NOT reconciled the same way: rpk's only knob is
+# `add-partitions --num N`, which ADDS N rather than setting a target,
+# so it isn't idempotent and can't be dropped into a re-runnable script
+# as-is. A topic created with the wrong partition count has to be
+# recreated by hand — this script can't fix that drift. Disabling
+# auto-creation above removes the main way that drift would happen
+# unnoticed.
+create_topic() {
+  local topic="$1" retention_ms="$2"
+  rpk topic create "$topic" --if-not-exists \
+    --partitions 3 --replicas 1 \
+    -c "retention.ms=$retention_ms" \
+    --brokers "$BOOTSTRAP"
+  rpk topic alter-config "$topic" --set "retention.ms=$retention_ms" --no-confirm \
+    --brokers "$BOOTSTRAP"
+}
+
 # Buffer, not the system of record — ClickHouse is. Short retention is
 # fine: the enrichment job is expected to keep up, this only needs to
 # survive a brief consumer outage/redeploy.
-rpk topic create hexgate.otlp.raw --if-not-exists \
-  --partitions 3 --replicas 1 \
-  -c retention.ms=259200000 `#3 days` \
-  --brokers "$BOOTSTRAP"
+create_topic hexgate.otlp.raw 259200000 # 3 days
 
 # Intended for permanently-rejected events (unfixable validation,
 # unresolvable agent_version_id) reaching the enrichment job — once that
@@ -25,9 +58,6 @@ rpk topic create hexgate.otlp.raw --if-not-exists \
 # anything that can reach it can write here directly. Nothing currently
 # enforces "auth rejections never reach this topic" as an actual
 # guarantee — that's a property the Collector work still has to build.
-rpk topic create hexgate.otlp.dlq --if-not-exists \
-  --partitions 3 --replicas 1 \
-  -c retention.ms=2592000000 `#30 days` \
-  --brokers "$BOOTSTRAP"
+create_topic hexgate.otlp.dlq 2592000000 # 30 days
 
 rpk topic list --brokers "$BOOTSTRAP"

--- a/platform/redpanda/init/create-topics.sh
+++ b/platform/redpanda/init/create-topics.sh
@@ -8,7 +8,7 @@
 # load-tested figure — revisit once real throughput numbers exist.
 set -euo pipefail
 
-BOOTSTRAP="${REDPANDA_BOOTSTRAP_SERVER:-localhost:9092}"
+BOOTSTRAP="${HEXGATE_REDPANDA_BOOTSTRAP_SERVER:-localhost:9092}"
 
 # Buffer, not the system of record — ClickHouse is. Short retention is
 # fine: the enrichment job is expected to keep up, this only needs to

--- a/platform/redpanda/init/create-topics.sh
+++ b/platform/redpanda/init/create-topics.sh
@@ -1,24 +1,22 @@
 #!/usr/bin/env bash
 # Creates the topics that buffer OTLP spans between the ingestion
 # Collector and the enrichment job that writes them to ClickHouse. Not
-# auto-run on container start (Kafka has no docker-entrypoint-initdb.d
-# equivalent) — invoked via `make kafka-topics` once the broker is up.
-# Idempotent (--if-not-exists), safe to re-run.
+# auto-run on container start — invoked via `make redpanda-topics` once
+# the broker is up. Idempotent (--if-not-exists), safe to re-run.
 #
 # Partition count (3) is a local-dev placeholder for parallelism, not a
 # load-tested figure — revisit once real throughput numbers exist.
 set -euo pipefail
 
-BOOTSTRAP="${KAFKA_BOOTSTRAP_SERVER:-localhost:9092}"
-TOPICS_SH=/opt/kafka/bin/kafka-topics.sh
+BOOTSTRAP="${REDPANDA_BOOTSTRAP_SERVER:-localhost:9092}"
 
 # Buffer, not the system of record — ClickHouse is. Short retention is
 # fine: the enrichment job is expected to keep up, this only needs to
 # survive a brief consumer outage/redeploy.
-"$TOPICS_SH" --bootstrap-server "$BOOTSTRAP" \
-  --create --if-not-exists --topic hexgate.otlp.raw \
-  --partitions 3 --replication-factor 1 \
-  --config retention.ms=259200000 # 3 days
+rpk topic create hexgate.otlp.raw --if-not-exists \
+  --partitions 3 --replicas 1 \
+  -c retention.ms=259200000 `#3 days` \
+  --brokers "$BOOTSTRAP"
 
 # Intended for permanently-rejected events (unfixable validation,
 # unresolvable agent_version_id) reaching the enrichment job — once that
@@ -27,9 +25,9 @@ TOPICS_SH=/opt/kafka/bin/kafka-topics.sh
 # anything that can reach it can write here directly. Nothing currently
 # enforces "auth rejections never reach this topic" as an actual
 # guarantee — that's a property the Collector work still has to build.
-"$TOPICS_SH" --bootstrap-server "$BOOTSTRAP" \
-  --create --if-not-exists --topic hexgate.otlp.dlq \
-  --partitions 3 --replication-factor 1 \
-  --config retention.ms=2592000000 # 30 days
+rpk topic create hexgate.otlp.dlq --if-not-exists \
+  --partitions 3 --replicas 1 \
+  -c retention.ms=2592000000 `#30 days` \
+  --brokers "$BOOTSTRAP"
 
-"$TOPICS_SH" --bootstrap-server "$BOOTSTRAP" --list
+rpk topic list --brokers "$BOOTSTRAP"


### PR DESCRIPTION
Design doc: [OpenTelemetry migration design](https://app.notion.com/p/3b2fb45dbae2803ca64adb866704d69b) — Design 3, row 1 ("Kafka infra" — now Redpanda, see below) from the "PR Plan (Design 2)" table.

**Updated 2026-08-07**: this PR started as Kafka infra and was swapped to Redpanda mid-flight (see the doc's new "Design 3" section for why — same architecture, different broker, chosen for operational simplicity while staying Kafka-wire-protocol-compatible for potential enterprise clients who may already run Kafka themselves).

## What is Changing
- Add a `redpanda` service to `platform/docker-compose.yml`: single-binary Redpanda broker (`--mode dev-container`, no JVM/ZooKeeper), local dev only, no auth.
- Two client-facing listeners, same shape as the original Kafka version: `PLAINTEXT` (host-machine clients, `localhost:9092`) and `DOCKER` (sibling containers on the compose network, `redpanda:29092`) — matches how `docker-compose.deploy.yml` already points other services at each other by service name instead of `localhost`.
- `platform/redpanda/init/create-topics.sh` (moved from `platform/kafka/`): creates `hexgate.otlp.raw` (3-day retention) and `hexgate.otlp.dlq` (30-day retention), 3 partitions each. Also disables `auto_create_topics_enabled` and reconciles retention on every run, not just on first creation — see the review-fixes section below.
- Makefile targets renamed: `redpanda-up`, `redpanda-stop`, `redpanda-topics`, `redpanda-list-topics`, `redpanda-reset`.
- `CLAUDE.md`: Tech Stack line + commit-scope list updated (`kafka` → `redpanda`).
- `clickhouse-down`/`clickhouse-reset` scoped to the `clickhouse` service only (previously ran `down`/`down -v` on the whole compose project — see below).
- Topic names, retention, and partition-by-`project_id` (via the future Collector's `kafkaexporter` config — unaffected, since Redpanda speaks the same Kafka wire protocol) are unchanged from the original Kafka version.

## Why is this change necessary
First infra piece of the OTLP-ingestion pipeline: the Go Collector needs a real topic to write to and test against. Redpanda over Kafka specifically: single binary, no JVM/ZooKeeper to configure — `--mode dev-container` bundles the tuning flags Kafka needed several separate `KAFKA_*` env vars for. Still Kafka-wire-protocol-compatible, so nothing downstream (the Collector's `kafkaexporter` config) needed to change.

## Review fixes (4 issues, all reproduced and verified fixed)
1. **`create --if-not-exists` never applied retention on an existing topic.** Reproduced: pre-created `hexgate.otlp.raw` with 1 partition/default 7-day retention, ran the script — still 7-day retention afterward, exit 0, no error. Fixed by reconciling retention via `rpk topic alter-config` every run, regardless of whether create just made the topic. Partition count is deliberately *not* reconciled the same way — rpk's only knob (`add-partitions --num N`) adds rather than sets a target, so it can't be idempotent; a wrong partition count needs a manual fix.
2. **`auto_create_topics_enabled` was left at its default `true`.** Confirmed rpk applies this (and other dev-container defaults) regardless of whether `--mode dev-container` was actually passed — a stale/wrong topic name from any producer would silently fabricate a topic with cluster defaults instead of erroring. Now disabled at the top of `create-topics.sh`, applied live via `rpk cluster config set`.
3. **`redpanda-reset` wiped the volume but never recreated topics.** Unlike ClickHouse (which re-runs its init scripts for free via `docker-entrypoint-initdb.d`), Redpanda has no such hook. Confirmed empty topic list after a reset. Fixed by appending `$(MAKE) redpanda-topics` to the recipe (not a prerequisite — Make would run that *before* the recipe, creating the topics and then wiping them).
4. **`clickhouse-down`/`clickhouse-reset` also destroyed Redpanda.** Both ran `down`/`down -v` on the whole compose project; confirmed via `--dry-run` that `platform_redpanda-data` gets removed alongside ClickHouse's own volume. Scoped both to the `clickhouse` service only, matching the `postgres-*`/`redpanda-*` pattern already used elsewhere, and dropped the old NOTE comment warning about this blast radius (previously only mentioned Postgres) since it's no longer true for either service.

## Tests
Re-verified end-to-end against the real committed config:
- Broker starts and reports healthy on `make redpanda-up` (cold start, fresh volume, ~6s).
- `make redpanda-topics` creates both topics; re-running it is a no-op that also re-applies retention (see fix #1).
- Retention confirmed via `rpk topic describe -c`: `retention.ms=259200000` (raw) / `2592000000` (DLQ), including after simulating drift.
- Produce → consume round trip succeeded on `hexgate.otlp.raw` from **both** a host-side client (`localhost:9092`) and a real sibling container on the compose network (`redpanda:29092`) — both messages readable back from either path.
- `redpanda-stop`/`redpanda-reset` are scoped to the `redpanda` service only — confirmed `clickhouse` stayed running throughout; `clickhouse-down`/`clickhouse-reset` are now scoped the same way — confirmed `redpanda` stays running/intact through both.
- Caught and fixed one real bug while re-verifying the healthcheck itself: `rpk cluster health --brokers ...` doesn't accept `--brokers` at all (only `rpk topic` subcommands do) — would have left the container stuck in "starting" forever and never satisfied `--wait`. Fixed to bare `rpk cluster health`, which defaults to the local node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)