### PR TITLE
feat(sdk): role-aware policy assembly (roles as capability bindings)

### DIFF
--- a/deploy/demo_policies/policies/capabilities/read_only.yaml
+++ b/deploy/demo_policies/policies/capabilities/read_only.yaml
@@ -1,0 +1,5 @@
+# Read-only capability pack (team-owned). Grants only. Shared by every role,
+# so it lives once here instead of being copied into each role.
+tools:
+  view_orders: { mode: allow }
+  lookup_order: { mode: allow }

--- a/deploy/demo_policies/roles.yaml
+++ b/deploy/demo_policies/roles.yaml
@@ -1,0 +1,11 @@
+# Role bindings. A role is a named set of capabilities, not a policy — it lives
+# outside policies/ on purpose. Boundaries (policies/boundaries/) apply to every
+# role automatically and are never listed here.
+#
+#   hexgate policy resolve --dir deploy/demo_policies              # all roles
+#   hexgate policy resolve --dir deploy/demo_policies --role billing
+version: 1
+roles:
+  default: [read_only]                        # fallback: read-only
+  support: [read_only, support_leaf]          # + email / escalate
+  billing: [read_only, payments]              # + refunds (capped by the boundary)

--- a/deploy/policy_modules_demo.py
+++ b/deploy/policy_modules_demo.py
@@ -98,7 +98,8 @@ def _(mo):
 
 @app.cell
 def _(dedent):
-    # Three modules — the same files that live in deploy/demo_policies/. Edit
+    # A boundary + two capabilities, mirroring deploy/demo_policies/ (which also
+    # ships a read_only capability and a roles.yaml for the multi-role view). Edit
     # them here and the whole notebook re-resolves.
     BOUNDARIES = {
         "org_core": dedent(

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -226,6 +226,15 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         help="Repo root containing a policies/ tree (default: current dir).",
     )
     p_resolve.add_argument(
+        "--role",
+        default=None,
+        help=(
+            "Print just this role's effective policy. Without it, a multi-role "
+            "project (a roles.yaml) prints every role; a single-role project "
+            "prints the one effective policy."
+        ),
+    )
+    p_resolve.add_argument(
         "-o",
         "--output",
         help="Write the effective policy YAML here (default: stdout).",
@@ -249,6 +258,11 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
         "--dir",
         default=".",
         help="Repo root containing a policies/ tree (default: current dir).",
+    )
+    p_check.add_argument(
+        "--role",
+        default=None,
+        help="Restrict lints to this role (plus project-level ones). Default: all roles.",
     )
     p_check.add_argument(
         "--manifest",
@@ -496,15 +510,17 @@ def _main_show_rego(args: argparse.Namespace) -> int:
 
 
 def _main_resolve(args: argparse.Namespace) -> int:
-    """Link the local module bundle into one effective policy and print it."""
+    """Resolve the local project into effective policy per role and print it."""
     from hexgate.security import (
         LinkError,
-        link_policy_set,
         load_local_modules,
+        load_roles,
+        resolve_for_project,
     )
 
     try:
         boundaries, capabilities = load_local_modules(args.dir)
+        roles = load_roles(args.dir)
     except (ValueError, OSError) as exc:
         print(f"load error: {exc}", file=sys.stderr)
         return 1
@@ -517,15 +533,49 @@ def _main_resolve(args: argparse.Namespace) -> int:
         return 1
 
     try:
-        result = link_policy_set(boundaries, capabilities)
+        result = resolve_for_project(boundaries, capabilities, roles)
     except (LinkError, PolicySetError, ConstraintParseError, ValidationError) as exc:
         print(f"link error: {exc}", file=sys.stderr)
         return 1
 
-    effective = result.effective[DEFAULT_ROLE_NAME]
-    # Full dump (not exclude_defaults): a tool set to the default `deny` mode
-    # would otherwise render as `{}`, hiding the outcome in an inspection view.
-    text = yaml.safe_dump(effective.model_dump(mode="json"), sort_keys=False)
+    if args.role is not None and args.role not in result.by_role:
+        print(
+            f'role "{args.role}" not defined (known roles: {sorted(result.by_role)!r})',
+            file=sys.stderr,
+        )
+        return 1
+
+    # Full dump (not exclude_defaults): a tool at the default `deny` mode would
+    # otherwise render as `{}`, hiding the outcome in an inspection view. A
+    # single-role project prints the one policy (back-compat); a multi-role one
+    # (or an explicit --role over several) prints a role-keyed mapping.
+    if args.role is not None:
+        payload: Any = (
+            result.by_role[args.role]
+            .effective[DEFAULT_ROLE_NAME]
+            .model_dump(mode="json")
+        )
+        roles_shown = [args.role]
+    elif len(result.by_role) == 1:
+        only = next(iter(result.by_role))
+        payload = (
+            result.by_role[only].effective[DEFAULT_ROLE_NAME].model_dump(mode="json")
+        )
+        roles_shown = [only]
+    else:
+        # Wrap in `roles:` so the emitted file round-trips through
+        # load_policy_set_from_dict / `hexgate policy build`. A bare top-level
+        # role-keyed mapping would be read as a single flat AgentPolicy, and the
+        # role keys silently dropped, compiling a deny-everything bundle.
+        payload = {
+            "roles": {
+                role: lr.effective[DEFAULT_ROLE_NAME].model_dump(mode="json")
+                for role, lr in sorted(result.by_role.items())
+            }
+        }
+        roles_shown = sorted(result.by_role)
+
+    text = yaml.safe_dump(payload, sort_keys=False)
     if args.output:
         Path(args.output).write_text(text, encoding="utf-8")
         print(f"✓ wrote effective policy to {args.output}")
@@ -533,23 +583,25 @@ def _main_resolve(args: argparse.Namespace) -> int:
         sys.stdout.write(text)
 
     # Provenance to stderr so stdout stays a clean policy document.
-    print("\nlayers (resolution order):", file=sys.stderr)
-    for prov in result.layers:
-        print(f"  [{prov.kind:10}] {prov.module}  ({prov.source})", file=sys.stderr)
-    if result.trace.shadowed:
-        print("shadowed (ineligible under a ceiling):", file=sys.stderr)
-        for tool, by in sorted(result.trace.shadowed.items()):
-            print(f"  {tool}  ← {by.module} ({by.source})", file=sys.stderr)
+    for role in roles_shown:
+        lr = result.by_role[role]
+        print(f"\n[{role}] layers (resolution order):", file=sys.stderr)
+        for prov in lr.layers:
+            print(f"  [{prov.kind:10}] {prov.module}  ({prov.source})", file=sys.stderr)
+        if lr.trace.shadowed:
+            print("  shadowed (ineligible under a ceiling):", file=sys.stderr)
+            for tool, by in sorted(lr.trace.shadowed.items()):
+                print(f"    {tool}  ← {by.module} ({by.source})", file=sys.stderr)
     return 0
 
 
 def _main_check(args: argparse.Namespace) -> int:
-    """Lint the local module bundle; exit non-zero at/above --max-severity."""
-    from hexgate.security import check as check_bundle
-    from hexgate.security import load_local_modules
+    """Lint the local project; exit non-zero at/above --max-severity."""
+    from hexgate.security import check_project, load_local_modules, load_roles
 
     try:
         boundaries, capabilities = load_local_modules(args.dir)
+        roles = load_roles(args.dir)
     except (ValueError, OSError) as exc:
         print(f"load error: {exc}", file=sys.stderr)
         return 1
@@ -557,6 +609,18 @@ def _main_check(args: argparse.Namespace) -> int:
         print(
             f"no modules found under {args.dir}/policies/"
             " (expected policies/boundaries/ and/or policies/capabilities/)",
+            file=sys.stderr,
+        )
+        return 1
+    # Validate against the resolved role set, not the raw roles map: a project
+    # with no roles.yaml still has the synthesised `default` role, and one that
+    # omits `default` still gets it. This keeps `check` in step with `resolve`
+    # (which validates against the resolved set) so a typo'd role errors instead
+    # of silently matching nothing and hiding every lint.
+    known_roles = set(roles or ()) | {DEFAULT_ROLE_NAME}
+    if args.role is not None and args.role not in known_roles:
+        print(
+            f'role "{args.role}" not defined (known roles: {sorted(known_roles)!r})',
             file=sys.stderr,
         )
         return 1
@@ -575,7 +639,12 @@ def _main_check(args: argparse.Namespace) -> int:
 
     from hexgate.security.analyzer import SEVERITY_RANK
 
-    lints = check_bundle(boundaries, capabilities, manifest=manifest)
+    lints = check_project(boundaries, capabilities, roles, manifest=manifest)
+
+    # --role narrows to that role's lints plus project-level ones (role is None,
+    # e.g. unused-capability), so a role view still surfaces global problems.
+    if args.role is not None:
+        lints = [lint for lint in lints if lint.role in (args.role, None)]
 
     # A link error short-circuits before drift/soft lints run, so the
     # "supply a manifest" hint only makes sense when linking succeeded.
@@ -596,7 +665,10 @@ def _main_check(args: argparse.Namespace) -> int:
     icon = {"error": "✗", "warning": "!", "info": "·"}
     for lint in lints:
         where = f" ({lint.source})" if lint.source else ""
-        print(f"{icon.get(lint.severity, '·')} [{lint.code}] {lint.message}{where}")
+        role = f" [{lint.role}]" if lint.role else ""
+        print(
+            f"{icon.get(lint.severity, '·')} [{lint.code}]{role} {lint.message}{where}"
+        )
     _drift_hint()
 
     threshold = SEVERITY_RANK[args.max_severity]

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -86,12 +86,23 @@ from hexgate.security.modules import (
     LinkError,
     LinkResult,
     ModuleContent,
+    ProjectLinkResult,
     Provenance,
     RuleTrace,
 )
-from hexgate.security.linker import link, link_policy_set
-from hexgate.security.analyzer import PolicyLint, analyze, check
-from hexgate.security.module_loader import ModuleLoader, load_local_modules
+from hexgate.security.linker import link, link_policy_set, resolve_for_project
+from hexgate.security.analyzer import (
+    PolicyLint,
+    analyze,
+    analyze_project,
+    check,
+    check_project,
+)
+from hexgate.security.module_loader import (
+    ModuleLoader,
+    load_local_modules,
+    load_roles,
+)
 from hexgate.security.rego import compile_default_only, compile_to_rego
 from hexgate.security.rego_wasm import (
     DEFAULT_ENTRYPOINTS,
@@ -129,13 +140,18 @@ __all__ = [
     "ModuleContent",
     "ModuleLoader",
     "PolicyLint",
+    "ProjectLinkResult",
     "Provenance",
     "RuleTrace",
     "analyze",
+    "analyze_project",
     "check",
+    "check_project",
     "link",
     "link_policy_set",
     "load_local_modules",
+    "load_roles",
+    "resolve_for_project",
     "EMPTY_BAN_SET",
     "BanContentError",
     "BanEnforcementEvent",

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -20,7 +20,8 @@ always-false, subsumption.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal
 
 from hexgate.security.constraints import (
@@ -28,13 +29,18 @@ from hexgate.security.constraints import (
     iter_arg_refs,
     parse_constraint,
 )
-from hexgate.security.linker import link_policy_set
+from hexgate.security.linker import (
+    link_policy_set,
+    resolve_for_project,
+    resolve_role_map,
+)
 from hexgate.security.modules import (
     GRANT_MODES,
     LayerKind,
     LinkError,
     LinkResult,
     ModuleContent,
+    ProjectLinkResult,
 )
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySetError
 
@@ -60,6 +66,7 @@ class PolicyLint:
     line: int | None = None
     tier: LayerKind | None = None
     tool: str | None = None
+    role: str | None = None
 
 
 def check(
@@ -103,6 +110,110 @@ def analyze(
     if manifest is not None:
         lints += _drift(boundaries, capabilities, manifest)
     return sorted(lints, key=lambda lint: SEVERITY_RANK[lint.severity])
+
+
+def check_project(
+    boundaries: list[ModuleContent],
+    library: list[ModuleContent],
+    roles: Mapping[str, Sequence[str]] | None,
+    *,
+    agent_leaf: Sequence[ModuleContent] = (),
+    agent_boundaries: Sequence[ModuleContent] = (),
+    manifest: AgentManifest | None = None,
+) -> list[PolicyLint]:
+    """Resolve a project and lint every role. See :func:`check` for the single-role
+    form. A hard failure folds into one ``error`` lint, same contract as ``check``.
+    """
+    try:
+        result = resolve_for_project(
+            boundaries,
+            library,
+            roles,
+            agent_leaf=agent_leaf,
+            agent_boundaries=agent_boundaries,
+        )
+    except (LinkError, PolicySetError, ConstraintParseError) as exc:
+        return [PolicyLint("link-error", "error", str(exc))]
+    return analyze_project(
+        result,
+        boundaries,
+        library,
+        roles,
+        agent_leaf=agent_leaf,
+        agent_boundaries=agent_boundaries,
+        manifest=manifest,
+    )
+
+
+def analyze_project(
+    result: ProjectLinkResult,
+    boundaries: list[ModuleContent],
+    library: list[ModuleContent],
+    roles: Mapping[str, Sequence[str]] | None,
+    *,
+    agent_leaf: Sequence[ModuleContent] = (),
+    agent_boundaries: Sequence[ModuleContent] = (),
+    manifest: AgentManifest | None = None,
+) -> list[PolicyLint]:
+    """Soft lints across every role, each tagged with the role it fired in.
+
+    A grant dead under one role's ceiling can be alive under another, so the
+    per-capability lints run once per role over that role's imported set. Two
+    project-level lints span roles: ``unused-capability`` (a library pack no role
+    imports) and ``no-default-role`` (roles defined but no ``default``, so unroled
+    callers get fail-closed deny).
+    """
+    # Same expansion the resolver used, so the analyzer lints exactly the roles
+    # that compiled. Raises LinkError on an unknown capability, matching
+    # resolve_for_project — but check_project resolves first, so by the time we
+    # get here the same input has already succeeded.
+    resolved = resolve_role_map(roles, library)
+    fences = [*boundaries, *agent_boundaries]
+
+    lints: list[PolicyLint] = []
+    for role, caps in resolved.items():
+        role_result = result.by_role.get(role)
+        if role_result is None:
+            continue
+        for lint in analyze(
+            role_result, fences, [*caps, *agent_leaf], manifest=manifest
+        ):
+            lints.append(replace(lint, role=role))
+
+    lints += _unused_capabilities(library, resolved)
+    if roles and DEFAULT_ROLE_NAME not in roles:
+        lints.append(
+            PolicyLint(
+                code="no-default-role",
+                severity="info",
+                message=(
+                    f"no {DEFAULT_ROLE_NAME!r} role defined; a caller with no role "
+                    "resolves to fail-closed deny"
+                ),
+                # role stays None: this spans roles, so a role-scoped `check
+                # --role X` view must still surface it (like unused-capability).
+            )
+        )
+    return sorted(lints, key=lambda lint: SEVERITY_RANK[lint.severity])
+
+
+def _unused_capabilities(
+    library: list[ModuleContent], resolved: Mapping[str, Sequence[ModuleContent]]
+) -> list[PolicyLint]:
+    """A library capability that no role imports. An authoring dead-weight signal."""
+    imported = {cap.name for caps in resolved.values() for cap in caps}
+    return [
+        PolicyLint(
+            code="unused-capability",
+            severity="info",
+            message=f"capability {cap.name!r} is imported by no role",
+            source=cap.source,
+            tier="capability",
+            tool=None,
+        )
+        for cap in library
+        if cap.name not in imported
+    ]
 
 
 def _dead_grants(

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -30,6 +30,8 @@ against the live grammar.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
+
 from hexgate.security.constraints import parse_constraint
 from hexgate.security.models import (
     AgentPolicy,
@@ -42,6 +44,7 @@ from hexgate.security.modules import (
     LinkError,
     LinkResult,
     ModuleContent,
+    ProjectLinkResult,
     Provenance,
     RuleTrace,
 )
@@ -67,6 +70,100 @@ def link_policy_set(
         layers=layers,
         trace=trace,
     )
+
+
+def resolve_role_map(
+    roles: Mapping[str, Sequence[str]] | None, library: list[ModuleContent]
+) -> dict[str, list[ModuleContent]]:
+    """Expand a role binding into ``{role: [capability modules]}``.
+
+    The one place that defines role expansion, shared by the resolver and the
+    analyzer so they can never lint a different role set than what compiles.
+
+    ``roles is None`` (no ``roles.yaml``) means a single ``default`` importing
+    every capability — the all-compose back-compat default. An **empty** binding
+    (``{}``, a present-but-empty or typo'd ``roles.yaml``) is not the same: it
+    yields a fail-closed empty ``default``, so a mistake can't silently widen
+    access. A ``default`` bucket is always present. An unknown capability name is
+    a :class:`LinkError` (same contract from both callers).
+    """
+    index: dict[str, ModuleContent] = {cap.name: cap for cap in library}
+    if roles is None:
+        names_by_role: dict[str, list[str]] = {
+            DEFAULT_ROLE_NAME: [cap.name for cap in library]
+        }
+    else:
+        names_by_role = {name: list(sel) for name, sel in roles.items()}
+    names_by_role.setdefault(DEFAULT_ROLE_NAME, [])
+
+    resolved: dict[str, list[ModuleContent]] = {}
+    for role, cap_names in names_by_role.items():
+        caps: list[ModuleContent] = []
+        for name in cap_names:
+            cap = index.get(name)
+            if cap is None:
+                raise LinkError(
+                    f"role {role!r} imports unknown capability {name!r} "
+                    f"(known capabilities: {sorted(index)!r})"
+                )
+            caps.append(cap)
+        resolved[role] = caps
+    return resolved
+
+
+def resolve_for_project(
+    boundaries: list[ModuleContent],
+    library: list[ModuleContent],
+    roles: Mapping[str, Sequence[str]] | None,
+    *,
+    agent_leaf: Sequence[ModuleContent] = (),
+    agent_boundaries: Sequence[ModuleContent] = (),
+) -> ProjectLinkResult:
+    """Resolve a project into one role-keyed :class:`PolicySet`.
+
+    Boundaries are role-independent: every role is folded against the same
+    ``boundaries + agent_boundaries``, so a role can only ever narrow, never
+    widen, its ceiling. A role names the **capabilities** it imports; the fold
+    (:func:`link`) is reused unchanged, once per role.
+
+    ``roles`` maps a role name to the capability *names* it selects (a name is a
+    :attr:`ModuleContent.name`). ``None`` (no binding at all) means a single
+    ``default`` role importing every capability — the all-compose back-compat
+    path. A ``default`` role is always present, so unroled callers get
+    fail-closed deny rather than a missing bucket.
+
+    Every capability in the library is validated up front (:func:`_reject_capability_denies`),
+    not just the ones a role imports, so a malformed but unbound module fails
+    loudly instead of lurking until someone binds it.
+    """
+    _reject_capability_denies([*library, *agent_leaf])
+    resolved = resolve_role_map(roles, library)
+    fences = [*boundaries, *agent_boundaries]
+    by_role: dict[str, LinkResult] = {}
+    effective: dict[str, AgentPolicy] = {}
+    for role, caps in resolved.items():
+        result = link_policy_set(fences, [*caps, *agent_leaf])
+        by_role[role] = result
+        effective[role] = result.effective[DEFAULT_ROLE_NAME]
+
+    return ProjectLinkResult(policy_set=PolicySet(effective), by_role=by_role)
+
+
+def _reject_capability_denies(capabilities: Sequence[ModuleContent]) -> None:
+    """A capability that denies is a config error, checked over the WHOLE library.
+
+    The per-tool guard in :func:`_fold_tool` only runs for capabilities a role
+    imports, so an unbound malformed module would slip through resolution. This
+    is a per-module property (a capability tool with ``mode: deny``), so it is
+    hoisted here and run over every capability, bound or not.
+    """
+    for cap in capabilities:
+        for tool, tp in cap.policy.tools.items():
+            if tp.mode == "deny":
+                raise LinkError(
+                    f"capability {cap.name!r} denies {tool!r}; capabilities may "
+                    f"only grant — move the deny to a boundary ({cap.source})"
+                )
 
 
 def link(

--- a/hexgate/security/module_loader.py
+++ b/hexgate/security/module_loader.py
@@ -24,6 +24,12 @@ from hexgate.security.modules import LayerKind, ModuleContent
 BOUNDARY_SUBDIR = ("policies", "boundaries")
 CAPABILITY_SUBDIR = ("policies", "capabilities")
 
+# The role-binding file. Lives at the repo root, deliberately OUTSIDE policies/,
+# because a role is a binding (role -> capabilities), not a policy module. Module
+# discovery never walks it. Mirrors the platform's `role_binding` table, which is
+# separate from `policy_module`.
+ROLES_FILE = "roles.yaml"
+
 
 class ModuleLoader(Protocol):
     """Resolve the modules that apply to an agent.
@@ -55,14 +61,75 @@ def load_local_modules(
     return boundaries, capabilities
 
 
+def load_roles(root: str | Path) -> dict[str, list[str]] | None:
+    """Load the role bindings from ``<root>/roles.yaml``.
+
+    Returns ``None`` when the file is **absent** — the signal the resolver reads
+    as "no roles, one default importing every capability" (all-compose
+    back-compat). Returns a dict (possibly empty) when the file **exists**: an
+    empty or typo'd binding resolves to a fail-closed default, not all-compose,
+    so a one-character mistake can't silently widen access. Boundaries are never
+    listed here; a role selects capabilities only.
+
+    Shape::
+
+        version: 1
+        roles:
+          support: [read_only, refunds_small]
+          default: [read_only]
+    """
+    path = Path(root) / ROLES_FILE
+    if not path.is_file():
+        return None
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # noqa: BLE001 — surface the offending file
+        raise ValueError(f"{ROLES_FILE} is invalid: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"{ROLES_FILE}: top level must be a mapping (got {type(payload).__name__})"
+        )
+    unknown = set(payload) - {"version", "roles"}
+    if unknown:
+        # A typo'd `role:` would otherwise parse to no binding and fall through
+        # to a silent, fail-open all-compose. Reject it loudly instead.
+        raise ValueError(
+            f"{ROLES_FILE}: unknown top-level key(s) {sorted(unknown)!r} "
+            f"(expected 'version' and/or 'roles')"
+        )
+
+    raw = payload.get("roles")
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{ROLES_FILE}: 'roles' must be a mapping of role -> [names]")
+
+    roles: dict[str, list[str]] = {}
+    for role, names in raw.items():
+        if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+            raise ValueError(
+                f"{ROLES_FILE}: role {role!r} must map to a list of capability names"
+            )
+        roles[str(role)] = list(names)
+    return roles
+
+
 def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:
     if not directory.is_dir():
         return []
     files = sorted({*directory.glob("**/*.yaml"), *directory.glob("**/*.yml")})
     modules: list[ModuleContent] = []
+    seen: dict[str, Path] = {}
     for file in files:
-        # Parse + validate inside the try so a malformed-YAML file names itself
-        # in the error too, not just a schema-invalid one.
+        # Path-relative name (no suffix) so nested files with the same stem stay
+        # distinct, e.g. "team/refunds" vs "refunds".
+        name = file.relative_to(directory).with_suffix("").as_posix()
+        if name in seen:
+            # Two files collapsing to one name (e.g. dup.yaml + dup.yml) would
+            # otherwise silently shadow each other and drop one file's grants.
+            raise ValueError(f"duplicate module name {name!r}: {seen[name]} and {file}")
+        seen[name] = file
         # Everything that can fail on a bad file — parse, validate, hash — runs
         # inside the try so the error always names the offending file.
         try:
@@ -75,9 +142,7 @@ def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:
             ) from exc
         modules.append(
             ModuleContent(
-                # Path-relative name (no suffix) so nested files with the same
-                # stem stay distinct, e.g. "team/refunds" vs "refunds".
-                name=file.relative_to(directory).with_suffix("").as_posix(),
+                name=name,
                 kind=kind,
                 policy=policy,
                 source=str(file),

--- a/hexgate/security/modules.py
+++ b/hexgate/security/modules.py
@@ -104,3 +104,18 @@ class LinkResult:
     effective: dict[str, AgentPolicy]
     layers: list[Provenance]
     trace: RuleTrace
+
+
+@dataclass(frozen=True)
+class ProjectLinkResult:
+    """A whole project resolved into one role-keyed :class:`PolicySet`.
+
+    ``policy_set`` folds every role and feeds ``compile_to_rego`` unchanged.
+    ``by_role`` keeps each role's single-role :class:`LinkResult` (effective +
+    layers + trace), so the analyzer and editor can attribute a lint to the role
+    it fired in. Boundaries apply to every role; only the capability selection
+    differs, so a grant dead in one role can be alive in another.
+    """
+
+    policy_set: "PolicySet"
+    by_role: dict[str, LinkResult]

--- a/tests/cli/test_policy_check.py
+++ b/tests/cli/test_policy_check.py
@@ -70,3 +70,128 @@ def test_check_link_error_exits_one(tmp_path):
         "tools:\n  refund: { mode: deny }\n",  # capabilities may not deny
     )
     assert _run("policy", "check", "--dir", str(tmp_path)) == 1
+
+
+# --- roles: resolve/check over a multi-role project ------------------------
+
+
+def _multi_role_project(root: Path) -> None:
+    _write(
+        root,
+        "policies/boundaries/org.yaml",
+        "default_policy: { mode: allow }\n"
+        'tools:\n  refund: { mode: allow, constraints: ["args.amount <= 100"] }\n',
+    )
+    _write(
+        root,
+        "policies/capabilities/read_only.yaml",
+        "tools:\n  view: { mode: allow }\n",
+    )
+    _write(
+        root,
+        "policies/capabilities/payments.yaml",
+        "tools:\n  refund: { mode: allow }\n",
+    )
+    _write(
+        root,
+        "roles.yaml",
+        "version: 1\nroles:\n  default: [read_only]\n  billing: [read_only, payments]\n",
+    )
+
+
+def test_resolve_multi_role_exits_zero(tmp_path):
+    _multi_role_project(tmp_path)
+    assert _run("policy", "resolve", "--dir", str(tmp_path)) == 0
+    assert _run("policy", "resolve", "--dir", str(tmp_path), "--role", "billing") == 0
+
+
+def test_resolve_unknown_role_exits_one(tmp_path):
+    _multi_role_project(tmp_path)
+    assert _run("policy", "resolve", "--dir", str(tmp_path), "--role", "ghost") == 1
+
+
+def test_check_multi_role_exits_zero(tmp_path):
+    _multi_role_project(tmp_path)
+    assert _run("policy", "check", "--dir", str(tmp_path)) == 0
+
+
+def test_check_unknown_role_exits_one(tmp_path):
+    _multi_role_project(tmp_path)
+    assert _run("policy", "check", "--dir", str(tmp_path), "--role", "ghost") == 1
+
+
+def test_resolve_no_roles_backcompat_exits_zero(tmp_path):
+    # No roles.yaml: single default importing every capability, as before.
+    _write(
+        tmp_path,
+        "policies/boundaries/org.yaml",
+        "default_policy: { mode: allow }\ntools:\n  refund: { mode: allow }\n",
+    )
+    _write(
+        tmp_path,
+        "policies/capabilities/pay.yaml",
+        "tools:\n  refund: { mode: allow }\n",
+    )
+    assert _run("policy", "resolve", "--dir", str(tmp_path)) == 0
+
+
+def test_check_unknown_role_no_roles_exits_one(tmp_path):
+    # No roles.yaml: only the synthesised `default` role exists. A typo'd role
+    # must error, not silently pass and hide every lint.
+    _write(
+        tmp_path,
+        "policies/boundaries/org.yaml",
+        "default_policy: { mode: allow }\ntools:\n  refund: { mode: allow }\n",
+    )
+    _write(
+        tmp_path,
+        "policies/capabilities/pay.yaml",
+        "tools:\n  refund: { mode: allow }\n",
+    )
+    assert _run("policy", "check", "--dir", str(tmp_path), "--role", "ghost") == 1
+    assert _run("policy", "check", "--dir", str(tmp_path), "--role", "default") == 0
+
+
+def test_check_and_resolve_accept_synthesised_default(tmp_path):
+    # roles.yaml omits `default`; both subcommands still accept --role default
+    # (resolve synthesises it, so check must too).
+    _write(
+        tmp_path,
+        "policies/capabilities/read_only.yaml",
+        "tools:\n  view: { mode: allow }\n",
+    )
+    _write(tmp_path, "roles.yaml", "version: 1\nroles:\n  billing: [read_only]\n")
+    assert _run("policy", "resolve", "--dir", str(tmp_path), "--role", "default") == 0
+    assert _run("policy", "check", "--dir", str(tmp_path), "--role", "default") == 0
+
+
+def test_resolve_output_roundtrips_through_policy_set(tmp_path):
+    # A multi-role `resolve -o` must emit a `roles:` document that
+    # load_policy_set_from_dict (and `policy build`) reads back with tools
+    # intact, not a bare role mapping that flattens to a deny-everything policy.
+    import yaml
+
+    from hexgate.security import load_policy_set_from_dict
+
+    _multi_role_project(tmp_path)
+    out = tmp_path / "eff.yaml"
+    assert _run("policy", "resolve", "--dir", str(tmp_path), "-o", str(out)) == 0
+
+    payload = yaml.safe_load(out.read_text(encoding="utf-8"))
+    assert "roles" in payload  # wrapped, not a bare top-level role mapping
+
+    ps = load_policy_set_from_dict(payload)
+    billing = ps.policy_for("billing")
+    assert "view" in billing.tools and "refund" in billing.tools  # survived
+
+
+def test_typo_in_roles_key_is_an_error_not_silent_all_compose(tmp_path):
+    # `role:` (typo of `roles:`) must fail loudly, not resolve to every capability.
+    _write(
+        tmp_path,
+        "policies/capabilities/read_only.yaml",
+        "tools:\n  view: { mode: allow }\n",
+    )
+    _write(tmp_path, "roles.yaml", "role:\n  default: [read_only]\n")
+    assert _run("policy", "resolve", "--dir", str(tmp_path)) == 1
+    assert _run("policy", "check", "--dir", str(tmp_path)) == 1

--- a/tests/security/test_analyzer.py
+++ b/tests/security/test_analyzer.py
@@ -10,6 +10,7 @@ from hexgate.security import (
     ModuleContent,
     analyze,
     check,
+    check_project,
     link_policy_set,
 )
 
@@ -236,3 +237,57 @@ def test_default_policy_constraints_rejected_as_link_error():
     lints = check([module], [])
     assert [lint.code for lint in lints] == ["link-error"]
     assert "default_policy constraints" in lints[0].message
+
+
+# --- check_project: per-role attribution + project-level lints -------------
+
+
+def test_check_project_tags_a_dead_grant_with_its_role():
+    ceiling = _mod("org", "boundary", {"refund": _allow()}, default_mode="deny")
+    pay = _mod("pay", "capability", {"refund": _allow(), "send_email": _allow()})
+
+    lints = check_project([ceiling], [pay], {"support": ["pay"]})
+
+    dead = [lint for lint in lints if lint.code == "dead-grant"]
+    assert len(dead) == 1
+    assert dead[0].tool == "send_email"  # ceiling excludes it
+    assert dead[0].role == "support"
+
+
+def test_unused_capability_is_flagged():
+    used = _mod("used", "capability", {"x": _allow()})
+    unused = _mod("unused", "capability", {"y": _allow()})
+
+    lints = check_project([], [used, unused], {"default": ["used"]})
+
+    un = [lint for lint in lints if lint.code == "unused-capability"]
+    assert len(un) == 1
+    assert un[0].source == "unused.yaml"
+    assert "unused" in un[0].message
+
+
+def test_no_default_role_is_flagged():
+    cap = _mod("c", "capability", {"x": _allow()})
+    lints = check_project([], [cap], {"billing": ["c"]})
+    nd = [lint for lint in lints if lint.code == "no-default-role"]
+    assert len(nd) == 1
+    # role stays None so a role-scoped `check --role X` still surfaces it.
+    assert nd[0].role is None
+
+
+def test_check_project_unknown_capability_is_a_link_error():
+    # Same contract as resolve_for_project: an unknown capability name in a role
+    # fails, it is not silently dropped.
+    cap = _mod("c", "capability", {"x": _allow()})
+    lints = check_project([], [cap], {"r": ["missing"]})
+    assert [lint.code for lint in lints] == ["link-error"]
+
+
+def test_no_roles_emit_no_project_lints():
+    # None (no roles.yaml) -> one default importing everything. Nothing unused,
+    # and the default is present, so neither project-level lint fires.
+    cap = _mod("c", "capability", {"x": _allow()})
+    lints = check_project([], [cap], None)
+    codes = {lint.code for lint in lints}
+    assert "unused-capability" not in codes
+    assert "no-default-role" not in codes

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -25,6 +25,7 @@ from hexgate.security import (
     evaluate_tool_call,
     link,
     link_policy_set,
+    resolve_for_project,
 )
 
 _OPA_AVAILABLE = shutil.which("opa") is not None
@@ -355,3 +356,89 @@ def test_resolved_policy_parity_pydantic_vs_wasm(floor_bundle):
             role="default",
         )
         assert pyd.outcome is wsm.outcome, (tool, args)
+
+
+# --- resolve_for_project: roles as capability bindings ---------------------
+
+
+def test_resolve_folds_each_role_independently():
+    # Floor boundary caps refund at <= 100 for every role.
+    org = _mod("org", "boundary", {"refund": _allow(["args.amount <= 100"])})
+    read_only = _mod("read_only", "capability", {"view": _allow()})
+    payments = _mod("payments", "capability", {"refund": _allow()})
+
+    result = resolve_for_project(
+        [org],
+        [read_only, payments],
+        {"default": ["read_only"], "billing": ["read_only", "payments"]},
+    )
+
+    assert set(result.by_role) == {"default", "billing"}
+    default_pol = result.policy_set.policy_for("default")
+    billing_pol = result.policy_set.policy_for("billing")
+    # default imports read_only only -> no refund grant.
+    assert "view" in default_pol.tools
+    assert "refund" not in default_pol.tools
+    # billing imports payments too -> refund granted, capped by the boundary.
+    assert billing_pol.tools["refund"].mode == "allow"
+    assert "args.amount <= 100" in billing_pol.tools["refund"].constraints
+
+
+def test_boundary_applies_to_every_role():
+    # An unconditional boundary deny wins in every role, regardless of imports.
+    org = _mod("org", "boundary", {"delete": _deny()})
+    cap = _mod("c", "capability", {"delete": _allow(), "x": _allow()})
+
+    result = resolve_for_project([org], [cap], {"r1": ["c"], "r2": ["c"]})
+
+    for role in ("r1", "r2"):
+        assert result.policy_set.policy_for(role).tools["delete"].mode == "deny"
+
+
+def test_unknown_capability_in_a_role_raises_link_error():
+    cap = _mod("c", "capability", {"x": _allow()})
+    with pytest.raises(LinkError, match="unknown capability"):
+        resolve_for_project([], [cap], {"r": ["missing"]})
+
+
+def test_none_roles_means_one_default_importing_everything():
+    # None == "no roles.yaml" -> all-compose back-compat.
+    caps = [
+        _mod("a", "capability", {"x": _allow()}),
+        _mod("b", "capability", {"y": _allow()}),
+    ]
+    result = resolve_for_project([], caps, None)
+
+    assert result.policy_set.roles == ["default"]
+    tools = result.policy_set.policy_for("default").tools
+    assert {"x", "y"} <= set(tools)
+
+
+def test_empty_roles_is_fail_closed_not_all_compose():
+    # {} == "roles.yaml present but binds nothing" -> fail-closed empty default,
+    # NOT all-compose. This is the fix for a typo'd roles: key widening access.
+    caps = [_mod("a", "capability", {"x": _allow()})]
+    result = resolve_for_project([], caps, {})
+
+    assert result.policy_set.roles == ["default"]
+    assert result.policy_set.policy_for("default").tools == {}
+
+
+def test_unbound_capability_deny_is_rejected():
+    # A capability that denies must fail even when no role imports it — validated
+    # over the whole library, not just the folded-in modules.
+    good = _mod("good", "capability", {"x": _allow()})
+    bad = _mod("bad", "capability", {"refund": _deny()})
+    with pytest.raises(LinkError, match="capabilities may only grant"):
+        resolve_for_project([], [good, bad], {"r": ["good"]})
+
+
+def test_default_role_synthesised_when_absent_is_deny_all():
+    # roles.yaml with no `default` -> an empty default so unroled callers get
+    # fail-closed deny, not a missing bucket.
+    cap = _mod("c", "capability", {"x": _allow()})
+    result = resolve_for_project([], [cap], {"billing": ["c"]})
+
+    assert "default" in result.by_role
+    assert result.policy_set.policy_for("default").tools == {}
+    assert "x" in result.policy_set.policy_for("billing").tools

--- a/tests/security/test_module_loader.py
+++ b/tests/security/test_module_loader.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from hexgate.security import load_local_modules
+from hexgate.security import load_local_modules, load_roles
 
 
 def _write(root: Path, rel: str, body: str) -> None:
@@ -108,3 +108,70 @@ def test_nested_same_stem_modules_stay_distinct(tmp_path):
     )
     _, capabilities = load_local_modules(tmp_path)
     assert sorted(c.name for c in capabilities) == ["team_a/refunds", "team_b/refunds"]
+
+
+# --- load_roles: the role-binding file (outside policies/) -----------------
+
+
+def test_load_roles_reads_bindings(tmp_path):
+    _write(
+        tmp_path,
+        "roles.yaml",
+        "version: 1\nroles:\n  default: [read_only]\n  billing: [read_only, payments]\n",
+    )
+    assert load_roles(tmp_path) == {
+        "default": ["read_only"],
+        "billing": ["read_only", "payments"],
+    }
+
+
+def test_load_roles_missing_file_is_none(tmp_path):
+    # No roles.yaml -> None (the all-compose signal), distinct from an empty
+    # binding, and not an error.
+    assert load_roles(tmp_path) is None
+
+
+def test_load_roles_lives_outside_policies(tmp_path):
+    # A roles.yaml placed under policies/ is NOT the binding file — discovery
+    # only looks at the repo root, so this reads as "absent" (None).
+    _write(tmp_path, "policies/roles.yaml", "roles:\n  default: [x]\n")
+    assert load_roles(tmp_path) is None
+
+
+def test_load_roles_present_but_empty_is_a_dict_not_none(tmp_path):
+    # File exists but binds nothing -> {} (fail-closed), NOT None (all-compose).
+    # A one-character typo must not silently widen access.
+    _write(tmp_path, "roles.yaml", "version: 1\nroles: {}\n")
+    assert load_roles(tmp_path) == {}
+
+
+def test_load_roles_rejects_unknown_top_level_key(tmp_path):
+    # A typo'd `role:` (instead of `roles:`) is a loud error, not a silent empty.
+    _write(tmp_path, "roles.yaml", "role:\n  default: [x]\n")
+    with pytest.raises(ValueError, match="unknown top-level key"):
+        load_roles(tmp_path)
+
+
+def test_load_roles_rejects_non_mapping_document(tmp_path):
+    _write(tmp_path, "roles.yaml", "- default\n- billing\n")
+    with pytest.raises(ValueError, match="top level must be a mapping"):
+        load_roles(tmp_path)
+
+
+def test_load_roles_rejects_non_list_value(tmp_path):
+    _write(tmp_path, "roles.yaml", "roles:\n  default: read_only\n")
+    with pytest.raises(ValueError, match="list of capability names"):
+        load_roles(tmp_path)
+
+
+def test_duplicate_module_name_across_extensions_is_rejected(tmp_path):
+    # dup.yaml + dup.yml both resolve to name "dup" -> one would silently shadow
+    # the other and drop its grants. Reject at load instead.
+    _write(
+        tmp_path, "policies/capabilities/dup.yaml", "tools:\n  view: { mode: allow }\n"
+    )
+    _write(
+        tmp_path, "policies/capabilities/dup.yml", "tools:\n  refund: { mode: allow }\n"
+    )
+    with pytest.raises(ValueError, match="duplicate module name 'dup'"):
+        load_local_modules(tmp_path)


### PR DESCRIPTION
Make policy resolution role-aware: a project with many roles now resolves each role to its own effective policy, instead of the linker folding everything into a single `default`. This is the SDK groundwork for phase 3 (bringing multi-module policy to the platform), after #97 (modules + linker) and #101 (analyzer). Pure SDK, fully local, no platform change.

The real policies are multi-role, but doing that by mapping roles to authored inheritance is exactly what gets dangerous at scale (role bundles duplicated per agent, an `inherits` DAG whose effective permissions you have to compute). This PR avoids that.

## Design

A role stops being a policy block with `inherits`. It becomes a thin binding, `role -> [capability names]`, in a `roles.yaml` that lives outside `policies/` on purpose (a role is a binding, not a policy module). Three properties fall out:

- Capabilities are the only authored, reusable unit. A role selects them, flat union, no inheritance.
- Boundaries are role-independent ceilings. Every role folds against the same boundaries, so a role can only narrow, never widen, its ceiling. Escalation past a boundary is structurally impossible.
- Multi-role is compiled, not authored: the role-keyed `PolicySet` the WASM engine already expects is a derived expansion of the binding map.

`resolve_for_project(boundaries, library, roles, *, agent_leaf, agent_boundaries)` loops the existing fold once per role and returns `ProjectLinkResult(policy_set, by_role)`. No `roles.yaml` means one `default` role importing every capability, the all-compose behaviour `--dir` had before, so existing bundles resolve unchanged. A missing `default` is synthesised as an empty selection (unroled callers get fail-closed deny). An unknown capability name in a role is a `LinkError`.

The analyzer runs per role and tags each lint with the role it fired in (a grant dead under one role's ceiling can be alive under another), plus two project-level lints:

| Lint | Severity | From |
| --- | --- | --- |
| `unused-capability` | info | a library capability no role imports |
| `no-default-role` | info | roles defined but no `default`, so unroled callers deny |

## Important files

| File | What to look at |
| --- | --- |
| `hexgate/security/linker.py` | `resolve_for_project`: the per-role loop over the unchanged `link`. The fold is untouched, this only picks each role's inputs. |
| `hexgate/security/module_loader.py` | `load_roles`: reads `<root>/roles.yaml`, and why it sits outside `policies/`. |
| `hexgate/security/analyzer.py` | `check_project` / `analyze_project`: per-role attribution and the two new lints. |
| `hexgate/security/modules.py` | `ProjectLinkResult`. |
| `hexgate/cli/policy/main.py` | `--role` on `resolve` and `check`, and the single-role vs multi-role output. |
| `tests/security/test_linker.py` | role folding, boundary-applies-to-all, unknown capability, no-roles back-compat, synthesised default. |

## Try it

```
hexgate policy resolve --dir deploy/demo_policies                 # every role
hexgate policy resolve --dir deploy/demo_policies --role billing  # one role
hexgate policy check   --dir deploy/demo_policies                 # lints, per role
```

`deploy/demo_policies` now ships a `roles.yaml` (default / support / billing) and a shared `read_only` capability. billing gets refunds capped at 1000 by the boundary and to USD/EUR by the payments pack; default is read-only; support adds email and escalate.

## Notes

- Full SDK suite green (1789 passed, 6 opt-in skips). ruff clean. No `platform/api` changes.
- Untouched on purpose: the single-role `link` / `link_policy_set`, the compile path, the WASM runtime, and signing.
- Design and the remaining phase-3 plan (platform `policy_module` + `role_binding` store, dashboard, converter) are in `policy-modules-phase3-design.md`.
