### PR TITLE
refactor(sdk): user -> context/hexgate_context rename + ctx.* docs

### DIFF
--- a/docs/adapters/google-adk.mdx
+++ b/docs/adapters/google-adk.mdx
@@ -28,7 +28,7 @@ from google.adk.models.lite_llm import LiteLlm
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
-from hexgate.runtime import User
+from hexgate.runtime import HexgateContext
 from hexgate.adapters.google import HexgateRunner
 
 INSTRUCTION = (
@@ -64,13 +64,13 @@ async def main():
         tools=[read_logs, restart_service, scale_deployment],
     )
 
-    user = User(user_id="engineer_1", session_id="session_1", role="operator")
+    hexgate_context = HexgateContext(user_id="engineer_1", session_id="session_1", user_roles=["operator"])
 
     session_service = InMemorySessionService()
     await session_service.create_session(
         app_name="devops_demo",
-        user_id=user.user_id,
-        session_id=user.session_id,
+        user_id=hexgate_context.user_id,
+        session_id=hexgate_context.session_id,
     )
 
     runner = HexgateRunner(
@@ -84,7 +84,7 @@ async def main():
         parts=[types.Part(text="Scale the checkout service to 5 replicas in staging.")],
     )
 
-    async for event in runner.run_async(new_message=user_msg, user=user):
+    async for event in runner.run_async(new_message=user_msg, hexgate_context=hexgate_context):
         if event.is_final_response():
             print(event.content.parts[0].text)
 
@@ -103,14 +103,14 @@ if __name__ == "__main__":
   `FunctionTool` (matching what ADK does internally) so the guard has a stable
   `BaseTool` surface. Each tool is then `copy.copy`'d and its `run_async` replaced
   with an enforcer-gated version.
-- Each `run` / `run_async` call opens a `User` scope (`user.sync_scope()` /
-  `async with user:`) and dispatches to the cached underlying `Runner`. On
+- Each `run` / `run_async` call opens a `HexgateContext` scope (`hexgate_context.sync_scope()` /
+  `async with hexgate_context:`) and dispatches to the cached underlying `Runner`. On
   non-allow, the guard returns `decision.as_error_message()` so the ADK runtime
   forwards it to the model as the tool output instead of aborting the run.
 - Observability is set up lazily on each call: `GoogleADKInstrumentor().instrument()`
   plus `nest_asyncio.apply()` (ADK's runner spins its own loop), and the run
   executes inside `propagate_attributes(user_id=..., session_id=...,
-  metadata={"user_role": ...}, tags=["google.runner.run.<agent_name>"])`.
+  metadata={"user_roles": ...}, tags=["google.runner.run.<agent_name>"])`.
 
 ## Runnable example
 

--- a/docs/adapters/langchain.mdx
+++ b/docs/adapters/langchain.mdx
@@ -18,8 +18,8 @@ in that table — check the deepagents row, not the langchain one.
 `wrap_langchain_agent` builds a `PolicyEnforcer` once and installs it on each tool
 in place (`install_enforcer_on_tool`) so the same instances inside the compiled
 graph become policy-gated. It returns a `HexgateLangchainAgent` proxy that opens a
-`User` scope and injects a Langfuse callback into every `invoke` / `ainvoke` /
-`stream` / `astream` / `astream_events` call. The `user` is supplied **per call**,
+`HexgateContext` scope and injects a Langfuse callback into every `invoke` / `ainvoke` /
+`stream` / `astream` / `astream_events` call. The `hexgate_context` is supplied **per call**,
 so a single wrapped agent can serve many users concurrently — role resolution
 happens at call time from the contextvar.
 
@@ -30,7 +30,7 @@ from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
 from langgraph.prebuilt import create_react_agent
 
-from hexgate.runtime import User
+from hexgate.runtime import HexgateContext
 from hexgate.adapters.langchain import wrap_langchain_agent
 
 INSTRUCTION = (
@@ -77,7 +77,7 @@ async def main():
     result = await agent.ainvoke(
         {"messages": [{"role": "user",
                        "content": "Scale the checkout service to 5 replicas in staging."}]},
-        user=User(user_id="engineer_1", role="operator", session_id="session_1"),
+        hexgate_context=HexgateContext(user_id="engineer_1", user_roles=["operator"], session_id="session_1"),
     )
     print(result)
 
@@ -94,9 +94,9 @@ if __name__ == "__main__":
   `coroutine` with enforcer-gated closures. `handle_tool_error` is forced to
   `True`. Installation is idempotent — re-installing rebinds the captured
   originals to the new enforcer without stacking gates.
-- Each invocation method on `HexgateLangchainAgent` takes `user=` and opens an
-  `async with user:` (or `user.sync_scope()` for sync) around the delegated
-  `CompiledStateGraph` call. The active `User` is pushed onto a contextvar; the
+- Each invocation method on `HexgateLangchainAgent` takes `hexgate_context=` and opens an
+  `async with hexgate_context:` (or `hexgate_context.sync_scope()` for sync) around the delegated
+  `CompiledStateGraph` call. The active context is pushed onto a contextvar; the
   guards read it at tool-call time to resolve the matching role's policy.
 - A non-allow `Decision` is rendered as `{"ok": False, "error":
   decision.as_error_payload()}` so the LangChain runtime surfaces the structured

--- a/docs/adapters/openai.mdx
+++ b/docs/adapters/openai.mdx
@@ -17,7 +17,7 @@ table](/adapters/overview#compatible-framework-versions) for the verified
 ## `HexgateRunner`
 
 `HexgateRunner` is a drop-in replacement for `agents.Runner`. It wraps the
-agent's tools with a `PolicyEnforcer` at construction time and opens a `User`
+agent's tools with a `PolicyEnforcer` at construction time and opens a `HexgateContext`
 scope around each `Runner.run` / `run_sync` / `run_streamed` call so role
 resolution happens at call time.
 
@@ -26,7 +26,7 @@ import asyncio
 from agents import Agent, function_tool
 from dotenv import load_dotenv
 
-from hexgate.runtime import User
+from hexgate.runtime import HexgateContext
 from hexgate.adapters.openai import HexgateRunner
 
 INSTRUCTION = (
@@ -69,7 +69,7 @@ async def main():
     result = await runner.run(
         agent,
         "Scale the checkout service to 5 replicas in staging.",
-        user=User(user_id="engineer_1", session_id="session_1", role="operator"),
+        hexgate_context=HexgateContext(user_id="engineer_1", session_id="session_1", user_roles=["operator"]),
     )
     print(result.final_output)
 
@@ -84,13 +84,13 @@ if __name__ == "__main__":
   `(api_key, agent.name, tool_names)`, constructs one `PolicyEnforcer`, and returns
   a `dataclasses.replace`'d copy of the agent with policy-gated tool copies — your
   original `agent` is untouched.
-- The runner opens an `async with user:` scope around the underlying `Runner.run*`
+- The runner opens an `async with hexgate_context:` scope around the underlying `Runner.run*`
   call. When the model calls a tool, the guard asks `enforcer.decide(...)` for a
   `Decision`. On non-allow, it returns `decision.as_error_message()` — a
   `[policy_denied]` or `[approval_required]` markered string the model can
   interpret and recover from.
 - The run executes inside `propagate_attributes(user_id=..., session_id=...,
-  metadata={"user_role": ...})`, so Langfuse spans carry the caller identity.
+  metadata={"user_roles": ...})`, so Langfuse spans carry the caller identity.
 
 `run_sync` and `run_streamed` work the same way.
 

--- a/docs/adapters/overview.mdx
+++ b/docs/adapters/overview.mdx
@@ -16,7 +16,7 @@ logic:
    marker the model sees as tool output (or, for pydantic_ai, a `ModelRetry`)
    rather than aborting the run, so the agent can recover.
 2. **User-aware observability.** Every run is traced through Langfuse with the
-   active [`User`](/concepts/user-scope)'s identity (user id, session id, role)
+   active [`HexgateContext`](/concepts/user-scope)'s identity (user id, session id, role)
    propagated onto the spans.
 
 The four integrations differ in shape because the underlying SDKs do:
@@ -27,9 +27,9 @@ The four integrations differ in shape because the underlying SDKs do:
 | Tool wrapping | Copies each `FunctionTool`, replaces `on_invoke_tool` | Mutates each `BaseTool` in place (`install_enforcer_on_tool`), sets `handle_tool_error=True` | Copies each `BaseTool` (normalizing bare callables to `FunctionTool`), replaces `run_async` | Copies each `Tool` and overrides `function_schema.call` |
 | Denial behavior | Returns `decision.as_error_message()` as tool output | Returns `{"ok": False, "error": decision.as_error_payload()}` | Returns `decision.as_error_message()` as tool output | Raises `ModelRetry(decision.as_error_message())` |
 | Tracing | `OpenAIAgentsInstrumentor` + `propagate_attributes` | Langfuse `CallbackHandler` in each `RunnableConfig` + `propagate_attributes` | `GoogleADKInstrumentor` + `propagate_attributes` | `Agent.instrument_all()` + `propagate_attributes` |
-| Per-call identity | `user: User` on `run` / `run_sync` / `run_streamed` | `user: User` on `invoke` / `ainvoke` / `stream` / `astream` / `astream_events` | `user: User` on `run` / `run_async` | `user: User` on `run` / `run_sync` / `run_stream` / `iter` |
+| Per-call identity | `hexgate_context: HexgateContext` on `run` / `run_sync` / `run_streamed` | `hexgate_context: HexgateContext` on `invoke` / `ainvoke` / `stream` / `astream` / `astream_events` | `hexgate_context: HexgateContext` on `run` / `run_async` | `hexgate_context: HexgateContext` on `run` / `run_sync` / `run_stream` / `iter` |
 
-Role resolution happens **at call time** from the active `User` contextvar — one
+Role resolution happens **at call time** from the active `HexgateContext` contextvar — one
 wrapped agent serves many users concurrently because the scope is per-call. All
 adapters resolve the API key the same way: from the explicit `api_key=` argument,
 falling back to the `HEXGATE_API_KEY` environment variable.

--- a/docs/adapters/pydantic-ai.mdx
+++ b/docs/adapters/pydantic-ai.mdx
@@ -17,7 +17,7 @@ table](/adapters/overview#compatible-framework-versions) for the verified
 `wrap_pydantic_agent` returns a `HexgatePydanticAgent` proxy backed by a clone of
 the original agent whose tools are gated by a freshly built `PolicyEnforcer`.
 Tools registered via the `Agent(...)` constructor or via `@agent.tool` /
-`@agent.tool_plain` are all picked up. The `user` is supplied **per call**, so a
+`@agent.tool_plain` are all picked up. The `hexgate_context` is supplied **per call**, so a
 single wrapped agent can serve many users concurrently — role resolution happens
 at call time from the contextvar.
 
@@ -26,7 +26,7 @@ import asyncio
 from dotenv import load_dotenv
 from pydantic_ai import Agent
 
-from hexgate.runtime import User
+from hexgate.runtime import HexgateContext
 from hexgate.adapters.pydantic_ai import wrap_pydantic_agent
 
 INSTRUCTION = (
@@ -64,9 +64,9 @@ async def main():
 
     result = await agent.run(
         "Scale the checkout service to 5 replicas in staging.",
-        user=User(
+        hexgate_context=HexgateContext(
             user_id="engineer_1",
-            role="operator",
+            user_roles=["operator"],
             session_id="session_1",
         ),
     )
@@ -85,7 +85,7 @@ if __name__ == "__main__":
   whose toolset holds those gated copies — your original `agent` is untouched, so
   it can be reused or wrapped again independently.
 - Each invocation method on `HexgatePydanticAgent` (`run` / `run_sync` /
-  `run_stream` / `iter`) takes `user=` and opens a `User` scope around the
+  `run_stream` / `iter`) takes `hexgate_context=` and opens a `HexgateContext` scope around the
   delegated `Agent` call. The contextvar is per-task, so concurrent `run` calls
   for different users do not see each other's policies.
 - A non-allow `Decision` raises `ModelRetry(decision.as_error_message())`;

--- a/docs/cli/policy.mdx
+++ b/docs/cli/policy.mdx
@@ -51,3 +51,18 @@ lists each violated constraint string verbatim:
   violations:
     • args.amount <= 500
 ```
+
+## Testing `ctx.*` attribute rules
+
+Constraints can filter on caller attributes via `ctx.*` (see
+[constraints](/policy/constraints)). Pass them to `test` with `--attributes`, a
+JSON object so numbers and booleans keep their type:
+
+```bash
+hexgate policy test policy.yaml --role billing --tool refund_order \
+    --args '{"amount": 30}' \
+    --attributes '{"department": "finance", "clearance_level": 3}'
+```
+
+A `ctx.*` key you don't pass is treated as missing and fails closed, exactly as
+at runtime when the request scope omits it.

--- a/docs/concepts/approval-required.mdx
+++ b/docs/concepts/approval-required.mdx
@@ -49,10 +49,10 @@ The `Decision` object holds everything the enforcer knew when it flagged the cal
 | `tool_name` | `str` | Name the model asked to call, e.g. `refund_order`, `mcp-slack-send_message`. |
 | `arguments` | `dict[str, Any]` | Exact arguments the model produced. Show these to the human verbatim, they're what will run. |
 | `reason` | `str` | Human-readable string from the policy engine, usually the failing constraint or the `reason:` field. |
-| `role` | `str \| None` | Active role from `User(role=...)` at the time of the call. |
+| `role` | `str \| None` | Active primary role from `HexgateContext(user_roles=[...])` at the time of the call. |
 | `agent_name` | `str` | Which agent issued the call. Useful when several agents share one approval sink. |
 
-If your UI needs more context than this (customer ID, current balance, whatever), thread it into the arguments the model calls the tool with, or attach it via `User` scope. The callback shouldn't be reaching out to fetch its own context.
+If your UI needs more context than this (customer ID, current balance, whatever), thread it into the arguments the model calls the tool with, or attach it via the `HexgateContext` scope. The callback shouldn't be reaching out to fetch its own context.
 
 ## Common shapes
 

--- a/docs/concepts/bans.mdx
+++ b/docs/concepts/bans.mdx
@@ -14,7 +14,7 @@ There are exactly two ban types, both scoped to a single project:
 | **Agent ban** | one agent | all users |
 | **User ban** | one `user_id` | all agents in the project |
 
-A user ban matches the `user_id` from the [`User` scope](/concepts/user-scope) your integration supplies at runtime. If a run has no `User`, only the agent dimension is evaluated.
+A user ban matches the `user_id` from the [request context](/concepts/user-scope) your integration supplies at runtime. If a run has no `HexgateContext`, only the agent dimension is evaluated.
 
 ## Ban vs. policy
 
@@ -117,6 +117,6 @@ Bans require the platform. In fully local modes (`HEXGATE_LOCAL_MODE`, `HEXGATE_
 
 ## Where to next
 
-- [User scope](/concepts/user-scope) — how `user_id` reaches the runtime, the basis for user bans.
+- [Request context](/concepts/user-scope) — how `user_id` reaches the runtime, the basis for user bans.
 - [Policy decision](/concepts/policy-decision) — the per-tool-call decisions a ban sits in front of.
 - [Audit trail](/concepts/audit-trail) — the decision telemetry that runs alongside blocked-attempt reporting.

--- a/docs/concepts/egress.mdx
+++ b/docs/concepts/egress.mdx
@@ -26,7 +26,7 @@ framework-agnostic and covers any HTTP client running in the agent's process.
 request code does not change.
 
 ```python
-from hexgate import PolicyBuilder, User
+from hexgate import PolicyBuilder, HexgateContext
 from hexgate.egress import egress_guard
 from hexgate.security.enforcer import build_enforcer
 from hexgate.security.policy_set import load_policy_set
@@ -34,7 +34,7 @@ from hexgate.security.policy_set import load_policy_set
 policy = PolicyBuilder(default="deny").net_allow(hosts=["api.github.com"]).build()
 enforcer = build_enforcer(load_policy_set(policy), agent_name="support-agent")
 
-async with egress_guard(enforcer, User(user_id="alice", role="agent")):
+async with egress_guard(enforcer, HexgateContext(user_id="alice", user_roles=["agent"])):
     ...  # every outbound HTTP(S) request in this block is gated
 ```
 

--- a/docs/concepts/policy-decision.mdx
+++ b/docs/concepts/policy-decision.mdx
@@ -14,8 +14,8 @@ Deny-by-default; the [policy file](/policy/yaml-shape) lists what's allowed.
 
 The decision is built from the tool name and its arguments against the active
 policy bundle. The caller's role is a third input, but it isn't passed at the
-call site — `decide` resolves it internally from the active [`User`
-scope](/concepts/user-scope) via a contextvar.
+call site — `decide` resolves it internally from the active [request
+context](/concepts/user-scope) via a contextvar.
 
 ## Where enforcement happens
 
@@ -25,7 +25,7 @@ is replaced with a guarded version that runs the enforcer before the real tool:
 1. The model emits a tool call; the framework dispatches it.
 2. The guarded tool asks the enforcer to decide, passing the tool name and its
    arguments. The caller's role isn't a parameter — it's resolved from the active
-   [`User` scope](/concepts/user-scope) (a contextvar), so the call site only
+   [request context](/concepts/user-scope) (a contextvar), so the call site only
    supplies the tool name and arguments.
 3. The enforcer evaluates the call against the active policy. Two engines back
    this — an in-process pydantic engine (the default) and a WASM engine (what

--- a/docs/concepts/user-scope.mdx
+++ b/docs/concepts/user-scope.mdx
@@ -1,17 +1,17 @@
 ---
-title: "User scope"
-description: "Per-request user identity, role resolution, biscuit attenuation."
+title: "Request context"
+description: "Per-request caller identity, role selection, attributes, biscuit attenuation."
 ---
 
 Real backends serve many users, and different users get different capabilities.
 Hexgate splits that into two pieces:
 
-- **`User`** — the per-request scope. Marks "this invocation acts on behalf of
-  alice, in role X." Async context manager; pushes a fact-bearing Biscuit through
-  the agent runtime.
+- **`HexgateContext`** — the per-request scope. Marks "this invocation acts on
+  behalf of alice, with roles X, and these attributes." Async context manager;
+  pushes a fact-bearing Biscuit through the agent runtime.
 - **Role policies** — one `policy.yaml` per role, optionally inheriting from a
   base mixin. The runtime picks the right one at call time based on the active
-  `User.role`.
+  context's primary role.
 
 The two are deliberately decoupled: tokens carry **identity** (who is calling),
 policy files carry **rules** (what they can do).
@@ -19,11 +19,11 @@ policy files carry **rules** (what they can do).
 ## Minimal example
 
 ```python
-from hexgate import User, load_hexgate_agent, stream_agent
+from hexgate import HexgateContext, load_hexgate_agent, stream_agent
 
 agent, handler = load_hexgate_agent("support_bot")          # client + roles attached at load
 
-async with User(user_id="alice", role="billing", ttl_seconds=300):
+async with HexgateContext(user_id="alice", user_roles=["billing"], ttl_seconds=300):
     async for event in stream_agent(agent, handler, "refund customer 30"):
         ...
 ```
@@ -32,17 +32,54 @@ No manual `attenuate_for_user`, `extract_facts`, or `ToolUseContext` plumbing at
 the call site. The runtime mints the per-request token, picks the `billing`
 role's policy file, and evaluates its constraints against each tool call.
 
+## Filtering on attributes (`ctx.*`)
+
+Beyond the role, a context can carry an open **attributes** bag that policy
+constraints read through the `ctx.*` namespace — turning role-based access into
+attribute-based (ABAC) filtering:
+
+```python
+async with HexgateContext(
+    user_id="alice",
+    user_roles=["billing"],
+    attributes={"department": "finance", "region": "EU", "clearance_level": 3},
+):
+    async for event in stream_agent(agent, handler, "refund customer 30"):
+        ...
+```
+
+```yaml
+# the billing policy can now gate on caller attributes, not just role
+tools:
+  refund_order:
+    mode: allow
+    constraints:
+      - args.amount <= 500
+      - 'ctx.department == "finance"'
+      - "ctx.clearance_level >= 3"
+```
+
+A missing `ctx.<key>` fails closed (deny), like any absent reference.
+
+<Warning>
+**Attributes are exactly as trustworthy as the code that sets them.** `ctx.*`
+may gate `deny` decisions, but it carries the **same trust contract as
+`user_roles`**: populate `attributes` from trusted server-side data (your
+auth/session/IdP), never from raw client input. Hexgate does not independently
+verify attribute values.
+</Warning>
+
 ## FastAPI pattern
 
 The scope must enclose the **streaming iteration itself**, because the role is
 resolved lazily — read on each tool call as the agent runs (see [Notes](#notes)).
-The robust shape is to open the `User` scope *inside the generator* that produces
-the response:
+The robust shape is to open the scope *inside the generator* that produces the
+response:
 
 ```python
 from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
-from hexgate import User, load_hexgate_agent, stream_agent
+from hexgate import HexgateContext, load_hexgate_agent, stream_agent
 
 app = FastAPI()
 agent, handler = load_hexgate_agent("support_bot")          # at startup
@@ -53,10 +90,11 @@ async def chat(request: Request, req: ChatRequest):
 
     async def scoped_events():
         # scope wraps the iteration, so every tool call sees the role
-        async with User(
+        async with HexgateContext(
             user_id=auth.id,
-            role=auth.role,                                   # e.g. "billing"
+            user_roles=auth.roles,                            # e.g. ["billing"]
             session_id=request.state.session_id,
+            attributes={"department": auth.department},       # trusted server data
             ttl_seconds=300,
         ):
             async for event in stream_agent(agent, handler, req.message):
@@ -68,25 +106,29 @@ async def chat(request: Request, req: ChatRequest):
 <Warning>
 **Don't scope auth in `@app.middleware("http")`.** Starlette's
 `BaseHTTPMiddleware` returns the response *before* the `StreamingResponse` body is
-iterated, so a `async with User(...): return await call_next(request)` exits the
-scope before the first event is produced. Because hexgate resolves the role at
-tool-call time, every call during streaming then reads `role=None` and silently
-falls back to the `default` policy — a silent authorization downgrade, no error
-raised. Scope inside the generator (above), or use a pure **ASGI** middleware that
-wraps the `send` channel — not `BaseHTTPMiddleware`.
+iterated, so a `async with HexgateContext(...): return await call_next(request)`
+exits the scope before the first event is produced. Because hexgate resolves the
+role at tool-call time, every call during streaming then reads no role and
+silently falls back to the `default` policy — a silent authorization downgrade,
+no error raised. Scope inside the generator (above), or use a pure **ASGI**
+middleware that wraps the `send` channel — not `BaseHTTPMiddleware`.
 </Warning>
 
-For a non-streaming endpoint, `async with User(...): return await
+For a non-streaming endpoint, `async with HexgateContext(...): return await
 invoke_agent(...)` is fine — the agent runs to completion inside the scope.
 
-## `User` fields
+## `HexgateContext` fields
 
 | Field | Type | Required | Effect |
 |---|---|---|---|
 | `user_id` | `str` | ✅ | Becomes `user("alice")` in the attenuated Biscuit. |
-| `role` | `str?` | optional | Becomes `role("billing")` in the Biscuit. Selects which role policy file applies at tool-call time. Fall-back: the `default` role. |
+| `user_roles` | `list[str]` | optional | The first role selects which role policy file applies at tool-call time. Fall-back: the `default` role. |
 | `session_id` | `str?` | optional | Trace tagging — surfaces on Langfuse spans. |
+| `attributes` | `dict[str, str \| int \| bool \| list[str]]` | optional | Caller attributes exposed to `ctx.*` constraints. Populate from trusted server data. |
 | `ttl_seconds` | `int?` | optional | Embeds a `check if time($t), $t < now+ttl` predicate so the token can't outlive the request. |
+
+Only the **first** role in `user_roles` reaches policy selection today (read via
+`primary_role`); the rest are carried but inert until multi-role selection lands.
 
 ## Role policies — one file per role
 
@@ -98,7 +140,7 @@ agent/
 ├── agent.yaml
 ├── system.md
 └── policies/
-    ├── default.yaml          # fallback when User.role is None / unknown
+    ├── default.yaml          # fallback when no role matches
     ├── read_only.yaml        # mixin — is_mixin: true
     ├── support.yaml          # inherits: [read_only]
     └── billing.yaml          # inherits: [read_only, support]
@@ -134,22 +176,22 @@ tools:
       - args.amount <= 100000
 ```
 
-See [constraints](/policy/constraints) for the expression grammar and a
-role-scoped end-to-end walkthrough.
+See [constraints](/policy/constraints) for the expression grammar (including
+`ctx.*`) and a role-scoped end-to-end walkthrough.
 
 ## Notes
 
 - **Single-file policies still work.** A legacy `policy.yaml` is treated as the
   `default` role — no migration needed.
-- **Lazy attenuation.** `User.__aenter__` only pushes a contextvar — the
-  cryptographic work happens inside `stream_agent` / `invoke_agent` the first
+- **Lazy attenuation.** `HexgateContext.__aenter__` only pushes a contextvar —
+  the cryptographic work happens inside `stream_agent` / `invoke_agent` the first
   time the agent runs. Errors surface at first agent call, not at scope entry.
-- **Local agents skip attenuation.** A `User` scope around a `load_local_agent`
+- **Local agents skip attenuation.** A context scope around a `load_local_agent`
   agent logs a warning and runs with no facts. The `default` policy still applies
   — use `load_hexgate_agent` for the full signed chain.
 - **Explicit override.** Passing `tool_use_context=` explicitly to `stream_agent`
-  / `invoke_agent` wins over an active `User` scope. Useful for tests or one-off
+  / `invoke_agent` wins over an active context scope. Useful for tests or one-off
   bypass.
-- **Sync callers.** `User` exposes both `async with user:` and
-  `user.sync_scope()`. The async form is the primary API; the sync mirror exists
+- **Sync callers.** `HexgateContext` exposes both `async with ctx:` and
+  `ctx.sync_scope()`. The async form is the primary API; the sync mirror exists
   for CLI loops and `Runner.run_sync`-style callers.

--- a/docs/guides/build-an-agent.mdx
+++ b/docs/guides/build-an-agent.mdx
@@ -31,20 +31,20 @@ it once and you're done:
 
 ```python
 from hexgate.adapters.openai import HexgateRunner   # or .langchain.wrap_langchain_agent, .google.HexgateRunner, .pydantic_ai.wrap_pydantic_agent
-from hexgate.runtime import User
+from hexgate.runtime import HexgateContext
 
 runner = HexgateRunner()                            # picks up HEXGATE_API_KEY from env
 await runner.run(
     my_agent,
     "refund 30",
-    user=User(user_id="alice", role="billing"),     # per-call scope
+    hexgate_context=HexgateContext(user_id="alice", user_roles=["billing"]),     # per-call scope
 )
 ```
 
 That's it. You get:
 
 - Tool-call enforcement at every tool boundary (`PolicyEnforcer.decide()`)
-- Role resolution from the active `User.role` at call time
+- Role resolution from the active context's primary role at call time
 - Per-request biscuit attenuation
 - Langfuse traces tagged with the caller's identity
 
@@ -78,10 +78,10 @@ only verifies against the platform instance that minted it.
 
 ## Two carve-outs worth knowing
 
-1. **Per-call identity stays explicit.** `User` is the one piece the adapter
+1. **Per-call identity stays explicit.** `HexgateContext` is the one piece the adapter
    can't infer from env, because it's per-request, not per-process. One line
-   wrapping each call (`user=User(...)` kwarg on adapters, `async with User(...)`
-   for native). See [User scope](/concepts/user-scope).
+   wrapping each call (`hexgate_context=HexgateContext(...)` kwarg on adapters, `async with HexgateContext(...)`
+   for native). See [Request context](/concepts/user-scope).
 2. **`approval_required` tools.** If the policy uses that mode, dev decides what
    happens — pass `approval_handler=` (True / False / callable) when wrapping.
    The CLI default is `ask` for both commands: `hexgate chat` prompts the TTY,

--- a/docs/internals/audit-pipeline.md
+++ b/docs/internals/audit-pipeline.md
@@ -104,7 +104,7 @@ NEEDS_APPROVAL    "needs_approval"  "approval_required"
 ### 2.3 Wire payload — `AuditEvent.as_payload()`
 
 `hexgate/audit.py` — `AuditEvent` wraps a `Decision` plus the caller identity
-read from the active `User` scope (`user_id`, `session_id`). `as_payload()`
+read from the active `HexgateContext` scope (`user_id`, `session_id`). `as_payload()`
 produces a flat JSON object whose keys mirror the platform's `DecisionEvent`:
 
 ```json
@@ -120,7 +120,7 @@ produces a flat JSON object whose keys mirror the platform's `DecisionEvent`:
   "violations":  ["v1", "v2"],     // tuple → list
   "hint":        {"glob": "/x/**"},// or null
   "arguments":   {"path": "/etc/passwd"},  // or null; may be truncated upstream
-  "user_id":     "alice",          // "" when no User scope
+  "user_id":     "alice",          // "" when no request context
   "session_id":  "sess_1"          // "" when unset
 }
 ```
@@ -136,7 +136,7 @@ Server-resolved fields (`project_id`, `agent_version_id`, `received_at`) are
 
 `PolicyEnforcer.decide()` (`hexgate/security/enforcer.py`):
 
-1. Resolve `role` from the active `User` contextvar.
+1. Resolve `role` from the active `HexgateContext` contextvar.
 2. Ask the policy engine for a `Verdict`; lift it into a `Decision`.
 3. If an `AuditSender` was injected into this enforcer, `emit()` an `AuditEvent`.
 4. Return the `Decision` to the adapter (synchronous, unaffected by step 3).

--- a/docs/internals/ban-enforcement.md
+++ b/docs/internals/ban-enforcement.md
@@ -20,7 +20,7 @@ There are exactly **two ban types**:
 | Type | Blocks | Scope | Matched against |
 |------|--------|-------|-----------------|
 | **`agent`** | one agent, for **all** users | project | the agent's `agent_name` |
-| **`user`**  | one `user_id`, across **all** agents | project | `user.user_id` from the runtime `User` scope |
+| **`user`**  | one `user_id`, across **all** agents | project | `user.user_id` from the runtime `HexgateContext` scope |
 
 Key properties:
 
@@ -293,14 +293,14 @@ staging vs prod get distinct sources.
 The gate is `BanGate` (`bans.py:227`). It is per-agent but points at the shared source, and decides:
 
 ```python
-def _decide(self, bans, user):
+def _decide(self, bans, context):
     # Agent ban checked FIRST so a coincident agent+user ban emits a deterministic ban_type/ban_id.
     hit = bans.agent_ban(self._agent_name)
-    if hit is None and user is not None:
-        hit = bans.user_ban(user.user_id)
+    if hit is None and context is not None:
+        hit = bans.user_ban(context.user_id)
     if hit is None:
         return
-    self._emit(hit, user)                       # fire-and-forget telemetry (§4.5)
+    self._emit(hit, context)                    # fire-and-forget telemetry (§4.5)
     target = hit.target_agent_name if hit.ban_type == "agent" else hit.target_user_id
     raise AgentBannedError(
         ban_type=hit.ban_type, target=target or "",
@@ -310,12 +310,12 @@ def _decide(self, bans, user):
 
 Two entry points:
 
-- `check(user)` — sync: fetch (fail-soft) → decide.
-- `check_async(user)` — fetches off-loop via `asyncio.to_thread`, then decides + emits + raises
+- `check(context)` — sync: fetch (fail-soft) → decide.
+- `check_async(context)` — fetches off-loop via `asyncio.to_thread`, then decides + emits + raises
   **on the loop** (the fire-and-forget `AuditSender` only adopts a running loop on its on-loop path,
   so emitting from the worker thread would drop the event).
 
-**Precedence.** Agent ban wins over a coincident user ban. When `user is None`, only the agent
+**Precedence.** Agent ban wins over a coincident user ban. When `context is None`, only the agent
 dimension is evaluated. Tool-level bans don't exist on the SDK side.
 
 **The exception.** `AgentBannedError` (`hexgate/security/errors.py:14`) is a `RuntimeError` enriched
@@ -341,7 +341,7 @@ nothing (no partial output, no fake terminal message).
 
 | Integration | Gate resolution | Fired in (after policy refresh, before the LLM) |
 |-------------|-----------------|--------------------------------------------------|
-| **Native factory** (`agents/factory.py`) | threaded through `with_tools` rebuilds; user is **ambient** via `get_current_user()` | `ainvoke`, `astream_events` (via `_check_ban()`) |
+| **Native factory** (`agents/factory.py`) | threaded through `with_tools` rebuilds; user is **ambient** via `get_current_context()` | `ainvoke`, `astream_events` (via `_check_ban()`) |
 | **OpenAI** (`adapters/openai/runner.py`) | lazy per-agent cache `_ban_gate_for` | `run` (async), `run_sync`, `run_streamed` (before the background task spawns) |
 | **Google ADK** (`adapters/google/runner.py`) | single gate at construction | `run` (sync generator), `run_async` |
 | **LangChain** (`adapters/langchain/agent.py`) | injected via wrapper | `invoke`, `ainvoke`, `stream`, `astream`, `astream_events` |
@@ -498,7 +498,7 @@ All ban routes live in `features/bans/router.py`; the enforcement telemetry rout
 - **Concurrent creates racing** → the "one active ban per target" check is service-level, not a DB
   constraint, so two simultaneous creates can produce duplicate active bans. This is fail-safe
   (over-blocks, never under-blocks); a partial unique index would back it at the DB level (see §9).
-- **`user_id` trust** → the `user_id` is read from the integrator-supplied runtime `User` scope. It
+- **`user_id` trust** → the `user_id` is read from the integrator-supplied runtime `HexgateContext` scope. It
   is bypassable by the integrator's own process, not by their end-users — which matches the threat
   model (a trusted integrator stopping a misbehaving agent or abusive end-user). Binding `user_id`
   into the attenuated biscuit is a known gap (see §9).

--- a/docs/internals/policy-binding-spec.md
+++ b/docs/internals/policy-binding-spec.md
@@ -387,7 +387,7 @@ run boundary:
 
 | method | refresh call |
 |---|---|
-| `ainvoke`, `astream`, `astream_events` | `await self._binding.refresh_async()` (first line, before entering the User scope) |
+| `ainvoke`, `astream`, `astream_events` | `await self._binding.refresh_async()` (first line, before entering the request context) |
 | `invoke`, `stream` | `self._binding.refresh()` (first line) |
 
 The graph and its in-place-mutated tools are never touched again — only
@@ -424,7 +424,7 @@ def _binding_for(self, agent: Agent) -> PolicyBinding:
   object, so refresh reaches every copy.
 - Run methods:
   - `run` (async): `binding = self._binding_for(agent)` →
-    `await binding.refresh_async()` → wrap → run inside the User scope.
+    `await binding.refresh_async()` → wrap → run inside the request context.
   - `run_sync`: same with `binding.refresh()`.
   - `run_streamed`: **refresh synchronously in the setup body, before
     `Runner.run_streamed` is called.** Tools execute later, during
@@ -449,7 +449,7 @@ ADK `Runner`. Spec:
   built once, as today. Construction becomes the loud-failure point (network,
   signature, 404-without-register all raise here).
 - `run` (sync generator): `self._binding.refresh()` first line, before
-  `user.sync_scope()`.
+  `hexgate_context.sync_scope()`.
 - `run_async` (async generator): `await self._binding.refresh_async()` first
   line.
 
@@ -507,7 +507,7 @@ The governing rule, inherited from the loader and made universal:
    caches bundles that passed signature + integrity; the 304 path can only
    return previously verified objects.
 5. **Role resolution stays call-time.** `PolicyEnforcer.decide` re-reads the
-   `User` contextvar per tool call (`enforcer.py:42-44`); binding/refresh is
+   `HexgateContext` contextvar per tool call (`enforcer.py:42-44`); binding/refresh is
    user-agnostic. One binding safely serves many concurrent users.
 6. **Refresh can deny freshness, never grant access.** The worst a
    compromised refresh channel can do is keep an old (verified) policy in

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -64,7 +64,7 @@ from.
   <Card title="Author a policy" icon="shield" href="/policy/yaml-shape">
     Roles, tools, modes, and argument constraints — the full policy shape.
   </Card>
-  <Card title="User scope + roles" icon="user" href="/concepts/user-scope">
+  <Card title="Request context + roles" icon="user" href="/concepts/user-scope">
     How the end user's identity + role reach the decision at call time.
   </Card>
   <Card title="Framework adapters" icon="puzzle-piece" href="/adapters/overview">
@@ -88,7 +88,7 @@ Hexgate is two things that move together:
 Two things feed the decision, and one thing records it:
 
 - The **end user's identity and role** are a **decision input** — carried
-  per-request via [`User`](/concepts/user-scope), they select which role's rules
+  per-request via [`HexgateContext`](/concepts/user-scope), they select which role's rules
   apply. (They also tag traces, but that's secondary.)
 - The **policy** supplies the rules — a [YAML file or signed WASM
   bundle](/policy/wasm-bundles), loaded locally or from the platform.

--- a/docs/platform/hosted.mdx
+++ b/docs/platform/hosted.mdx
@@ -34,11 +34,11 @@ no other code change. Load a registered agent by name and its policy comes from
 the platform (see the [platform workflow](/platform/workflow)):
 
 ```python
-from hexgate import load_hexgate_agent, stream_agent, User
+from hexgate import load_hexgate_agent, stream_agent, HexgateContext
 
 agent, handler = load_hexgate_agent("support_bot")   # the seeded agent; note the underscore
 
-async with User(user_id="alice", role="billing"):
+async with HexgateContext(user_id="alice", user_roles=["billing"]):
     async for event in stream_agent(agent, handler, "refund customer 30"):
         ...
 ```

--- a/docs/platform/overview.mdx
+++ b/docs/platform/overview.mdx
@@ -4,7 +4,7 @@ description: "Three ways to enforce policy: local, Hexgate Cloud, or self-hosted
 ---
 
 The SDK enforces policy in one of three modes. They share the same enforcement
-seam and the same `User` scope — they differ only in **where the policy lives and
+seam and the same `HexgateContext` scope — they differ only in **where the policy lives and
 who runs the infrastructure**.
 
 | Mode | You set | Policy + audit live | Who runs infra |

--- a/docs/platform/workflow.mdx
+++ b/docs/platform/workflow.mdx
@@ -85,11 +85,11 @@ resolves the agent's policy from the platform and enforces it on every tool call
 no policy files shipped in your image, no `enforce_policy(...)` call to remember:
 
 ```python
-from hexgate import load_hexgate_agent, stream_agent, User
+from hexgate import load_hexgate_agent, stream_agent, HexgateContext
 
 agent, handler = load_hexgate_agent("my_agent")   # pulls the signed bundle
 
-async with User(user_id=request.user_id, role=request.role):
+async with HexgateContext(user_id=request.user_id, user_roles=[request.role]):
     async for event in stream_agent(agent, handler, message):
         ...
 ```

--- a/docs/policy/constraints.mdx
+++ b/docs/policy/constraints.mdx
@@ -70,6 +70,29 @@ Besides `args.*`, constraints can reference two **call-scope facts**: `role`
 `role == "admin"` or `tool == "refund_order"`. These mirror Rego's
 `input.role` / `input.tool`.
 
+## Caller attributes (`ctx.*`)
+
+Constraints can also filter on the caller's **attributes** — an open bag set on
+the request scope (`HexgateContext(attributes={...})`) — through the `ctx.<key>`
+namespace, alongside `args.*` / `role` / `tool`:
+
+```yaml
+tools:
+  refund_order:
+    mode: allow
+    constraints:
+      - 'ctx.department == "finance"'
+      - "ctx.clearance_level >= 3"
+      - 'ctx.region in ["EU", "UK"]'
+```
+
+A missing `ctx.<key>` fails closed (deny), like any absent reference.
+
+`ctx.*` may gate `allow`/`deny` decisions — but it carries the **same trust
+contract as `role`**: populate `HexgateContext.attributes` from trusted
+server-side data (your auth/session/IdP), never from raw client input. An
+attribute is exactly as trustworthy as the code that set it.
+
 ## Named constants
 
 Define reusable values once in a `consts:` block and reference them as
@@ -107,8 +130,8 @@ constraint *lines* are still AND-ed, so `and` is only needed to combine with an
 
 ## End to end
 
-With this `billing` role policy and `async with User(user_id="alice",
-role="billing")`:
+With this `billing` role policy and `async with HexgateContext(user_id="alice",
+user_roles=["billing"])`:
 
 ```yaml
 tools:
@@ -128,7 +151,7 @@ tools:
 - `refund_order(amount=200, currency="EUR")` → ❌ denied — constraint `args.currency == "USD"`
 - `wire_transfer(amount=50000)` → ✋ requires approval (mode = `approval_required`)
 
-Switch to `role="default"` and `refund_order` is missing from that policy — it
+Switch to `user_roles=["default"]` and `refund_order` is missing from that policy — it
 falls through to `default_policy.mode` (deny).
 
 Constraints are Rego-compatible by design: the WASM engine compiles them to OPA

--- a/docs/policy/yaml-shape.mdx
+++ b/docs/policy/yaml-shape.mdx
@@ -67,5 +67,5 @@ inject policy later.
 Agents that need per-role behaviour ship a `policies/` directory (one file per
 role, with inheritance) instead of a single `policy.yaml`. A legacy single-file
 `policy.yaml` is treated as the `default` role — no migration needed. See
-[User scope + roles](/concepts/user-scope#role-policies-one-file-per-role) for the
+[Request context + roles](/concepts/user-scope#role-policies-one-file-per-role) for the
 multi-file shape and inheritance rules.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -66,11 +66,11 @@ description: "Watch a role + arguments decide a tool call — first offline, the
   <Step title="Enforce it in a live agent">
     Now put the same policy in front of a real agent. Build one with
     `create_agent`, apply the policy with `enforce_policy`, and run the **same
-    request** under two roles — the role comes from the `User` scope:
+    request** under two roles — the role comes from the `HexgateContext` scope:
 
     ```python
     import asyncio
-    from hexgate import agent_tool, create_agent, enforce_policy, stream_agent, User
+    from hexgate import agent_tool, create_agent, enforce_policy, stream_agent, HexgateContext
 
 
     @agent_tool(name="refund_order")
@@ -87,7 +87,7 @@ description: "Watch a role + arguments decide a tool call — first offline, the
 
     async def refund_as(role: str):
         print(f"\n[{role}]")
-        async with User(user_id="u-1", role=role):
+        async with HexgateContext(user_id="u-1", user_roles=[role]):
             async for event in stream_agent(agent, handler, "Refund $400 on order O-42"):
                 ...  # render events however you like
 
@@ -103,7 +103,7 @@ description: "Watch a role + arguments decide a tool call — first offline, the
     Same agent, same request — under `support` the model's `refund_order($400)`
     call is **blocked** by the policy (over the $50 cap) and it receives a
     `[policy_denied]` marker it can recover from; under `billing` it goes through.
-    That's `enforce_policy` + the per-call `User` doing the work — no platform, no
+    That's `enforce_policy` + the per-call `HexgateContext` doing the work — no platform, no
     extra services.
 
     <Note>
@@ -124,7 +124,7 @@ description: "Watch a role + arguments decide a tool call — first offline, the
   <Card title="Author a policy" icon="shield" href="/policy/yaml-shape">
     Roles, tools, modes, argument constraints, inheritance — the full spec.
   </Card>
-  <Card title="User scope + roles" icon="user" href="/concepts/user-scope">
+  <Card title="Request context + roles" icon="user" href="/concepts/user-scope">
     How the end user's identity + role reach the decision at call time.
   </Card>
   <Card title="Try the terminal REPL" icon="terminal" href="/cli/chat">

--- a/docs/sdk/index.mdx
+++ b/docs/sdk/index.mdx
@@ -22,7 +22,7 @@ from hexgate import (
     load_registered_agent,
     load_hexgate_agent,
     register_agent_factory,
-    User,
+    HexgateContext,
 )
 ```
 
@@ -64,7 +64,7 @@ from hexgate import (
 
 | Symbol | What it does |
 |---|---|
-| `User(user_id, role=…, session_id=…, ttl_seconds=…)` | Per-request scope context manager — its `role` is the decision input. See [user scope](/concepts/user-scope). |
+| `HexgateContext(user_id, user_roles=[…], session_id=…, ttl_seconds=…, attributes={…})` | Per-request scope context manager — its primary role is the decision input. See [user scope](/concepts/user-scope). |
 
 ## Built-in tools
 

--- a/examples/deepagent.py
+++ b/examples/deepagent.py
@@ -46,7 +46,7 @@ async def main():
 
     result = await agent.ainvoke(
         {"messages": [{"role": "user", "content": "What is the weather in Tokyo?"}]},
-        user=HexgateContext(
+        hexgate_context=HexgateContext(
             user_id="deepagent_user_1",
             user_roles=["member"],
             session_id="deepagent_session_1",

--- a/examples/devops_agent.py
+++ b/examples/devops_agent.py
@@ -4,7 +4,7 @@ from agents import Agent, function_tool
 from dotenv import load_dotenv
 
 from hexgate.adapters.openai import HexgateRunner
-from hexgate.runtime import User
+from hexgate.runtime import HexgateContext
 
 INSTRUCTION = (
     "You are a DevOps assistant for a Kubernetes platform. Help engineers read "
@@ -47,7 +47,9 @@ async def main() -> None:
     result = await runner.run(
         agent,
         "Check the logs of the web service in prod, then restart it.",
-        user=User(user_id="olivia", session_id="session_1", role="operator"),
+        hexgate_context=HexgateContext(
+            user_id="olivia", session_id="session_1", user_roles=["operator"]
+        ),
     )
     print(result.final_output)
 

--- a/examples/devops_google.py
+++ b/examples/devops_google.py
@@ -44,15 +44,15 @@ async def main() -> None:
         tools=[read_logs, restart_service, scale_deployment],
     )
 
-    user = HexgateContext(
+    hexgate_context = HexgateContext(
         user_id="engineer_1", session_id="session_1", user_roles=["operator"]
     )
 
     session_service = InMemorySessionService()
     await session_service.create_session(
         app_name=_APP_NAME,
-        user_id=user.user_id,
-        session_id=user.session_id,
+        user_id=hexgate_context.user_id,
+        session_id=hexgate_context.session_id,
     )
 
     runner = HexgateRunner(
@@ -66,7 +66,9 @@ async def main() -> None:
         parts=[types.Part(text="Scale the checkout service to 5 replicas in staging.")],
     )
 
-    async for event in runner.run_async(new_message=message, user=user):
+    async for event in runner.run_async(
+        new_message=message, hexgate_context=hexgate_context
+    ):
         if event.is_final_response() and event.content and event.content.parts:
             print(event.content.parts[0].text)
 

--- a/examples/devops_langchain.py
+++ b/examples/devops_langchain.py
@@ -54,7 +54,7 @@ async def main() -> None:
                 }
             ]
         },
-        user=HexgateContext(
+        hexgate_context=HexgateContext(
             user_id="engineer_1", session_id="session_1", user_roles=["operator"]
         ),
     )

--- a/examples/devops_openai.py
+++ b/examples/devops_openai.py
@@ -46,7 +46,7 @@ async def main() -> None:
     result = await runner.run(
         agent,
         "Scale the checkout service to 5 replicas in staging.",
-        user=HexgateContext(
+        hexgate_context=HexgateContext(
             user_id="engineer_1", session_id="session_1", user_roles=["operator"]
         ),
     )

--- a/examples/devops_pydantic_ai.py
+++ b/examples/devops_pydantic_ai.py
@@ -38,7 +38,7 @@ async def main() -> None:
 
     result = await agent.run(
         "Scale the checkout service to 5 replicas in staging.",
-        user=HexgateContext(
+        hexgate_context=HexgateContext(
             user_id="engineer_1", session_id="session_1", user_roles=["operator"]
         ),
     )

--- a/examples/egress_demo.py
+++ b/examples/egress_demo.py
@@ -44,11 +44,11 @@ async def main() -> None:
         agent_name="egress-demo",
         decision_observer=_print_decision,
     )
-    user = HexgateContext(user_id="demo", user_roles=["agent"])
+    context = HexgateContext(user_id="demo", user_roles=["agent"])
 
     # no_proxy would include the Hexgate control-plane host if audit were on,
     # so audit POSTs bypass the proxy. This demo runs without an API key.
-    async with egress_guard(enforcer, user):
+    async with egress_guard(enforcer, context):
         async with httpx.AsyncClient(timeout=10) as client:
             for url in ("https://api.github.com/zen", "https://example.com/"):
                 print(f"\nGET {url}")

--- a/examples/google_demo.py
+++ b/examples/google_demo.py
@@ -36,7 +36,7 @@ async def main():
         tools=[get_current_time, get_weather],
     )
 
-    user = HexgateContext(
+    hexgate_context = HexgateContext(
         user_id="google_user_1",
         session_id="google_session_1",
         user_roles=["user"],
@@ -45,8 +45,8 @@ async def main():
     session_service = InMemorySessionService()
     await session_service.create_session(
         app_name="google_runner_example",
-        user_id=user.user_id,
-        session_id=user.session_id,
+        user_id=hexgate_context.user_id,
+        session_id=hexgate_context.session_id,
     )
 
     runner = HexgateRunner(
@@ -59,7 +59,9 @@ async def main():
         role="user", parts=[types.Part(text="what is the weather in New Delhi?")]
     )
 
-    async for event in runner.run_async(new_message=user_msg, user=user):
+    async for event in runner.run_async(
+        new_message=user_msg, hexgate_context=hexgate_context
+    ):
         if event.is_final_response():
             print(event.content.parts[0].text)
 

--- a/examples/openai_demo.py
+++ b/examples/openai_demo.py
@@ -25,7 +25,7 @@ async def main():
     result = await runner.run(
         agent=agent,
         input="What's the weather in Cherbourg?",
-        user=HexgateContext(
+        hexgate_context=HexgateContext(
             user_id="openai_user_1",
             session_id="openai_session_1",
             user_roles=["member"],

--- a/examples/pydantic_ai_demo.py
+++ b/examples/pydantic_ai_demo.py
@@ -25,7 +25,7 @@ async def main():
 
     result = await agent.run(
         "What is the weather in Tokyo?",
-        user=HexgateContext(
+        hexgate_context=HexgateContext(
             user_id="pydantic_ai_user_1",
             user_roles=["member"],
             session_id="pydantic_ai_session_1",

--- a/examples/tcp_egress_demo.py
+++ b/examples/tcp_egress_demo.py
@@ -52,8 +52,8 @@ async def _probe(policy, target: tuple[str, int]) -> None:
         agent_name="tcp-demo",
         decision_observer=_print_decision,
     )
-    user = HexgateContext(user_id="demo", user_roles=["agent"])
-    async with tcp_egress_guard(enforcer, user, target=target) as proxy:
+    context = HexgateContext(user_id="demo", user_roles=["agent"])
+    async with tcp_egress_guard(enforcer, context, target=target) as proxy:
         try:
             reader, writer = await asyncio.open_connection(proxy.host, proxy.port)
             writer.write(b"SELECT 1")

--- a/hexgate/__init__.py
+++ b/hexgate/__init__.py
@@ -21,7 +21,13 @@ from hexgate.agents.loader import (
 )
 from hexgate.cloud import HexgateClient, HexgateConfig
 from hexgate.manifest import AgentManifest, create_manifest
-from hexgate.runtime import HexgateContext, LocalWorkspace, ToolUseContext, Workspace
+from hexgate.runtime import (
+    ContextAttributeValue,
+    HexgateContext,
+    LocalWorkspace,
+    ToolUseContext,
+    Workspace,
+)
 from hexgate.security import (
     AgentPolicy,
     C,
@@ -50,6 +56,7 @@ __all__ = [
     "assert_allows",
     "assert_denies",
     "assert_needs_approval",
+    "ContextAttributeValue",
     "HexgateClient",
     "HexgateConfig",
     "HexgateContext",

--- a/hexgate/adapters/_common.py
+++ b/hexgate/adapters/_common.py
@@ -47,12 +47,14 @@ def drain_pending_tasks(
         pass
 
 
-def langfuse_propagate_kwargs(user: HexgateContext, tag: str) -> dict[str, Any]:
+def langfuse_propagate_kwargs(context: HexgateContext, tag: str) -> dict[str, Any]:
     """Build the ``propagate_attributes(**kwargs)`` mapping for a Langfuse
     span tagged ``tag``, carrying the active context's identity."""
     return {
         "tags": [tag],
-        "user_id": user.user_id,
-        "session_id": user.session_id,
-        "metadata": {"user_role": user.primary_role},
+        "user_id": context.user_id,
+        "session_id": context.session_id,
+        # Langfuse drops non-string metadata values, so stamp the full role
+        # list as a readable comma-joined string (not the lossy single role).
+        "metadata": {"user_roles": ", ".join(context.user_roles)},
     }

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -79,10 +79,12 @@ class HexgateRunner:
         GoogleADKInstrumentor().instrument()
 
     @contextmanager
-    def _propagate(self, user: HexgateContext):
+    def _propagate(self, context: HexgateContext):
         """Propagate HexgateContext identity into Langfuse spans for the block."""
         with propagate_attributes(
-            **langfuse_propagate_kwargs(user, f"google.runner.run.{self._agent_name}")
+            **langfuse_propagate_kwargs(
+                context, f"google.runner.run.{self._agent_name}"
+            )
         ):
             yield
 
@@ -90,7 +92,7 @@ class HexgateRunner:
         self,
         *,
         new_message: types.Content,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         **kwargs: Any,
     ) -> Generator[Any, None, None]:
         """Run the Google ADK agent synchronously, yielding events.
@@ -103,11 +105,11 @@ class HexgateRunner:
         self._setup_observability()
         self._binding.refresh()  # per-run policy pull; 304 when unchanged
         if self._ban_gate is not None:
-            self._ban_gate.check(user)
-        with user.sync_scope(), self._propagate(user):
+            self._ban_gate.check(hexgate_context)
+        with hexgate_context.sync_scope(), self._propagate(hexgate_context):
             agen = self._runner.run_async(
-                user_id=user.user_id,
-                session_id=user.session_id,
+                user_id=hexgate_context.user_id,
+                session_id=hexgate_context.session_id,
                 new_message=new_message,
                 **kwargs,
             )
@@ -133,19 +135,19 @@ class HexgateRunner:
         self,
         *,
         new_message: types.Content | None = None,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         **kwargs: Any,
     ) -> AsyncGenerator[Any, None]:
         """Run the Google ADK agent asynchronously, yielding events."""
         self._setup_observability()
         await self._binding.refresh_async()  # per-run policy pull; 304 when unchanged
         if self._ban_gate is not None:
-            await self._ban_gate.check_async(user)
-        async with user:
-            with self._propagate(user):
+            await self._ban_gate.check_async(hexgate_context)
+        async with hexgate_context:
+            with self._propagate(hexgate_context):
                 async for event in self._runner.run_async(
-                    user_id=user.user_id,
-                    session_id=user.session_id,
+                    user_id=hexgate_context.user_id,
+                    session_id=hexgate_context.session_id,
                     new_message=new_message,
                     **kwargs,
                 ):

--- a/hexgate/adapters/langchain/agent.py
+++ b/hexgate/adapters/langchain/agent.py
@@ -24,7 +24,7 @@ class HexgateLangchainAgent:
     Tools are already enforcer-installed at construction (by
     :func:`wrap_langchain_agent`). This proxy pushes the active
     :class:`HexgateContext` onto the contextvar and propagates identity into
-    Langfuse spans. ``user`` is per-call, so one proxy serves many
+    Langfuse spans. ``hexgate_context`` is per-call, so one proxy serves many
     users concurrently. When a policy binding is attached, every run
     method refreshes it first (fail-soft; 304 when unchanged).
     """
@@ -60,17 +60,17 @@ class HexgateLangchainAgent:
         if self._binding is not None:
             self._binding.refresh()
 
-    async def _check_ban_async(self, user: HexgateContext) -> None:
+    async def _check_ban_async(self, context: HexgateContext) -> None:
         """Refuse a banned agent/user before running, if a gate is attached."""
         if self._ban_gate is not None:
-            await self._ban_gate.check_async(user)
+            await self._ban_gate.check_async(context)
 
-    def _check_ban(self, user: HexgateContext) -> None:
+    def _check_ban(self, context: HexgateContext) -> None:
         if self._ban_gate is not None:
-            self._ban_gate.check(user)
+            self._ban_gate.check(context)
 
-    def _propagate_kwargs(self, user: HexgateContext, method: str) -> dict[str, Any]:
-        return langfuse_propagate_kwargs(user, f"langchain.agent.{method}")
+    def _propagate_kwargs(self, context: HexgateContext, method: str) -> dict[str, Any]:
+        return langfuse_propagate_kwargs(context, f"langchain.agent.{method}")
 
     def _with_callbacks(self, config: RunnableConfig | None) -> RunnableConfig:
         """Append the Hexgate callback handlers to ``config['callbacks']``."""
@@ -86,15 +86,17 @@ class HexgateLangchainAgent:
         self,
         input: dict[str, Any],
         *,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Invoke the agent asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
-        await self._check_ban_async(user)
-        async with user:
-            with propagate_attributes(**self._propagate_kwargs(user, "ainvoke")):
+        await self._check_ban_async(hexgate_context)
+        async with hexgate_context:
+            with propagate_attributes(
+                **self._propagate_kwargs(hexgate_context, "ainvoke")
+            ):
                 return await self._agent.ainvoke(
                     input, self._with_callbacks(config), **kwargs
                 )
@@ -103,30 +105,34 @@ class HexgateLangchainAgent:
         self,
         input: dict[str, Any],
         *,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Invoke the agent synchronously inside a HexgateContext scope."""
         self._refresh()
-        self._check_ban(user)
-        with user.sync_scope():
-            with propagate_attributes(**self._propagate_kwargs(user, "invoke")):
+        self._check_ban(hexgate_context)
+        with hexgate_context.sync_scope():
+            with propagate_attributes(
+                **self._propagate_kwargs(hexgate_context, "invoke")
+            ):
                 return self._agent.invoke(input, self._with_callbacks(config), **kwargs)
 
     async def astream(
         self,
         input: dict[str, Any],
         *,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream the agent asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
-        await self._check_ban_async(user)
-        async with user:
-            with propagate_attributes(**self._propagate_kwargs(user, "astream")):
+        await self._check_ban_async(hexgate_context)
+        async with hexgate_context:
+            with propagate_attributes(
+                **self._propagate_kwargs(hexgate_context, "astream")
+            ):
                 async for chunk in self._agent.astream(
                     input, self._with_callbacks(config), **kwargs
                 ):
@@ -136,15 +142,17 @@ class HexgateLangchainAgent:
         self,
         input: dict[str, Any],
         *,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         config: RunnableConfig | None = None,
         **kwargs: Any,
     ) -> Iterator[dict[str, Any]]:
         """Stream the agent synchronously inside a HexgateContext scope."""
         self._refresh()
-        self._check_ban(user)
-        with user.sync_scope():
-            with propagate_attributes(**self._propagate_kwargs(user, "stream")):
+        self._check_ban(hexgate_context)
+        with hexgate_context.sync_scope():
+            with propagate_attributes(
+                **self._propagate_kwargs(hexgate_context, "stream")
+            ):
                 yield from self._agent.stream(
                     input, self._with_callbacks(config), **kwargs
                 )
@@ -153,16 +161,18 @@ class HexgateLangchainAgent:
         self,
         input: dict[str, Any],
         *,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         config: RunnableConfig | None = None,
         version: Literal["v1", "v2"] = "v2",
         **kwargs: Any,
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream the agent events asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
-        await self._check_ban_async(user)
-        async with user:
-            with propagate_attributes(**self._propagate_kwargs(user, "astream_events")):
+        await self._check_ban_async(hexgate_context)
+        async with hexgate_context:
+            with propagate_attributes(
+                **self._propagate_kwargs(hexgate_context, "astream_events")
+            ):
                 async for event in self._agent.astream_events(
                     input,
                     config=self._with_callbacks(config),

--- a/hexgate/adapters/langchain/wrapper.py
+++ b/hexgate/adapters/langchain/wrapper.py
@@ -32,7 +32,7 @@ def wrap_langchain_agent(
     """Wrap a pre-built LangGraph agent with Hexgate policy enforcement.
 
     Mutates ``tools`` in place so the graph keeps its references.
-    The returned proxy takes ``user`` per invocation; role resolves at
+    The returned proxy takes ``hexgate_context`` per invocation; role resolves at
     call time from the active :class:`HexgateContext`. ``api_key`` falls back to
     ``HEXGATE_API_KEY``. ``NEEDS_APPROVAL`` outcomes render as structured
     errors — wire any host-side approval flow outside the SDK. The

--- a/hexgate/adapters/openai/mcp.py
+++ b/hexgate/adapters/openai/mcp.py
@@ -23,7 +23,7 @@ Usage::
             tools=[*wrap_mcp_toolset(mcp), *native_tools],
         )
         wrapped = wrap_openai_agent(agent, enforcer=enforcer)
-        await HexgateRunner(api_key).run(wrapped, "…", user=user)
+        await HexgateRunner(api_key).run(wrapped, "…", hexgate_context=context)
 """
 
 from __future__ import annotations

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -146,10 +146,10 @@ class HexgateRunner:
         OpenAIAgentsInstrumentor().instrument()
 
     @contextmanager
-    def _propagate(self, user: HexgateContext, agent_name: str):
+    def _propagate(self, context: HexgateContext, agent_name: str):
         """Propagate HexgateContext identity into Langfuse spans for the block."""
         with propagate_attributes(
-            **langfuse_propagate_kwargs(user, f"openai.runner.run.{agent_name}")
+            **langfuse_propagate_kwargs(context, f"openai.runner.run.{agent_name}")
         ):
             yield
 
@@ -165,7 +165,7 @@ class HexgateRunner:
         self,
         agent: Agent,
         input: str | list[TResponseInputItem] | RunState[TContext],
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         run_config: RunConfig | None = None,
         hooks: RunHooks | None = None,
         **kwargs,
@@ -176,14 +176,14 @@ class HexgateRunner:
         await binding.refresh_async()  # per-run policy pull; 304 when unchanged
         ban_gate = self._ban_gate_for(agent)
         if ban_gate is not None:
-            await ban_gate.check_async(user)
+            await ban_gate.check_async(hexgate_context)
         wrapped_agent = wrap_openai_agent(
             agent,
             enforcer=binding.enforcer,
             approval_handler=self._approval_handler,
         )
-        async with user:
-            with self._propagate(user, agent.name):
+        async with hexgate_context:
+            with self._propagate(hexgate_context, agent.name):
                 return await Runner.run(
                     wrapped_agent,
                     input,
@@ -196,7 +196,7 @@ class HexgateRunner:
         self,
         agent: Agent,
         input: str | list[TResponseInputItem] | RunState[TContext],
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         run_config: RunConfig | None = None,
         hooks: RunHooks | None = None,
         **kwargs,
@@ -207,14 +207,14 @@ class HexgateRunner:
         binding.refresh()  # per-run policy pull; 304 when unchanged
         ban_gate = self._ban_gate_for(agent)
         if ban_gate is not None:
-            ban_gate.check(user)
+            ban_gate.check(hexgate_context)
         wrapped_agent = wrap_openai_agent(
             agent,
             enforcer=binding.enforcer,
             approval_handler=self._approval_handler,
         )
-        with user.sync_scope():
-            with self._propagate(user, agent.name):
+        with hexgate_context.sync_scope():
+            with self._propagate(hexgate_context, agent.name):
                 try:
                     return Runner.run_sync(
                         wrapped_agent,
@@ -254,7 +254,7 @@ class HexgateRunner:
         self,
         agent: Agent,
         input: str | list[TResponseInputItem] | RunState[TContext],
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         run_config: RunConfig | None = None,
         hooks: RunHooks | None = None,
         **kwargs,
@@ -273,15 +273,15 @@ class HexgateRunner:
         ban_gate = self._ban_gate_for(agent)
         if ban_gate is not None:
             # Before run_streamed spawns its task, so a banned run yields nothing.
-            ban_gate.check(user)
+            ban_gate.check(hexgate_context)
         wrapped_agent = wrap_openai_agent(
             agent,
             enforcer=binding.enforcer,
             approval_handler=self._approval_handler,
         )
 
-        with user.sync_scope():
-            with self._propagate(user, agent.name):
+        with hexgate_context.sync_scope():
+            with self._propagate(hexgate_context, agent.name):
                 result = Runner.run_streamed(
                     wrapped_agent,
                     input,
@@ -293,8 +293,8 @@ class HexgateRunner:
         original_stream_events = result.stream_events
 
         async def _stream_events_with_scope():
-            async with user:
-                with self._propagate(user, agent.name):
+            async with hexgate_context:
+                with self._propagate(hexgate_context, agent.name):
                     async for event in original_stream_events():
                         yield event
 

--- a/hexgate/adapters/pydantic_ai/agent.py
+++ b/hexgate/adapters/pydantic_ai/agent.py
@@ -25,7 +25,7 @@ class HexgatePydanticAgent:
     Tools are already enforcer-installed at construction (by
     :func:`wrap_pydantic_agent`). This proxy pushes the active
     :class:`HexgateContext` onto the contextvar and propagates identity into
-    Langfuse spans. ``user`` is per-call, so one proxy serves many
+    Langfuse spans. ``hexgate_context`` is per-call, so one proxy serves many
     users concurrently. When a policy binding is attached, every run
     method refreshes it first (fail-soft; 304 when unchanged).
     """
@@ -57,46 +57,46 @@ class HexgatePydanticAgent:
         if self._binding is not None:
             self._binding.refresh()
 
-    async def _check_ban_async(self, user: HexgateContext) -> None:
+    async def _check_ban_async(self, context: HexgateContext) -> None:
         """Refuse a banned agent/user before running, if a gate is attached."""
         if self._ban_gate is not None:
-            await self._ban_gate.check_async(user)
+            await self._ban_gate.check_async(context)
 
-    def _check_ban(self, user: HexgateContext) -> None:
+    def _check_ban(self, context: HexgateContext) -> None:
         if self._ban_gate is not None:
-            self._ban_gate.check(user)
+            self._ban_gate.check(context)
 
     def _setup_observability(self) -> None:
         """Globally instrument all pydantic_ai Agents (idempotent)."""
         Agent.instrument_all()
 
-    def _propagate_kwargs(self, user: HexgateContext, method: str) -> dict[str, Any]:
-        return langfuse_propagate_kwargs(user, f"pydantic_ai.agent.{method}")
+    def _propagate_kwargs(self, context: HexgateContext, method: str) -> dict[str, Any]:
+        return langfuse_propagate_kwargs(context, f"pydantic_ai.agent.{method}")
 
     @asynccontextmanager
-    async def _abind(self, user: HexgateContext, method: str) -> AsyncIterator[None]:
+    async def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
         """Async HexgateContext scope + Langfuse propagation."""
-        async with user:
-            with propagate_attributes(**self._propagate_kwargs(user, method)):
+        async with context:
+            with propagate_attributes(**self._propagate_kwargs(context, method)):
                 yield
 
     @contextmanager
-    def _bind(self, user: HexgateContext, method: str) -> Iterator[None]:
+    def _bind(self, context: HexgateContext, method: str) -> Iterator[None]:
         """Sync HexgateContext scope + Langfuse propagation."""
-        with user.sync_scope():
-            with propagate_attributes(**self._propagate_kwargs(user, method)):
+        with context.sync_scope():
+            with propagate_attributes(**self._propagate_kwargs(context, method)):
                 yield
 
     async def run(
         self,
         *args: Any,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         **kwargs: Any,
     ) -> AgentRunResult[Any]:
         """Run the agent asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
-        await self._check_ban_async(user)
-        async with self._abind(user, "run"):
+        await self._check_ban_async(hexgate_context)
+        async with self._abind(hexgate_context, "run"):
             result = await self._agent.run(*args, **kwargs)
             emit_run_usage(self._agent_name, self._agent, result, api_key=self._api_key)
             return result
@@ -104,13 +104,13 @@ class HexgatePydanticAgent:
     def run_sync(
         self,
         *args: Any,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         **kwargs: Any,
     ) -> AgentRunResult[Any]:
         """Run the agent synchronously inside a HexgateContext scope."""
         self._refresh()
-        self._check_ban(user)
-        with self._bind(user, "run_sync"):
+        self._check_ban(hexgate_context)
+        with self._bind(hexgate_context, "run_sync"):
             result = self._agent.run_sync(*args, **kwargs)
             emit_run_usage(self._agent_name, self._agent, result, api_key=self._api_key)
             return result
@@ -119,13 +119,13 @@ class HexgatePydanticAgent:
     async def run_stream(
         self,
         *args: Any,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         **kwargs: Any,
     ) -> AsyncIterator[StreamedRunResult[Any, Any]]:
         """Stream the agent response asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
-        await self._check_ban_async(user)
-        async with self._abind(user, "run_stream"):
+        await self._check_ban_async(hexgate_context)
+        async with self._abind(hexgate_context, "run_stream"):
             async with self._agent.run_stream(*args, **kwargs) as result:
                 yield result
                 # Emit usage only if the run completed, not if the caller aborted mid-stream,
@@ -142,13 +142,13 @@ class HexgatePydanticAgent:
     async def iter(
         self,
         *args: Any,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         **kwargs: Any,
     ) -> AsyncIterator[AgentRun[Any, Any]]:
         """Iterate over the agent execution graph asynchronously."""
         await self._refresh_async()
-        await self._check_ban_async(user)
-        async with self._abind(user, "iter"):
+        await self._check_ban_async(hexgate_context)
+        async with self._abind(hexgate_context, "iter"):
             async with self._agent.iter(*args, **kwargs) as run:
                 yield run
                 if run.result is not None:

--- a/hexgate/adapters/pydantic_ai/mcp.py
+++ b/hexgate/adapters/pydantic_ai/mcp.py
@@ -19,7 +19,7 @@ Usage::
     async with MCPToolset(slack) as mcp:
         agent = Agent("openai:gpt-5.4", tools=[*wrap_mcp_toolset(mcp), *native])
         proxy = wrap_pydantic_agent(agent=agent)
-        await proxy.run("…", user=user)
+        await proxy.run("…", hexgate_context=context)
 """
 
 from __future__ import annotations

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -57,7 +57,7 @@ def wrap_pydantic_agent(
 
     Returns a :class:`HexgatePydanticAgent` backed by a clone of the
     caller's ``agent``; the original is not mutated. The proxy takes
-    ``user`` per call; role resolves at call time from the active
+    ``hexgate_context`` per call; role resolves at call time from the active
     :class:`HexgateContext`. ``NEEDS_APPROVAL`` fires ``approval_handler`` (async
     ``fn(decision) -> bool`` or ``bool`` shorthand); a truthy return
     runs the tool, falsy or missing handler raises :class:`ModelRetry`

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -26,7 +26,7 @@ import yaml
 from pydantic import TypeAdapter, ValidationError
 from yaml.error import MarkedYAMLError
 
-from hexgate.runtime.context import AttrValue
+from hexgate.runtime.context import ContextAttributeValue
 from hexgate.security import (
     AgentPolicy,
     DecisionOutcome,
@@ -54,8 +54,8 @@ from hexgate.security.constraints import ConstraintParseError, parse_constraint
 # Same schema ``HexgateContext.attributes`` enforces at runtime, so a bag the
 # simulator accepts is a bag production can actually produce — including the
 # lax coercions (3.0 -> 3), not just the rejections.
-_ATTRIBUTES_ADAPTER: TypeAdapter[dict[str, AttrValue]] = TypeAdapter(
-    dict[str, AttrValue]
+_ATTRIBUTES_ADAPTER: TypeAdapter[dict[str, ContextAttributeValue]] = TypeAdapter(
+    dict[str, ContextAttributeValue]
 )
 
 
@@ -630,8 +630,8 @@ def _main_test(args: argparse.Namespace) -> int:
         print("--attributes must be a JSON object (dict).", file=sys.stderr)
         return 1
     try:
-        attributes: dict[str, AttrValue] = _ATTRIBUTES_ADAPTER.validate_python(
-            attributes_raw
+        attributes: dict[str, ContextAttributeValue] = (
+            _ATTRIBUTES_ADAPTER.validate_python(attributes_raw)
         )
     except ValidationError as exc:
         print(

--- a/hexgate/cli/serve.py
+++ b/hexgate/cli/serve.py
@@ -322,8 +322,8 @@ async def _run_chat_turn(
     # the attached PolicySource sends If-None-Match and reuses the
     # cached bundle on 304. No need for serve to rebuild the runtime.
     context.state.start_turn(text)
-    user = _context_from_payload(payload.get("user_attenuation"))
-    async with _maybe_user_scope(user):
+    hexgate_context = _context_from_payload(payload.get("user_attenuation"))
+    async with _maybe_user_scope(hexgate_context):
         async for event in stream_agent(
             context.runtime.agent,
             context.runtime.handler,

--- a/hexgate/egress/gate.py
+++ b/hexgate/egress/gate.py
@@ -50,13 +50,13 @@ class Gate:
     def __init__(
         self,
         enforcer: PolicyEnforcer,
-        user: HexgateContext,
+        context: HexgateContext,
         *,
         tool: str = NET_TOOL,
         approval_handler: ApprovalHandler | None = None,
     ) -> None:
         self._enforcer = enforcer
-        self._user = user
+        self._context = context
         self._tool = tool
         self._approval_handler = approval_handler
 
@@ -66,10 +66,10 @@ class Gate:
         The caller identity lives in a contextvar the enforcer reads on
         ``decide()``. Connection handlers run in their own asyncio task, which
         does not inherit the agent's ``async with HexgateContext(...)`` scope, so we
-        re-bind the run's user in *this* task via ``sync_scope()`` for the
+        re-bind the run's context in *this* task via ``sync_scope()`` for the
         duration of the synchronous decide call.
         """
-        with self._user.sync_scope():
+        with self._context.sync_scope():
             decision = self._enforcer.decide(self._tool, args)
 
         if decision.allowed:

--- a/hexgate/egress/proxy.py
+++ b/hexgate/egress/proxy.py
@@ -51,8 +51,8 @@ _guard_active = False
 class EgressProxy(ProxyServer):
     """An asyncio forward proxy that authorizes each request via ``Gate``.
 
-    One proxy serves one agent run: the ``user`` fixes the identity every
-    egress decision is attributed to. Start it, point the process's HTTP
+    One proxy serves one agent run: the ``hexgate_context`` fixes the identity
+    every egress decision is attributed to. Start it, point the process's HTTP
     clients at ``http://{host}:{port}``, and every request is gated. Socket
     lifecycle (bind / accept / teardown) is inherited from :class:`ProxyServer`.
     """
@@ -60,7 +60,7 @@ class EgressProxy(ProxyServer):
     def __init__(
         self,
         enforcer: PolicyEnforcer,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         *,
         host: str = "127.0.0.1",
         port: int = 0,
@@ -68,7 +68,7 @@ class EgressProxy(ProxyServer):
         transport: Transport | None = None,
     ) -> None:
         super().__init__(host=host, port=port)
-        self._gate = Gate(enforcer, user, approval_handler=approval_handler)
+        self._gate = Gate(enforcer, hexgate_context, approval_handler=approval_handler)
         self._transport: Transport = (
             transport if transport is not None else TunnelTransport()
         )
@@ -106,7 +106,7 @@ class EgressProxy(ProxyServer):
 @contextlib.asynccontextmanager
 async def egress_guard(
     enforcer: PolicyEnforcer,
-    user: HexgateContext,
+    hexgate_context: HexgateContext,
     *,
     host: str = "127.0.0.1",
     port: int = 0,
@@ -138,7 +138,11 @@ async def egress_guard(
         )
     _guard_active = True
     proxy = EgressProxy(
-        enforcer, user, host=host, port=port, approval_handler=approval_handler
+        enforcer,
+        hexgate_context,
+        host=host,
+        port=port,
+        approval_handler=approval_handler,
     )
     saved = {name: os.environ.get(name) for name in _PROXY_ENV_VARS}
     try:

--- a/hexgate/egress/tcp.py
+++ b/hexgate/egress/tcp.py
@@ -39,8 +39,8 @@ _log = logging.getLogger(__name__)
 class TcpEgressProxy(ProxyServer):
     """An asyncio TCP proxy that authorizes each connection to one target.
 
-    One proxy forwards one ``(host, port)`` target; the ``user`` fixes the
-    identity every decision is attributed to. Start it, point a client at
+    One proxy forwards one ``(host, port)`` target; the ``hexgate_context``
+    fixes the identity every decision is attributed to. Start it, point a client at
     ``proxy.host:proxy.port``, and each accepted connection is gated on
     ``net.tcp_connect`` before it is tunnelled to the target. Socket lifecycle
     (bind / accept / teardown) is inherited from :class:`ProxyServer`.
@@ -49,7 +49,7 @@ class TcpEgressProxy(ProxyServer):
     def __init__(
         self,
         enforcer: PolicyEnforcer,
-        user: HexgateContext,
+        hexgate_context: HexgateContext,
         *,
         target: tuple[str, int],
         host: str = "127.0.0.1",
@@ -58,7 +58,10 @@ class TcpEgressProxy(ProxyServer):
     ) -> None:
         super().__init__(host=host, port=port)
         self._gate = Gate(
-            enforcer, user, tool=NET_TCP_CONNECT, approval_handler=approval_handler
+            enforcer,
+            hexgate_context,
+            tool=NET_TCP_CONNECT,
+            approval_handler=approval_handler,
         )
         self._target = target
 
@@ -96,7 +99,7 @@ class TcpEgressProxy(ProxyServer):
 @contextlib.asynccontextmanager
 async def tcp_egress_guard(
     enforcer: PolicyEnforcer,
-    user: HexgateContext,
+    hexgate_context: HexgateContext,
     *,
     target: tuple[str, int],
     host: str = "127.0.0.1",
@@ -110,13 +113,13 @@ async def tcp_egress_guard(
     ``proxy.host`` / ``proxy.port`` from the yielded proxy and points its
     connection string there.
 
-        async with tcp_egress_guard(enforcer, user, target=("db.internal", 5432)) as p:
+        async with tcp_egress_guard(enforcer, hexgate_context, target=("db.internal", 5432)) as p:
             dsn = f"postgresql://user@{p.host}:{p.port}/app"
             ...
     """
     proxy = TcpEgressProxy(
         enforcer,
-        user,
+        hexgate_context,
         target=target,
         host=host,
         port=port,

--- a/hexgate/runtime/__init__.py
+++ b/hexgate/runtime/__init__.py
@@ -11,6 +11,7 @@ from hexgate.runtime.command_policy import (
     check_command,
 )
 from hexgate.runtime.context import (
+    ContextAttributeValue,
     HexgateContext,
     ToolUseContext,
     get_current_context,
@@ -37,6 +38,7 @@ __all__ = [
     "MINIMAL_COMMANDS",
     "Rejected",
     "SHELL_BUILTINS",
+    "ContextAttributeValue",
     "HexgateContext",
     "SrtUnavailableError",
     "ToolUseContext",

--- a/hexgate/runtime/context.py
+++ b/hexgate/runtime/context.py
@@ -56,7 +56,7 @@ def reset_current_tool_use_context(token: Token[ToolUseContext | None]) -> None:
     _CURRENT_TOOL_USE_CONTEXT.reset(token)
 
 
-AttrValue = str | int | bool | list[str]
+ContextAttributeValue = str | int | bool | list[str]
 
 
 class HexgateContext(BaseModel):
@@ -108,7 +108,7 @@ class HexgateContext(BaseModel):
     )
     session_id: str | None = None
     ttl_seconds: int | None = None
-    attributes: dict[str, AttrValue] = Field(
+    attributes: dict[str, ContextAttributeValue] = Field(
         default_factory=dict,
         description=(
             "Caller attributes for ABAC ctx.* filtering. Untrusted (spoofable, "

--- a/hexgate/security/bans.py
+++ b/hexgate/security/bans.py
@@ -253,15 +253,15 @@ class BanGate:
         # that avoids enforcement depending on which gate polled first.
         return EMPTY_BAN_SET if self._source is None else self._source.fetch()
 
-    def _decide(self, bans: BanSet, user: HexgateContext | None) -> None:
+    def _decide(self, bans: BanSet, context: HexgateContext | None) -> None:
         # Agent ban checked first so a coincident agent+user ban emits a
         # deterministic ban_type/ban_id.
         hit = bans.agent_ban(self._agent_name)
-        if hit is None and user is not None:
-            hit = bans.user_ban(user.user_id)
+        if hit is None and context is not None:
+            hit = bans.user_ban(context.user_id)
         if hit is None:
             return
-        self._emit(hit, user)
+        self._emit(hit, context)
         target = (
             hit.target_agent_name if hit.ban_type == "agent" else hit.target_user_id
         )
@@ -272,11 +272,11 @@ class BanGate:
             reason=hit.reason,
         )
 
-    def check(self, user: HexgateContext | None) -> None:
+    def check(self, context: HexgateContext | None) -> None:
         """Raise :class:`AgentBannedError` if this agent or user is banned."""
-        self._decide(self._current(), user)
+        self._decide(self._current(), context)
 
-    async def check_async(self, user: HexgateContext | None) -> None:
+    async def check_async(self, context: HexgateContext | None) -> None:
         """Async check: fetch off-loop, decide + emit + raise on the loop.
 
         The emit must stay on the loop — the fire-and-forget ``AuditSender``
@@ -284,9 +284,9 @@ class BanGate:
         ``to_thread`` worker would drop the event.
         """
         bans = await asyncio.to_thread(self._current)
-        self._decide(bans, user)
+        self._decide(bans, context)
 
-    def _emit(self, hit: BanEntry, user: HexgateContext | None) -> None:
+    def _emit(self, hit: BanEntry, context: HexgateContext | None) -> None:
         # Best-effort: on sync entrypoints with no running loop, a sink built
         # off-loop drops the event (shared AuditSender limitation, not
         # ban-specific). The refusal itself is unaffected.
@@ -298,8 +298,8 @@ class BanGate:
                 ban_id=hit.ban_id,
                 reason=hit.reason,
                 agent_name=self._agent_name,
-                user_id=user.user_id if user else "",
-                session_id=(user.session_id or "") if user else "",
+                user_id=context.user_id if context else "",
+                session_id=(context.session_id or "") if context else "",
             )
         )
 

--- a/hexgate/security/constraints.py
+++ b/hexgate/security/constraints.py
@@ -38,9 +38,12 @@ as a ref to an absent field. ``matches`` is an RE2 regex and is
 element inside a quantifier body and is rejected elsewhere. ``every`` over an
 empty list is vacuously true; ``any`` over an empty list is false.
 
-Besides ``args.*``, two call-scope facts are in scope: ``role`` (the caller's
-role) and ``tool`` (the tool being invoked) — mirroring Rego's ``input.role``
-/ ``input.tool``. E.g. ``role == "admin"`` or ``tool == "refund_order"``.
+Besides ``args.*``, three caller-scope fact families are in scope: ``role``
+(the caller's role) and ``tool`` (the tool being invoked) — mirroring Rego's
+``input.role`` / ``input.tool`` — and ``ctx.<key>``, the caller's ABAC
+attributes (``input.ctx`` in Rego). E.g. ``role == "admin"``,
+``tool == "refund_order"``, or ``ctx.department == "finance"``. A missing
+``ctx.<key>`` fails closed like any absent ref.
 
 Concrete examples (all of these parse and evaluate today):
 

--- a/hexgate/tracing/usage.py
+++ b/hexgate/tracing/usage.py
@@ -74,7 +74,7 @@ def emit_llm_usage(
         sender = configure_usage_sender(api_key)
         if sender is None:
             return
-        user = get_current_context()
+        context = get_current_context()
         sender.emit(
             LlmUsageEvent(
                 agent_name=agent_name,
@@ -83,10 +83,10 @@ def emit_llm_usage(
                 output_tokens=output_tokens,
                 latency_ms=latency_ms,
                 status=status,
-                session_id=user.session_id
-                if (user is not None and user.session_id)
+                session_id=context.session_id
+                if (context is not None and context.session_id)
                 else "",
-                user_id=user.user_id if user is not None else "",
+                user_id=context.user_id if context is not None else "",
                 error_code=error_code,
             )
         )

--- a/tests/adapters/google/test_integration.py
+++ b/tests/adapters/google/test_integration.py
@@ -120,14 +120,16 @@ def test_wrapped_run_pulls_policy_and_lands_decision_and_usage_events(
         api_key=hexgate_platform_env.api_key,
         auto_create_session=True,
     )
-    user = HexgateContext(
+    context = HexgateContext(
         user_id=f"{USER_ID_PREFIX}google", session_id=session_id, user_roles=["tester"]
     )
     new_message = types.Content(
         role="user", parts=[types.Part(text="What's the weather in Paris?")]
     )
 
-    events: list[Any] = list(runner.run(new_message=new_message, user=user))
+    events: list[Any] = list(
+        runner.run(new_message=new_message, hexgate_context=context)
+    )
     assert events  # the scripted model produced at least the final turn
 
     # Both sends are fire-and-forget (background thread / task) — poll

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -267,9 +267,9 @@ def test_run_drives_run_async_inline_under_user_scope(
         session_service=InMemorySessionService(),
         api_key="k",
     )
-    user = _user()
+    context = _user()
 
-    events = list(runner.run(new_message="hello", user=user))
+    events = list(runner.run(new_message="hello", hexgate_context=context))
 
     assert events == [{"event": "first"}, {"event": "second"}]
     assert setup_counts["setup"] == 1
@@ -284,7 +284,7 @@ def test_run_drives_run_async_inline_under_user_scope(
     }
     # HexgateContext scope was live during the underlying call.
     [active] = fake_runner.active_users
-    assert active is user
+    assert active is context
     # Scope unwound after the call.
     assert get_current_context() is None
 
@@ -331,7 +331,7 @@ def test_run_drains_pending_tasks_before_closing_loop(
             api_key="k",
         )
 
-        events = list(runner.run(new_message="hello", user=_user()))
+        events = list(runner.run(new_message="hello", hexgate_context=_user()))
 
         assert events == [{"event": "first"}, {"event": "second"}]
         # If run() had closed the loop without draining pending tasks first,
@@ -355,7 +355,7 @@ def test_run_keeps_scope_visible_across_awaits(
         session_service=InMemorySessionService(),
         api_key="k",
     )
-    user = _user()
+    context = _user()
     seen: list[Any] = []
 
     async def run_async(**_kwargs: Any) -> Any:
@@ -365,10 +365,10 @@ def test_run_keeps_scope_visible_across_awaits(
 
     runner._runner.run_async = run_async  # type: ignore[attr-defined]
 
-    events = list(runner.run(new_message="hi", user=user))
+    events = list(runner.run(new_message="hi", hexgate_context=context))
 
     assert events == [{"event": "only"}]
-    assert seen == [user]
+    assert seen == [context]
     assert get_current_context() is None
 
 
@@ -386,9 +386,14 @@ async def test_run_async_opens_user_scope_and_yields_events(
         session_service=InMemorySessionService(),
         api_key="k",
     )
-    user = _user()
+    context = _user()
 
-    events = [event async for event in runner.run_async(new_message="hello", user=user)]
+    events = [
+        event
+        async for event in runner.run_async(
+            new_message="hello", hexgate_context=context
+        )
+    ]
 
     assert events == [{"event": "first"}, {"event": "second"}]
     assert setup_counts["setup"] == 1
@@ -400,7 +405,7 @@ async def test_run_async_opens_user_scope_and_yields_events(
         "new_message": "hello",
     }
     [active] = fake_runner.active_users
-    assert active is user
+    assert active is context
     assert get_current_context() is None
 
 
@@ -435,13 +440,13 @@ def test_run_propagates_user_identity_to_langfuse(
         api_key="k",
     )
 
-    list(runner.run(new_message="hi", user=_user()))
+    list(runner.run(new_message="hi", hexgate_context=_user()))
 
     [call] = propagate_calls
     assert call["tags"] == ["google.runner.run.custom_agent"]
     assert call["user_id"] == "u-1"
     assert call["session_id"] == "s-1"
-    assert call["metadata"] == {"user_role": "developer"}
+    assert call["metadata"] == {"user_roles": "developer"}
 
 
 @pytest.mark.asyncio
@@ -471,7 +476,7 @@ async def test_run_async_propagates_user_identity_to_langfuse(
         api_key="k",
     )
 
-    async for _ in runner.run_async(new_message="hi", user=_user()):
+    async for _ in runner.run_async(new_message="hi", hexgate_context=_user()):
         pass
 
     [call] = propagate_calls
@@ -528,7 +533,7 @@ def test_run_refused_before_events_when_banned(
     runner = _banned_runner(monkeypatch)
 
     with pytest.raises(AgentBannedError) as exc:
-        list(runner.run(new_message="hi", user=_user()))
+        list(runner.run(new_message="hi", hexgate_context=_user()))
 
     assert exc.value.code == "agent_banned"
     [fake_runner] = _FakeRunner.instances
@@ -542,7 +547,7 @@ async def test_run_async_refused_before_first_event_when_banned(
 ) -> None:
     runner = _banned_runner(monkeypatch)
 
-    agen = runner.run_async(new_message="hi", user=_user())
+    agen = runner.run_async(new_message="hi", hexgate_context=_user())
     with pytest.raises(AgentBannedError):
         await agen.__anext__()
 
@@ -561,7 +566,7 @@ def test_not_banned_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     runner._ban_gate = _agent_ban_gate("my_agent", banned="some-other-agent")
 
-    events = list(runner.run(new_message="hi", user=_user()))
+    events = list(runner.run(new_message="hi", hexgate_context=_user()))
 
     assert events == [{"event": "first"}, {"event": "second"}]
 
@@ -602,8 +607,8 @@ def test_run_refreshes_binding_per_call(monkeypatch: pytest.MonkeyPatch) -> None
     """Every run() pulls the policy before any event is yielded."""
     runner, binding = _runner_with_counting_binding(monkeypatch)
 
-    list(runner.run(new_message="hi", user=_user()))
-    list(runner.run(new_message="hi again", user=_user()))
+    list(runner.run(new_message="hi", hexgate_context=_user()))
+    list(runner.run(new_message="hi again", hexgate_context=_user()))
 
     assert binding.refreshes == 2
 
@@ -614,7 +619,7 @@ async def test_run_async_refreshes_binding_per_call(
 ) -> None:
     runner, binding = _runner_with_counting_binding(monkeypatch)
 
-    async for _ in runner.run_async(new_message="hi", user=_user()):
+    async for _ in runner.run_async(new_message="hi", hexgate_context=_user()):
         pass
 
     assert binding.refreshes == 1
@@ -740,9 +745,9 @@ async def test_usage_plugin_context_propagates_through_run_async(
         session_service=InMemorySessionService(),
         api_key="k",
     )
-    user = _user()
+    context = _user()
 
-    async for _ in runner.run_async(new_message=None, user=user):
+    async for _ in runner.run_async(new_message=None, hexgate_context=context):
         pass
 
     [event] = fake_sender.events

--- a/tests/adapters/langchain/test_agent.py
+++ b/tests/adapters/langchain/test_agent.py
@@ -167,15 +167,15 @@ def test_invoke_opens_user_scope_and_delegates() -> None:
     """The active HexgateContext contextvar is live during the wrapped invoke."""
     graph = _RecordingGraph()
     proxy = HexgateLangchainAgent(agent=graph, api_key="k", tool_names=["echo"])
-    user = _user()
+    context = _user()
 
     assert get_current_context() is None
 
-    result = proxy.invoke({"input": "hi"}, user=user)
+    result = proxy.invoke({"input": "hi"}, hexgate_context=context)
 
     assert result == {"messages": ["sync-ok"]}
     [call] = graph.invoke_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert call["input"] == {"input": "hi"}
     assert proxy._callback_handler in call["config"]["callbacks"]
     # Scope unwound after the call.
@@ -186,13 +186,13 @@ def test_invoke_opens_user_scope_and_delegates() -> None:
 async def test_ainvoke_opens_user_scope_and_delegates() -> None:
     graph = _RecordingGraph()
     proxy = HexgateLangchainAgent(agent=graph, api_key="k", tool_names=["echo"])
-    user = _user()
+    context = _user()
 
-    result = await proxy.ainvoke({"input": "hi"}, user=user)
+    result = await proxy.ainvoke({"input": "hi"}, hexgate_context=context)
 
     assert result == {"messages": ["async-ok"]}
     [call] = graph.ainvoke_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert proxy._callback_handler in call["config"]["callbacks"]
     assert get_current_context() is None
 
@@ -200,13 +200,13 @@ async def test_ainvoke_opens_user_scope_and_delegates() -> None:
 def test_stream_opens_user_scope_and_yields_chunks() -> None:
     graph = _RecordingGraph()
     proxy = HexgateLangchainAgent(agent=graph, api_key="k", tool_names=["echo"])
-    user = _user()
+    context = _user()
 
-    chunks = list(proxy.stream({"input": "hi"}, user=user))
+    chunks = list(proxy.stream({"input": "hi"}, hexgate_context=context))
 
     assert chunks == [{"chunk": 1}, {"chunk": 2}]
     [call] = graph.stream_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert proxy._callback_handler in call["config"]["callbacks"]
     assert get_current_context() is None
 
@@ -215,13 +215,15 @@ def test_stream_opens_user_scope_and_yields_chunks() -> None:
 async def test_astream_opens_user_scope_and_yields_chunks() -> None:
     graph = _RecordingGraph()
     proxy = HexgateLangchainAgent(agent=graph, api_key="k", tool_names=["echo"])
-    user = _user()
+    context = _user()
 
-    chunks = [chunk async for chunk in proxy.astream({"input": "hi"}, user=user)]
+    chunks = [
+        chunk async for chunk in proxy.astream({"input": "hi"}, hexgate_context=context)
+    ]
 
     assert chunks == [{"chunk": 1}, {"chunk": 2}]
     [call] = graph.astream_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert get_current_context() is None
 
 
@@ -229,18 +231,20 @@ async def test_astream_opens_user_scope_and_yields_chunks() -> None:
 async def test_astream_events_forwards_version_and_opens_scope() -> None:
     graph = _RecordingGraph()
     proxy = HexgateLangchainAgent(agent=graph, api_key="k", tool_names=["echo"])
-    user = _user()
+    context = _user()
 
     events = [
         evt
-        async for evt in proxy.astream_events({"input": "hi"}, version="v2", user=user)
+        async for evt in proxy.astream_events(
+            {"input": "hi"}, version="v2", hexgate_context=context
+        )
     ]
 
     assert events == [{"event": "start"}, {"event": "end"}]
     [call] = graph.astream_events_calls
     assert call["version"] == "v2"
     assert call["config"] is not None  # version did not leak into the config slot
-    assert call["user"] is user
+    assert call["user"] is context
     assert get_current_context() is None
 
 
@@ -250,7 +254,10 @@ async def test_astream_events_defaults_version_to_v2() -> None:
     graph = _RecordingGraph()
     proxy = HexgateLangchainAgent(agent=graph, api_key="k", tool_names=["echo"])
 
-    _ = [evt async for evt in proxy.astream_events({"input": "hi"}, user=_user())]
+    _ = [
+        evt
+        async for evt in proxy.astream_events({"input": "hi"}, hexgate_context=_user())
+    ]
 
     [call] = graph.astream_events_calls
     assert call["version"] == "v2"
@@ -268,7 +275,7 @@ def test_user_scope_is_unwound_when_invoke_raises() -> None:
     proxy = HexgateLangchainAgent(agent=BoomGraph(), api_key="k", tool_names=[])
 
     with pytest.raises(RuntimeError, match="boom"):
-        proxy.invoke({"input": "hi"}, user=_user())
+        proxy.invoke({"input": "hi"}, hexgate_context=_user())
 
     assert get_current_context() is None
 
@@ -288,7 +295,7 @@ def test_invoke_refused_before_graph_runs_when_banned() -> None:
     )
 
     with pytest.raises(AgentBannedError) as exc:
-        proxy.invoke({"input": "hi"}, user=_user())
+        proxy.invoke({"input": "hi"}, hexgate_context=_user())
 
     assert exc.value.code == "agent_banned"
     assert graph.invoke_calls == []  # graph never ran
@@ -305,7 +312,7 @@ async def test_astream_raises_before_first_chunk_when_banned() -> None:
         ban_gate=_agent_ban_gate(graph.name),
     )
 
-    agen = proxy.astream({"input": "hi"}, user=_user())
+    agen = proxy.astream({"input": "hi"}, hexgate_context=_user())
     with pytest.raises(AgentBannedError):
         await agen.__anext__()
     assert graph.astream_calls == []  # no chunk yielded
@@ -321,7 +328,7 @@ def test_not_banned_passes_through() -> None:
         ban_gate=_agent_ban_gate(graph.name, banned="some-other-agent"),
     )
 
-    result = proxy.invoke({"input": "hi"}, user=_user())
+    result = proxy.invoke({"input": "hi"}, hexgate_context=_user())
 
     assert result == {"messages": ["sync-ok"]}
     assert len(graph.invoke_calls) == 1
@@ -405,9 +412,9 @@ async def test_usage_handler_context_propagates_through_ainvoke(
     proxy = HexgateLangchainAgent(
         agent=_CallbackFiringGraph(), api_key="k", agent_name="my-agent", tool_names=[]
     )
-    user = _user()
+    context = _user()
 
-    await proxy.ainvoke({"input": "hi"}, user=user)
+    await proxy.ainvoke({"input": "hi"}, hexgate_context=context)
 
     [event] = fake_sender.events
     assert event.agent_name == "my-agent"
@@ -429,7 +436,7 @@ def test_usage_handler_context_propagates_through_sync_invoke(
         agent=_CallbackFiringGraph(), api_key="k", agent_name="my-agent", tool_names=[]
     )
 
-    proxy.invoke({"input": "hi"}, user=_user())
+    proxy.invoke({"input": "hi"}, hexgate_context=_user())
 
     [event] = fake_sender.events
     assert event.user_id == "u-1"

--- a/tests/adapters/langchain/test_integration.py
+++ b/tests/adapters/langchain/test_integration.py
@@ -129,14 +129,14 @@ async def test_agent_run_lands_policy_decision_and_llm_usage_events(
         agent=raw_agent, tools=tools, api_key=hexgate_platform_env.api_key
     )
 
-    user = HexgateContext(
+    context = HexgateContext(
         user_id=f"{USER_ID_PREFIX}langchain",
         session_id=session_id,
         user_roles=["tester"],
     )
     result = await wrapped.ainvoke(
         {"messages": [{"role": "user", "content": "What's the weather in Paris?"}]},
-        user=user,
+        hexgate_context=context,
     )
     assert result["messages"][-1].content
 

--- a/tests/adapters/langchain/test_wrapper.py
+++ b/tests/adapters/langchain/test_wrapper.py
@@ -258,8 +258,8 @@ def test_invoke_refreshes_binding_first() -> None:
         binding=binding,  # type: ignore[arg-type]
     )
 
-    proxy.invoke({"messages": []}, user=_user())
-    proxy.invoke({"messages": []}, user=_user())
+    proxy.invoke({"messages": []}, hexgate_context=_user())
+    proxy.invoke({"messages": []}, hexgate_context=_user())
 
     assert binding.refreshes == 2
 
@@ -274,7 +274,7 @@ async def test_ainvoke_refreshes_binding_first() -> None:
         binding=binding,  # type: ignore[arg-type]
     )
 
-    await proxy.ainvoke({"messages": []}, user=_user())
+    await proxy.ainvoke({"messages": []}, hexgate_context=_user())
 
     assert binding.refreshes == 1
 
@@ -283,4 +283,4 @@ def test_proxy_without_binding_runs_fine() -> None:
     """Back-compat: a binding-less proxy (direct construction) still works."""
     proxy = HexgateLangchainAgent(agent=_RunnableGraph(), api_key="k", tool_names=[])
 
-    assert proxy.invoke({"messages": []}, user=_user()) == {"ok": True}
+    assert proxy.invoke({"messages": []}, hexgate_context=_user()) == {"ok": True}

--- a/tests/adapters/openai/test_integration.py
+++ b/tests/adapters/openai/test_integration.py
@@ -163,10 +163,12 @@ def test_tool_call_records_policy_decision_and_llm_usage(
     register_agent(raw_agent)
 
     runner = HexgateRunner(api_key=hexgate_platform_env.api_key)
-    user = HexgateContext(
+    context = HexgateContext(
         user_id=f"{USER_ID_PREFIX}openai", session_id=session_id, user_roles=["tester"]
     )
-    result = runner.run_sync(raw_agent, "What's the weather in Paris?", user=user)
+    result = runner.run_sync(
+        raw_agent, "What's the weather in Paris?", hexgate_context=context
+    )
     assert result.final_output
 
     assert_policy_and_usage_events_landed(

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -198,9 +198,9 @@ async def test_run_wraps_agent_opens_user_scope_and_calls_runner_run(
 
     runner = HexgateRunner(api_key="k")
     agent = _make_agent()
-    user = _user()
+    context = _user()
 
-    result = await runner.run(agent, "hello", user=user)
+    result = await runner.run(agent, "hello", hexgate_context=context)
 
     assert result == "run-result"
     assert setup_counts["setup"] == 1
@@ -210,7 +210,7 @@ async def test_run_wraps_agent_opens_user_scope_and_calls_runner_run(
     assert captured["kwargs"]["run_config"] is None
     assert isinstance(captured["kwargs"]["hooks"], HexgateUsageHooks)
     # HexgateContext scope was live for the duration of Runner.run.
-    assert captured["active_user"] is user
+    assert captured["active_user"] is context
     # Scope unwound on exit — no leak.
     assert get_current_context() is None
 
@@ -235,15 +235,15 @@ def test_run_sync_opens_user_scope_and_calls_runner_run_sync(
 
     runner = HexgateRunner(api_key="k")
     agent = _make_agent()
-    user = _user()
+    context = _user()
 
-    result = runner.run_sync(agent, "hello", user=user)
+    result = runner.run_sync(agent, "hello", hexgate_context=context)
 
     assert result == "run-sync-result"
     assert setup_counts["setup"] == 1
     assert captured["agent"] is not agent
     assert captured["input"] == "hello"
-    assert captured["active_user"] is user
+    assert captured["active_user"] is context
     assert get_current_context() is None
 
 
@@ -286,7 +286,7 @@ def test_run_sync_drains_pending_tasks_on_the_default_loop(
 
         try:
             runner = HexgateRunner(api_key="k")
-            result = runner.run_sync(_make_agent(), "hello", user=_user())
+            result = runner.run_sync(_make_agent(), "hello", hexgate_context=_user())
 
             assert result == "run-sync-result"
             # If run_sync() had returned without draining the default loop,
@@ -336,16 +336,16 @@ async def test_run_streamed_wraps_stream_events_to_re_enter_scope_and_propagatio
 
     runner = HexgateRunner(api_key="k")
     agent = _make_agent()
-    user = _user()
+    context = _user()
 
-    result = runner.run_streamed(agent, "hello", user=user)
+    result = runner.run_streamed(agent, "hello", hexgate_context=context)
 
     assert result is fake_result
     assert captured["agent"].name == agent.name
     assert len(propagate_calls) == 1
     assert propagate_calls[0]["user_id"] == "u-1"
     assert propagate_calls[0]["session_id"] == "s-1"
-    assert propagate_calls[0]["metadata"] == {"user_role": "developer"}
+    assert propagate_calls[0]["metadata"] == {"user_roles": "developer"}
     assert propagate_calls[0]["tags"] == ["openai.runner.run.my-agent"]
 
     events = [event async for event in result.stream_events()]
@@ -373,11 +373,11 @@ async def test_run_streamed_opens_user_scope_around_run_streamed_call(
     )
 
     runner = HexgateRunner(api_key="k")
-    user = _user()
+    context = _user()
 
-    runner.run_streamed(_make_agent(), "hello", user=user)
+    runner.run_streamed(_make_agent(), "hello", hexgate_context=context)
 
-    assert captured["active_user"] is user
+    assert captured["active_user"] is context
     assert get_current_context() is None
 
 
@@ -411,13 +411,13 @@ async def test_run_propagates_user_identity_to_langfuse(
 
     runner = HexgateRunner(api_key="k")
 
-    await runner.run(_make_agent("custom-name"), "hi", user=_user())
+    await runner.run(_make_agent("custom-name"), "hi", hexgate_context=_user())
 
     [call] = propagate_calls
     assert call["tags"] == ["openai.runner.run.custom-name"]
     assert call["user_id"] == "u-1"
     assert call["session_id"] == "s-1"
-    assert call["metadata"] == {"user_role": "developer"}
+    assert call["metadata"] == {"user_roles": "developer"}
 
 
 # ---------------------------------------------------------------------------
@@ -444,7 +444,7 @@ async def test_run_refused_before_runner_run_when_banned(
     runner._ban_gates["my-agent"] = _agent_ban_gate("my-agent")
 
     with pytest.raises(AgentBannedError) as exc:
-        await runner.run(_make_agent("my-agent"), "hi", user=_user())
+        await runner.run(_make_agent("my-agent"), "hi", hexgate_context=_user())
 
     assert exc.value.code == "agent_banned"
     assert called == []  # Runner.run never reached
@@ -472,7 +472,7 @@ def test_run_streamed_refused_before_task_spawns_when_banned(
     runner._ban_gates["my-agent"] = _agent_ban_gate("my-agent")
 
     with pytest.raises(AgentBannedError):
-        runner.run_streamed(_make_agent("my-agent"), "hi", user=_user())
+        runner.run_streamed(_make_agent("my-agent"), "hi", hexgate_context=_user())
 
     assert called == []  # background task never spawned
 
@@ -495,7 +495,7 @@ async def test_not_banned_passes_through(
         "my-agent", banned="some-other-agent"
     )
 
-    result = await runner.run(_make_agent("my-agent"), "hi", user=_user())
+    result = await runner.run(_make_agent("my-agent"), "hi", hexgate_context=_user())
 
     assert result == "ok"
 
@@ -547,8 +547,8 @@ async def test_binding_is_cached_per_agent_name(
     runner = HexgateRunner(api_key="k")
     agent = _make_agent("my-agent")
 
-    await runner.run(agent, "one", user=_user())
-    await runner.run(agent, "two", user=_user())
+    await runner.run(agent, "one", hexgate_context=_user())
+    await runner.run(agent, "two", hexgate_context=_user())
 
     assert _stub_resolve == ["my-agent"]
 
@@ -562,8 +562,8 @@ async def test_distinct_agent_names_get_distinct_bindings(
 
     runner = HexgateRunner(api_key="k")
 
-    await runner.run(_make_agent("agent-a"), "x", user=_user())
-    await runner.run(_make_agent("agent-b"), "x", user=_user())
+    await runner.run(_make_agent("agent-a"), "x", hexgate_context=_user())
+    await runner.run(_make_agent("agent-b"), "x", hexgate_context=_user())
 
     assert _stub_resolve == ["agent-a", "agent-b"]
     assert set(runner._bindings) == {"agent-a", "agent-b"}
@@ -597,8 +597,8 @@ async def test_run_refreshes_cached_binding_per_call(
     binding = _CountingBinding()
     runner._bindings["my-agent"] = binding  # type: ignore[assignment]
 
-    await runner.run(_make_agent("my-agent"), "one", user=_user())
-    await runner.run(_make_agent("my-agent"), "two", user=_user())
+    await runner.run(_make_agent("my-agent"), "one", hexgate_context=_user())
+    await runner.run(_make_agent("my-agent"), "two", hexgate_context=_user())
 
     assert binding.refreshes == 2
 
@@ -620,7 +620,7 @@ def test_run_sync_refreshes_cached_binding_per_call(
     binding = _CountingBinding()
     runner._bindings["my-agent"] = binding  # type: ignore[assignment]
 
-    runner.run_sync(_make_agent("my-agent"), "one", user=_user())
+    runner.run_sync(_make_agent("my-agent"), "one", hexgate_context=_user())
 
     assert binding.refreshes == 1
 
@@ -653,7 +653,7 @@ def test_run_streamed_refreshes_before_setup(
     binding = _OrderedBinding()
     runner._bindings["my-agent"] = binding  # type: ignore[assignment]
 
-    runner.run_streamed(_make_agent("my-agent"), "hello", user=_user())
+    runner.run_streamed(_make_agent("my-agent"), "hello", hexgate_context=_user())
 
     assert order == ["refresh", "run_streamed"]
 
@@ -709,7 +709,7 @@ async def test_run_passes_a_usage_hooks_instance_when_caller_passes_none(
     )
 
     runner = HexgateRunner(api_key="k")
-    await runner.run(_make_agent(), "hi", user=_user())
+    await runner.run(_make_agent(), "hi", hexgate_context=_user())
 
     assert isinstance(captured["hooks"], HexgateUsageHooks)
 
@@ -735,7 +735,7 @@ async def test_run_composes_caller_supplied_hooks_instead_of_clobbering(
     caller_hooks = _RecordingHooks()
     runner = HexgateRunner(api_key="k")
 
-    await runner.run(_make_agent(), "hi", user=_user(), hooks=caller_hooks)
+    await runner.run(_make_agent(), "hi", hexgate_context=_user(), hooks=caller_hooks)
 
     assert captured["hooks"] is not caller_hooks  # composed, not passed through raw
     assert caller_hooks.llm_end_calls == 1  # still fired
@@ -765,9 +765,9 @@ async def test_usage_hook_context_propagates_through_run(
     )
 
     runner = HexgateRunner(api_key="k")
-    user = _user()
+    context = _user()
 
-    await runner.run(_make_agent("my-agent"), "hi", user=user)
+    await runner.run(_make_agent("my-agent"), "hi", hexgate_context=context)
 
     [event] = fake_sender.events
     assert event.agent_name == "my-agent"

--- a/tests/adapters/pydantic_ai/test_agent.py
+++ b/tests/adapters/pydantic_ai/test_agent.py
@@ -175,15 +175,15 @@ async def test_run_opens_user_scope_and_delegates(
         api_key="k",
         agent_name="recording-agent",
     )
-    user = _user()
+    context = _user()
 
     assert get_current_context() is None
 
-    result = await proxy.run("hello", user=user)
+    result = await proxy.run("hello", hexgate_context=context)
 
     assert result.value == "run-ok"
     [call] = inner.run_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert call["args"] == ("hello",)
     assert get_current_context() is None
 
@@ -201,13 +201,13 @@ def test_run_sync_opens_user_scope_and_delegates(
         api_key="k",
         agent_name="recording-agent",
     )
-    user = _user()
+    context = _user()
 
-    result = proxy.run_sync("hello", user=user)
+    result = proxy.run_sync("hello", hexgate_context=context)
 
     assert result.value == "run-sync-ok"
     [call] = inner.run_sync_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert get_current_context() is None
 
 
@@ -225,15 +225,15 @@ async def test_run_stream_opens_user_scope_and_yields_result(
         api_key="k",
         agent_name="recording-agent",
     )
-    user = _user()
+    context = _user()
 
-    async with proxy.run_stream("hello", user=user) as result:
+    async with proxy.run_stream("hello", hexgate_context=context) as result:
         assert result.value == "stream-result"
         # Scope is live during the body.
-        assert get_current_context() is user
+        assert get_current_context() is context
 
     [call] = inner.run_stream_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert get_current_context() is None
 
 
@@ -251,14 +251,14 @@ async def test_iter_opens_user_scope_and_yields_run(
         api_key="k",
         agent_name="recording-agent",
     )
-    user = _user()
+    context = _user()
 
-    async with proxy.iter("hello", user=user) as run:
+    async with proxy.iter("hello", hexgate_context=context) as run:
         assert run.value == "iter-result"
-        assert get_current_context() is user
+        assert get_current_context() is context
 
     [call] = inner.iter_calls
-    assert call["user"] is user
+    assert call["user"] is context
     assert get_current_context() is None
 
 
@@ -281,7 +281,7 @@ def test_user_scope_is_unwound_when_run_sync_raises(
     )
 
     with pytest.raises(RuntimeError, match="boom"):
-        proxy.run_sync("hi", user=_user())
+        proxy.run_sync("hi", hexgate_context=_user())
 
     assert get_current_context() is None
 
@@ -313,7 +313,7 @@ async def test_run_refused_before_agent_runs_when_banned(
     proxy = _banned_proxy(monkeypatch, inner)
 
     with pytest.raises(AgentBannedError) as exc:
-        await proxy.run("hi", user=_user())
+        await proxy.run("hi", hexgate_context=_user())
 
     assert exc.value.code == "agent_banned"
     assert inner.run_calls == []
@@ -328,7 +328,7 @@ async def test_run_stream_raises_before_first_chunk_when_banned(
     proxy = _banned_proxy(monkeypatch, inner)
 
     with pytest.raises(AgentBannedError):
-        async with proxy.run_stream("hi", user=_user()) as _r:
+        async with proxy.run_stream("hi", hexgate_context=_user()) as _r:
             pass
     assert inner.run_stream_calls == []
 
@@ -346,7 +346,7 @@ async def test_not_banned_passes_through(monkeypatch: pytest.MonkeyPatch) -> Non
         ban_gate=_agent_ban_gate(inner.name, banned="some-other-agent"),
     )
 
-    result = await proxy.run("hi", user=_user())
+    result = await proxy.run("hi", hexgate_context=_user())
 
     assert result.value == "run-ok"
     assert len(inner.run_calls) == 1
@@ -406,8 +406,8 @@ def _proxy_with_counting_binding() -> tuple[HexgatePydanticAgent, _CountingBindi
 async def test_run_refreshes_binding_per_call() -> None:
     proxy, binding = _proxy_with_counting_binding()
 
-    await proxy.run("one", user=_user())
-    await proxy.run("two", user=_user())
+    await proxy.run("one", hexgate_context=_user())
+    await proxy.run("two", hexgate_context=_user())
 
     assert binding.refreshes == 2
 
@@ -415,7 +415,7 @@ async def test_run_refreshes_binding_per_call() -> None:
 def test_run_sync_refreshes_binding_per_call() -> None:
     proxy, binding = _proxy_with_counting_binding()
 
-    proxy.run_sync("one", user=_user())
+    proxy.run_sync("one", hexgate_context=_user())
 
     assert binding.refreshes == 1
 
@@ -424,7 +424,7 @@ def test_run_sync_refreshes_binding_per_call() -> None:
 async def test_run_stream_refreshes_binding_per_call() -> None:
     proxy, binding = _proxy_with_counting_binding()
 
-    async with proxy.run_stream("one", user=_user()) as result:
+    async with proxy.run_stream("one", hexgate_context=_user()) as result:
         assert result.value == "stream-result"
 
     assert binding.refreshes == 1
@@ -434,7 +434,7 @@ async def test_run_stream_refreshes_binding_per_call() -> None:
 async def test_iter_refreshes_binding_per_call() -> None:
     proxy, binding = _proxy_with_counting_binding()
 
-    async with proxy.iter("one", user=_user()):
+    async with proxy.iter("one", hexgate_context=_user()):
         pass
 
     assert binding.refreshes == 1
@@ -448,7 +448,7 @@ def test_proxy_without_binding_runs_fine() -> None:
         agent_name="recording-agent",
     )
 
-    assert proxy.run_sync("one", user=_user()).value == "run-sync-ok"
+    assert proxy.run_sync("one", hexgate_context=_user()).value == "run-sync-ok"
 
 
 # ---------------------------------------------------------------------------
@@ -486,9 +486,9 @@ async def test_usage_emit_context_propagates_through_run(
         api_key="k",
         agent_name="my-agent",
     )
-    user = _user()
+    context = _user()
 
-    await proxy.run("hello", user=user)
+    await proxy.run("hello", hexgate_context=context)
 
     [event] = fake_sender.events
     assert event.agent_name == "my-agent"
@@ -517,9 +517,9 @@ async def test_usage_emit_context_propagates_through_run_stream(
         api_key="k",
         agent_name="my-agent",
     )
-    user = _user()
+    context = _user()
 
-    async with proxy.run_stream("hello", user=user) as result:
+    async with proxy.run_stream("hello", hexgate_context=context) as result:
         assert result.value == "stream-result"
         assert fake_sender.events == []  # not emitted until the block exits
 
@@ -559,7 +559,7 @@ async def test_run_stream_does_not_emit_usage_when_caller_exits_early(
         agent_name="my-agent",
     )
 
-    async with proxy.run_stream("hello", user=_user()):
+    async with proxy.run_stream("hello", hexgate_context=_user()):
         pass
 
     assert fake_sender.events == []
@@ -591,7 +591,7 @@ async def test_iter_emits_usage_when_run_completes(
         agent_name="my-agent",
     )
 
-    async with proxy.iter("hello", user=_user()):
+    async with proxy.iter("hello", hexgate_context=_user()):
         pass
 
     [event] = fake_sender.events
@@ -624,7 +624,7 @@ async def test_iter_does_not_emit_usage_when_caller_exits_early(
         agent_name="my-agent",
     )
 
-    async with proxy.iter("hello", user=_user()):
+    async with proxy.iter("hello", hexgate_context=_user()):
         pass
 
     assert fake_sender.events == []

--- a/tests/adapters/pydantic_ai/test_integration.py
+++ b/tests/adapters/pydantic_ai/test_integration.py
@@ -67,12 +67,12 @@ def test_run_sync_with_no_event_loop_delivers_llm_usage_event(
     register_agent(raw_agent)
     wrapped = wrap_pydantic_agent(agent=raw_agent, api_key=hexgate_platform_env.api_key)
 
-    user = HexgateContext(
+    context = HexgateContext(
         user_id=f"{USER_ID_PREFIX}pydantic_ai",
         session_id=session_id,
         user_roles=["tester"],
     )
-    result = wrapped.run_sync("What's the weather in Paris?", user=user)
+    result = wrapped.run_sync("What's the weather in Paris?", hexgate_context=context)
     assert result.output
 
     assert_policy_and_usage_events_landed(

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -592,7 +592,7 @@ def test_test_rejects_non_json_attributes(
 @pytest.mark.parametrize(
     "attributes",
     [
-        '{"clearance_level": 3.5}',  # float — no AttrValue arm accepts it
+        '{"clearance_level": 3.5}',  # float — no ContextAttributeValue arm accepts it
         '{"scope": {"nested": 1}}',  # nested object
         '{"tags": [1, 2]}',  # list of non-strings
         '{"department": null}',  # null

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -27,7 +27,7 @@ from hexgate.runtime import HexgateContext, get_current_context
 
 def test_context_from_payload_returns_user_with_all_fields() -> None:
     """A complete payload yields a fully-populated HexgateContext."""
-    user = _context_from_payload(
+    context = _context_from_payload(
         {
             "user": "alice",
             "role": "billing",
@@ -35,42 +35,42 @@ def test_context_from_payload_returns_user_with_all_fields() -> None:
             "ttl_seconds": 300,
         }
     )
-    assert user is not None
-    assert user.user_id == "alice"
-    assert user.primary_role == "billing"
-    assert user.user_roles == ["billing"]
-    assert user.session_id == "sess_abc"
-    assert user.ttl_seconds == 300
+    assert context is not None
+    assert context.user_id == "alice"
+    assert context.primary_role == "billing"
+    assert context.user_roles == ["billing"]
+    assert context.session_id == "sess_abc"
+    assert context.ttl_seconds == 300
 
 
 def test_context_from_payload_maps_roles_list() -> None:
     """A ``roles`` list is carried verbatim; ``primary_role`` is the first."""
-    user = _context_from_payload({"user": "alice", "roles": ["billing", "support"]})
-    assert user is not None
-    assert user.user_roles == ["billing", "support"]
-    assert user.primary_role == "billing"
+    context = _context_from_payload({"user": "alice", "roles": ["billing", "support"]})
+    assert context is not None
+    assert context.user_roles == ["billing", "support"]
+    assert context.primary_role == "billing"
 
 
 def test_context_from_payload_maps_legacy_single_role() -> None:
     """The legacy singular ``role`` wire key maps to a one-element list."""
-    user = _context_from_payload({"user": "alice", "role": "billing"})
-    assert user is not None
-    assert user.user_roles == ["billing"]
+    context = _context_from_payload({"user": "alice", "role": "billing"})
+    assert context is not None
+    assert context.user_roles == ["billing"]
 
 
 def test_context_from_payload_no_role_yields_empty_roles() -> None:
     """Neither ``roles`` nor ``role`` present → empty list (falls back to default)."""
-    user = _context_from_payload({"user": "bob"})
-    assert user is not None
-    assert user.user_roles == []
+    context = _context_from_payload({"user": "bob"})
+    assert context is not None
+    assert context.user_roles == []
 
 
 def test_context_from_payload_returns_user_with_just_user_id() -> None:
     """Minimal ``{"user": ...}`` is enough."""
-    user = _context_from_payload({"user": "bob"})
-    assert user is not None
-    assert user.user_id == "bob"
-    assert user.primary_role is None
+    context = _context_from_payload({"user": "bob"})
+    assert context is not None
+    assert context.user_id == "bob"
+    assert context.primary_role is None
 
 
 def test_context_from_payload_returns_none_for_empty_dict() -> None:

--- a/tests/egress/test_proxy.py
+++ b/tests/egress/test_proxy.py
@@ -137,13 +137,13 @@ async def test_http_forward_preserves_query() -> None:
 
 async def test_egress_guard_reentrancy_raises() -> None:
     enforcer = _enforcer("127.0.0.1")
-    user = HexgateContext(user_id="u", user_roles=["agent"])
-    async with egress_guard(enforcer, user):
+    context = HexgateContext(user_id="u", user_roles=["agent"])
+    async with egress_guard(enforcer, context):
         with pytest.raises(RuntimeError, match="already active"):
-            async with egress_guard(enforcer, user):
+            async with egress_guard(enforcer, context):
                 pass
     # The guard flag is released after the outer exits — a fresh guard works.
-    async with egress_guard(enforcer, user):
+    async with egress_guard(enforcer, context):
         pass
 
 

--- a/tests/framework_compat/conftest.py
+++ b/tests/framework_compat/conftest.py
@@ -67,7 +67,7 @@ def _reset_executions():
 
 
 @pytest.fixture
-def probe_user() -> HexgateContext:
+def probe_context() -> HexgateContext:
     """A representative caller; role ``member`` falls back to the default role."""
     return HexgateContext(
         user_id="probe-user", user_roles=["member"], session_id="probe-session"

--- a/tests/framework_compat/probe_policy.yaml
+++ b/tests/framework_compat/probe_policy.yaml
@@ -3,7 +3,7 @@
 # Loaded offline via HEXGATE_LOCAL_POLICY (compiled to WASM by opa, the
 # production-shaped enforcement path). Deliberately minimal: one allowed
 # tool, one denied tool. The `default` role is mandatory (PolicySet
-# requires it) and is the fallback for any User.role, so the probes need
+# requires it) and is the fallback for any caller role, so the probes need
 # no role-specific entries.
 #
 # For the SaaS confirmation pass, paste an equivalent policy into the

--- a/tests/framework_compat/test_deepagents.py
+++ b/tests/framework_compat/test_deepagents.py
@@ -85,23 +85,23 @@ def test_contract():
     assert isinstance(graph, CompiledStateGraph)
 
 
-def test_deny_path_blocks_and_does_not_execute(probe_user):
+def test_deny_path_blocks_and_does_not_execute(probe_context):
     """Tier 1 — the denied tool's guarded func returns the structured error."""
     tools = _build_tools()
     _build_wrapped(tools)  # installs enforcer on `tools` in place
     denied = next(t for t in tools if t.name == DENIED_TOOL)
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         result = denied.func(user_id="u1")
     assert isinstance(result, dict) and result.get("ok") is False
     assert DENY_MARKER in str(result.get("error"))
     assert not _probe.was_executed(DENIED_TOOL)
 
 
-def test_allow_decision(probe_user):
+def test_allow_decision(probe_context):
     """Tier 1 — the resolved policy allows the allowed tool."""
     tools = _build_tools()
     wrapped = _build_wrapped(tools)
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         decision = wrapped._binding.enforcer.decide(ALLOWED_TOOL, {"city": "Paris"})
     assert decision.allowed
 
@@ -109,12 +109,12 @@ def test_allow_decision(probe_user):
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="Tier 2 e2e needs OPENAI_API_KEY"
 )
-async def test_e2e_allow_executes(probe_user):
+async def test_e2e_allow_executes(probe_context):
     """Tier 2 — a full deep-agent run drives the seam and runs the allowed tool."""
     tools = _build_tools()
     wrapped = _build_wrapped(tools)
     await wrapped.ainvoke(
         {"messages": [{"role": "user", "content": "Weather in Tokyo?"}]},
-        user=probe_user,
+        hexgate_context=probe_context,
     )
     assert _probe.was_executed(ALLOWED_TOOL)

--- a/tests/framework_compat/test_google.py
+++ b/tests/framework_compat/test_google.py
@@ -63,21 +63,21 @@ def test_contract():
     assert hasattr(BaseTool, "run_async")
 
 
-async def test_deny_path_blocks_and_does_not_execute(probe_user):
+async def test_deny_path_blocks_and_does_not_execute(probe_context):
     """Tier 1 — the denied tool's run_async returns the deny marker."""
     wrapped, _binding = _build_wrapped()
     tool = next(t for t in wrapped.tools if t.name == DENIED_TOOL)
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         # tool_context is unused on the deny short-circuit
         result = await tool.run_async(args={"user_id": "u1"}, tool_context=None)
     assert DENY_MARKER in str(result)
     assert not _probe.was_executed(DENIED_TOOL)
 
 
-def test_allow_decision(probe_user):
+def test_allow_decision(probe_context):
     """Tier 1 — the resolved policy allows the allowed tool."""
     _wrapped, binding = _build_wrapped()
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         decision = binding.enforcer.decide(ALLOWED_TOOL, {"city": "Paris"})
     assert decision.allowed
 
@@ -86,7 +86,7 @@ def test_allow_decision(probe_user):
     not os.environ.get("OPENAI_API_KEY"),
     reason="Tier 2 e2e needs OPENAI_API_KEY (LiteLLM → OpenAI)",
 )
-async def test_e2e_allow_executes(probe_user):
+async def test_e2e_allow_executes(probe_context):
     """Tier 2 — a full runner drives the seam and runs the allowed tool."""
     from google.adk.sessions import InMemorySessionService
     from google.genai import types
@@ -96,8 +96,8 @@ async def test_e2e_allow_executes(probe_user):
     session_service = InMemorySessionService()
     await session_service.create_session(
         app_name="version_probe",
-        user_id=probe_user.user_id,
-        session_id=probe_user.session_id,
+        user_id=probe_context.user_id,
+        session_id=probe_context.session_id,
     )
     runner = HexgateRunner(
         agent=_build_agent(),
@@ -106,6 +106,8 @@ async def test_e2e_allow_executes(probe_user):
         api_key="local-probe-key",
     )
     message = types.Content(role="user", parts=[types.Part(text="Weather in Tokyo?")])
-    async for _event in runner.run_async(new_message=message, user=probe_user):
+    async for _event in runner.run_async(
+        new_message=message, hexgate_context=probe_context
+    ):
         pass
     assert _probe.was_executed(ALLOWED_TOOL)

--- a/tests/framework_compat/test_langchain.py
+++ b/tests/framework_compat/test_langchain.py
@@ -65,23 +65,23 @@ def test_contract():
     assert hasattr(tool, "func")
 
 
-def test_deny_path_blocks_and_does_not_execute(probe_user):
+def test_deny_path_blocks_and_does_not_execute(probe_context):
     """Tier 1 — the denied tool's guarded func returns the structured error."""
     tools = _build_tools()
     _build_wrapped(tools)  # installs enforcer on `tools` in place
     denied = next(t for t in tools if t.name == DENIED_TOOL)
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         result = denied.func(user_id="u1")
     assert isinstance(result, dict) and result.get("ok") is False
     assert DENY_MARKER in str(result.get("error"))
     assert not _probe.was_executed(DENIED_TOOL)
 
 
-def test_allow_decision(probe_user):
+def test_allow_decision(probe_context):
     """Tier 1 — the resolved policy allows the allowed tool."""
     tools = _build_tools()
     wrapped = _build_wrapped(tools)
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         decision = wrapped._binding.enforcer.decide(ALLOWED_TOOL, {"city": "Paris"})
     assert decision.allowed
 
@@ -89,12 +89,12 @@ def test_allow_decision(probe_user):
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="Tier 2 e2e needs OPENAI_API_KEY"
 )
-async def test_e2e_allow_executes(probe_user):
+async def test_e2e_allow_executes(probe_context):
     """Tier 2 — a full graph run drives the seam and runs the allowed tool."""
     tools = _build_tools()
     wrapped = _build_wrapped(tools)
     await wrapped.ainvoke(
         {"messages": [{"role": "user", "content": "Weather in Tokyo?"}]},
-        user=probe_user,
+        hexgate_context=probe_context,
     )
     assert _probe.was_executed(ALLOWED_TOOL)

--- a/tests/framework_compat/test_openai.py
+++ b/tests/framework_compat/test_openai.py
@@ -61,21 +61,21 @@ def test_contract():
     assert hasattr(tool, "on_invoke_tool")
 
 
-async def test_deny_path_blocks_and_does_not_execute(probe_user):
+async def test_deny_path_blocks_and_does_not_execute(probe_context):
     """Tier 1 — the denied tool's on_invoke_tool returns the deny marker."""
     wrapped, _ = _build_wrapped()
     tool = next(t for t in wrapped.tools if t.name == DENIED_TOOL)
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         # ToolContext is unused on the deny short-circuit
         result = await tool.on_invoke_tool(None, '{"user_id": "u1"}')
     assert DENY_MARKER in str(result)
     assert not _probe.was_executed(DENIED_TOOL)
 
 
-def test_allow_decision(probe_user):
+def test_allow_decision(probe_context):
     """Tier 1 — the resolved policy allows the allowed tool."""
     _, enforcer = _build_wrapped()
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         decision = enforcer.decide(ALLOWED_TOOL, {"city": "Paris"})
     assert decision.allowed
 
@@ -83,12 +83,14 @@ def test_allow_decision(probe_user):
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="Tier 2 e2e needs OPENAI_API_KEY"
 )
-async def test_e2e_allow_executes(probe_user):
+async def test_e2e_allow_executes(probe_context):
     """Tier 2 — a full runner drives the seam and runs the allowed tool."""
     from hexgate.adapters.openai import HexgateRunner
 
     runner = HexgateRunner()
     await runner.run(
-        agent=_build_agent(), input="What is the weather in Tokyo?", user=probe_user
+        agent=_build_agent(),
+        input="What is the weather in Tokyo?",
+        hexgate_context=probe_context,
     )
     assert _probe.was_executed(ALLOWED_TOOL)

--- a/tests/framework_compat/test_pydantic_ai.py
+++ b/tests/framework_compat/test_pydantic_ai.py
@@ -58,13 +58,13 @@ def test_contract():
     assert hasattr(toolset, "tools")
 
 
-async def test_deny_path_blocks_and_does_not_execute(probe_user):
+async def test_deny_path_blocks_and_does_not_execute(probe_context):
     """Tier 1 — the denied tool's guarded call raises before running."""
     from pydantic_ai.exceptions import ModelRetry
 
     wrapped = _build_wrapped()
     tool = wrapped._agent._function_toolset.tools[DENIED_TOOL]
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         with pytest.raises(ModelRetry) as excinfo:
             # context is unused on the deny short-circuit
             await tool.function_schema.call({"user_id": "u1"}, None)
@@ -72,10 +72,10 @@ async def test_deny_path_blocks_and_does_not_execute(probe_user):
     assert not _probe.was_executed(DENIED_TOOL)
 
 
-def test_allow_decision(probe_user):
+def test_allow_decision(probe_context):
     """Tier 1 — the resolved policy allows the allowed tool."""
     wrapped = _build_wrapped()
-    with probe_user.sync_scope():
+    with probe_context.sync_scope():
         decision = wrapped._binding.enforcer.decide(ALLOWED_TOOL, {"city": "Paris"})
     assert decision.allowed
 
@@ -83,8 +83,8 @@ def test_allow_decision(probe_user):
 @pytest.mark.skipif(
     not os.environ.get("OPENAI_API_KEY"), reason="Tier 2 e2e needs OPENAI_API_KEY"
 )
-async def test_e2e_allow_executes(probe_user):
+async def test_e2e_allow_executes(probe_context):
     """Tier 2 — a full model run drives the seam and runs the allowed tool."""
     wrapped = _build_wrapped(model=MODEL)
-    await wrapped.run("What is the weather in Tokyo?", user=probe_user)
+    await wrapped.run("What is the weather in Tokyo?", hexgate_context=probe_context)
     assert _probe.was_executed(ALLOWED_TOOL)

--- a/tests/runtime/test_context.py
+++ b/tests/runtime/test_context.py
@@ -80,22 +80,22 @@ async def test_user_scope_sets_and_resets_contextvar() -> None:
     """A vanilla ``async with`` pushes + pops the HexgateContext on the contextvar."""
     assert get_current_context() is None
     async with HexgateContext(user_id="alice", user_roles=["billing"]):
-        user = get_current_context()
-        assert user is not None
-        assert user.user_id == "alice"
-        assert user.primary_role == "billing"
+        context = get_current_context()
+        assert context is not None
+        assert context.user_id == "alice"
+        assert context.primary_role == "billing"
     assert get_current_context() is None
 
 
 @pytest.mark.asyncio
 async def test_user_scope_nests_same_instance() -> None:
     """Same HexgateContext entered twice still resets cleanly to None on full exit."""
-    user = HexgateContext(user_id="bob")
-    async with user:
-        async with user:
-            assert get_current_context() is user
-        # Inner exit restores the outer set (still the same user).
-        assert get_current_context() is user
+    context = HexgateContext(user_id="bob")
+    async with context:
+        async with context:
+            assert get_current_context() is context
+        # Inner exit restores the outer set (still the same context).
+        assert get_current_context() is context
     assert get_current_context() is None
 
 
@@ -131,8 +131,8 @@ def test_sync_scope_exit_survives_foreign_context() -> None:
     Enter and exit each run in their own copied Context so neither touches the
     test's real context (and the distinct contexts are what reproduce the bug).
     """
-    user = HexgateContext(user_id="alice")
-    cm = user.sync_scope()
+    context = HexgateContext(user_id="alice")
+    cm = context.sync_scope()
     contextvars.copy_context().run(cm.__enter__)  # set in context A
     contextvars.copy_context().run(cm.__exit__, None, None, None)  # exit in B: no raise
     assert get_current_context() is None  # test's own context never polluted
@@ -143,7 +143,7 @@ async def test_async_scope_exit_survives_foreign_context() -> None:
     """async __aexit__ in a foreign Context must not raise (astream_events
     aclose() runs in the event loop's finalizer task). __aexit__ does no real
     awaiting, so a single send() drives it to completion."""
-    user = HexgateContext(user_id="alice")
+    context = HexgateContext(user_id="alice")
 
     def _drive(coro: object) -> None:
         try:
@@ -151,9 +151,9 @@ async def test_async_scope_exit_survives_foreign_context() -> None:
         except StopIteration:
             pass
 
-    contextvars.copy_context().run(_drive, user.__aenter__())  # enter in context A
+    contextvars.copy_context().run(_drive, context.__aenter__())  # enter in context A
     contextvars.copy_context().run(
-        _drive, user.__aexit__(None, None, None)
+        _drive, context.__aexit__(None, None, None)
     )  # B: no raise
     assert get_current_context() is None
 

--- a/tests/security/test_enforcer_observer.py
+++ b/tests/security/test_enforcer_observer.py
@@ -104,7 +104,9 @@ async def test_observer_attribute_snapshot_survives_later_bag_mutation() -> None
     async with HexgateContext(user_id="alice", attributes={"tags": ["eu"]}) as ctx:
         enforcer.decide("read_file", {})
         tags = ctx.attributes["tags"]
-        assert isinstance(tags, list)  # narrow AttrValue for the mutation below
+        assert isinstance(
+            tags, list
+        )  # narrow ContextAttributeValue for the mutation below
         tags.append("us")
 
     assert captured[0].attributes == {"tags": ["eu"]}


### PR DESCRIPTION
Naming cleanup + `ctx.*` docs closeout of the `User → HexgateContext` work. **No engine or security-logic change.**

**Eliminates the standalone `user` identifier** (confusing now that the scope type is `HexgateContext`):
- Consumer-facing kwarg **`user=` → `hexgate_context=`** on every adapter method (langchain `ainvoke`/`invoke`/`astream`/`stream`/`astream_events`; google/openai/pydantic_ai runners) and the egress guards. **Breaking**: callers passing `user=` must switch.
- Internal scope variables/params **`user` → `context`** (adapter helpers, `Gate`, `BanGate`, `tracing/usage`, tests, examples).
- Kept as-is: the `HexgateContext.user_id`/`user_roles` fields, `attenuate_for_user(user=<id>)`, biscuit `user(...)` facts, plain-English "user", and `role="user"` message fields.

**Type rename**: the attribute-bag value type **`AttrValue` → `ContextAttributeValue`** (full-word, house-style; avoids colliding with OpenTelemetry's `AttributeValue`), now **exported** from `hexgate` and `hexgate.runtime` so consumers can type their `attributes` bag.

**Adapter metadata**: Langfuse span metadata now stamps `user_roles` (comma-joined string, since the propagation layer drops non-string values) instead of the lossy single `user_role`.

**`ctx.*` docs**: documented the attribute namespace as a first-class advisory fact (peer of `args.*`/`role`/`tool`) in `constraints.py`, `docs/policy/constraints.mdx`, and `docs/cli/policy.mdx`, with the trust contract (populate from trusted server data, same as `user_roles`) — no `trusted_attributes`/signing (that tier is parked in #109).

**Docs migration**: the whole `docs/` tree + `examples/` moved off the removed `User` API to `HexgateContext`; `docs/concepts/user-scope.mdx` rewritten ("Request context") with a worked advisory `ctx.*` example.

Verification: full suite green (1761 passed, 87.6% cov), ruff clean, repo-wide grep gate confirms zero standalone `user` scope identifiers and zero `AttrValue` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)