### PR TITLE
feat(platform-api): compile modular agents' bundles from resolved modules

### DIFF
--- a/agent-policy-dimension-design.md
+++ b/agent-policy-dimension-design.md
@@ -1,0 +1,382 @@
+# Agent dimension for modular policy — design
+
+*Adding per-agent policy to the modular `(boundaries + capabilities + role bindings)`
+model, so agents in one project can differ without splitting into separate
+projects — and reconciling the three different "agent" notions currently in
+flight into one.*
+
+> Status: design proposal. Grounded in the code as of the `agent-admission-gate`
+> (#124, which carries the merged #122 agent model) and `modular-policy-compile`
+> (#121) branches. Not implemented; no PR yet.
+
+## The problem
+
+Modular policy today resolves to a **role-keyed** policy set: `{role: AgentPolicy}`.
+Every agent in a project enforces the **same** resolved bundle — on the platform,
+`recompile_project` builds one bundle and assigns it to every agent. So two agents
+in one project (a `triage_bot` and a `billing_bot`, say) cannot differ in policy;
+the only way to differentiate them today is to put them in **separate projects**,
+which duplicates boundaries and role bindings and fragments a single logical
+multi-agent system across projects.
+
+We want per-agent policy **within** a project: "for caller role R, `billing_bot`
+may refund but `triage_bot` may not," expressed once, composed the same way roles
+already are.
+
+## Three "agent" notions — and which we keep
+
+The word "agent" already means three different things in the codebase. Untangling
+them is the core of this design.
+
+1. **#121 — `agent_leaf` / `agent_boundaries` (ad-hoc, name-less).**
+   `resolve_for_project(..., *, agent_leaf=(), agent_boundaries=())` appends an
+   agent's own modules to the fold: `fences = [*boundaries, *agent_boundaries]`,
+   `caps = [*role_caps, *agent_leaf]`. There is **no agent name** — the identity
+   lives in whoever calls `resolve`. It is unwired (nothing on the platform
+   populates it). **Verdict: retire it.** It is the right *intent* (per-agent tool
+   policy) expressed the wrong way.
+
+2. **#122 / #124 — agent as first-class named keys (lowered to synthetic tools).**
+   The agent policy model lowers agent-level rules into reserved tool keys that
+   **both engines decide on the existing tool path, with no engine change**
+   (`AgentPolicy.effective_tools`):
+   - `agent.run` — **admission** (ingress). *Opt-in*: absence admits. Decided with
+     `{"agent": <executing agent name>}` as args, so a policy can gate on
+     `args.agent`.
+   - `agent.tool:<target>` / `agent.handoff:<target>` — **reach** (egress).
+     *Closed-world*: an unlisted target denies regardless of `default_policy`.
+     `via ∈ {tool, handoff}`.
+   **Verdict: keep it, unchanged.** This is the correct model for the
+   *who-can-run / who-can-reach-whom* dimension, which is inherently runtime
+   (the handoff target is only known at decision time).
+
+3. **New — the `(role, agent)` tool-policy matrix (this doc).** Per-agent *tool*
+   policy: "what tools does this agent get, per caller role." Distinct from both
+   above. **Verdict: add it, resolved away at compile time (see Path A).**
+
+The unification is not "merge #121's seam with #124's keys." It is:
+
+> **Delete #121's ad-hoc seam. Keep #124's key model for admission/reach. Add a
+> `(role, agent)` matrix for per-agent tool policy. Make all three agree on one
+> agent identity — the agent's name (default `"main"`).**
+
+## The model
+
+**Role is the umbrella.** Everything hangs off the caller `role`: a generic
+baseline that applies to every agent, plus per-agent refinements, plus (later)
+other resource dimensions. The role's binding stops being a flat capability list
+and becomes a **structured value** — an open set of sections under the role:
+
+```yaml
+# roles.yaml  (role -> { generic baseline, per-agent overrides }).
+# "*" = the generic default; a bare list stays valid (back-compat).
+roles:
+  member:
+    "*":                                  # generic baseline for any agent
+      capabilities: [read_only]
+    billing_bot:                          # a first-class agent under this role
+      capabilities: [read_only, payments]
+      handoffs: [refund_bot]              # sugar for agents: {refund_bot: {via: [handoff]}}
+    triage_bot:
+      capabilities: [read_only]           # more restricted than payments-holders
+      handoffs: [billing_bot]
+    refund_bot:                           # a SIBLING node, never nested under billing_bot
+      capabilities: [read_only, refunds]
+    # mcp: [...]        # a later resource section, added without a schema change
+```
+
+The `agent` here is the **generalization** of #122's sub-agent concept: the same
+identity that governs handoff / agent-as-tool now also governs *first-level*
+agents. `billing_bot` is just an agent under the role, whether it's the main agent
+or reached by handoff.
+
+Design rules (each carried over from the existing modular model or decided here):
+
+- **Boundaries stay global ceilings** — role- *and* agent-independent, and
+  distinct from the role's generic capability baseline. The safety invariant is
+  unchanged: no role or agent can exceed the org/project ceiling. (Don't conflate
+  the generic `"*"` capability baseline with boundaries — the baseline is grants,
+  boundaries are the ceiling above all cells.)
+- **Capabilities stay the only authored, reusable unit.** A `(role, agent)` node
+  *selects* capabilities; it never inlines tool policy. Reuse (`read_only`
+  everywhere) comes from importing the same capability, not from magic.
+- **A named agent *replaces* the generic, so it can be *more restricted*.** The
+  `"*"` section is the generic baseline; a named agent's section **fully specifies
+  that agent** (it does not inherit-and-merge the baseline). This is the reading
+  that lets an agent do *less* than the role generally allows — e.g. `triage_bot`
+  omits `payments`, so it is strictly more restricted than a payments-holder —
+  which capability-selection alone could not express under a merge/inherit reading
+  (capabilities only ever *grant*, never tighten). Specificity wins at the
+  granularity of the whole agent cell; the cost is repeating a baseline
+  capability, which is a one-word import. It stays two levels (generic → agent),
+  so it never reintroduces the inheritance-DAG hazard rejected for roles.
+- **`"*"` is the generic default agent.** A flat `role: [caps]` stays valid as
+  sugar for `role: {"*": {capabilities: [caps]}}`, so **every existing
+  `roles.yaml` and every existing project keeps its exact meaning** (additive, no
+  migration of meaning).
+- **No recursion.** Sub-agents are **sibling nodes referenced by name** in
+  `handoffs`, never nested subtrees with their own `tools`. This is enforced
+  structurally: `handoffs` is a **list of names**, so there is no slot to hang a
+  sub-agent's tools off — the illegal shape is unrepresentable, not policed. Each
+  agent's tool policy has exactly one definition — its own node.
+- **`handoffs` reuses the #122 `agents:` grammar.** `handoffs: [refund_bot]` is
+  shorthand for `agents: {refund_bot: {via: [handoff]}}`; agent-as-tool is
+  `{via: [tool]}`. Admission is the existing `admission:` block. No new agent-key
+  grammar is introduced.
+- **The role value is an open, extensible object.** `capabilities` + `agents`
+  today; `mcp` and other resource dimensions can be added later as new sections
+  under the role — and because the value is stored as JSON under `(project_id,
+  role)` (see Storage), each new dimension is a value-shape change with **no DB
+  migration**.
+
+### Why no path-dependence is needed
+
+The reason to want path-dependent policy ("`refund_bot` should be weaker when
+reached via an untrusted path") is the confused-deputy case. It is covered by the
+**reach edges controlling the graph**: if only `billing_bot` lists `refund_bot`
+in `handoffs`, then `triage_bot` cannot reach it at all — the restriction comes
+from the edge, not from keying `refund_bot`'s tools by caller path. Reach (control
+the graph) + per-agent capabilities (control each node) together cover it, without
+a computed closure.
+
+## Resolution — Path A (resolve per agent; the bundle stays role-keyed)
+
+This is the load-bearing decision. There are two ways to make `(role, agent)`
+selection real, and they cost wildly differently.
+
+**Path A (chosen).** The `(role, agent)` matrix is authoring/storage only. At
+**resolve time**, each agent gets **its own role-keyed bundle** — that agent's
+column merged over `"*"`, folded once per `(role)` exactly as today. Then:
+
+- `PolicySet`, `policy_for(role)`, the Rego template, the enforcer, and the
+  pydantic↔WASM parity gate are **unchanged** — the served agent still enforces a
+  plain role-keyed bundle; the agent dimension is compiled away first. This is the
+  "resolve, then compile" invariant roles already follow.
+- It fits what already exists: every wrapped agent already loads its own artifact
+  by name, and the platform already stores `compiled_wasm` **per agent** (today it
+  just fills them all with the *same* bundle). Path A = resolve per agent in that
+  existing loop. The per-agent compile cost is absorbed by the
+  sha256-memoization already in the recompile path (agents whose column resolves
+  identically dedupe).
+- **Admission and reach ride inside each agent's per-agent bundle** as the #122
+  lowered synthetic tools (`agent.run`, `agent.handoff:<target>`), decided at
+  runtime on the existing path. So one per-agent bundle carries both halves: the
+  role-keyed tool policy (resolved from the matrix column) *and* that agent's
+  `agent.*` admission/reach rules.
+
+**Path B (rejected).** One shared bundle keyed by `(role, agent)`, selected at
+enforcement. This forces: re-keying `PolicySet` to `(role, agent)` (a breaking
+change that escapes into `rego.py`, the enforcer, and every legacy loader),
+`input.agent` guards in Rego, extending the pydantic↔WASM parity gate, **and**
+plumbing a *dynamic* executing-agent identity through `HexgateContext` and every
+framework adapter — which no adapter does today (they resolve a separate artifact
+per agent; they do not re-key one). Path B reopens the two-engine surgery Path A
+avoids entirely.
+
+> Split of concerns, made explicit: **"what tools does agent A use?"** is static
+> per agent → resolved away at compile (Path A). **"May A hand off to B?"** depends
+> on the runtime target → stays a keyed rule (`agent.handoff:B`) in A's bundle
+> (#122/#124). You cannot resolve reach away; you can and should resolve tool
+> policy away.
+
+### Path A vs Path B — the honest tradeoff
+
+Both are internally consistent. The choice is *where you spend complexity*, not
+whether the feature works. Recorded here so the reasoning outlives the decision.
+
+**What B genuinely does better.** The intuition "we're already multi-key on role,
+agent is just one more input" is correct, and B has real merits:
+
+- **One signed artifact per project** — one signature, one version, one thing to
+  distribute and audit. A produces *N* per-agent bundles.
+- **Uniform keying** — `decide(role, agent, tool, args)` is one more `input` field
+  on a bundle that already selects by `input.role`.
+- **Less compile work** — one compile per project vs one per distinct agent column.
+
+So B does not "hurt" at the distribution level; there it is arguably *simpler*.
+
+**Why A wins anyway.** The cost of B is precise and architectural, not
+performance:
+
+1. **B pushes the agent dimension into both engines.** The modular design exists
+   to keep composition at the **model layer** so the pydantic and WASM engines
+   only ever see *one resolved policy* ("resolve, then compile"). B adds
+   `input.agent` guards + a two-level fallback to the Rego template, re-keys
+   `PolicySet`, and — the sharp part — **extends the pydantic↔WASM parity gate**,
+   the one seam where a silent, asymmetric divergence is the worst-case bug. A
+   leaves the engines and the parity gate untouched.
+2. **Least-exposure of signed artifacts.** Under A, each agent's signed bundle
+   carries **only its own authority** — `billing_bot`'s bundle has no trace of
+   `triage_bot`'s grants. Under B, every agent ships the **entire project matrix**.
+   For a security product that is a real property, not a nicety.
+3. **A is not actually more infrastructure.** The platform already stores a bundle
+   **per agent** (`compiled_wasm` per `Agent` row); today #121 compiles once and
+   copies identical bytes to every row. A turns those identical copies into real
+   per-agent compiles — no new storage or schema — and the sha256 memoization
+   already in the recompile path bounds the extra compiles (identical columns
+   dedupe). The infrastructure is already shaped for A.
+
+**A correction, in fairness to B.** An earlier framing claimed B needs "dynamic
+per-call executing-agent plumbing that no adapter does." That is too strong. Each
+wrapped agent already has its **own** enforcer holding its **own** static
+`agent_name`, and that enforcer *is* that agent — so passing `agent=self.agent_name`
+into `evaluate()` is a one-liner and the static name suffices. B's real cost is
+**not** context plumbing; it is the **Rego two-level fallback + parity-gate
+extension + `PolicySet` re-key**. Feasible — but landing squarely on the seam the
+architecture most wants to protect.
+
+**Reach does not tip the choice.** Under A, an agent's `agent.handoff:<target>`
+rules resolve into *its own* bundle with the executing agent implicit (it is whose
+bundle it is), so no `input.agent` is forced by reach either. Both paths keep
+reach as closed-world keyed rules; neither is more "reach-native."
+
+**Choose B only if** "one signed artifact + one version per project" is a hard
+requirement for the audit/distribution story — that is the single thing B does
+strictly better, and worth the parity cost *only* if that constraint is real.
+Absent that, **A** keeps composition at the model layer, protects the parity gate,
+and gives per-agent least-exposure bundles on infrastructure that already exists.
+
+## Selection & the sentinel reconciliation
+
+At compile time, agent A's bundle is `fold` of `(role, A)` cells merged over
+`(role, "*")`, for every role. At **run** time nothing new happens for tool
+policy — A enforces its own role-keyed bundle. The fallback that matters is at
+*resolve*: a `(role, agent)` cell, else the `(role, "*")` cell, else the role is
+absent from A's bundle → fail-closed deny.
+
+Three default sentinels currently collide and **must be reconciled**:
+
+- `"*"` — the matrix default-agent key (this doc).
+- `"default"` — the executing-agent name default in `enforcer.py` / the adapters
+  today.
+- `"default"` — `DEFAULT_ROLE_NAME`.
+
+Decision: **the default executing-agent name becomes `"main"`** (reconcile
+`factory.py` / `enforcer.py` and the adapter name-fallbacks), distinct from both
+`"*"` (the matrix wildcard *key*) and the `default` *role*. Otherwise the
+`(role, "*")` fallback silently never matches a real executing agent named
+`"default"`, and every unroled agent fails closed (or matches the wrong cell).
+
+## Storage — keep `(project_id, role)`, evolve the value (no migration)
+
+The DB change is **independent of Path A vs B** — both must persist the matrix.
+The question is only *how*, and it decides whether there is a migration.
+
+**Chosen — evolve the JSON value (no migration).** Keep the `role_binding` table
+exactly as is: key `(project_id, role)`, and the already-`Column(JSON)`
+`capabilities` field. Let the *value* carry the structure — role is the umbrella,
+everything nests under it:
+
+- legacy row: `["read_only"]` (a flat list)
+- new row: `{"*": {capabilities: […]}, "billing_bot": {capabilities: […], agents: {…}}, …}`
+
+Read logic normalizes a legacy flat `list` to `{"*": {capabilities: <list>}}` (the
+generic baseline). Then:
+
+- **`metadata.create_all` is a no-op** (the table schema is unchanged) → **no
+  migration on any DB, fresh or populated** — which matters because the platform
+  has no migration tool and an additive-only posture.
+- **Existing rows keep working for free** (flat list = generic baseline).
+- New sections (`agents`, later `mcp`, …) are value-shape changes only — the table
+  never changes again.
+- The one thing we give up — querying *by agent* in SQL — we never do:
+  `get_roles` already loads a project's whole binding and resolves in the SDK, and
+  `roles_importing` already walks it in Python.
+
+**Rejected — row-per-cell.** Add an `agent` column and change the unique key to
+`(project_id, role, agent)`. Clean on a fresh DB, but on a populated one it is a
+real migration (`create_all` won't add a column or alter a UNIQUE constraint on an
+existing table): manual `ALTER` + constraint drop/recreate + backfill `agent="*"`,
+with no in-repo tooling to run it. Buys SQL-queryability by agent that we don't
+use.
+
+No new tables either: per-agent **bundles already live** in `compiled_wasm` on the
+`Agent` row (today filled identically; Path A makes them differ).
+
+## Impact — quantified (Path A)
+
+From a file-level review of the SDK, platform, editor, and PR stack.
+
+| Surface | Change | Size |
+| --- | --- | --- |
+| SDK `module_loader.load_roles` | parse the matrix; accept flat form as sugar for `{"*": …}` | M |
+| SDK `linker` | normalize the matrix; per-agent resolve (filter column ∪ `"*"`, reuse the fold) | M |
+| SDK `analyzer` | lints gain an `agent` tag; surface multiplies per `(role, agent)` cell | M (deferrable) |
+| SDK `policy_set` / `rego` / `enforcer` / parity | **unchanged** (Path A) | — |
+| Platform `RoleBinding` | evolve the JSON value shape; key unchanged; read legacy flat list as `"*"` | S, **no migration** |
+| Platform schemas | `RoleBindings{Read,Write}` nested; accept flat on write | S |
+| Platform service | `get_roles` / `set_roles` / `roles_importing` / `_norm` / `resolve*` matrix-aware | M |
+| Platform recompile | fan out per agent (loop exists; resolve per column; memoized) | M |
+| Editor `api.ts` types | `RoleBindings`, `ResolvedPolicy`, `PolicyTestRequest + agent` | S |
+| Editor `EditorPane` parse/dump | matrix + flat form (`roles.yaml` is free-text, so authoring stays small) | M |
+| Editor Inspector + Test panel | add the agent axis (second selector) | M |
+| Tests | ~21 platform + ~8 SDK + 2 dashboard files reshaped | M |
+
+**Verdicts:** `roles.yaml` schema = **additive/non-breaking**. HTTP `/policy-roles`
+shape = **breaking, but no current dashboard consumer** (keep flat-form accepted on
+write). DB = **no migration** (JSON value evolves; key unchanged). `PolicySet` /
+runtime / parity = **untouched** (this is the whole point of Path A). Net: a
+**medium–large** feature with **no L item, no engine surgery, and no DB migration**.
+
+### Top risks
+
+1. **The sentinel collision** — pin the executing-agent default to `"main"` and
+   reconcile the `enforcer.py` / adapter fallbacks, or the `(role, "*")` fallback
+   silently never matches and unroled agents fail closed / match the wrong cell.
+2. **`_norm` / `roles_importing` must become matrix-aware**, or the
+   recompile-skip and capability-delete guards regress into stale enforcement.
+3. **Legacy-value normalization must be exactly right.** A stored flat list must
+   read as `{"*": {capabilities: […]}}` everywhere it's consumed; a miss here is a
+   silent semantic change to existing projects (the price of the no-migration
+   storage is that the compatibility lives in code, not the schema).
+4. **Parity is only at risk under Path B.** Under Path A the two engines never see
+   the agent dimension, so there is nothing to keep in lockstep.
+5. **Not a migration, but a behavior shift on the platform:** #121 today serves
+   *one* bundle to every agent; Path A makes per-agent bundles differ. Agents whose
+   effective policy actually changes will re-compile on the next policy write — an
+   intended enforcement change, worth calling out in the rollout.
+
+## Where it lands (PRs)
+
+Two PRs carry the whole feature: **#121 + #132**. The SDK foundation is **wired
+directly into #121** (not a separate base PR): #121's branch already carries the
+merged SDK foundation (#115/#117) and already edits `linker.py` (its
+`agent_leaf`/`agent_boundaries` seam), so the matrix `load_roles` + per-agent
+resolve belong with the per-agent *compile* that consumes them. Kept as their own
+clean commits within #121 so review stays tractable.
+
+Everything builds on the **already-merged #122 grammar** (`admission`/`agents`
+blocks + lower-to-synthetic-tools), which lives on `main` — so no closed PR is
+edited and no new base PR is needed.
+
+- **#121** — SDK (matrix `load_roles`, per-agent resolve, analyzer agent tags) +
+  platform compile (`recompile_project` fans out **per agent**; retire the
+  `agent_leaf`/`agent_boundaries` seam). Rebased onto current `main` (it predates
+  #122), on top of the review fixes already on its branch.
+- **#132** (stacked on #121) — `role_binding` **value-shape** change (no
+  migration) + `/policy-roles` API matrix-aware + the editor agent axis.
+- **#124 → #142 → #138** — **not touched** for the matrix; they only need to agree
+  on the agent-**name** identity (`"main"`). Retiring #121's ad-hoc seam is what
+  makes #121 and #124 stop diverging — both converge on #122. (#142 is already
+  conflicting and needs a rebase regardless — its own pre-existing issue.)
+
+## Open decisions
+
+1. **Path A vs Path B.** This doc chooses **A**. B is only warranted if we
+   specifically want one runtime bundle serving many agents (and accept the
+   engine/parity/adapter cost).
+2. **`capabilities:` selection vs inline `tools:`** under a node — this doc keeps
+   capabilities-only, consistent with "capabilities are the only authored unit."
+3. **Default executing-agent name = `"main"`** (reconcile the existing `"default"`).
+4. **Scope of unification with reach/admission** — share one agent identity across
+   the matrix and the `agents:`/`agent.*` keys (recommended), which couples the
+   sequencing of the two stacks at the "agent name" level only.
+
+## What does not change
+
+- Boundaries as global, role- and agent-independent ceilings.
+- Capabilities as the only authored, reusable unit; roles/agents as thin bindings.
+- The compile path: effective policy → Rego → WASM → signed bundle.
+- The pydantic and WASM engines, and their parity gate (Path A).
+- The #122/#124 admission/reach key model and its "lower to synthetic tools"
+  mechanism.

--- a/docs/adr/R-POL-002-compile-agents-from-modules.md
+++ b/docs/adr/R-POL-002-compile-agents-from-modules.md
@@ -1,0 +1,45 @@
+# R-POL-002: Compile modular agents' bundles from resolved modules
+
+**Status:** Accepted · 2026-08-17
+**Applies to:** `platform/api/hexgate_api/features/policy_modules/**`, `platform/api/hexgate_api/features/agents/**`
+
+## Decision
+
+A project is **modular** iff it has at least one role binding. Follows from R-POL-001; this ADR covers how a modular project's agents are enforced.
+
+- A modular agent's signed bundle MUST be compiled from the project's *resolved* role-keyed policy (`resolve` → inline-`roles:` YAML → `build_signed_bundle`), not from `agent.policy_yaml`. A classic project (no bindings) MUST keep compiling from `policy_yaml`, unchanged.
+- Editing a module or a role binding MUST recompile every agent in the project (fan-out). The project resolves once; the single bundle is reused for all its agents (they are identical until agent-scoped modules exist).
+- A recompile that can't resolve, or resolves but can't compile (e.g. `opa` absent), MUST leave existing bundles untouched. A broken or work-in-progress edit MUST NOT blank agents that were working.
+- Modular MUST be inferred from the presence of a role binding. There MUST NOT be a `policy_mode` column in this phase.
+- The serve path MUST NOT change: the bundle stays on the `Agent` row and the SDK fetches it as today.
+
+## Why
+
+Enforcement has to come from the composed modules, or the whole module system is inert (it only fed inspection before this). The one real question is *when* a project switches from `policy_yaml` to modules, and how not to break live agents doing it.
+
+Inferring modular from a role binding, rather than adding a `policy_mode` column, is deliberate on two counts. First, it needs no migration: the platform has no Alembic, and `create_all` can add tables but not columns to a populated DB, so a column would force that decision now for no functional gain. Second, binding a role is the meaningful opt-in — you have decided which roles map to which capabilities. Uploading a capability or boundary module alone must *not* flip enforcement, or dropping in a single boundary would resolve every agent to a deny-all default and brick them.
+
+Fan-out is required because the policy is project-level: one module edit changes every agent's effective policy, so every agent must recompile. Reusing one resolved bundle for all of them keeps that to a single `opa` call per edit.
+
+Leaving bundles untouched on an unresolvable edit is the safety property. The alternative — clearing bundles when the project doesn't resolve — turns a typo in the dashboard into an outage across every agent in the project. Failing safe means the last good policy keeps enforcing while `check` surfaces the problem. This is why the write endpoints do not reject an unresolvable edit: the store can hold a work-in-progress state, but only a clean resolve replaces what is enforced.
+
+## Consequences
+
+- No schema change, no migration. Additive code only.
+- All modular agents in a project share one bundle (redundant bytes on each row). Deduping into a per-project bundle is a later optimization, not needed for correctness.
+- For a modular agent, `agent.policy_yaml` is no longer what's enforced (the resolved modules are). The dashboard must edit modules, not per-agent `policy_yaml`, for modular projects.
+- A saved-but-unresolvable project keeps enforcing its last good bundle; the divergence is visible through `check`, never silent.
+
+## Rejected alternatives
+
+- **A `policy_mode` column on `Project`.** Forces Alembic now (the column can't be added to a live DB by `create_all`) for no behavior a role binding doesn't already imply.
+- **A per-project compiled-bundle table.** Removes the redundant per-agent bytes but changes the serve path (agents would fetch a project bundle). Deferred; not worth the serve-path risk yet.
+- **Clearing bundles when a project won't resolve.** A one-character typo would blank every agent in the project. Fail-safe (leave last good) is mandatory for a product whose value is uninterrupted enforcement.
+
+## Verify
+
+```
+cd platform/api && pytest tests/features/policy_modules/ -q
+```
+
+Covers: `is_modular` flips on the first binding; `bundle_for_agent` routes classic vs modular; `recompile_project` fans out to every agent; an unresolvable edit leaves bundles untouched; and (with `opa`) a modular agent's bundle equals compiling the resolved YAML.

--- a/docs/adr/R-POL-002-compile-agents-from-modules.md
+++ b/docs/adr/R-POL-002-compile-agents-from-modules.md
@@ -8,7 +8,7 @@
 A project is **modular** iff it has at least one role binding. Follows from R-POL-001; this ADR covers how a modular project's agents are enforced.
 
 - A modular agent's signed bundle MUST be compiled from the project's *resolved* role-keyed policy (`resolve` → inline-`roles:` YAML → `build_signed_bundle`), not from `agent.policy_yaml`. A classic project (no bindings) MUST keep compiling from `policy_yaml`, unchanged.
-- Editing a module or a role binding MUST recompile every agent in the project (fan-out). The project resolves once; the single bundle is reused for all its agents (they are identical until agent-scoped modules exist).
+- Editing a module or a role binding MUST recompile every agent in the project (fan-out). Each agent is resolved for its own column of the `(role, agent)` matrix and compiled to its **own** bundle; agents that resolve to identical policy share a single `opa` compile (memoized). *(This superseded the original single-shared-bundle design once the `(role, agent)` matrix landed — see `agent-policy-dimension-design.md`.)*
 - A recompile that can't resolve, or resolves but can't compile (e.g. `opa` absent), MUST leave existing bundles untouched. A broken or work-in-progress edit MUST NOT blank agents that were working.
 - Modular MUST be inferred from the presence of a role binding. There MUST NOT be a `policy_mode` column in this phase.
 - The serve path MUST NOT change: the bundle stays on the `Agent` row and the SDK fetches it as today.
@@ -19,14 +19,16 @@ Enforcement has to come from the composed modules, or the whole module system is
 
 Inferring modular from a role binding, rather than adding a `policy_mode` column, is deliberate on two counts. First, it needs no migration: the platform has no Alembic, and `create_all` can add tables but not columns to a populated DB, so a column would force that decision now for no functional gain. Second, binding a role is the meaningful opt-in — you have decided which roles map to which capabilities. Uploading a capability or boundary module alone must *not* flip enforcement, or dropping in a single boundary would resolve every agent to a deny-all default and brick them.
 
-Fan-out is required because the policy is project-level: one module edit changes every agent's effective policy, so every agent must recompile. Reusing one resolved bundle for all of them keeps that to a single `opa` call per edit.
+Fan-out is required because the policy is project-level: one module edit changes every agent's effective policy, so every agent must recompile. Each agent resolves its own `(role, agent)` column into its own bundle; agents whose columns resolve identically are compiled once (memoized), so a project whose agents all share the generic `*` column still pays a single `opa` call per edit.
 
-Leaving bundles untouched on an unresolvable edit is the safety property. The alternative — clearing bundles when the project doesn't resolve — turns a typo in the dashboard into an outage across every agent in the project. Failing safe means the last good policy keeps enforcing while `check` surfaces the problem. This is why the write endpoints do not reject an unresolvable edit: the store can hold a work-in-progress state, but only a clean resolve replaces what is enforced.
+Leaving *compiled bundles* untouched when an edit can't **build** (e.g. `opa` absent) is the safety property: clearing bundles on a transient build failure would turn it into an enforcement outage across every agent. Failing safe means the last good bundle keeps enforcing while `check` surfaces the problem.
+
+A later refinement tightened this: a write whose result is **semantically unresolvable** (a role importing an unknown capability, a capability with a `deny`) is now **rejected at write time** (409), not silently stored. The roles PUT validates the proposed bindings *before* writing; the module PUT/DELETE reject and roll back an edit that breaks resolution. So the store no longer holds an uncomposable state that keeps the old bundle with no signal — only a *transient* build failure (opa down) leaves the last-good bundle in place.
 
 ## Consequences
 
 - No schema change, no migration. Additive code only.
-- All modular agents in a project share one bundle (redundant bytes on each row). Deduping into a per-project bundle is a later optimization, not needed for correctness.
+- Each modular agent compiles to its own bundle from its `(role, agent)` column; agents that resolve to the same policy dedupe the `opa` compile (memoized). *(Originally all agents shared one bundle; the `(role, agent)` matrix made bundles per-agent so each carries only its own authority.)*
 - For a modular agent, `agent.policy_yaml` is no longer what's enforced (the resolved modules are). The dashboard must edit modules, not per-agent `policy_yaml`, for modular projects.
 - A saved-but-unresolvable project keeps enforcing its last good bundle; the divergence is visible through `check`, never silent.
 

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -565,6 +565,7 @@ def _main_resolve(args: argparse.Namespace) -> int:
     """Resolve the local project into effective policy per role and print it."""
     from hexgate.security import (
         LinkError,
+        effective_policy_by_role,
         load_local_modules,
         load_roles,
         resolve_for_project,
@@ -619,12 +620,7 @@ def _main_resolve(args: argparse.Namespace) -> int:
         # load_policy_set_from_dict / `hexgate policy build`. A bare top-level
         # role-keyed mapping would be read as a single flat AgentPolicy, and the
         # role keys silently dropped, compiling a deny-everything bundle.
-        payload = {
-            "roles": {
-                role: lr.effective[DEFAULT_ROLE_NAME].model_dump(mode="json")
-                for role, lr in sorted(result.by_role.items())
-            }
-        }
+        payload = {"roles": effective_policy_by_role(result)}
         roles_shown = sorted(result.by_role)
 
     text = yaml.safe_dump(payload, sort_keys=False)

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -95,7 +95,12 @@ from hexgate.security.modules import (
     Provenance,
     RuleTrace,
 )
-from hexgate.security.linker import link, link_policy_set, resolve_for_project
+from hexgate.security.linker import (
+    effective_policy_by_role,
+    link,
+    link_policy_set,
+    resolve_for_project,
+)
 from hexgate.security.analyzer import (
     PolicyLint,
     analyze,
@@ -158,6 +163,7 @@ __all__ = [
     "check_project",
     "link",
     "link_policy_set",
+    "effective_policy_by_role",
     "load_local_modules",
     "load_roles",
     "resolve_for_project",

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -87,12 +87,15 @@ from hexgate.security.policy_set import (
     load_policy_set_from_dict,
 )
 from hexgate.security.modules import (
+    DEFAULT_AGENT,
+    AgentBinding,
     LayerKind,
     LinkError,
     LinkResult,
     ModuleContent,
     ProjectLinkResult,
     Provenance,
+    RoleMatrix,
     RuleTrace,
 )
 from hexgate.security.linker import (
@@ -148,6 +151,9 @@ __all__ = [
     "AgentTargetPolicy",
     "AgentVia",
     "agent_target_key",
+    "DEFAULT_AGENT",
+    "AgentBinding",
+    "RoleMatrix",
     "LayerKind",
     "LinkError",
     "LinkResult",

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -22,7 +22,7 @@ always-false, subsumption.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -43,6 +43,7 @@ from hexgate.security.modules import (
     LinkResult,
     ModuleContent,
     ProjectLinkResult,
+    RoleMatrix,
 )
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySet, PolicySetError
 
@@ -117,72 +118,55 @@ def analyze(
 def check_project(
     boundaries: list[ModuleContent],
     library: list[ModuleContent],
-    roles: Mapping[str, Sequence[str]] | None,
+    roles: RoleMatrix | None,
     *,
-    agent_leaf: Sequence[ModuleContent] = (),
-    agent_boundaries: Sequence[ModuleContent] = (),
     manifest: AgentManifest | None = None,
 ) -> list[PolicyLint]:
     """Resolve a project and lint every role. See :func:`check` for the single-role
     form. A hard failure folds into one ``error`` lint, same contract as ``check``.
+
+    Lints the generic (``"*"``) agent view — the baseline every agent shares.
+    Per-agent lint refinement (tagging by executing agent) is a follow-up.
     """
     try:
-        result = resolve_for_project(
-            boundaries,
-            library,
-            roles,
-            agent_leaf=agent_leaf,
-            agent_boundaries=agent_boundaries,
-        )
+        result = resolve_for_project(boundaries, library, roles)
     except (LinkError, PolicySetError, ConstraintParseError) as exc:
         return [PolicyLint("link-error", "error", str(exc))]
-    return analyze_project(
-        result,
-        boundaries,
-        library,
-        roles,
-        agent_leaf=agent_leaf,
-        agent_boundaries=agent_boundaries,
-        manifest=manifest,
-    )
+    return analyze_project(result, boundaries, library, roles, manifest=manifest)
 
 
 def analyze_project(
     result: ProjectLinkResult,
     boundaries: list[ModuleContent],
     library: list[ModuleContent],
-    roles: Mapping[str, Sequence[str]] | None,
+    roles: RoleMatrix | None,
     *,
-    agent_leaf: Sequence[ModuleContent] = (),
-    agent_boundaries: Sequence[ModuleContent] = (),
     manifest: AgentManifest | None = None,
 ) -> list[PolicyLint]:
     """Soft lints across every role, each tagged with the role it fired in.
 
     A grant dead under one role's ceiling can be alive under another, so the
-    per-capability lints run once per role over that role's imported set. Two
-    project-level lints span roles: ``unused-capability`` (a library pack no role
-    imports) and ``no-default-role`` (roles defined but no ``default``, so unroled
-    callers get fail-closed deny).
+    per-capability lints run once per role over that role's imported set (for the
+    generic ``"*"`` agent view). Two project-level lints span roles:
+    ``unused-capability`` (a library pack no role/agent imports) and
+    ``no-default-role`` (roles defined but no ``default``, so unroled callers get
+    fail-closed deny).
     """
     # Same expansion the resolver used, so the analyzer lints exactly the roles
     # that compiled. Raises LinkError on an unknown capability, matching
     # resolve_for_project — but check_project resolves first, so by the time we
     # get here the same input has already succeeded.
     resolved = resolve_role_map(roles, library)
-    fences = [*boundaries, *agent_boundaries]
 
     lints: list[PolicyLint] = []
     for role, caps in resolved.items():
         role_result = result.by_role.get(role)
         if role_result is None:
             continue
-        for lint in analyze(
-            role_result, fences, [*caps, *agent_leaf], manifest=manifest
-        ):
+        for lint in analyze(role_result, boundaries, caps, manifest=manifest):
             lints.append(replace(lint, role=role))
 
-    lints += _unused_capabilities(library, resolved)
+    lints += _unused_capabilities(library, _all_imported_names(roles, library))
     if roles and DEFAULT_ROLE_NAME not in roles:
         lints.append(
             PolicyLint(
@@ -199,11 +183,31 @@ def analyze_project(
     return sorted(lints, key=lambda lint: SEVERITY_RANK[lint.severity])
 
 
+def _all_imported_names(
+    roles: RoleMatrix | None, library: list[ModuleContent]
+) -> set[str]:
+    """Capability names imported by ANY ``(role, agent)`` cell.
+
+    Spans the whole matrix (every agent column, not just ``"*"``) so a capability
+    used only by a named agent isn't falsely flagged unused. ``roles is None`` is
+    the all-compose case: every library capability counts as imported.
+    """
+    if roles is None:
+        return {cap.name for cap in library}
+    names: set[str] = set()
+    for cells in roles.values():
+        if isinstance(cells, Mapping):  # the (role, agent) matrix
+            for binding in cells.values():
+                names.update(binding.capabilities)
+        else:  # legacy flat `role: [names]`
+            names.update(cells)
+    return names
+
+
 def _unused_capabilities(
-    library: list[ModuleContent], resolved: Mapping[str, Sequence[ModuleContent]]
+    library: list[ModuleContent], imported: set[str]
 ) -> list[PolicyLint]:
-    """A library capability that no role imports. An authoring dead-weight signal."""
-    imported = {cap.name for caps in resolved.values() for cap in caps}
+    """A library capability that no role/agent imports. Authoring dead-weight."""
     return [
         PolicyLint(
             code="unused-capability",

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -37,6 +37,7 @@ from hexgate.security.linker import (
     resolve_role_map,
 )
 from hexgate.security.modules import (
+    DEFAULT_AGENT,
     GRANT_MODES,
     LayerKind,
     LinkError,
@@ -125,14 +126,46 @@ def check_project(
     """Resolve a project and lint every role. See :func:`check` for the single-role
     form. A hard failure folds into one ``error`` lint, same contract as ``check``.
 
-    Lints the generic (``"*"``) agent view — the baseline every agent shares.
-    Per-agent lint refinement (tagging by executing agent) is a follow-up.
+    Soft lints (dead-grant, drift, ...) run over the generic (``"*"``) agent
+    view — the baseline every agent shares; per-agent soft-lint refinement is a
+    follow-up. Hard **link errors** are surfaced for every named agent column too,
+    so a named-agent cell importing an unknown capability is visible on ``check``
+    (not just rejected at write time / silently fail-closed at serve time).
     """
     try:
         result = resolve_for_project(boundaries, library, roles)
     except (LinkError, PolicySetError, ConstraintParseError) as exc:
         return [PolicyLint("link-error", "error", str(exc))]
-    return analyze_project(result, boundaries, library, roles, manifest=manifest)
+    lints = analyze_project(result, boundaries, library, roles, manifest=manifest)
+    lints += _named_agent_link_errors(boundaries, library, roles)
+    return lints
+
+
+def _named_agent_link_errors(
+    boundaries: list[ModuleContent],
+    library: list[ModuleContent],
+    roles: RoleMatrix | None,
+) -> list[PolicyLint]:
+    """A ``link-error`` lint per named-agent column that doesn't resolve.
+
+    ``check_project`` resolves the ``"*"`` column for its soft lints; this covers
+    the hard-error case for named columns (an unknown-capability import in
+    ``roles: {member: {billing_bot: [nope]}}``), which ``"*"`` never touches."""
+    if not isinstance(roles, Mapping):
+        return []
+    named = {
+        agent
+        for cells in roles.values()
+        if isinstance(cells, Mapping)
+        for agent in cells
+    } - {DEFAULT_AGENT}
+    lints: list[PolicyLint] = []
+    for agent in sorted(named):
+        try:
+            resolve_for_project(boundaries, library, roles, agent=agent)
+        except (LinkError, PolicySetError, ConstraintParseError) as exc:
+            lints.append(PolicyLint("link-error", "error", f"agent {agent!r}: {exc}"))
+    return lints
 
 
 def analyze_project(

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -40,12 +40,14 @@ from hexgate.security.models import (
     ToolPolicy,
 )
 from hexgate.security.modules import (
+    DEFAULT_AGENT,
     GRANT_MODES,
     LinkError,
     LinkResult,
     ModuleContent,
     ProjectLinkResult,
     Provenance,
+    RoleMatrix,
     RuleTrace,
 )
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySet
@@ -73,19 +75,26 @@ def link_policy_set(
 
 
 def resolve_role_map(
-    roles: Mapping[str, Sequence[str]] | None, library: list[ModuleContent]
+    roles: RoleMatrix | Mapping[str, Sequence[str]] | None,
+    library: list[ModuleContent],
+    agent: str = DEFAULT_AGENT,
 ) -> dict[str, list[ModuleContent]]:
-    """Expand a role binding into ``{role: [capability modules]}``.
+    """Expand a role binding into ``{role: [capability modules]}`` for one agent.
 
     The one place that defines role expansion, shared by the resolver and the
     analyzer so they can never lint a different role set than what compiles.
 
+    ``agent`` is the executing agent name. Per role, its binding is the agent's
+    own cell if named, else the ``"*"`` generic cell, else empty (fail-closed) —
+    the ``(role, agent) -> (role, "*") -> deny`` fallback. A named agent's cell
+    **replaces** ``"*"`` (it does not merge), so an agent can be more restricted.
+
     ``roles is None`` (no ``roles.yaml``) means a single ``default`` importing
-    every capability — the all-compose back-compat default. An **empty** binding
-    (``{}``, a present-but-empty or typo'd ``roles.yaml``) is not the same: it
-    yields a fail-closed empty ``default``, so a mistake can't silently widen
-    access. A ``default`` bucket is always present. An unknown capability name is
-    a :class:`LinkError` (same contract from both callers).
+    every capability — the all-compose back-compat default, agent-independent. An
+    **empty** binding (``{}``, a present-but-empty or typo'd ``roles.yaml``) is
+    not the same: it yields a fail-closed empty ``default``, so a mistake can't
+    silently widen access. A ``default`` bucket is always present. An unknown
+    capability name is a :class:`LinkError` (same contract from both callers).
     """
     index: dict[str, ModuleContent] = {cap.name: cap for cap in library}
     if roles is None:
@@ -93,7 +102,13 @@ def resolve_role_map(
             DEFAULT_ROLE_NAME: [cap.name for cap in library]
         }
     else:
-        names_by_role = {name: list(sel) for name, sel in roles.items()}
+        names_by_role = {}
+        for role, cells in roles.items():
+            if isinstance(cells, Mapping):  # the (role, agent) matrix
+                binding = cells.get(agent) or cells.get(DEFAULT_AGENT)
+                names_by_role[role] = list(binding.capabilities) if binding else []
+            else:  # legacy flat `role: [names]` — agent-independent, = the "*" cell
+                names_by_role[role] = list(cells)
     names_by_role.setdefault(DEFAULT_ROLE_NAME, [])
 
     resolved: dict[str, list[ModuleContent]] = {}
@@ -103,8 +118,8 @@ def resolve_role_map(
             cap = index.get(name)
             if cap is None:
                 raise LinkError(
-                    f"role {role!r} imports unknown capability {name!r} "
-                    f"(known capabilities: {sorted(index)!r})"
+                    f"role {role!r} agent {agent!r} imports unknown capability "
+                    f"{name!r} (known capabilities: {sorted(index)!r})"
                 )
             caps.append(cap)
         resolved[role] = caps
@@ -114,35 +129,38 @@ def resolve_role_map(
 def resolve_for_project(
     boundaries: list[ModuleContent],
     library: list[ModuleContent],
-    roles: Mapping[str, Sequence[str]] | None,
+    roles: RoleMatrix | None,
     *,
-    agent_leaf: Sequence[ModuleContent] = (),
-    agent_boundaries: Sequence[ModuleContent] = (),
+    agent: str = DEFAULT_AGENT,
 ) -> ProjectLinkResult:
-    """Resolve a project into one role-keyed :class:`PolicySet`.
+    """Resolve a project into one role-keyed :class:`PolicySet`, **for one agent**.
 
-    Boundaries are role-independent: every role is folded against the same
-    ``boundaries + agent_boundaries``, so a role can only ever narrow, never
-    widen, its ceiling. A role names the **capabilities** it imports; the fold
-    (:func:`link`) is reused unchanged, once per role.
+    ``agent`` names the executing agent whose column of the ``(role, agent)``
+    matrix to resolve (defaulting to the ``"*"`` generic agent — the whole-project
+    view and the back-compat path). Each agent gets its own role-keyed result;
+    the caller folds one bundle per agent (Path A: the agent dimension is resolved
+    away here, so the compiled bundle and the engines stay role-keyed).
 
-    ``roles`` maps a role name to the capability *names* it selects (a name is a
-    :attr:`ModuleContent.name`). ``None`` (no binding at all) means a single
-    ``default`` role importing every capability — the all-compose back-compat
-    path. A ``default`` role is always present, so unroled callers get
-    fail-closed deny rather than a missing bucket.
+    Boundaries are role- *and* agent-independent global ceilings: every role is
+    folded against the same ``boundaries``, so no role or agent can widen its
+    ceiling. A ``(role, agent)`` cell names the **capabilities** it imports; the
+    fold (:func:`link`) is reused unchanged, once per role.
 
-    Every capability in the library is validated up front (:func:`_reject_capability_denies`),
-    not just the ones a role imports, so a malformed but unbound module fails
-    loudly instead of lurking until someone binds it.
+    ``roles`` is the normalized matrix (``role -> agent-or-"*" -> AgentBinding``).
+    ``None`` (no binding at all) means a single ``default`` role importing every
+    capability — the all-compose back-compat path. A ``default`` role is always
+    present, so unroled callers get fail-closed deny rather than a missing bucket.
+
+    Every capability in the library is validated up front
+    (:func:`_reject_capability_denies`), not just the ones a role imports, so a
+    malformed but unbound module fails loudly instead of lurking until bound.
     """
-    _reject_capability_denies([*library, *agent_leaf])
-    resolved = resolve_role_map(roles, library)
-    fences = [*boundaries, *agent_boundaries]
+    _reject_capability_denies(library)
+    resolved = resolve_role_map(roles, library, agent)
     by_role: dict[str, LinkResult] = {}
     effective: dict[str, AgentPolicy] = {}
     for role, caps in resolved.items():
-        result = link_policy_set(fences, [*caps, *agent_leaf])
+        result = link_policy_set(boundaries, caps)
         by_role[role] = result
         effective[role] = result.effective[DEFAULT_ROLE_NAME]
 

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -149,6 +149,24 @@ def resolve_for_project(
     return ProjectLinkResult(policy_set=PolicySet(effective), by_role=by_role)
 
 
+def effective_policy_by_role(
+    result: ProjectLinkResult, roles: Sequence[str] | None = None
+) -> dict[str, dict]:
+    """Role -> effective-policy JSON dict, in a canonical (sorted) role order.
+
+    The single serializer shared by ``hexgate policy resolve`` and the platform's
+    resolved-policy YAML, so the same project emits identical bytes from either
+    (the two used to iterate ``by_role`` in different orders — CLI sorted, the
+    platform in insertion order — quietly breaking that parity). ``roles``
+    narrows to a subset in the given order; ``None`` yields every role, sorted.
+    """
+    names = sorted(result.by_role) if roles is None else list(roles)
+    return {
+        name: result.by_role[name].effective[DEFAULT_ROLE_NAME].model_dump(mode="json")
+        for name in names
+    }
+
+
 def _reject_capability_denies(capabilities: Sequence[ModuleContent]) -> None:
     """A capability that denies is a config error, checked over the WHOLE library.
 

--- a/hexgate/security/module_loader.py
+++ b/hexgate/security/module_loader.py
@@ -19,7 +19,13 @@ from typing import Protocol
 import yaml
 
 from hexgate.security.models import AgentPolicy
-from hexgate.security.modules import LayerKind, ModuleContent
+from hexgate.security.modules import (
+    DEFAULT_AGENT,
+    AgentBinding,
+    LayerKind,
+    ModuleContent,
+    RoleMatrix,
+)
 
 BOUNDARY_SUBDIR = ("policies", "boundaries")
 CAPABILITY_SUBDIR = ("policies", "capabilities")
@@ -61,8 +67,8 @@ def load_local_modules(
     return boundaries, capabilities
 
 
-def load_roles(root: str | Path) -> dict[str, list[str]] | None:
-    """Load the role bindings from ``<root>/roles.yaml``.
+def load_roles(root: str | Path) -> RoleMatrix | None:
+    """Load the role bindings from ``<root>/roles.yaml`` as a ``(role, agent)`` matrix.
 
     Returns ``None`` when the file is **absent** — the signal the resolver reads
     as "no roles, one default importing every capability" (all-compose
@@ -71,12 +77,20 @@ def load_roles(root: str | Path) -> dict[str, list[str]] | None:
     so a one-character mistake can't silently widen access. Boundaries are never
     listed here; a role selects capabilities only.
 
-    Shape::
+    A role maps either to a **flat** capability list (applies to any agent) or to
+    a per-agent **matrix**; both normalize to ``{agent-or-"*": AgentBinding}``::
 
         version: 1
         roles:
-          support: [read_only, refunds_small]
-          default: [read_only]
+          support: [read_only]                 # flat: sugar for {"*": [read_only]}
+          member:
+            "*": [read_only]                    # generic default for any agent
+            billing_bot:                        # a named agent, more specific
+              capabilities: [read_only, payments]
+            triage_bot: [read_only]             # agent value may also be a bare list
+
+    A named agent's binding **replaces** ``"*"`` for that agent (it does not merge),
+    so an agent can be more restricted than the role's generic baseline.
     """
     path = Path(root) / ROLES_FILE
     if not path.is_file():
@@ -103,16 +117,57 @@ def load_roles(root: str | Path) -> dict[str, list[str]] | None:
     if raw is None:
         return {}
     if not isinstance(raw, dict):
-        raise ValueError(f"{ROLES_FILE}: 'roles' must be a mapping of role -> [names]")
+        raise ValueError(f"{ROLES_FILE}: 'roles' must be a mapping of role -> binding")
 
-    roles: dict[str, list[str]] = {}
-    for role, names in raw.items():
-        if not isinstance(names, list) or not all(isinstance(n, str) for n in names):
+    return {
+        str(role): _parse_role_binding(str(role), value) for role, value in raw.items()
+    }
+
+
+def _parse_role_binding(role: str, value: object) -> dict[str, AgentBinding]:
+    """Normalize one role's value into ``{agent-or-"*": AgentBinding}``.
+
+    A bare list is the flat form (the generic ``"*"`` agent); a mapping is the
+    per-agent matrix, each agent's value itself either a bare capability list or a
+    ``{capabilities: [...]}`` block.
+    """
+    if isinstance(value, list):
+        return {DEFAULT_AGENT: _agent_binding(role, DEFAULT_AGENT, value)}
+    if isinstance(value, dict):
+        return {
+            str(agent): _agent_binding(role, str(agent), cell)
+            for agent, cell in value.items()
+        }
+    raise ValueError(
+        f"{ROLES_FILE}: role {role!r} must map to a capability list or an "
+        f"agent mapping (got {type(value).__name__})"
+    )
+
+
+def _agent_binding(role: str, agent: str, cell: object) -> AgentBinding:
+    """One ``(role, agent)`` cell → :class:`AgentBinding`. ``cell`` is a bare
+    capability list or a ``{capabilities: [...]}`` mapping."""
+    if isinstance(cell, list):
+        caps = cell
+    elif isinstance(cell, dict):
+        unknown = set(cell) - {"capabilities"}
+        if unknown:
             raise ValueError(
-                f"{ROLES_FILE}: role {role!r} must map to a list of capability names"
+                f"{ROLES_FILE}: role {role!r} agent {agent!r} has unknown key(s) "
+                f"{sorted(unknown)!r} (expected 'capabilities')"
             )
-        roles[str(role)] = list(names)
-    return roles
+        caps = cell.get("capabilities", [])
+    else:
+        raise ValueError(
+            f"{ROLES_FILE}: role {role!r} agent {agent!r} must be a capability list "
+            f"or a {{capabilities: [...]}} mapping (got {type(cell).__name__})"
+        )
+    if not isinstance(caps, list) or not all(isinstance(c, str) for c in caps):
+        raise ValueError(
+            f"{ROLES_FILE}: role {role!r} agent {agent!r} capabilities must be a "
+            f"list of capability names"
+        )
+    return AgentBinding(capabilities=tuple(caps))
 
 
 def _read_dir(directory: Path, kind: LayerKind) -> list[ModuleContent]:

--- a/hexgate/security/modules.py
+++ b/hexgate/security/modules.py
@@ -27,6 +27,33 @@ LayerKind = Literal["boundary", "capability"]
 # and the analyzer's lints so they can't drift out of lockstep.
 GRANT_MODES: tuple[str, ...] = ("allow", "approval_required")
 
+# The wildcard / default agent key in a role binding — applies to any executing
+# agent not named explicitly. Deliberately distinct from the default executing
+# agent NAME ("main") and from the default ROLE name, so the three never collide.
+DEFAULT_AGENT = "*"
+
+
+@dataclass(frozen=True)
+class AgentBinding:
+    """One ``(role, agent)`` cell of a role binding.
+
+    A thin *selection*, not authored policy: ``capabilities`` names the capability
+    modules this agent imports for the role. A named agent's binding **replaces**
+    the ``"*"`` default for that agent (so an agent can be *more restricted*),
+    never merges with it — the reading that lets capability-selection alone
+    express "this agent does less than the role generally allows".
+
+    (Reach edges — handoff / agent-as-tool — attach here in a later commit; kept
+    to capabilities for now so the capabilities matrix lands first.)
+    """
+
+    capabilities: tuple[str, ...] = ()
+
+
+# role -> agent-or-"*" -> binding. The normalized shape of a project's role
+# bindings; a flat ``role: [caps]`` is sugar for ``{role: {"*": <caps>}}``.
+RoleMatrix = dict[str, dict[str, AgentBinding]]
+
 
 class LinkError(ValueError):
     """Raised when a bundle of modules can't be composed.

--- a/platform/api/hexgate_api/core/locks.py
+++ b/platform/api/hexgate_api/core/locks.py
@@ -1,0 +1,26 @@
+"""Per-project in-process locks serializing a policy write + its recompile.
+
+A policy write (module or role edit) resolves the project, compiles a bundle,
+then commits. Two overlapping writes on the same project can otherwise interleave
+those steps and commit bundles out of order: writer A resolves R1 and yields on
+the opa compile, B commits R2 and its bundles, then A commits the R1 bundle over
+them — DB and ``/policy/resolve`` say R2 while agents enforce R1, with no error.
+Holding this lock across the whole read→write→recompile makes them serial.
+
+Scope: one event loop / process only. Under multiple uvicorn workers it does not
+serialize across processes; the durable fix is a DB advisory lock (Postgres
+``pg_advisory_xact_lock``), deferred here because policy writes are admin-only
+and infrequent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+
+_locks: defaultdict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
+
+def project_lock(project_id: str) -> asyncio.Lock:
+    """The lock for one project — the same object per id within this process."""
+    return _locks[project_id]

--- a/platform/api/hexgate_api/features/agents/compiler.py
+++ b/platform/api/hexgate_api/features/agents/compiler.py
@@ -12,6 +12,13 @@ from hexgate_api.schemas import AgentManifest
 
 logger = logging.getLogger("hexgate.platform.agents.compiler")
 
+# Fail-closed starter policy for a brand-new agent in a MODULAR project. The
+# agent's real enforcement is the shared modular bundle; policy_yaml is only the
+# SDK's pydantic fallback if that bundle can't be built or served (e.g. opa
+# down). A modular agent must fall back to deny-all, not to a permissive
+# tool-derived starter — otherwise a transient compile failure fails open.
+DENY_ALL_POLICY_YAML = "version: 1\ndefault_policy:\n  mode: deny\n"
+
 
 def compile_bundle(
     policy_yaml: str, sign: Callable[[bytes], bytes]

--- a/platform/api/hexgate_api/features/agents/router.py
+++ b/platform/api/hexgate_api/features/agents/router.py
@@ -179,19 +179,24 @@ async def api_update_agent(
     session: AsyncSession = Depends(get_session),
 ) -> AgentRead:
     from hexgate_api.core.keystore import keystore
+    from hexgate_api.core.locks import project_lock
 
     await ensure_default_project(session)
-    agent = await update_agent(
-        session,
-        project_id,
-        name,
-        agent_yaml=body.agent_yaml,
-        policy_yaml=body.policy_yaml,
-        system_md=body.system_md,
-        # Compile + sign the policy into a WASM bundle at save time, using
-        # the platform's root key (same key that signs biscuits).
-        sign=keystore.sign,
-    )
+    # Hold the project lock: this compiles + writes a bundle, so it must not
+    # interleave with recompile_project (a concurrent policy write) and commit
+    # out of order. See core.locks.
+    async with project_lock(project_id):
+        agent = await update_agent(
+            session,
+            project_id,
+            name,
+            agent_yaml=body.agent_yaml,
+            policy_yaml=body.policy_yaml,
+            system_md=body.system_md,
+            # Compile + sign the policy into a WASM bundle at save time, using
+            # the platform's root key (same key that signs biscuits).
+            sign=keystore.sign,
+        )
     if agent is None:
         raise HTTPException(status_code=404, detail="agent not found")
     return _agent_read(agent)
@@ -348,10 +353,14 @@ async def api_register_agent(
     edits are preserved.
     """
     from hexgate_api.core.keystore import keystore
+    from hexgate_api.core.locks import project_lock
 
-    version, created = await register_manifest(
-        session, project_id, body.manifest, sign=keystore.sign
-    )
+    # Hold the project lock: a first-time register compiles + writes a bundle,
+    # so it must not interleave with recompile_project and commit out of order.
+    async with project_lock(project_id):
+        version, created = await register_manifest(
+            session, project_id, body.manifest, sign=keystore.sign
+        )
     response.status_code = 201 if created else 200
     return RegisterAgentResponse(
         agent_id=version.agent_id,

--- a/platform/api/hexgate_api/features/agents/router.py
+++ b/platform/api/hexgate_api/features/agents/router.py
@@ -354,10 +354,19 @@ async def api_register_agent(
     """
     from hexgate_api.core.keystore import keystore
     from hexgate_api.core.locks import project_lock
+    from hexgate_api.features.agents.service import get_agent
 
-    # Hold the project lock: a first-time register compiles + writes a bundle,
-    # so it must not interleave with recompile_project and commit out of order.
-    async with project_lock(project_id):
+    # Only a FIRST registration compiles + writes a bundle; re-registering an
+    # existing agent just snapshots the manifest (no compile). Take the project
+    # lock only in that case — otherwise a fleet redeploy's no-op re-registers
+    # (`hexgate serve` auto-registers on startup) would all queue behind the lock
+    # and any in-flight recompile for nothing.
+    if await get_agent(session, project_id, body.manifest.name) is None:
+        async with project_lock(project_id):
+            version, created = await register_manifest(
+                session, project_id, body.manifest, sign=keystore.sign
+            )
+    else:
         version, created = await register_manifest(
             session, project_id, body.manifest, sign=keystore.sign
         )

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -91,16 +91,34 @@ def _apply_bundle(agent: Agent, bundle: tuple[bytes, str, bytes] | None) -> None
         agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
 
 
+# The generic/default agent key — the "*" column of the (role, agent) matrix.
+# Mirrors hexgate.security.DEFAULT_AGENT; kept local so this module doesn't import
+# the SDK at load (the SDK is imported lazily on the modular path only).
+_DEFAULT_AGENT = "*"
+
+
 async def _modular_bundle(
-    session: AsyncSession, project_id: str, sign: Callable[[bytes], bytes]
+    session: AsyncSession,
+    project_id: str,
+    sign: Callable[[bytes], bytes],
+    *,
+    agent: str = _DEFAULT_AGENT,
+    compiled: dict[str, tuple[bytes, str, bytes] | None] | None = None,
 ) -> tuple[bytes, str, bytes] | None:
-    """Resolve a modular project once and compile its single shared bundle.
+    """Resolve + compile the bundle for ONE agent's column of the matrix (Path A).
+
+    ``agent`` selects the executing agent's ``(role, agent)`` column (default the
+    generic ``"*"``). Each agent resolves to its own role-keyed bundle, so a
+    signed artifact carries only that agent's authority.
 
     Returns ``None`` (never raises) when the project doesn't resolve or the
     resolved policy can't compile (e.g. ``opa`` absent), so callers can leave
     live bundles untouched — the fail-safe in docs/adr/R-POL-002. The SDK
     resolve exceptions are imported here, on the modular path only, so a classic
     save never touches the SDK.
+
+    ``compiled`` is an optional sha256-keyed compile cache: a fan-out over agents
+    that resolve to identical policy then shells out to ``opa`` only once.
 
     The except tuple also covers ``yaml.YAMLError`` / pydantic ``ValidationError``:
     ``resolved_policy_yaml`` re-parses every stored module, and a row valid at
@@ -115,7 +133,9 @@ async def _modular_bundle(
     from hexgate_api.features.policy_modules import service as modules
 
     try:
-        policy_yaml = await modules.resolved_policy_yaml(session, project_id)
+        policy_yaml = await modules.resolved_policy_yaml(
+            session, project_id, agent=agent
+        )
     except (
         LinkError,
         PolicySetError,
@@ -124,12 +144,17 @@ async def _modular_bundle(
         yaml.YAMLError,
     ) as exc:
         logger.warning(
-            "modular project %s does not resolve; no bundle: %s", project_id, exc
+            "modular project %s agent %r does not resolve; no bundle: %s",
+            project_id,
+            agent,
+            exc,
         )
         return None
-    # opa is a synchronous subprocess — run it off the event loop so a policy
-    # write doesn't block every other in-flight request for the compile.
-    return await asyncio.to_thread(compile_bundle, policy_yaml, sign)
+    # opa is a synchronous subprocess — run it off the event loop (inside
+    # _compile_memoized) so a policy write doesn't block every in-flight request.
+    return await _compile_memoized(
+        {} if compiled is None else compiled, policy_yaml, sign
+    )
 
 
 async def bundle_for_agent(
@@ -137,14 +162,14 @@ async def bundle_for_agent(
 ) -> tuple[bytes, str, bytes] | None:
     """Compile the signed bundle for one agent, from the right source.
 
-    Modular project (has a role binding): the project's resolved role-keyed
-    policy. Classic project: the agent's own ``policy_yaml`` (unchanged
-    behavior). See docs/adr/R-POL-002.
+    Modular project (has a role binding): the agent's own column of the resolved
+    ``(role, agent)`` matrix (Path A — one bundle per agent, keyed by name).
+    Classic project: the agent's own ``policy_yaml`` (unchanged). See R-POL-002.
     """
     from hexgate_api.features.policy_modules import service as modules
 
     if await modules.is_modular(session, agent.project_id):
-        return await _modular_bundle(session, agent.project_id, sign)
+        return await _modular_bundle(session, agent.project_id, sign, agent=agent.name)
     return await asyncio.to_thread(compile_bundle, agent.policy_yaml, sign)
 
 
@@ -153,11 +178,12 @@ async def recompile_project(
 ) -> int | None:
     """Recompile every agent in a project after its modules or roles change.
 
-    Modular: resolve + compile once, reusing the single bundle for all agents.
-    On an unresolvable project (or a resolved policy that won't compile) live
-    bundles are left untouched — the fail-safe in docs/adr/R-POL-002, because the
-    modules haven't changed what each agent should enforce, we just can't build
-    it right now.
+    Modular: resolve + compile **per agent** (each agent gets its own column of
+    the (role, agent) matrix), memoizing the opa compile so agents that resolve
+    identically build once. It's all-or-nothing: if ANY agent can't be built
+    (unresolvable project, or a resolved policy that won't compile), live bundles
+    are left untouched for the WHOLE project — the fail-safe in docs/adr/R-POL-002
+    (never a partial update where some agents move and others are stale).
 
     Classic — including a project that just dropped its last role binding, so
     enforcement returns to each agent's ``policy_yaml`` — recompiles each agent
@@ -180,11 +206,17 @@ async def recompile_project(
 
     count = 0
     if await modules.is_modular(session, project_id):
-        bundle = await _modular_bundle(session, project_id, sign)
-        if bundle is None:
-            return None  # can't build now: leave live bundles as-is
+        compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
+        built: dict[str, tuple[bytes, str, bytes]] = {}
         for agent in agents:
-            _apply_bundle(agent, bundle)  # same shared bundle for every agent
+            bundle = await _modular_bundle(
+                session, project_id, sign, agent=agent.name, compiled=compiled
+            )
+            if bundle is None:
+                return None  # any agent unbuildable → keep ALL live (no partial state)
+            built[agent.id] = bundle
+        for agent in agents:
+            _apply_bundle(agent, built[agent.id])  # each agent's own bundle
             session.add(agent)
             count += 1
     else:
@@ -316,17 +348,21 @@ async def backfill_bundles(
 
     count = 0
     for project_id, project_agents in pending.items():
+        compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
         if await modules.is_modular(session, project_id):
-            # Resolve + compile once for the whole project, not once per agent.
-            bundle = await _modular_bundle(session, project_id, sign)
-            if bundle is None:
-                continue
+            # Per agent: each resolves its own column of the (role, agent) matrix,
+            # memoized so agents that resolve identically compile once. A bundle
+            # that can't build is skipped (agent stays bundle-less), not fatal.
             for agent in project_agents:
-                _apply_bundle(agent, bundle)  # same shared bundle for every agent
+                bundle = await _modular_bundle(
+                    session, project_id, sign, agent=agent.name, compiled=compiled
+                )
+                if bundle is None:
+                    continue
+                _apply_bundle(agent, bundle)
                 session.add(agent)
                 count += 1
         else:
-            compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
             for agent in project_agents:
                 bundle = await _compile_memoized(compiled, agent.policy_yaml, sign)
                 if bundle is None:

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -124,24 +124,13 @@ async def _modular_bundle(
     write time can later fail to parse (an SDK schema tightening, or a row edited
     directly in the DB). Those must fold to "no bundle", not escape as a 500.
     """
-    import yaml
-    from pydantic import ValidationError
-
-    from hexgate.security import LinkError, PolicySetError
-    from hexgate.security.constraints import ConstraintParseError
     from hexgate_api.features.policy_modules import service as modules
 
     try:
         policy_yaml = await modules.resolved_policy_yaml(
             session, project_id, agent=agent
         )
-    except (
-        LinkError,
-        PolicySetError,
-        ConstraintParseError,
-        ValidationError,
-        yaml.YAMLError,
-    ) as exc:
+    except modules.compose_error_types() as exc:
         logger.warning(
             "modular project %s agent %r does not resolve; no bundle: %s",
             project_id,
@@ -162,25 +151,14 @@ async def _resolved_yaml_or_none(
     """Resolve every named agent's policy YAML in one store read (fan-out helper).
 
     Returns ``None`` (never raises) if the project doesn't compose for some agent —
-    the R-POL-002 fail-safe, so callers keep live bundles. Mirrors
-    :func:`_modular_bundle`'s except set. Resolving here (once) rather than per
-    agent avoids re-reading the store + re-parsing every module N times."""
-    import yaml
-    from pydantic import ValidationError
-
-    from hexgate.security import LinkError, PolicySetError
-    from hexgate.security.constraints import ConstraintParseError
+    the R-POL-002 fail-safe, so callers keep live bundles. Resolving here (once)
+    rather than per agent avoids re-reading the store + re-parsing every module N
+    times."""
     from hexgate_api.features.policy_modules import service as modules
 
     try:
         return await modules.resolved_yaml_by_agent(session, project_id, agent_names)
-    except (
-        LinkError,
-        PolicySetError,
-        ConstraintParseError,
-        ValidationError,
-        yaml.YAMLError,
-    ) as exc:
+    except modules.compose_error_types() as exc:
         logger.warning(
             "modular project %s does not resolve; no bundles: %s", project_id, exc
         )

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -60,6 +60,24 @@ async def get_agent(session: AsyncSession, project_id: str, name: str) -> Agent 
     return (await session.exec(stmt)).first()
 
 
+async def _compile_memoized(
+    cache: dict[str, tuple[bytes, str, bytes] | None],
+    policy_yaml: str,
+    sign: Callable[[bytes], bytes],
+) -> tuple[bytes, str, bytes] | None:
+    """Compile ``policy_yaml`` once per distinct policy within a fan-out.
+
+    A classic recompile/backfill runs opa once per agent, serially — but agents
+    routinely share a policy (the seeds especially), so identical policies were
+    recompiled N times, delaying startup readiness. Memoize by ``sha256`` of the
+    policy text so each distinct policy shells out to opa at most once per call.
+    """
+    key = hashlib.sha256(policy_yaml.encode("utf-8")).hexdigest()
+    if key not in cache:
+        cache[key] = await asyncio.to_thread(compile_bundle, policy_yaml, sign)
+    return cache[key]
+
+
 def _apply_bundle(agent: Agent, bundle: tuple[bytes, str, bytes] | None) -> None:
     """Set an agent's three bundle columns from a compile result, or null all
     three when ``bundle`` is ``None`` (drop a stale bundle → the SDK falls back
@@ -170,11 +188,12 @@ async def recompile_project(
             session.add(agent)
             count += 1
     else:
+        compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
         for agent in agents:
-            # Classic: each agent from its own policy. A policy that no longer
-            # compiles nulls the stale bundle (fall back to pydantic), never
-            # keeps a wrong one.
-            bundle = await asyncio.to_thread(compile_bundle, agent.policy_yaml, sign)
+            # Classic: each agent from its own policy (memoized per distinct
+            # policy). A policy that no longer compiles nulls the stale bundle
+            # (fall back to pydantic), never keeps a wrong one.
+            bundle = await _compile_memoized(compiled, agent.policy_yaml, sign)
             _apply_bundle(agent, bundle)
             session.add(agent)
             count += 1
@@ -307,10 +326,9 @@ async def backfill_bundles(
                 session.add(agent)
                 count += 1
         else:
+            compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
             for agent in project_agents:
-                bundle = await asyncio.to_thread(
-                    compile_bundle, agent.policy_yaml, sign
-                )
+                bundle = await _compile_memoized(compiled, agent.policy_yaml, sign)
                 if bundle is None:
                     continue  # leave bundle-less (already None) — don't count
                 _apply_bundle(agent, bundle)

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -233,8 +233,22 @@ async def recompile_project(
             session.add(agent)
             count += 1
     else:
+        from hexgate_api.features.agents.compiler import DENY_ALL_POLICY_YAML
+
         compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
         for agent in agents:
+            # An agent registered while the project was modular kept a deny-all
+            # policy_yaml as its fail-closed fallback; on a revert to classic that
+            # fallback becomes the ENFORCED policy. Fail-closed (safe), but the
+            # operator should re-author it — surface it rather than silently
+            # compiling deny-all. (See docs/adr/R-POL-002.)
+            if agent.policy_yaml == DENY_ALL_POLICY_YAML:
+                logger.warning(
+                    "agent %s in project %s reverted to classic with a deny-all "
+                    "fallback policy; edit its policy to grant tools",
+                    agent.name,
+                    project_id,
+                )
             # Classic: each agent from its own policy (memoized per distinct
             # policy). A policy that no longer compiles nulls the stale bundle
             # (fall back to pydantic), never keeps a wrong one.

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -25,6 +25,11 @@ from hexgate_api.features.agents.compiler import (
     compile_bundle,
 )
 
+# The generic/default agent key. Shared from the policy-modules service (the one
+# platform copy) so store and compile can't drift on the sentinel. This import is
+# SDK-free — policy_modules.service imports the SDK lazily — so it's safe at load.
+from hexgate_api.features.policy_modules.service import DEFAULT_AGENT
+
 logger = logging.getLogger("hexgate.platform.agents")
 
 
@@ -91,18 +96,12 @@ def _apply_bundle(agent: Agent, bundle: tuple[bytes, str, bytes] | None) -> None
         agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
 
 
-# The generic/default agent key — the "*" column of the (role, agent) matrix.
-# Mirrors hexgate.security.DEFAULT_AGENT; kept local so this module doesn't import
-# the SDK at load (the SDK is imported lazily on the modular path only).
-_DEFAULT_AGENT = "*"
-
-
 async def _modular_bundle(
     session: AsyncSession,
     project_id: str,
     sign: Callable[[bytes], bytes],
     *,
-    agent: str = _DEFAULT_AGENT,
+    agent: str = DEFAULT_AGENT,
     compiled: dict[str, tuple[bytes, str, bytes] | None] | None = None,
 ) -> tuple[bytes, str, bytes] | None:
     """Resolve + compile the bundle for ONE agent's column of the matrix (Path A).
@@ -157,6 +156,37 @@ async def _modular_bundle(
     )
 
 
+async def _resolved_yaml_or_none(
+    session: AsyncSession, project_id: str, agent_names: set[str]
+) -> dict[str, str] | None:
+    """Resolve every named agent's policy YAML in one store read (fan-out helper).
+
+    Returns ``None`` (never raises) if the project doesn't compose for some agent —
+    the R-POL-002 fail-safe, so callers keep live bundles. Mirrors
+    :func:`_modular_bundle`'s except set. Resolving here (once) rather than per
+    agent avoids re-reading the store + re-parsing every module N times."""
+    import yaml
+    from pydantic import ValidationError
+
+    from hexgate.security import LinkError, PolicySetError
+    from hexgate.security.constraints import ConstraintParseError
+    from hexgate_api.features.policy_modules import service as modules
+
+    try:
+        return await modules.resolved_yaml_by_agent(session, project_id, agent_names)
+    except (
+        LinkError,
+        PolicySetError,
+        ConstraintParseError,
+        ValidationError,
+        yaml.YAMLError,
+    ) as exc:
+        logger.warning(
+            "modular project %s does not resolve; no bundles: %s", project_id, exc
+        )
+        return None
+
+
 async def bundle_for_agent(
     session: AsyncSession, agent: Agent, sign: Callable[[bytes], bytes]
 ) -> tuple[bytes, str, bytes] | None:
@@ -206,12 +236,17 @@ async def recompile_project(
 
     count = 0
     if await modules.is_modular(session, project_id):
+        # Resolve every agent's column in ONE store read, then compile each
+        # (memoized so agents that resolve identically shell out to opa once).
+        yaml_by_agent = await _resolved_yaml_or_none(
+            session, project_id, {a.name for a in agents}
+        )
+        if yaml_by_agent is None:
+            return None  # unresolvable → keep ALL live (fail-safe)
         compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
         built: dict[str, tuple[bytes, str, bytes]] = {}
         for agent in agents:
-            bundle = await _modular_bundle(
-                session, project_id, sign, agent=agent.name, compiled=compiled
-            )
+            bundle = await _compile_memoized(compiled, yaml_by_agent[agent.name], sign)
             if bundle is None:
                 return None  # any agent unbuildable → keep ALL live (no partial state)
             built[agent.id] = bundle
@@ -350,12 +385,20 @@ async def backfill_bundles(
     for project_id, project_agents in pending.items():
         compiled: dict[str, tuple[bytes, str, bytes] | None] = {}
         if await modules.is_modular(session, project_id):
-            # Per agent: each resolves its own column of the (role, agent) matrix,
-            # memoized so agents that resolve identically compile once. A bundle
-            # that can't build is skipped (agent stays bundle-less), not fatal.
+            # Resolve all agents' columns in one store read; if the project
+            # doesn't resolve, leave every agent bundle-less (consistent — same
+            # as recompile). Backfill stays best-effort only on the opa COMPILE:
+            # unlike recompile it fills the agents that compile and skips the rest,
+            # because startup backfill is opportunistic (a skipped agent falls back
+            # to pydantic on its own policy_yaml) and shouldn't fail the whole boot.
+            yaml_by_agent = await _resolved_yaml_or_none(
+                session, project_id, {a.name for a in project_agents}
+            )
+            if yaml_by_agent is None:
+                continue
             for agent in project_agents:
-                bundle = await _modular_bundle(
-                    session, project_id, sign, agent=agent.name, compiled=compiled
+                bundle = await _compile_memoized(
+                    compiled, yaml_by_agent[agent.name], sign
                 )
                 if bundle is None:
                     continue

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -70,14 +70,28 @@ async def _modular_bundle(
     live bundles untouched — the fail-safe in docs/adr/R-POL-002. The SDK
     resolve exceptions are imported here, on the modular path only, so a classic
     save never touches the SDK.
+
+    The except tuple also covers ``yaml.YAMLError`` / pydantic ``ValidationError``:
+    ``resolved_policy_yaml`` re-parses every stored module, and a row valid at
+    write time can later fail to parse (an SDK schema tightening, or a row edited
+    directly in the DB). Those must fold to "no bundle", not escape as a 500.
     """
+    import yaml
+    from pydantic import ValidationError
+
     from hexgate.security import LinkError, PolicySetError
     from hexgate.security.constraints import ConstraintParseError
     from hexgate_api.features.policy_modules import service as modules
 
     try:
         policy_yaml = await modules.resolved_policy_yaml(session, project_id)
-    except (LinkError, PolicySetError, ConstraintParseError) as exc:
+    except (
+        LinkError,
+        PolicySetError,
+        ConstraintParseError,
+        ValidationError,
+        yaml.YAMLError,
+    ) as exc:
         logger.warning(
             "modular project %s does not resolve; no bundle: %s", project_id, exc
         )
@@ -105,7 +119,7 @@ async def bundle_for_agent(
 
 async def recompile_project(
     session: AsyncSession, project_id: str, sign: Callable[[bytes], bytes]
-) -> int:
+) -> int | None:
     """Recompile every agent in a project after its modules or roles change.
 
     Modular: resolve + compile once, reusing the single bundle for all agents.
@@ -119,7 +133,13 @@ async def recompile_project(
     from its own policy and **nulls the bundle when that policy no longer
     compiles**, matching ``update_agent`` and the ``Agent.compiled_wasm``
     invariant (a broken policy drops its stale bundle so the SDK falls back to
-    pydantic rather than serving a now-wrong WASM). Returns the count touched.
+    pydantic rather than serving a now-wrong WASM).
+
+    Returns the number of agents whose bundle was set, or ``None`` when the
+    project is modular but its bundle could not be built (live bundles left
+    untouched). The ``None`` return lets a caller distinguish "nothing to do"
+    (``0``: no agents) from "could not build" — the classic→modular flip relies
+    on it to avoid leaving agents on a stale classic bundle (see the roles PUT).
     """
     from hexgate_api.features.policy_modules import service as modules
 
@@ -131,7 +151,7 @@ async def recompile_project(
     if await modules.is_modular(session, project_id):
         bundle = await _modular_bundle(session, project_id, sign)
         if bundle is None:
-            return 0  # fail-safe: leave live bundles as-is
+            return None  # can't build now: leave live bundles as-is
         for agent in agents:
             agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
             session.add(agent)
@@ -361,7 +381,19 @@ async def register_manifest(
         # Brand-new agent — seed the policy + bundle so the dashboard's
         # Policies editor has something to render and ``hexgate serve``
         # has a signed bundle to ship.
-        agent.policy_yaml = _default_policy_for_manifest(manifest)
+        #
+        # In a MODULAR project the agent enforces the shared modular bundle;
+        # policy_yaml is only the pydantic fallback if that bundle can't be
+        # built/served. Seed it deny-all (fail closed) rather than the
+        # permissive tool-derived starter, so a transient modular-compile
+        # failure can't hand the new agent more than the modules would allow.
+        from hexgate_api.features.agents.compiler import DENY_ALL_POLICY_YAML
+        from hexgate_api.features.policy_modules import service as modules
+
+        if await modules.is_modular(session, project_id):
+            agent.policy_yaml = DENY_ALL_POLICY_YAML
+        else:
+            agent.policy_yaml = _default_policy_for_manifest(manifest)
         bundle = await bundle_for_agent(session, agent, sign)
         if bundle is not None:
             agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -6,6 +6,7 @@ upsert path (manifest → Agent + AgentVersion + Tool rows, with a generated
 starter policy on first registration).
 """
 
+import asyncio
 import hashlib
 import json
 import logging
@@ -57,6 +58,103 @@ async def list_agents(session: AsyncSession, project_id: str) -> list[Agent]:
 async def get_agent(session: AsyncSession, project_id: str, name: str) -> Agent | None:
     stmt = select(Agent).where(Agent.project_id == project_id, Agent.name == name)
     return (await session.exec(stmt)).first()
+
+
+async def _modular_bundle(
+    session: AsyncSession, project_id: str, sign: Callable[[bytes], bytes]
+) -> tuple[bytes, str, bytes] | None:
+    """Resolve a modular project once and compile its single shared bundle.
+
+    Returns ``None`` (never raises) when the project doesn't resolve or the
+    resolved policy can't compile (e.g. ``opa`` absent), so callers can leave
+    live bundles untouched — the fail-safe in docs/adr/R-POL-002. The SDK
+    resolve exceptions are imported here, on the modular path only, so a classic
+    save never touches the SDK.
+    """
+    from hexgate.security import LinkError, PolicySetError
+    from hexgate.security.constraints import ConstraintParseError
+    from hexgate_api.features.policy_modules import service as modules
+
+    try:
+        policy_yaml = await modules.resolved_policy_yaml(session, project_id)
+    except (LinkError, PolicySetError, ConstraintParseError) as exc:
+        logger.warning(
+            "modular project %s does not resolve; no bundle: %s", project_id, exc
+        )
+        return None
+    # opa is a synchronous subprocess — run it off the event loop so a policy
+    # write doesn't block every other in-flight request for the compile.
+    return await asyncio.to_thread(compile_bundle, policy_yaml, sign)
+
+
+async def bundle_for_agent(
+    session: AsyncSession, agent: Agent, sign: Callable[[bytes], bytes]
+) -> tuple[bytes, str, bytes] | None:
+    """Compile the signed bundle for one agent, from the right source.
+
+    Modular project (has a role binding): the project's resolved role-keyed
+    policy. Classic project: the agent's own ``policy_yaml`` (unchanged
+    behavior). See docs/adr/R-POL-002.
+    """
+    from hexgate_api.features.policy_modules import service as modules
+
+    if await modules.is_modular(session, agent.project_id):
+        return await _modular_bundle(session, agent.project_id, sign)
+    return await asyncio.to_thread(compile_bundle, agent.policy_yaml, sign)
+
+
+async def recompile_project(
+    session: AsyncSession, project_id: str, sign: Callable[[bytes], bytes]
+) -> int:
+    """Recompile every agent in a project after its modules or roles change.
+
+    Modular: resolve + compile once, reusing the single bundle for all agents.
+    On an unresolvable project (or a resolved policy that won't compile) live
+    bundles are left untouched — the fail-safe in docs/adr/R-POL-002, because the
+    modules haven't changed what each agent should enforce, we just can't build
+    it right now.
+
+    Classic — including a project that just dropped its last role binding, so
+    enforcement returns to each agent's ``policy_yaml`` — recompiles each agent
+    from its own policy and **nulls the bundle when that policy no longer
+    compiles**, matching ``update_agent`` and the ``Agent.compiled_wasm``
+    invariant (a broken policy drops its stale bundle so the SDK falls back to
+    pydantic rather than serving a now-wrong WASM). Returns the count touched.
+    """
+    from hexgate_api.features.policy_modules import service as modules
+
+    agents = await list_agents(session, project_id)
+    if not agents:
+        return 0
+
+    count = 0
+    if await modules.is_modular(session, project_id):
+        bundle = await _modular_bundle(session, project_id, sign)
+        if bundle is None:
+            return 0  # fail-safe: leave live bundles as-is
+        for agent in agents:
+            agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
+            session.add(agent)
+            count += 1
+    else:
+        for agent in agents:
+            bundle = await asyncio.to_thread(compile_bundle, agent.policy_yaml, sign)
+            if bundle is None:
+                # A classic agent's own policy failed to compile: drop the stale
+                # bundle (fall back to pydantic), never keep a wrong one.
+                agent.compiled_wasm = None
+                agent.bundle_manifest = None
+                agent.bundle_signature = None
+            else:
+                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
+                    bundle
+                )
+            session.add(agent)
+            count += 1
+
+    if count:
+        await session.commit()
+    return count
 
 
 async def get_latest_agent_version_id(
@@ -126,17 +224,24 @@ async def update_agent(
     if system_md is not None:
         agent.system_md = system_md
 
-    # Recompile + re-sign the bundle from the (possibly updated) policy. We
-    # always rebuild rather than diff so a fixed policy re-acquires a bundle
-    # and a newly-broken one drops its stale (now-wrong) bundle.
+    # Recompile from the agent's own policy — classic projects only. We rebuild
+    # rather than diff so a fixed policy re-acquires a bundle and a newly-broken
+    # one drops its stale (now-wrong) bundle. A modular agent's bundle is owned
+    # by recompile_project; leave it untouched here so editing agent_yaml while
+    # the project's modules are mid-change never blanks a live bundle (R-POL-002).
     if sign is not None:
-        bundle = compile_bundle(agent.policy_yaml, sign)
-        if bundle is not None:
-            agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
-        else:
-            agent.compiled_wasm = None
-            agent.bundle_manifest = None
-            agent.bundle_signature = None
+        from hexgate_api.features.policy_modules import service as modules
+
+        if not await modules.is_modular(session, project_id):
+            bundle = await asyncio.to_thread(compile_bundle, agent.policy_yaml, sign)
+            if bundle is not None:
+                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
+                    bundle
+                )
+            else:
+                agent.compiled_wasm = None
+                agent.bundle_manifest = None
+                agent.bundle_signature = None
 
     agent.updated_at = datetime.now(timezone.utc)
     session.add(agent)
@@ -160,17 +265,41 @@ async def backfill_bundles(
     policy that won't compile (or a platform without opa) is simply left
     bundle-less. Returns the number of agents backfilled.
     """
-    count = 0
+    from collections import defaultdict
+
+    from hexgate_api.features.policy_modules import service as modules
+
     agents = (await session.exec(select(Agent))).all()
+    pending: dict[str, list[Agent]] = defaultdict(list)
     for agent in agents:
-        if agent.compiled_wasm is not None:
-            continue
-        bundle = compile_bundle(agent.policy_yaml, sign)
-        if bundle is None:
-            continue
-        agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
-        session.add(agent)
-        count += 1
+        if agent.compiled_wasm is None:
+            pending[agent.project_id].append(agent)
+
+    count = 0
+    for project_id, project_agents in pending.items():
+        if await modules.is_modular(session, project_id):
+            # Resolve + compile once for the whole project, not once per agent.
+            bundle = await _modular_bundle(session, project_id, sign)
+            if bundle is None:
+                continue
+            for agent in project_agents:
+                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
+                    bundle
+                )
+                session.add(agent)
+                count += 1
+        else:
+            for agent in project_agents:
+                bundle = await asyncio.to_thread(
+                    compile_bundle, agent.policy_yaml, sign
+                )
+                if bundle is None:
+                    continue
+                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
+                    bundle
+                )
+                session.add(agent)
+                count += 1
     if count:
         await session.commit()
     return count
@@ -233,7 +362,7 @@ async def register_manifest(
         # Policies editor has something to render and ``hexgate serve``
         # has a signed bundle to ship.
         agent.policy_yaml = _default_policy_for_manifest(manifest)
-        bundle = compile_bundle(agent.policy_yaml, sign)
+        bundle = await bundle_for_agent(session, agent, sign)
         if bundle is not None:
             agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
         # Already in session via _get_or_create_agent; the mutation flushes

--- a/platform/api/hexgate_api/features/agents/service.py
+++ b/platform/api/hexgate_api/features/agents/service.py
@@ -60,6 +60,19 @@ async def get_agent(session: AsyncSession, project_id: str, name: str) -> Agent 
     return (await session.exec(stmt)).first()
 
 
+def _apply_bundle(agent: Agent, bundle: tuple[bytes, str, bytes] | None) -> None:
+    """Set an agent's three bundle columns from a compile result, or null all
+    three when ``bundle`` is ``None`` (drop a stale bundle → the SDK falls back
+    to the pydantic engine). One place so the triple can't drift when a bundle
+    column is added or its ordering changes."""
+    if bundle is None:
+        agent.compiled_wasm = None
+        agent.bundle_manifest = None
+        agent.bundle_signature = None
+    else:
+        agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
+
+
 async def _modular_bundle(
     session: AsyncSession, project_id: str, sign: Callable[[bytes], bytes]
 ) -> tuple[bytes, str, bytes] | None:
@@ -153,22 +166,16 @@ async def recompile_project(
         if bundle is None:
             return None  # can't build now: leave live bundles as-is
         for agent in agents:
-            agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
+            _apply_bundle(agent, bundle)  # same shared bundle for every agent
             session.add(agent)
             count += 1
     else:
         for agent in agents:
+            # Classic: each agent from its own policy. A policy that no longer
+            # compiles nulls the stale bundle (fall back to pydantic), never
+            # keeps a wrong one.
             bundle = await asyncio.to_thread(compile_bundle, agent.policy_yaml, sign)
-            if bundle is None:
-                # A classic agent's own policy failed to compile: drop the stale
-                # bundle (fall back to pydantic), never keep a wrong one.
-                agent.compiled_wasm = None
-                agent.bundle_manifest = None
-                agent.bundle_signature = None
-            else:
-                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
-                    bundle
-                )
+            _apply_bundle(agent, bundle)
             session.add(agent)
             count += 1
 
@@ -254,14 +261,7 @@ async def update_agent(
 
         if not await modules.is_modular(session, project_id):
             bundle = await asyncio.to_thread(compile_bundle, agent.policy_yaml, sign)
-            if bundle is not None:
-                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
-                    bundle
-                )
-            else:
-                agent.compiled_wasm = None
-                agent.bundle_manifest = None
-                agent.bundle_signature = None
+            _apply_bundle(agent, bundle)
 
     agent.updated_at = datetime.now(timezone.utc)
     session.add(agent)
@@ -303,9 +303,7 @@ async def backfill_bundles(
             if bundle is None:
                 continue
             for agent in project_agents:
-                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
-                    bundle
-                )
+                _apply_bundle(agent, bundle)  # same shared bundle for every agent
                 session.add(agent)
                 count += 1
         else:
@@ -314,10 +312,8 @@ async def backfill_bundles(
                     compile_bundle, agent.policy_yaml, sign
                 )
                 if bundle is None:
-                    continue
-                agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
-                    bundle
-                )
+                    continue  # leave bundle-less (already None) — don't count
+                _apply_bundle(agent, bundle)
                 session.add(agent)
                 count += 1
     if count:
@@ -394,9 +390,7 @@ async def register_manifest(
             agent.policy_yaml = DENY_ALL_POLICY_YAML
         else:
             agent.policy_yaml = _default_policy_for_manifest(manifest)
-        bundle = await bundle_for_agent(session, agent, sign)
-        if bundle is not None:
-            agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
+        _apply_bundle(agent, await bundle_for_agent(session, agent, sign))
         # Already in session via _get_or_create_agent; the mutation flushes
         # at commit time below alongside the AgentVersion + Tool rows.
 

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -100,6 +100,7 @@ async def api_put_policy_module(
     # Serialize the write + recompile per project so overlapping edits can't
     # commit bundles out of order (see core.locks).
     async with project_lock(project_id):
+        prev_hash = await service.get_module_hash(session, project_id, tier, path)
         try:
             row = await service.upsert_module(
                 session,
@@ -110,9 +111,12 @@ async def api_put_policy_module(
             )
         except service.InvalidModuleError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
-        # Module content only affects enforcement once the project is modular; a
-        # classic library edit changes no agent, so skip the recompile there.
-        if await service.is_modular(session, project_id):
+        # Recompile only when the content actually changed and the project is
+        # modular: a byte-identical re-PUT, or any edit to a classic library,
+        # changes no agent, so don't pay a resolve + opa compile for it.
+        if row.content_hash != prev_hash and await service.is_modular(
+            session, project_id
+        ):
             await _recompile_project_agents(session, project_id)
     return _module_read(row)
 

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -3,11 +3,14 @@
 Project-scoped: a project holds boundary + capability modules and a role
 binding, and the resolve/check endpoints compose them via the hexgate SDK.
 Reads gate on org membership; writes gate on project admin/owner (policy edits
-are a management action). Compiling an agent's bundle from these modules is a
-later step — this slice is store + inspection only, so no agent is touched.
+are a management action). A write to a modular project recompiles its agents'
+bundles from the resolved modules (see ``agents.service.recompile_project`` and
+docs/adr/R-POL-002).
 """
 
 from __future__ import annotations
+
+import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -29,6 +32,8 @@ from hexgate_api.schemas import (
 
 router = APIRouter()
 
+logger = logging.getLogger("hexgate.platform.policy_modules")
+
 
 def _module_read(row: PolicyModule) -> PolicyModuleRead:
     return PolicyModuleRead(
@@ -38,6 +43,26 @@ def _module_read(row: PolicyModule) -> PolicyModuleRead:
         content_hash=row.content_hash,
         updated_at=row.updated_at,
     )
+
+
+async def _recompile_project_agents(session: AsyncSession, project_id: str) -> None:
+    """Recompile the project's agent bundles after a policy change.
+
+    Best-effort and never fatal to the write: the store row is the source of
+    truth, the bundle is a derived artifact. A resolve failure leaves live
+    bundles untouched (handled in the service); any other failure (opa, signing,
+    a DB hiccup on the agent commit) is logged and swallowed so the policy edit
+    still returns success. ``check`` surfaces an unresolvable state. R-POL-002.
+    """
+    from hexgate_api.core.keystore import keystore
+    from hexgate_api.features.agents.service import recompile_project
+
+    try:
+        await recompile_project(session, project_id, keystore.sign)
+    except Exception:  # noqa: BLE001 — bundles are derived + fail-safe
+        logger.exception(
+            "recompile after policy change failed for project %s", project_id
+        )
 
 
 # --- module CRUD -------------------------------------------------------------
@@ -71,6 +96,10 @@ async def api_put_policy_module(
         )
     except service.InvalidModuleError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+    # Module content only affects enforcement once the project is modular; a
+    # classic library edit changes no agent, so skip the recompile there.
+    if await service.is_modular(session, project_id):
+        await _recompile_project_agents(session, project_id)
     return _module_read(row)
 
 
@@ -91,6 +120,8 @@ async def api_delete_policy_module(
     )
     if not deleted:
         raise HTTPException(status_code=404, detail="module not found")
+    if await service.is_modular(session, project_id):
+        await _recompile_project_agents(session, project_id)
     return Response(status_code=204)
 
 
@@ -113,7 +144,14 @@ async def api_set_policy_roles(
     _membership: tuple[User, OrganizationMember] = Depends(require_project_admin),
     session: AsyncSession = Depends(get_session),
 ) -> RoleBindingsRead:
+    before = await service.get_roles(session, project_id)
     roles = await service.set_roles(session, project_id=project_id, roles=body.roles)
+    # Recompile only when the bindings actually changed — an idempotent re-save
+    # shouldn't pay a resolve + opa compile. A real change (including a
+    # modular<->classic flip) still triggers it, and recompile_project handles
+    # both directions (resolved bundle vs each agent's policy_yaml).
+    if roles != before:
+        await _recompile_project_agents(session, project_id)
     return RoleBindingsRead(roles=roles)
 
 
@@ -130,7 +168,7 @@ async def api_resolve_policy(
     """The composed effective policy per role. 422 if the module set can't be
     composed (e.g. a capability that denies, or a role importing an unknown
     capability) — use /policy/check to see that as a lint instead."""
-    from hexgate.security import DEFAULT_ROLE_NAME, LinkError, PolicySetError
+    from hexgate.security import LinkError, PolicySetError
     from hexgate.security.constraints import ConstraintParseError
 
     try:
@@ -144,13 +182,7 @@ async def api_resolve_policy(
             detail=f"role {role!r} not defined (known: {sorted(result.by_role)})",
         )
 
-    items = result.by_role.items() if role is None else [(role, result.by_role[role])]
-    return ResolvedPolicyResponse(
-        roles={
-            r: lr.effective[DEFAULT_ROLE_NAME].model_dump(mode="json")
-            for r, lr in items
-        }
-    )
+    return ResolvedPolicyResponse(roles=service.roles_json(result, role=role))
 
 
 @router.get("/projects/{project_id}/policy/check", tags=["policy"])

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from hexgate_api.core.db import get_session
+from hexgate_api.core.locks import project_lock
 from hexgate_api.deps.org import require_org_member
 from hexgate_api.deps.project import require_project_admin
 from hexgate_api.features.policy_modules import service
@@ -33,6 +34,12 @@ from hexgate_api.schemas import (
 router = APIRouter()
 
 logger = logging.getLogger("hexgate.platform.policy_modules")
+
+
+def _norm(roles: dict[str, list[str]]) -> dict[str, list[str]]:
+    """Order-insensitive view of a role binding, so re-saving the same imports in
+    a different order doesn't read as a change and trigger a needless recompile."""
+    return {role: sorted(caps) for role, caps in roles.items()}
 
 
 def _module_read(row: PolicyModule) -> PolicyModuleRead:
@@ -90,16 +97,23 @@ async def api_put_policy_module(
 ) -> PolicyModuleRead:
     """Create or replace one module. 422 if the tier is unknown or the content
     is not a valid policy."""
-    try:
-        row = await service.upsert_module(
-            session, project_id=project_id, tier=tier, path=path, content=body.content
-        )
-    except service.InvalidModuleError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
-    # Module content only affects enforcement once the project is modular; a
-    # classic library edit changes no agent, so skip the recompile there.
-    if await service.is_modular(session, project_id):
-        await _recompile_project_agents(session, project_id)
+    # Serialize the write + recompile per project so overlapping edits can't
+    # commit bundles out of order (see core.locks).
+    async with project_lock(project_id):
+        try:
+            row = await service.upsert_module(
+                session,
+                project_id=project_id,
+                tier=tier,
+                path=path,
+                content=body.content,
+            )
+        except service.InvalidModuleError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
+        # Module content only affects enforcement once the project is modular; a
+        # classic library edit changes no agent, so skip the recompile there.
+        if await service.is_modular(session, project_id):
+            await _recompile_project_agents(session, project_id)
     return _module_read(row)
 
 
@@ -115,29 +129,30 @@ async def api_delete_policy_module(
     _membership: tuple[User, OrganizationMember] = Depends(require_project_admin),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
-    # Refuse to delete a capability a role binding still imports: the delete
-    # would otherwise succeed while the project stops resolving (linker: "role
-    # imports unknown capability"), so no new bundle builds and every agent
-    # keeps the old one — still granting the just-deleted capability. Make the
-    # dangling reference the caller's problem to fix first.
-    if tier == "capability":
-        used_by = await service.roles_importing(session, project_id, path)
-        if used_by:
-            raise HTTPException(
-                status_code=409,
-                detail=(
-                    f"capability {path!r} is still imported by role(s) "
-                    f"{used_by}; remove it from those role bindings first"
-                ),
-            )
+    async with project_lock(project_id):
+        # Refuse to delete a capability a role binding still imports: the delete
+        # would otherwise succeed while the project stops resolving (linker:
+        # "role imports unknown capability"), so no new bundle builds and every
+        # agent keeps the old one — still granting the just-deleted capability.
+        # Make the dangling reference the caller's problem to fix first.
+        if tier == "capability":
+            used_by = await service.roles_importing(session, project_id, path)
+            if used_by:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"capability {path!r} is still imported by role(s) "
+                        f"{used_by}; remove it from those role bindings first"
+                    ),
+                )
 
-    deleted = await service.delete_module(
-        session, project_id=project_id, tier=tier, path=path
-    )
-    if not deleted:
-        raise HTTPException(status_code=404, detail="module not found")
-    if await service.is_modular(session, project_id):
-        await _recompile_project_agents(session, project_id)
+        deleted = await service.delete_module(
+            session, project_id=project_id, tier=tier, path=path
+        )
+        if not deleted:
+            raise HTTPException(status_code=404, detail="module not found")
+        if await service.is_modular(session, project_id):
+            await _recompile_project_agents(session, project_id)
     return Response(status_code=204)
 
 
@@ -160,56 +175,66 @@ async def api_set_policy_roles(
     _membership: tuple[User, OrganizationMember] = Depends(require_project_admin),
     session: AsyncSession = Depends(get_session),
 ) -> RoleBindingsRead:
-    before = await service.get_roles(session, project_id)
-    roles = await service.set_roles(session, project_id=project_id, roles=body.roles)
-    # Idempotent re-save: nothing changed, so skip the resolve + opa compile.
-    if roles == before:
-        return RoleBindingsRead(roles=roles)
-
-    now_modular = bool(roles)
-    was_modular = bool(before)
-
-    # A modular project whose bindings don't resolve (a role importing an unknown
-    # capability, a link error) must not be saved: is_modular would flip True
-    # while agents keep stale/absent enforcement, with no way to notice. Reject
-    # and restore the previous bindings so the project stays in a resolvable state.
-    if now_modular and not await service.resolves(session, project_id):
-        await service.set_roles(session, project_id=project_id, roles=before)
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                "role bindings do not resolve to a valid policy; not saved "
-                "(see /policy/check for details)"
-            ),
+    # Hold the project lock across read-before → write → recompile so `before`
+    # can't go stale under a concurrent PUT (comparing a pre-write snapshot
+    # outside the lock could wrongly skip a needed recompile). See core.locks.
+    async with project_lock(project_id):
+        before = await service.get_roles(session, project_id)
+        roles = await service.set_roles(
+            session, project_id=project_id, roles=body.roles
         )
+        # Idempotent re-save (order-insensitive): nothing changed, so skip the
+        # resolve + opa compile.
+        if _norm(roles) == _norm(before):
+            return RoleBindingsRead(roles=roles)
 
-    if now_modular and not was_modular:
-        # classic→modular flip: agents currently hold policy_yaml-compiled
-        # bundles that are now wrong. Require a freshly-built modular bundle;
-        # if none can be built (e.g. opa unavailable) roll back rather than
-        # leave is_modular True with stale classic WASM in force.
-        from hexgate_api.core.keystore import keystore
-        from hexgate_api.features.agents.service import recompile_project
+        now_modular = bool(roles)
+        was_modular = bool(before)
 
-        try:
-            built = await recompile_project(session, project_id, keystore.sign)
-        except Exception:  # noqa: BLE001 — treat any compile failure as "can't build"
-            logger.exception("modular flip recompile failed for project %s", project_id)
-            built = None
-        if built is None:
+        # A modular project whose bindings don't resolve (a role importing an
+        # unknown capability, a link error) must not be saved: is_modular would
+        # flip True while agents keep stale/absent enforcement, with no way to
+        # notice. Reject and restore the previous bindings so the project stays
+        # in a resolvable state.
+        if now_modular and not await service.resolves(session, project_id):
             await service.set_roles(session, project_id=project_id, roles=before)
             raise HTTPException(
                 status_code=409,
                 detail=(
-                    "could not compile the modular policy bundle "
-                    "(is opa available?); role bindings not saved"
+                    "role bindings do not resolve to a valid policy; not saved "
+                    "(see /policy/check for details)"
                 ),
             )
-    else:
-        # Already modular (module/role tweak) or dropped back to classic — the
-        # existing best-effort fail-safe applies (keep live bundles on a
-        # transient failure; the store row is the source of truth).
-        await _recompile_project_agents(session, project_id)
+
+        if now_modular and not was_modular:
+            # classic→modular flip: agents currently hold policy_yaml-compiled
+            # bundles that are now wrong. Require a freshly-built modular bundle;
+            # if none can be built (e.g. opa unavailable) roll back rather than
+            # leave is_modular True with stale classic WASM in force.
+            from hexgate_api.core.keystore import keystore
+            from hexgate_api.features.agents.service import recompile_project
+
+            try:
+                built = await recompile_project(session, project_id, keystore.sign)
+            except Exception:  # noqa: BLE001 — any compile failure is "can't build"
+                logger.exception(
+                    "modular flip recompile failed for project %s", project_id
+                )
+                built = None
+            if built is None:
+                await service.set_roles(session, project_id=project_id, roles=before)
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        "could not compile the modular policy bundle "
+                        "(is opa available?); role bindings not saved"
+                    ),
+                )
+        else:
+            # Already modular (module/role tweak) or dropped back to classic —
+            # the existing best-effort fail-safe applies (keep live bundles on a
+            # transient failure; the store row is the source of truth).
+            await _recompile_project_agents(session, project_id)
 
     return RoleBindingsRead(roles=roles)
 

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -36,10 +36,14 @@ router = APIRouter()
 logger = logging.getLogger("hexgate.platform.policy_modules")
 
 
-def _norm(roles: dict[str, list[str]]) -> dict[str, list[str]]:
-    """Order-insensitive view of a role binding, so re-saving the same imports in
-    a different order doesn't read as a change and trigger a needless recompile."""
-    return {role: sorted(caps) for role, caps in roles.items()}
+def _norm(roles: dict[str, dict[str, list[str]]]) -> dict[str, dict[str, list[str]]]:
+    """Order-insensitive view of the ``(role, agent)`` matrix, so re-saving the
+    same imports in a different order doesn't read as a change and trigger a
+    needless recompile."""
+    return {
+        role: {agent: sorted(caps) for agent, caps in cells.items()}
+        for role, cells in roles.items()
+    }
 
 
 def _module_read(row: PolicyModule) -> PolicyModuleRead:
@@ -250,17 +254,19 @@ async def api_set_policy_roles(
 async def api_resolve_policy(
     project_id: str,
     role: str | None = None,
+    agent: str = "*",
     _user: User = Depends(require_org_member),
     session: AsyncSession = Depends(get_session),
 ) -> ResolvedPolicyResponse:
-    """The composed effective policy per role. 422 if the module set can't be
-    composed (e.g. a capability that denies, or a role importing an unknown
-    capability) — use /policy/check to see that as a lint instead."""
+    """The composed effective policy per role, for one executing agent (``agent``,
+    default the generic ``"*"``). 422 if the module set can't be composed (e.g. a
+    capability that denies, or a role importing an unknown capability) — use
+    /policy/check to see that as a lint instead."""
     from hexgate.security import LinkError, PolicySetError
     from hexgate.security.constraints import ConstraintParseError
 
     try:
-        result = await service.resolve(session, project_id)
+        result = await service.resolve(session, project_id, agent=agent)
     except (LinkError, PolicySetError, ConstraintParseError) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -115,6 +115,22 @@ async def api_delete_policy_module(
     _membership: tuple[User, OrganizationMember] = Depends(require_project_admin),
     session: AsyncSession = Depends(get_session),
 ) -> Response:
+    # Refuse to delete a capability a role binding still imports: the delete
+    # would otherwise succeed while the project stops resolving (linker: "role
+    # imports unknown capability"), so no new bundle builds and every agent
+    # keeps the old one — still granting the just-deleted capability. Make the
+    # dangling reference the caller's problem to fix first.
+    if tier == "capability":
+        used_by = await service.roles_importing(session, project_id, path)
+        if used_by:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"capability {path!r} is still imported by role(s) "
+                    f"{used_by}; remove it from those role bindings first"
+                ),
+            )
+
     deleted = await service.delete_module(
         session, project_id=project_id, tier=tier, path=path
     )
@@ -146,12 +162,55 @@ async def api_set_policy_roles(
 ) -> RoleBindingsRead:
     before = await service.get_roles(session, project_id)
     roles = await service.set_roles(session, project_id=project_id, roles=body.roles)
-    # Recompile only when the bindings actually changed — an idempotent re-save
-    # shouldn't pay a resolve + opa compile. A real change (including a
-    # modular<->classic flip) still triggers it, and recompile_project handles
-    # both directions (resolved bundle vs each agent's policy_yaml).
-    if roles != before:
+    # Idempotent re-save: nothing changed, so skip the resolve + opa compile.
+    if roles == before:
+        return RoleBindingsRead(roles=roles)
+
+    now_modular = bool(roles)
+    was_modular = bool(before)
+
+    # A modular project whose bindings don't resolve (a role importing an unknown
+    # capability, a link error) must not be saved: is_modular would flip True
+    # while agents keep stale/absent enforcement, with no way to notice. Reject
+    # and restore the previous bindings so the project stays in a resolvable state.
+    if now_modular and not await service.resolves(session, project_id):
+        await service.set_roles(session, project_id=project_id, roles=before)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "role bindings do not resolve to a valid policy; not saved "
+                "(see /policy/check for details)"
+            ),
+        )
+
+    if now_modular and not was_modular:
+        # classic→modular flip: agents currently hold policy_yaml-compiled
+        # bundles that are now wrong. Require a freshly-built modular bundle;
+        # if none can be built (e.g. opa unavailable) roll back rather than
+        # leave is_modular True with stale classic WASM in force.
+        from hexgate_api.core.keystore import keystore
+        from hexgate_api.features.agents.service import recompile_project
+
+        try:
+            built = await recompile_project(session, project_id, keystore.sign)
+        except Exception:  # noqa: BLE001 — treat any compile failure as "can't build"
+            logger.exception("modular flip recompile failed for project %s", project_id)
+            built = None
+        if built is None:
+            await service.set_roles(session, project_id=project_id, roles=before)
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "could not compile the modular policy bundle "
+                    "(is opa available?); role bindings not saved"
+                ),
+            )
+    else:
+        # Already modular (module/role tweak) or dropped back to classic — the
+        # existing best-effort fail-safe applies (keep live bundles on a
+        # transient failure; the store row is the source of truth).
         await _recompile_project_agents(session, project_id)
+
     return RoleBindingsRead(roles=roles)
 
 

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -104,7 +104,9 @@ async def api_put_policy_module(
     # Serialize the write + recompile per project so overlapping edits can't
     # commit bundles out of order (see core.locks).
     async with project_lock(project_id):
-        prev_hash = await service.get_module_hash(session, project_id, tier, path)
+        prev_content, prev_hash = await service.get_module_peek(
+            session, project_id, tier, path
+        )
         try:
             row = await service.upsert_module(
                 session,
@@ -121,6 +123,30 @@ async def api_put_policy_module(
         if row.content_hash != prev_hash and await service.is_modular(
             session, project_id
         ):
+            # An edit that breaks composition (e.g. a capability with a deny, which
+            # the linker rejects) must not be accepted silently: agents would keep
+            # the old bundle while the store holds an uncomposable module. Reject
+            # and restore the previous content (or delete a newly-created module).
+            if not await service.resolves(session, project_id):
+                if prev_content is None:
+                    await service.delete_module(
+                        session, project_id=project_id, tier=tier, path=path
+                    )
+                else:
+                    await service.upsert_module(
+                        session,
+                        project_id=project_id,
+                        tier=tier,
+                        path=path,
+                        content=prev_content,
+                    )
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"module {path!r} would break the project's policy "
+                        "resolution; not saved (see /policy/check for details)"
+                    ),
+                )
             await _recompile_project_agents(session, project_id)
     return _module_read(row)
 
@@ -188,24 +214,23 @@ async def api_set_policy_roles(
     # outside the lock could wrongly skip a needed recompile). See core.locks.
     async with project_lock(project_id):
         before = await service.get_roles(session, project_id)
-        roles = await service.set_roles(
-            session, project_id=project_id, roles=body.roles
-        )
+        proposed = service.normalize_roles(body.roles)
         # Idempotent re-save (order-insensitive): nothing changed, so skip the
-        # resolve + opa compile.
-        if _norm(roles) == _norm(before):
-            return RoleBindingsRead(roles=roles)
+        # write + resolve + opa compile.
+        if _norm(proposed) == _norm(before):
+            return RoleBindingsRead(roles=before)
 
-        now_modular = bool(roles)
+        now_modular = bool(proposed)
         was_modular = bool(before)
 
-        # A modular project whose bindings don't resolve (a role importing an
-        # unknown capability, a link error) must not be saved: is_modular would
-        # flip True while agents keep stale/absent enforcement, with no way to
-        # notice. Reject and restore the previous bindings so the project stays
-        # in a resolvable state.
-        if now_modular and not await service.resolves(session, project_id):
-            await service.set_roles(session, project_id=project_id, roles=before)
+        # Validate the PROPOSED bindings BEFORE writing them: a modular project
+        # whose bindings don't resolve (a role importing an unknown capability, a
+        # link error) must not be saved. Validating in memory first means an
+        # invalid binding is never briefly visible to a concurrent GET, and no
+        # rollback of the store is needed.
+        if now_modular and not await service.resolves_proposed(
+            session, project_id, proposed
+        ):
             raise HTTPException(
                 status_code=409,
                 detail=(
@@ -213,6 +238,8 @@ async def api_set_policy_roles(
                     "(see /policy/check for details)"
                 ),
             )
+
+        roles = await service.set_roles(session, project_id=project_id, roles=proposed)
 
         if now_modular and not was_modular:
             # classic→modular flip: agents currently hold policy_yaml-compiled

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -254,7 +254,7 @@ async def api_set_policy_roles(
 async def api_resolve_policy(
     project_id: str,
     role: str | None = None,
-    agent: str = "*",
+    agent: str = service.DEFAULT_AGENT,
     _user: User = Depends(require_org_member),
     session: AsyncSession = Depends(get_session),
 ) -> ResolvedPolicyResponse:

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -104,9 +104,34 @@ async def api_put_policy_module(
     # Serialize the write + recompile per project so overlapping edits can't
     # commit bundles out of order (see core.locks).
     async with project_lock(project_id):
-        prev_content, prev_hash = await service.get_module_peek(
+        _prev_content, prev_hash = await service.get_module_peek(
             session, project_id, tier, path
         )
+        modular = await service.is_modular(session, project_id)
+        # Validate the edit BEFORE writing: an edit that breaks composition (e.g.
+        # a capability with a deny, which the linker rejects) must not be accepted
+        # silently — agents would keep the old bundle while the store held an
+        # uncomposable module. Validating the draft in memory first means the
+        # store is never briefly written with a broken module (no commit-then-
+        # rollback window a concurrent GET could observe). Same pattern as the
+        # roles PUT. Only for modular projects — a classic library edit changes
+        # no agent, so composition doesn't gate it.
+        if modular:
+            try:
+                composes = await service.resolves_with_module(
+                    session, project_id, tier, path, body.content
+                )
+            except service.InvalidModuleError as exc:
+                raise HTTPException(status_code=422, detail=str(exc)) from exc
+            if not composes:
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"module {path!r} would break the project's policy "
+                        "resolution; not saved (see /policy/check for details)"
+                    ),
+                )
+
         try:
             row = await service.upsert_module(
                 session,
@@ -120,33 +145,7 @@ async def api_put_policy_module(
         # Recompile only when the content actually changed and the project is
         # modular: a byte-identical re-PUT, or any edit to a classic library,
         # changes no agent, so don't pay a resolve + opa compile for it.
-        if row.content_hash != prev_hash and await service.is_modular(
-            session, project_id
-        ):
-            # An edit that breaks composition (e.g. a capability with a deny, which
-            # the linker rejects) must not be accepted silently: agents would keep
-            # the old bundle while the store holds an uncomposable module. Reject
-            # and restore the previous content (or delete a newly-created module).
-            if not await service.resolves(session, project_id):
-                if prev_content is None:
-                    await service.delete_module(
-                        session, project_id=project_id, tier=tier, path=path
-                    )
-                else:
-                    await service.upsert_module(
-                        session,
-                        project_id=project_id,
-                        tier=tier,
-                        path=path,
-                        content=prev_content,
-                    )
-                raise HTTPException(
-                    status_code=409,
-                    detail=(
-                        f"module {path!r} would break the project's policy "
-                        "resolution; not saved (see /policy/check for details)"
-                    ),
-                )
+        if modular and row.content_hash != prev_hash:
             await _recompile_project_agents(session, project_id)
     return _module_read(row)
 

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -163,6 +163,20 @@ async def get_roles(session: AsyncSession, project_id: str) -> dict[str, list[st
     return {row.role: list(row.capabilities) for row in rows}
 
 
+async def roles_importing(
+    session: AsyncSession, project_id: str, path: str
+) -> list[str]:
+    """Role names whose binding still imports the capability ``path``.
+
+    Used to block deleting a capability that a role still references: without
+    this the delete succeeds but the project stops resolving (the SDK linker
+    raises "role imports unknown capability"), so no new bundle is built and
+    every agent keeps the old one — still granting the deleted capability.
+    """
+    roles = await get_roles(session, project_id)
+    return sorted(role for role, caps in roles.items() if path in caps)
+
+
 async def set_roles(
     session: AsyncSession, *, project_id: str, roles: dict[str, list[str]]
 ) -> dict[str, list[str]]:
@@ -249,6 +263,32 @@ async def check(session: AsyncSession, project_id: str):
 
     boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
     return check_project(boundaries, capabilities, roles)
+
+
+async def resolves(session: AsyncSession, project_id: str) -> bool:
+    """Whether the project's modules currently compose into a valid policy.
+
+    A cheap, opa-free precondition for accepting a policy write: ``True`` only if
+    ``resolve`` succeeds. Catches the same set as the compile fail-safe — the SDK
+    link/compose errors plus ``yaml.YAMLError`` / pydantic ``ValidationError``
+    from re-parsing a stored row (see ``agents.service._modular_bundle``).
+    """
+    from pydantic import ValidationError
+
+    from hexgate.security import LinkError, PolicySetError
+    from hexgate.security.constraints import ConstraintParseError
+
+    try:
+        await resolve(session, project_id)
+        return True
+    except (
+        LinkError,
+        PolicySetError,
+        ConstraintParseError,
+        ValidationError,
+        yaml.YAMLError,
+    ):
+        return False
 
 
 # --- enforcement integration (see docs/adr/R-POL-002) ------------------------

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -105,6 +105,17 @@ async def get_module_hash(
     return row.content_hash if row is not None else None
 
 
+async def get_module_peek(
+    session: AsyncSession, project_id: str, tier: str, path: str
+) -> tuple[str | None, str | None]:
+    """``(content, content_hash)`` of the stored module, or ``(None, None)``.
+
+    One read, so a caller can both detect a real change (compare the hash) and
+    restore the prior content if an edit turns out to break the project."""
+    row = await _get_module(session, project_id, tier, path)
+    return (row.content, row.content_hash) if row is not None else (None, None)
+
+
 async def upsert_module(
     session: AsyncSession,
     *,
@@ -297,26 +308,32 @@ def _to_module_content(row: PolicyModule):
     )
 
 
-async def _sdk_inputs(session: AsyncSession, project_id: str):
+def _to_role_matrix(matrix: RoleMatrixJson):
+    """The stored JSON matrix (``role -> agent -> [caps]``) → the SDK's RoleMatrix
+    (AgentBinding cells), or ``None`` when empty.
+
+    No role bindings maps to ``None``, not ``{}``: the SDK reads ``None`` as "no
+    roles, one default importing every capability" (the all-compose behaviour the
+    local ``hexgate policy resolve`` and docs/adr/R-POL-001 document), whereas
+    ``{}`` is a present-but-empty binding that fail-closes. The platform has no
+    typo-able roles file, so "no bindings" is the no-roles case, not the empty one.
+    """
     from hexgate.security import AgentBinding
 
-    rows = await list_modules(session, project_id)
-    boundaries = [_to_module_content(r) for r in rows if r.tier == "boundary"]
-    capabilities = [_to_module_content(r) for r in rows if r.tier == "capability"]
-    # Convert the stored JSON matrix into the SDK's RoleMatrix (AgentBinding cells).
-    # No role bindings maps to None, not {}: the SDK reads None as "no roles, one
-    # default importing every capability" (the all-compose behaviour the local
-    # `hexgate policy resolve` and docs/adr/R-POL-001 document), whereas {} is a
-    # present-but-empty binding that fail-closes. The platform has no typo-able
-    # roles file, so "no bindings" is the no-roles case, not the empty one.
-    matrix = await get_roles(session, project_id)
-    roles = {
+    return {
         role: {
             agent: AgentBinding(capabilities=tuple(caps))
             for agent, caps in cells.items()
         }
         for role, cells in matrix.items()
     } or None
+
+
+async def _sdk_inputs(session: AsyncSession, project_id: str):
+    rows = await list_modules(session, project_id)
+    boundaries = [_to_module_content(r) for r in rows if r.tier == "boundary"]
+    capabilities = [_to_module_content(r) for r in rows if r.tier == "capability"]
+    roles = _to_role_matrix(await get_roles(session, project_id))
     return boundaries, capabilities, roles
 
 
@@ -364,17 +381,12 @@ def compose_error_types() -> tuple[type[BaseException], ...]:
     )
 
 
-async def resolves(session: AsyncSession, project_id: str) -> bool:
-    """Whether the project's modules compose into a valid policy for EVERY agent.
-
-    A cheap, opa-free precondition for accepting a policy write: ``True`` only if
-    every agent column resolves (not just ``"*"``), so a named-agent cell that
-    imports an unknown capability is rejected at write time rather than accepted
-    and then silently failing to compile. Resolves only (no YAML serialization) —
-    it needs the resolution not to raise, not the bytes."""
+def _resolves_with(boundaries, capabilities, roles) -> bool:
+    """Whether ``boundaries + capabilities`` compose for EVERY agent column of
+    ``roles`` (not just ``"*"``, so a named-agent cell importing an unknown
+    capability is caught). Resolves only — no YAML serialization."""
     from hexgate.security import resolve_for_project
 
-    boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
     agents = {DEFAULT_AGENT}
     if roles:
         agents |= {agent for cells in roles.values() for agent in cells}
@@ -384,6 +396,33 @@ async def resolves(session: AsyncSession, project_id: str) -> bool:
         return True
     except compose_error_types():
         return False
+
+
+def normalize_roles(
+    roles: RoleMatrixJson | dict[str, list[str]],
+) -> RoleMatrixJson:
+    """A flat-or-matrix role binding → the matrix JSON shape (flat → ``"*"``)."""
+    return {role: _normalize_cell(cells) for role, cells in roles.items()}
+
+
+async def resolves(session: AsyncSession, project_id: str) -> bool:
+    """Whether the project's STORED modules + bindings compose for every agent.
+
+    A cheap, opa-free precondition for accepting a write that edits a MODULE
+    (the bindings are already stored). ``True`` only if every agent column
+    resolves."""
+    boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    return _resolves_with(boundaries, capabilities, roles)
+
+
+async def resolves_proposed(
+    session: AsyncSession, project_id: str, proposed: RoleMatrixJson
+) -> bool:
+    """Whether the STORED modules compose with the PROPOSED role bindings, for
+    every agent — validated in memory **before** writing, so an invalid binding
+    is never briefly visible via a concurrent GET and no rollback is needed."""
+    boundaries, capabilities, _stored = await _sdk_inputs(session, project_id)
+    return _resolves_with(boundaries, capabilities, _to_role_matrix(proposed))
 
 
 # --- enforcement integration (see docs/adr/R-POL-002) ------------------------

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
+from collections.abc import Iterable
 
 import yaml
 from sqlalchemy.exc import IntegrityError
@@ -19,6 +21,8 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from hexgate_api.core.ids import new_id
 from hexgate_api.models import PolicyModule, RoleBinding, utcnow
+
+logger = logging.getLogger("hexgate.platform.policy_modules")
 
 VALID_TIERS = ("boundary", "capability")
 
@@ -185,6 +189,13 @@ def _normalize_cell(stored: object) -> dict[str, list[str]]:
         return {str(agent): list(caps) for agent, caps in stored.items()}
     if isinstance(stored, list):
         return {DEFAULT_AGENT: [str(c) for c in stored]}
+    # The column is model-constrained to list|dict, so this only fires on a
+    # corrupt row (a direct DB edit, a future bug). Fail closed (the role grants
+    # nothing) but don't swallow it silently — log so check()/ops can see it.
+    logger.warning(
+        "role_binding.capabilities has unexpected shape %r; treating as empty",
+        type(stored).__name__,
+    )
     return {}
 
 
@@ -330,21 +341,34 @@ async def check(session: AsyncSession, project_id: str):
     return check_project(boundaries, capabilities, roles)
 
 
+def _bound_agents(matrix: RoleMatrixJson) -> set[str]:
+    """Every agent column present in the bindings, plus the generic ``"*"``.
+
+    The set of agents whose resolution must be validated: a named agent's column
+    can import a capability the ``"*"`` column doesn't, so validating only ``"*"``
+    would miss an unknown-capability error in a named column."""
+    return {DEFAULT_AGENT} | {agent for cells in matrix.values() for agent in cells}
+
+
 async def resolves(session: AsyncSession, project_id: str) -> bool:
-    """Whether the project's modules currently compose into a valid policy.
+    """Whether the project's modules compose into a valid policy for EVERY agent.
 
     A cheap, opa-free precondition for accepting a policy write: ``True`` only if
-    ``resolve`` succeeds. Catches the same set as the compile fail-safe — the SDK
-    link/compose errors plus ``yaml.YAMLError`` / pydantic ``ValidationError``
-    from re-parsing a stored row (see ``agents.service._modular_bundle``).
+    every agent column resolves (not just ``"*"``), so a named-agent cell that
+    imports an unknown capability is rejected at write time rather than accepted
+    and then silently failing to compile. Catches the same set as the compile
+    fail-safe — the SDK link/compose errors plus ``yaml.YAMLError`` / pydantic
+    ``ValidationError`` from re-parsing a stored row (see
+    ``agents.service._modular_bundle``).
     """
     from pydantic import ValidationError
 
     from hexgate.security import LinkError, PolicySetError
     from hexgate.security.constraints import ConstraintParseError
 
+    agents = _bound_agents(await get_roles(session, project_id))
     try:
-        await resolve(session, project_id)
+        await resolved_yaml_by_agent(session, project_id, agents)
         return True
     except (
         LinkError,
@@ -403,3 +427,23 @@ async def resolved_policy_yaml(
     """
     result = await resolve(session, project_id, agent=agent)
     return yaml.safe_dump({"roles": roles_json(result)}, sort_keys=False)
+
+
+async def resolved_yaml_by_agent(
+    session: AsyncSession, project_id: str, agents: Iterable[str]
+) -> dict[str, str]:
+    """Resolve several agents' policy YAML, loading modules + bindings **once**.
+
+    Compiling a modular project fans out over its agents; resolving each via
+    ``resolved_policy_yaml`` would re-read the store and re-parse every module per
+    agent. This loads the SDK inputs once and resolves each agent's column in
+    memory. Raises the SDK's link/compose errors if any agent's set doesn't
+    compose, so callers keep the last-good bundle (fail-safe)."""
+    from hexgate.security import resolve_for_project
+
+    boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    out: dict[str, str] = {}
+    for agent in agents:
+        result = resolve_for_project(boundaries, capabilities, roles, agent=agent)
+        out[agent] = yaml.safe_dump({"roles": roles_json(result)}, sort_keys=False)
+    return out

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -314,16 +314,14 @@ async def is_modular(session: AsyncSession, project_id: str) -> bool:
 def roles_json(result, role: str | None = None) -> dict:
     """The effective policy per role, as JSON-able dicts.
 
-    One place for the role-keying + ``DEFAULT_ROLE_NAME`` detail, shared by the
-    ``/policy/resolve`` endpoint and the compile path. ``role`` narrows to a
+    Delegates to the SDK's ``effective_policy_by_role`` so the resolve endpoint
+    and the compile path serialize a project the same way ``hexgate policy
+    resolve`` does — same role order (sorted), same bytes. ``role`` narrows to a
     single role (the resolve endpoint's ``?role=``); ``None`` returns all.
     """
-    from hexgate.security import DEFAULT_ROLE_NAME
+    from hexgate.security import effective_policy_by_role
 
-    items = result.by_role.items() if role is None else [(role, result.by_role[role])]
-    return {
-        r: lr.effective[DEFAULT_ROLE_NAME].model_dump(mode="json") for r, lr in items
-    }
+    return effective_policy_by_role(result, None if role is None else [role])
 
 
 async def resolved_policy_yaml(session: AsyncSession, project_id: str) -> str:

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -341,13 +341,27 @@ async def check(session: AsyncSession, project_id: str):
     return check_project(boundaries, capabilities, roles)
 
 
-def _bound_agents(matrix: RoleMatrixJson) -> set[str]:
-    """Every agent column present in the bindings, plus the generic ``"*"``.
+def compose_error_types() -> tuple[type[BaseException], ...]:
+    """Exceptions meaning "the module set doesn't compose right now".
 
-    The set of agents whose resolution must be validated: a named agent's column
-    can import a capability the ``"*"`` column doesn't, so validating only ``"*"``
-    would miss an unknown-capability error in a named column."""
-    return {DEFAULT_AGENT} | {agent for cells in matrix.values() for agent in cells}
+    The single source of truth shared by the write-time guard (:func:`resolves`)
+    and the compile fail-safe (``agents.service``), so they can't drift on which
+    errors fold to "keep the last-good bundle" versus escape as a 500 — the SDK
+    link/compose errors plus ``yaml.YAMLError`` / pydantic ``ValidationError``
+    from re-parsing a stored row. SDK imports stay lazy so this module loads
+    without the SDK."""
+    from pydantic import ValidationError
+
+    from hexgate.security import LinkError, PolicySetError
+    from hexgate.security.constraints import ConstraintParseError
+
+    return (
+        LinkError,
+        PolicySetError,
+        ConstraintParseError,
+        ValidationError,
+        yaml.YAMLError,
+    )
 
 
 async def resolves(session: AsyncSession, project_id: str) -> bool:
@@ -356,27 +370,19 @@ async def resolves(session: AsyncSession, project_id: str) -> bool:
     A cheap, opa-free precondition for accepting a policy write: ``True`` only if
     every agent column resolves (not just ``"*"``), so a named-agent cell that
     imports an unknown capability is rejected at write time rather than accepted
-    and then silently failing to compile. Catches the same set as the compile
-    fail-safe — the SDK link/compose errors plus ``yaml.YAMLError`` / pydantic
-    ``ValidationError`` from re-parsing a stored row (see
-    ``agents.service._modular_bundle``).
-    """
-    from pydantic import ValidationError
+    and then silently failing to compile. Resolves only (no YAML serialization) —
+    it needs the resolution not to raise, not the bytes."""
+    from hexgate.security import resolve_for_project
 
-    from hexgate.security import LinkError, PolicySetError
-    from hexgate.security.constraints import ConstraintParseError
-
-    agents = _bound_agents(await get_roles(session, project_id))
+    boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    agents = {DEFAULT_AGENT}
+    if roles:
+        agents |= {agent for cells in roles.values() for agent in cells}
     try:
-        await resolved_yaml_by_agent(session, project_id, agents)
+        for agent in agents:
+            resolve_for_project(boundaries, capabilities, roles, agent=agent)
         return True
-    except (
-        LinkError,
-        PolicySetError,
-        ConstraintParseError,
-        ValidationError,
-        yaml.YAMLError,
-    ):
+    except compose_error_types():
         return False
 
 

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -85,6 +85,17 @@ async def _get_module(
     ).first()
 
 
+async def get_module_hash(
+    session: AsyncSession, project_id: str, tier: str, path: str
+) -> str | None:
+    """The stored module's ``content_hash``, or ``None`` if it doesn't exist.
+
+    Lets a caller tell a real content change from a byte-identical re-PUT and
+    skip the (expensive) recompile when nothing changed."""
+    row = await _get_module(session, project_id, tier, path)
+    return row.content_hash if row is not None else None
+
+
 async def upsert_module(
     session: AsyncSession,
     *,

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -22,6 +22,11 @@ from hexgate_api.models import PolicyModule, RoleBinding, utcnow
 
 VALID_TIERS = ("boundary", "capability")
 
+# The generic/default agent key in a role binding. Mirrors
+# ``hexgate.security.DEFAULT_AGENT``; kept local so the store CRUD (get/set_roles)
+# doesn't import the SDK at module load — the SDK is imported lazily in resolve.
+DEFAULT_AGENT = "*"
+
 
 class InvalidModuleError(Exception):
     """A module's tier is unknown, or its content doesn't parse as a policy.
@@ -165,19 +170,42 @@ async def delete_module(
 # --- role bindings -----------------------------------------------------------
 
 
-async def get_roles(session: AsyncSession, project_id: str) -> dict[str, list[str]]:
+RoleMatrixJson = dict[str, dict[str, list[str]]]
+"""The platform's JSON-friendly binding shape: role -> agent-or-"*" -> caps."""
+
+
+def _normalize_cell(stored: object) -> dict[str, list[str]]:
+    """One stored ``RoleBinding.capabilities`` value → ``{agent: [caps]}``.
+
+    A legacy flat ``[names]`` list reads as the generic ``{"*": [names]}`` agent,
+    so old rows keep their exact meaning with no migration. A mapping is already
+    the matrix and passes through.
+    """
+    if isinstance(stored, dict):
+        return {str(agent): list(caps) for agent, caps in stored.items()}
+    if isinstance(stored, list):
+        return {DEFAULT_AGENT: [str(c) for c in stored]}
+    return {}
+
+
+async def get_roles(session: AsyncSession, project_id: str) -> RoleMatrixJson:
+    """The project's role bindings as ``role -> agent-or-"*" -> capabilities``.
+
+    Legacy flat rows normalize to the generic ``"*"`` agent, so a project written
+    before the agent axis reads back identically.
+    """
     rows = (
         await session.exec(
             select(RoleBinding).where(RoleBinding.project_id == project_id)
         )
     ).all()
-    return {row.role: list(row.capabilities) for row in rows}
+    return {row.role: _normalize_cell(row.capabilities) for row in rows}
 
 
 async def roles_importing(
     session: AsyncSession, project_id: str, path: str
 ) -> list[str]:
-    """Role names whose binding still imports the capability ``path``.
+    """Role names whose binding still imports the capability ``path`` under ANY agent.
 
     Used to block deleting a capability that a role still references: without
     this the delete succeeds but the project stops resolving (the SDK linker
@@ -185,13 +213,25 @@ async def roles_importing(
     every agent keeps the old one — still granting the deleted capability.
     """
     roles = await get_roles(session, project_id)
-    return sorted(role for role, caps in roles.items() if path in caps)
+    return sorted(
+        role
+        for role, cells in roles.items()
+        if any(path in caps for caps in cells.values())
+    )
 
 
 async def set_roles(
-    session: AsyncSession, *, project_id: str, roles: dict[str, list[str]]
-) -> dict[str, list[str]]:
+    session: AsyncSession,
+    *,
+    project_id: str,
+    roles: RoleMatrixJson | dict[str, list[str]],
+) -> RoleMatrixJson:
     """Replace the project's role bindings wholesale (a small, edited-together set).
+
+    Accepts either the matrix (``role -> {agent: [caps]}``) or the flat form
+    (``role -> [caps]``, normalized to the generic ``"*"`` agent), so a flat
+    caller stays valid. Stores each role's ``{agent: [caps]}`` mapping in the
+    row's JSON value — no schema change.
 
     Retries once on an IntegrityError: two concurrent wholesale replaces can each
     delete the existing rows and re-insert the same ``(project_id, role)``,
@@ -199,6 +239,7 @@ async def set_roles(
     replaces them cleanly instead of surfacing a 500 (same posture as
     ``upsert_module``'s create-race handling).
     """
+    normalized = {role: _normalize_cell(cells) for role, cells in roles.items()}
     for attempt in range(2):
         existing = (
             await session.exec(
@@ -211,13 +252,13 @@ async def set_roles(
         # order an INSERT first and trip the (project_id, role) unique constraint
         # when a role name recurs across edits (the common wholesale-replace case).
         await session.flush()
-        for role, caps in roles.items():
+        for role, cells in normalized.items():
             session.add(
                 RoleBinding(
                     id=new_id(RoleBinding),
                     project_id=project_id,
                     role=role,
-                    capabilities=list(caps),
+                    capabilities=dict(cells),
                 )
             )
         try:
@@ -246,25 +287,38 @@ def _to_module_content(row: PolicyModule):
 
 
 async def _sdk_inputs(session: AsyncSession, project_id: str):
+    from hexgate.security import AgentBinding
+
     rows = await list_modules(session, project_id)
     boundaries = [_to_module_content(r) for r in rows if r.tier == "boundary"]
     capabilities = [_to_module_content(r) for r in rows if r.tier == "capability"]
+    # Convert the stored JSON matrix into the SDK's RoleMatrix (AgentBinding cells).
     # No role bindings maps to None, not {}: the SDK reads None as "no roles, one
     # default importing every capability" (the all-compose behaviour the local
     # `hexgate policy resolve` and docs/adr/R-POL-001 document), whereas {} is a
     # present-but-empty binding that fail-closes. The platform has no typo-able
     # roles file, so "no bindings" is the no-roles case, not the empty one.
-    roles = await get_roles(session, project_id) or None
+    matrix = await get_roles(session, project_id)
+    roles = {
+        role: {
+            agent: AgentBinding(capabilities=tuple(caps))
+            for agent, caps in cells.items()
+        }
+        for role, cells in matrix.items()
+    } or None
     return boundaries, capabilities, roles
 
 
-async def resolve(session: AsyncSession, project_id: str):
-    """Compose the project into a role-keyed PolicySet. Raises the SDK's
-    LinkError / PolicySetError / ConstraintParseError on an invalid set."""
+async def resolve(session: AsyncSession, project_id: str, agent: str = DEFAULT_AGENT):
+    """Compose one agent's role-keyed PolicySet (Path A). Raises the SDK's
+    LinkError / PolicySetError / ConstraintParseError on an invalid set.
+
+    ``agent`` selects the executing agent's column of the ``(role, agent)`` matrix
+    (default ``"*"`` — the generic view). Each agent resolves to its own bundle."""
     from hexgate.security import resolve_for_project
 
     boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
-    return resolve_for_project(boundaries, capabilities, roles)
+    return resolve_for_project(boundaries, capabilities, roles, agent=agent)
 
 
 async def check(session: AsyncSession, project_id: str):
@@ -335,13 +389,17 @@ def roles_json(result, role: str | None = None) -> dict:
     return effective_policy_by_role(result, None if role is None else [role])
 
 
-async def resolved_policy_yaml(session: AsyncSession, project_id: str) -> str:
-    """The project's resolved role-keyed policy as inline-roles YAML.
+async def resolved_policy_yaml(
+    session: AsyncSession, project_id: str, agent: str = DEFAULT_AGENT
+) -> str:
+    """One agent's resolved role-keyed policy as inline-roles YAML.
 
     Serializes to the ``roles:`` shape ``build_signed_bundle`` accepts, so the
     platform compile path is byte-for-byte the same as a single-file policy.
-    Raises the SDK's ``LinkError`` / ``PolicySetError`` / ``ConstraintParseError``
-    if the modules don't compose, so callers can leave live bundles untouched.
+    ``agent`` selects that agent's column of the ``(role, agent)`` matrix (Path A:
+    one bundle per agent). Raises the SDK's ``LinkError`` / ``PolicySetError`` /
+    ``ConstraintParseError`` if the modules don't compose, so callers can leave
+    live bundles untouched.
     """
-    result = await resolve(session, project_id)
+    result = await resolve(session, project_id, agent=agent)
     return yaml.safe_dump({"roles": roles_json(result)}, sort_keys=False)

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -94,17 +94,6 @@ async def _get_module(
     ).first()
 
 
-async def get_module_hash(
-    session: AsyncSession, project_id: str, tier: str, path: str
-) -> str | None:
-    """The stored module's ``content_hash``, or ``None`` if it doesn't exist.
-
-    Lets a caller tell a real content change from a byte-identical re-PUT and
-    skip the (expensive) recompile when nothing changed."""
-    row = await _get_module(session, project_id, tier, path)
-    return row.content_hash if row is not None else None
-
-
 async def get_module_peek(
     session: AsyncSession, project_id: str, tier: str, path: str
 ) -> tuple[str | None, str | None]:
@@ -381,21 +370,17 @@ def compose_error_types() -> tuple[type[BaseException], ...]:
     )
 
 
-def _resolves_with(boundaries, capabilities, roles) -> bool:
-    """Whether ``boundaries + capabilities`` compose for EVERY agent column of
-    ``roles`` (not just ``"*"``, so a named-agent cell importing an unknown
-    capability is caught). Resolves only — no YAML serialization."""
+def _resolve_all_agents(boundaries, capabilities, roles) -> None:
+    """Resolve EVERY agent column of ``roles`` (not just ``"*"``, so a named-agent
+    cell importing an unknown capability is caught). Raises the SDK compose errors
+    on failure; resolves only (no YAML serialization)."""
     from hexgate.security import resolve_for_project
 
     agents = {DEFAULT_AGENT}
     if roles:
         agents |= {agent for cells in roles.values() for agent in cells}
-    try:
-        for agent in agents:
-            resolve_for_project(boundaries, capabilities, roles, agent=agent)
-        return True
-    except compose_error_types():
-        return False
+    for agent in agents:
+        resolve_for_project(boundaries, capabilities, roles, agent=agent)
 
 
 def normalize_roles(
@@ -410,9 +395,15 @@ async def resolves(session: AsyncSession, project_id: str) -> bool:
 
     A cheap, opa-free precondition for accepting a write that edits a MODULE
     (the bindings are already stored). ``True`` only if every agent column
-    resolves."""
-    boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
-    return _resolves_with(boundaries, capabilities, roles)
+    resolves. ``_sdk_inputs`` is inside the ``try`` because it re-parses every
+    stored module — a row that no longer parses is a compose failure (→ False →
+    409), not a 500."""
+    try:
+        boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+        _resolve_all_agents(boundaries, capabilities, roles)
+        return True
+    except compose_error_types():
+        return False
 
 
 async def resolves_proposed(
@@ -420,9 +411,52 @@ async def resolves_proposed(
 ) -> bool:
     """Whether the STORED modules compose with the PROPOSED role bindings, for
     every agent — validated in memory **before** writing, so an invalid binding
-    is never briefly visible via a concurrent GET and no rollback is needed."""
-    boundaries, capabilities, _stored = await _sdk_inputs(session, project_id)
-    return _resolves_with(boundaries, capabilities, _to_role_matrix(proposed))
+    is never briefly visible via a concurrent GET and no rollback is needed.
+    ``_sdk_inputs`` is inside the ``try`` for the same reason as :func:`resolves`."""
+    try:
+        boundaries, capabilities, _stored = await _sdk_inputs(session, project_id)
+        _resolve_all_agents(boundaries, capabilities, _to_role_matrix(proposed))
+        return True
+    except compose_error_types():
+        return False
+
+
+def _draft_module_content(tier: str, path: str, content: str):
+    """A :class:`ModuleContent` from an unsaved draft (hash recomputed, not stored)."""
+    from hexgate.security import ModuleContent
+
+    return ModuleContent(
+        name=path,
+        kind=tier,
+        policy=_parse_policy(content),  # raises on invalid YAML / schema
+        source=f"{tier}/{path}",
+        content_hash=_content_hash(content),
+    )
+
+
+async def resolves_with_module(
+    session: AsyncSession, project_id: str, tier: str, path: str, content: str
+) -> bool:
+    """Whether the project still resolves with this DRAFT module overlaid, without
+    writing it — validated in memory **before** the write, so a resolution-breaking
+    edit (e.g. a capability with a deny) is rejected without a commit-then-rollback
+    window a concurrent GET could observe.
+
+    Raises :class:`InvalidModuleError` if the content isn't a valid policy (the
+    caller maps that to 422); returns ``False`` only when the content is valid but
+    the project no longer composes with it (→ 409)."""
+    _validate_policy_yaml(content)  # → InvalidModuleError (422) on malformed content
+    try:
+        boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+        overlay = _draft_module_content(tier, path, content)
+        if tier == "boundary":
+            boundaries = [m for m in boundaries if m.name != path] + [overlay]
+        else:
+            capabilities = [m for m in capabilities if m.name != path] + [overlay]
+        _resolve_all_agents(boundaries, capabilities, roles)
+        return True
+    except compose_error_types():
+        return False
 
 
 # --- enforcement integration (see docs/adr/R-POL-002) ------------------------

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -249,3 +249,50 @@ async def check(session: AsyncSession, project_id: str):
 
     boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
     return check_project(boundaries, capabilities, roles)
+
+
+# --- enforcement integration (see docs/adr/R-POL-002) ------------------------
+
+
+async def is_modular(session: AsyncSession, project_id: str) -> bool:
+    """Whether the project compiles agents from modules rather than policy_yaml.
+
+    A project is modular once it has at least one role binding. Binding a role is
+    the deliberate opt-in: uploading a capability or boundary module alone does
+    not flip enforcement, so a half-built library never bricks live agents.
+    """
+    row = (
+        await session.exec(
+            select(RoleBinding.id)  # type: ignore[arg-type]
+            .where(RoleBinding.project_id == project_id)
+            .limit(1)
+        )
+    ).first()
+    return row is not None
+
+
+def roles_json(result, role: str | None = None) -> dict:
+    """The effective policy per role, as JSON-able dicts.
+
+    One place for the role-keying + ``DEFAULT_ROLE_NAME`` detail, shared by the
+    ``/policy/resolve`` endpoint and the compile path. ``role`` narrows to a
+    single role (the resolve endpoint's ``?role=``); ``None`` returns all.
+    """
+    from hexgate.security import DEFAULT_ROLE_NAME
+
+    items = result.by_role.items() if role is None else [(role, result.by_role[role])]
+    return {
+        r: lr.effective[DEFAULT_ROLE_NAME].model_dump(mode="json") for r, lr in items
+    }
+
+
+async def resolved_policy_yaml(session: AsyncSession, project_id: str) -> str:
+    """The project's resolved role-keyed policy as inline-roles YAML.
+
+    Serializes to the ``roles:`` shape ``build_signed_bundle`` accepts, so the
+    platform compile path is byte-for-byte the same as a single-file policy.
+    Raises the SDK's ``LinkError`` / ``PolicySetError`` / ``ConstraintParseError``
+    if the modules don't compose, so callers can leave live bundles untouched.
+    """
+    result = await resolve(session, project_id)
+    return yaml.safe_dump({"roles": roles_json(result)}, sort_keys=False)

--- a/platform/api/hexgate_api/models.py
+++ b/platform/api/hexgate_api/models.py
@@ -370,10 +370,16 @@ class PolicyModule(SQLModel, table=True):
 
 
 class RoleBinding(SQLModel, table=True):
-    """A project role: a named list of capability names it imports.
+    """A project role: the capabilities it imports, per executing agent.
 
     A role is a binding, not a policy (see R-POL-001) — boundaries apply to
     every role and are never listed here. One row per ``(project_id, role)``.
+
+    ``capabilities`` carries the ``(role, agent)`` matrix in its JSON value:
+    a mapping ``{agent-or-"*": [capability names]}``. A legacy flat ``[names]``
+    list is read as the generic ``{"*": [names]}`` agent — so the agent axis is
+    a value-shape evolution with no schema change (the column stays JSON, the
+    key stays ``(project_id, role)``). See ``agent-policy-dimension-design.md``.
     """
 
     __tablename__ = "role_binding"
@@ -384,6 +390,8 @@ class RoleBinding(SQLModel, table=True):
     id: str = Field(primary_key=True)  # new_id(RoleBinding) -> "rbd_…"
     project_id: str = Field(foreign_key="project.id", index=True)
     role: str = Field(index=True)
-    capabilities: list[str] = Field(
-        default_factory=list, sa_column=Column(JSON, nullable=False)
+    # list[str] (legacy flat) OR dict[agent, list[str]] (the matrix). Column is
+    # JSON either way, so widening the value shape needs no migration.
+    capabilities: list[str] | dict[str, list[str]] = Field(
+        default_factory=dict, sa_column=Column(JSON, nullable=False)
     )

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -368,13 +368,21 @@ class PolicyModuleWrite(BaseModel):
 
 
 class RoleBindingsRead(BaseModel):
-    """A project's role bindings: role name -> the capability names it imports."""
+    """A project's role bindings as the ``(role, agent)`` matrix:
+    ``role -> agent-or-"*" -> capability names``. The ``"*"`` agent is the
+    generic default; a project written before the agent axis reads back with all
+    capabilities under ``"*"``."""
 
-    roles: dict[str, list[str]] = Field(default_factory=dict)
+    roles: dict[str, dict[str, list[str]]] = Field(default_factory=dict)
 
 
 class RoleBindingsWrite(BaseModel):
-    roles: dict[str, list[str]] = Field(default_factory=dict)
+    """Write role bindings. Accepts either the ``(role, agent)`` matrix
+    (``role -> {agent: [caps]}``) or the flat form (``role -> [caps]``, applied to
+    the generic ``"*"`` agent) — the service normalizes both, so a flat client
+    stays valid."""
+
+    roles: dict[str, dict[str, list[str]] | list[str]] = Field(default_factory=dict)
 
 
 class ResolvedPolicyResponse(BaseModel):

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -716,3 +716,72 @@ async def test_register_into_modular_project_seeds_deny_all_fallback(
         agent = await asvc.get_agent(s, proj.id, "newbot")
         assert agent is not None
         assert agent.policy_yaml == DENY_ALL_POLICY_YAML
+
+
+def test_identical_module_put_skips_recompile(client: TestClient, monkeypatch) -> None:
+    # Re-PUTting byte-identical module content must not pay a recompile; a real
+    # content change still does.
+    import hexgate_api.features.agents.service as asvc
+
+    calls = {"n": 0}
+    real = asvc.recompile_project
+
+    async def spy(session, project_id, sign):
+        calls["n"] += 1
+        return await real(session, project_id, sign)
+
+    monkeypatch.setattr(asvc, "recompile_project", spy)
+
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    client.put(
+        f"/v1/projects/{pid}/policy-roles", json={"roles": {"default": ["read_only"]}}
+    )  # modular now
+    base = calls["n"]
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)  # identical
+    assert calls["n"] == base  # no recompile
+    _put_module(
+        client,
+        pid,
+        "capability",
+        "read_only",
+        "tools:\n  view_orders: { mode: allow }\n  list_orders: { mode: allow }\n",
+    )  # changed
+    assert calls["n"] == base + 1
+
+
+async def test_classic_recompile_memoizes_identical_policies(
+    session_factory, monkeypatch
+) -> None:
+    # Classic recompile shells out to opa once per DISTINCT policy, not once per
+    # agent — agents that share a policy compile a single time.
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.models import Agent
+
+    calls = {"n": 0}
+
+    def fake(policy_yaml, sign):
+        calls["n"] += 1
+        return (b"W", "M", b"S")
+
+    monkeypatch.setattr(asvc, "compile_bundle", fake)
+
+    async with session_factory() as s:
+        proj, _ = await _fresh_project_with_agent(s, policy_yaml="version: 1\n# same\n")
+        for name in ("a2", "a3"):
+            s.add(
+                Agent(
+                    id=new_id(Agent),
+                    project_id=proj.id,
+                    name=name,
+                    agent_yaml="",
+                    policy_yaml="version: 1\n# same\n",
+                    system_md="",
+                )
+            )
+        await s.commit()
+
+        n = await asvc.recompile_project(s, proj.id, _dummy_sign)
+        assert n == 3  # all three agents got a bundle
+        assert calls["n"] == 1  # ...from a single opa compile (memoized)

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -948,3 +948,29 @@ def test_capability_deny_put_rejected_on_modular_project(client: TestClient) -> 
         for m in client.get(f"/v1/projects/{pid}/policy-modules").json()
     }
     assert ("capability", "bad") not in paths
+
+
+async def test_resolves_false_on_unparseable_stored_module(session_factory) -> None:
+    # A stored module that no longer parses must make resolves() return False
+    # (→ 409 on a write), never raise (→ 500). Regression guard: _sdk_inputs
+    # re-parses stored modules and must be inside resolves()' try.
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.features.policy_modules import service as pm
+    from hexgate_api.models import PolicyModule
+
+    async with session_factory() as s:
+        proj, _ = await _fresh_project_with_agent(s)
+        # Valid YAML, but a list — not a valid AgentPolicy (model_validate raises).
+        s.add(
+            PolicyModule(
+                id=new_id(PolicyModule),
+                project_id=proj.id,
+                tier="capability",
+                path="broken",
+                content="- not\n- a\n- policy\n",
+                content_hash="x",
+            )
+        )
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["broken"]})
+        await s.commit()
+        assert await pm.resolves(s, proj.id) is False  # must not raise

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -824,6 +824,37 @@ def test_matrix_binding_resolves_per_agent(client: TestClient) -> None:
     assert "refund_order" not in generic  # unnamed agent -> "*" -> read_only only
 
 
+def test_named_agent_column_with_unknown_capability_is_rejected(
+    client: TestClient,
+) -> None:
+    # A named-agent cell importing a capability that doesn't exist must be
+    # rejected at write time — not accepted (because "*" resolves) and then
+    # silently fail to compile, leaving stored bindings diverged from bundles.
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    # Make it modular first with a valid binding.
+    assert (
+        client.put(
+            f"/v1/projects/{pid}/policy-roles",
+            json={"roles": {"member": {"*": ["read_only"]}}},
+        ).status_code
+        == 200
+    )
+    # Now a named agent imports an unknown capability — "*" still resolves, but
+    # billing_bot's column does not.
+    r = client.put(
+        f"/v1/projects/{pid}/policy-roles",
+        json={
+            "roles": {"member": {"*": ["read_only"], "billing_bot": ["nonexistent"]}}
+        },
+    )
+    assert r.status_code == 409, r.text
+    # Rolled back to the last valid binding.
+    assert client.get(f"/v1/projects/{pid}/policy-roles").json()["roles"] == {
+        "member": {"*": ["read_only"]}
+    }
+
+
 async def test_recompile_builds_distinct_bundles_per_agent(
     session_factory, monkeypatch
 ) -> None:

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -824,6 +824,16 @@ def test_matrix_binding_resolves_per_agent(client: TestClient) -> None:
     assert "refund_order" not in generic  # unnamed agent -> "*" -> read_only only
 
 
+def test_default_agent_sentinel_matches_sdk() -> None:
+    # The platform keeps its own "*" constant (to avoid importing the SDK at
+    # module load); guard against it drifting from the SDK's DEFAULT_AGENT.
+    from hexgate.security import DEFAULT_AGENT as SDK_DEFAULT_AGENT
+
+    from hexgate_api.features.policy_modules.service import DEFAULT_AGENT
+
+    assert DEFAULT_AGENT == SDK_DEFAULT_AGENT
+
+
 def test_named_agent_column_with_unknown_capability_is_rejected(
     client: TestClient,
 ) -> None:

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -199,8 +199,9 @@ def test_set_roles_is_idempotent_on_reused_role_name(client: TestClient) -> None
     assert r1.status_code == 200, r1.text
     r2 = client.put(f"/v1/projects/{pid}/policy-roles", json={"roles": {"default": []}})
     assert r2.status_code == 200, r2.text
+    # Flat write normalizes to the generic "*" agent in the (role, agent) matrix.
     assert client.get(f"/v1/projects/{pid}/policy-roles").json()["roles"] == {
-        "default": []
+        "default": {"*": []}
     }
 
 
@@ -785,3 +786,98 @@ async def test_classic_recompile_memoizes_identical_policies(
         n = await asvc.recompile_project(s, proj.id, _dummy_sign)
         assert n == 3  # all three agents got a bundle
         assert calls["n"] == 1  # ...from a single opa compile (memoized)
+
+
+# --- (role, agent) matrix ---------------------------------------------------
+
+
+def test_matrix_binding_resolves_per_agent(client: TestClient) -> None:
+    # A named agent sees its own column; an unnamed agent falls back to "*".
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    _put_module(client, pid, "capability", "payments", PAYMENTS)
+    r = client.put(
+        f"/v1/projects/{pid}/policy-roles",
+        json={
+            "roles": {
+                "member": {
+                    "*": ["read_only"],
+                    "billing_bot": ["read_only", "payments"],
+                }
+            }
+        },
+    )
+    assert r.status_code == 200, r.text
+    # Round-trips as the matrix.
+    assert client.get(f"/v1/projects/{pid}/policy-roles").json()["roles"] == {
+        "member": {"*": ["read_only"], "billing_bot": ["read_only", "payments"]}
+    }
+
+    billing = client.get(f"/v1/projects/{pid}/policy/resolve?agent=billing_bot").json()[
+        "roles"
+    ]["member"]["tools"]
+    assert "refund_order" in billing  # its own column grants payments
+
+    generic = client.get(f"/v1/projects/{pid}/policy/resolve?agent=triage_bot").json()[
+        "roles"
+    ]["member"]["tools"]
+    assert "refund_order" not in generic  # unnamed agent -> "*" -> read_only only
+
+
+async def test_recompile_builds_distinct_bundles_per_agent(
+    session_factory, monkeypatch
+) -> None:
+    # Two agents with different columns compile to different bundles (the yaml
+    # each agent resolves to differs), fanned out per agent.
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.features.policy_modules import service as pm
+    from hexgate_api.models import Agent
+
+    monkeypatch.setattr(
+        asvc, "compile_bundle", lambda py, sign: (py.encode(), "M", b"S")
+    )  # echo the resolved yaml as the wasm bytes so we can compare
+
+    async with session_factory() as s:
+        proj, billing = await _fresh_project_with_agent(s)  # agent name "a1"
+        billing.name = "billing_bot"
+        s.add(billing)
+        triage = Agent(
+            id=new_id(Agent),
+            project_id=proj.id,
+            name="triage_bot",
+            agent_yaml="",
+            policy_yaml="version: 1\n",
+            system_md="",
+        )
+        s.add(triage)
+        await s.commit()
+
+        await pm.upsert_module(
+            s,
+            project_id=proj.id,
+            tier="capability",
+            path="read_only",
+            content=READ_ONLY,
+        )
+        await pm.upsert_module(
+            s, project_id=proj.id, tier="capability", path="payments", content=PAYMENTS
+        )
+        await pm.set_roles(
+            s,
+            project_id=proj.id,
+            roles={
+                "default": {
+                    "billing_bot": ["read_only", "payments"],
+                    "triage_bot": ["read_only"],
+                }
+            },
+        )
+
+        n = await asvc.recompile_project(s, proj.id, _dummy_sign)
+        assert n == 2
+        await s.refresh(billing)
+        await s.refresh(triage)
+        # billing_bot's bundle carries refund_order; triage_bot's does not.
+        assert b"refund_order" in billing.compiled_wasm
+        assert b"refund_order" not in triage.compiled_wasm

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -405,7 +405,7 @@ async def test_recompile_project_noop_leaves_bundles_when_unresolvable(session_f
         await pm.set_roles(s, project_id=proj.id, roles={"default": ["nonexistent"]})
 
         n = await asvc.recompile_project(s, proj.id, _dummy_sign)
-        assert n == 0
+        assert n is None  # modular but couldn't build -> signal "not built"
         await s.refresh(agent)
         assert agent.compiled_wasm == b"OLD"  # last-good bundle untouched
 
@@ -558,3 +558,135 @@ def test_identical_role_put_skips_recompile(client: TestClient, monkeypatch) -> 
     # identical re-save -> no recompile
     assert client.put(f"/v1/projects/{pid}/policy-roles", json=body).status_code == 200
     assert calls["n"] == after_change
+
+
+# --- review fixes: fail-closed on modular flips / deletes -------------------
+
+
+def test_delete_capability_still_imported_is_409(client: TestClient) -> None:
+    # Deleting a capability a role still imports must 409, not silently succeed
+    # and leave every agent enforcing the old (still-granting) bundle.
+    pid = _project(client)
+    _seed_bundle(client, pid)  # 'billing' imports read_only + payments
+    r = client.delete(f"/v1/projects/{pid}/policy-modules/capability/payments")
+    assert r.status_code == 409, r.text
+    rows = client.get(f"/v1/projects/{pid}/policy-modules").json()
+    assert any(m["path"] == "payments" for m in rows)  # not deleted
+    # Removing it from the binding first makes the delete succeed.
+    client.put(
+        f"/v1/projects/{pid}/policy-roles",
+        json={"roles": {"default": ["read_only"], "billing": ["read_only"]}},
+    )
+    assert (
+        client.delete(
+            f"/v1/projects/{pid}/policy-modules/capability/payments"
+        ).status_code
+        == 204
+    )
+
+
+def test_flip_to_modular_with_unresolvable_roles_is_rejected(
+    client: TestClient,
+) -> None:
+    # Binding a role that imports an unknown capability would flip the project
+    # modular while it can't resolve -> reject and stay classic.
+    pid = _project(client)
+    r = client.put(
+        f"/v1/projects/{pid}/policy-roles", json={"roles": {"default": ["nope"]}}
+    )
+    assert r.status_code == 409, r.text
+    assert client.get(f"/v1/projects/{pid}/policy-roles").json()["roles"] == {}
+
+
+async def test_flip_to_modular_rejected_when_bundle_cannot_build(
+    session_factory, client: TestClient, monkeypatch
+) -> None:
+    # The flip resolves fine but the bundle can't compile (opa down). We must
+    # reject + roll back rather than leave is_modular True with the agent still
+    # on its now-wrong classic bundle.
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.models import Agent
+
+    monkeypatch.setattr(asvc, "compile_bundle", lambda py, sign: None)  # opa "down"
+
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    async with session_factory() as s:
+        agent = Agent(
+            id=new_id(Agent),
+            project_id=pid,
+            name="a1",
+            agent_yaml="",
+            policy_yaml="version: 1\n",
+            system_md="",
+        )
+        agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = (
+            b"CLASSIC",
+            "M",
+            b"S",
+        )
+        s.add(agent)
+        await s.commit()
+
+    r = client.put(
+        f"/v1/projects/{pid}/policy-roles", json={"roles": {"default": ["read_only"]}}
+    )
+    assert r.status_code == 409, r.text
+    assert client.get(f"/v1/projects/{pid}/policy-roles").json()["roles"] == {}
+
+    async with session_factory() as s:
+        from sqlmodel import select
+
+        from hexgate_api.models import Agent as A
+
+        row = (await s.exec(select(A).where(A.project_id == pid))).first()
+        assert row.compiled_wasm == b"CLASSIC"  # stale classic bundle left intact
+
+
+async def test_register_into_modular_project_seeds_deny_all_fallback(
+    session_factory, monkeypatch
+) -> None:
+    # A new agent in a modular project must fall back to deny-all (not a
+    # permissive tool-derived starter) if the modular bundle can't be served.
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.features.agents.compiler import DENY_ALL_POLICY_YAML
+    from hexgate_api.features.policy_modules import service as pm
+    from hexgate_api.schemas import (
+        AgentFramework,
+        AgentManifest,
+        InputSchema,
+        ToolDefinition,
+    )
+
+    monkeypatch.setattr(asvc, "compile_bundle", lambda py, sign: (b"W", "M", b"S"))
+
+    async with session_factory() as s:
+        proj, _ = await _fresh_project_with_agent(s)
+        await pm.upsert_module(
+            s,
+            project_id=proj.id,
+            tier="capability",
+            path="read_only",
+            content=READ_ONLY,
+        )
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["read_only"]})
+
+        manifest = AgentManifest(
+            name="newbot",
+            framework=AgentFramework.LANGCHAIN,
+            tools=[
+                ToolDefinition(
+                    name="delete_thing",  # write-shape: permissive under the starter
+                    description=None,
+                    input_schema=InputSchema(properties={}, required=[]),
+                )
+            ],
+        )
+        _, created = await asvc.register_manifest(
+            s, proj.id, manifest, sign=_dummy_sign
+        )
+        assert created
+        agent = await asvc.get_agent(s, proj.id, "newbot")
+        assert agent is not None
+        assert agent.policy_yaml == DENY_ALL_POLICY_YAML

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -9,6 +9,9 @@ test_projects.py.
 
 from __future__ import annotations
 
+import shutil
+
+import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
@@ -241,3 +244,317 @@ def test_content_hash_matches_sdk_loader_and_is_format_stable() -> None:
     assert a == b  # hash is over the parsed payload, not the raw text
     # byte-identical to what the SDK's file loader would compute for the module
     assert a == _canonical_hash(_yaml.safe_load("tools:\n  x: { mode: allow }\n"))
+
+
+# --- 3a-2: compile agent bundles from resolved modules (docs/adr/R-POL-002) ---
+
+needs_opa = pytest.mark.skipif(shutil.which("opa") is None, reason="opa not on PATH")
+
+
+def _dummy_sign(data: bytes) -> bytes:
+    return b"sig"
+
+
+async def _fresh_project_with_agent(
+    session, *, policy_yaml="version: 1\n", bundle=None
+):
+    """A project under the default org with one agent, isolated from the seeded
+    default project (which carries seeded agents)."""
+    import uuid
+
+    from hexgate_api.constants import DEFAULT_ORG_ID
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.models import Agent, Project
+
+    proj = Project(
+        id=str(uuid.uuid4()), org_id=DEFAULT_ORG_ID, name=f"mod-{uuid.uuid4().hex[:8]}"
+    )
+    session.add(proj)
+    agent = Agent(
+        id=new_id(Agent),
+        project_id=proj.id,
+        name="a1",
+        agent_yaml="",
+        policy_yaml=policy_yaml,
+        system_md="",
+    )
+    if bundle is not None:
+        agent.compiled_wasm, agent.bundle_manifest, agent.bundle_signature = bundle
+    session.add(agent)
+    await session.commit()
+    await session.refresh(proj)
+    await session.refresh(agent)
+    return proj, agent
+
+
+async def test_is_modular_flips_on_first_role_binding(session_factory):
+    from hexgate_api.features.policy_modules import service as pm
+
+    async with session_factory() as s:
+        proj, _ = await _fresh_project_with_agent(s)
+        assert await pm.is_modular(s, proj.id) is False
+        await pm.set_roles(s, project_id=proj.id, roles={"default": []})
+        assert await pm.is_modular(s, proj.id) is True
+
+
+async def test_resolved_policy_yaml_is_inline_roles_shape(session_factory):
+    import yaml
+
+    from hexgate_api.features.policy_modules import service as pm
+
+    async with session_factory() as s:
+        proj, _ = await _fresh_project_with_agent(s)
+        await pm.upsert_module(
+            s,
+            project_id=proj.id,
+            tier="capability",
+            path="read_only",
+            content=READ_ONLY,
+        )
+        await pm.set_roles(
+            s,
+            project_id=proj.id,
+            roles={"default": ["read_only"], "billing": ["read_only"]},
+        )
+        text = await pm.resolved_policy_yaml(s, proj.id)
+
+    doc = yaml.safe_load(text)
+    assert set(doc["roles"]) == {"default", "billing"}
+    assert "view_orders" in doc["roles"]["billing"]["tools"]
+
+
+async def test_bundle_for_agent_routes_by_mode(session_factory, monkeypatch):
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.features.policy_modules import service as pm
+
+    captured: list[str] = []
+
+    def fake_compile(policy_yaml, sign):
+        captured.append(policy_yaml)
+        return (b"w", "m", b"s")
+
+    monkeypatch.setattr(asvc, "compile_bundle", fake_compile)
+
+    async with session_factory() as s:
+        proj, agent = await _fresh_project_with_agent(s, policy_yaml="version: 1\n")
+        # classic: no role bindings -> compile from the agent's own policy_yaml
+        await asvc.bundle_for_agent(s, agent, _dummy_sign)
+        assert captured[-1] == "version: 1\n"
+
+        # make modular -> compile from the resolved role-keyed policy instead
+        await pm.upsert_module(
+            s,
+            project_id=proj.id,
+            tier="capability",
+            path="read_only",
+            content=READ_ONLY,
+        )
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["read_only"]})
+        await asvc.bundle_for_agent(s, agent, _dummy_sign)
+        assert "roles:" in captured[-1]
+        assert "view_orders" in captured[-1]
+
+
+async def test_recompile_project_fans_out_to_every_agent(session_factory, monkeypatch):
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.features.policy_modules import service as pm
+    from hexgate_api.models import Agent
+
+    monkeypatch.setattr(
+        asvc, "compile_bundle", lambda py, sign: (b"WASM", "MANI", b"SIG")
+    )
+
+    async with session_factory() as s:
+        proj, a1 = await _fresh_project_with_agent(s)
+        a2 = Agent(
+            id=new_id(Agent),
+            project_id=proj.id,
+            name="a2",
+            agent_yaml="",
+            policy_yaml="version: 1\n",
+            system_md="",
+        )
+        s.add(a2)
+        await s.commit()
+        await pm.upsert_module(
+            s,
+            project_id=proj.id,
+            tier="capability",
+            path="read_only",
+            content=READ_ONLY,
+        )
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["read_only"]})
+
+        n = await asvc.recompile_project(s, proj.id, _dummy_sign)
+        assert n == 2
+        for a in (a1, a2):
+            await s.refresh(a)
+            assert a.compiled_wasm == b"WASM"
+
+
+async def test_recompile_project_noop_leaves_bundles_when_unresolvable(session_factory):
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.features.policy_modules import service as pm
+
+    async with session_factory() as s:
+        proj, agent = await _fresh_project_with_agent(
+            s, bundle=(b"OLD", "OLDMANI", b"OLDSIG")
+        )
+        # role imports a capability that doesn't exist -> project won't resolve
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["nonexistent"]})
+
+        n = await asvc.recompile_project(s, proj.id, _dummy_sign)
+        assert n == 0
+        await s.refresh(agent)
+        assert agent.compiled_wasm == b"OLD"  # last-good bundle untouched
+
+
+def _capture_compile(monkeypatch, ret=(b"w", "m", b"s")):
+    import hexgate_api.features.agents.service as asvc
+
+    captured: list[str] = []
+
+    def fake(policy_yaml, sign):
+        captured.append(policy_yaml)
+        return ret
+
+    monkeypatch.setattr(asvc, "compile_bundle", fake)
+    return captured
+
+
+async def test_classic_project_recompiles_from_policy_yaml(
+    session_factory, monkeypatch
+):
+    import hexgate_api.features.agents.service as asvc
+
+    captured = _capture_compile(monkeypatch)
+    async with session_factory() as s:
+        proj, agent = await _fresh_project_with_agent(
+            s, policy_yaml="version: 1\n# classic\n"
+        )
+        # classic: recompile_project rebuilds each agent from its own policy_yaml
+        assert await asvc.recompile_project(s, proj.id, _dummy_sign) == 1
+        assert captured[-1] == "version: 1\n# classic\n"
+
+
+async def test_update_agent_does_not_blank_a_modular_bundle_when_unresolvable(
+    session_factory,
+):
+    # R-POL-002 fail-safe: editing an agent while the project's modules don't
+    # resolve must leave the last-good bundle enforced, not wipe it.
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.features.policy_modules import service as pm
+
+    async with session_factory() as s:
+        proj, agent = await _fresh_project_with_agent(
+            s, bundle=(b"LIVE", "MANI", b"SIG")
+        )
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["nonexistent"]})
+
+        updated = await asvc.update_agent(
+            s, proj.id, agent.name, system_md="edited", sign=_dummy_sign
+        )
+        assert updated is not None
+        assert updated.compiled_wasm == b"LIVE"  # untouched despite the edit
+
+
+async def test_modular_to_classic_transition_recompiles_from_policy_yaml(
+    session_factory, monkeypatch
+):
+    # Dropping the last role binding returns the project to classic; agents must
+    # recompile from policy_yaml, not keep enforcing the stale resolved bundle.
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.features.policy_modules import service as pm
+
+    captured = _capture_compile(monkeypatch)
+    async with session_factory() as s:
+        proj, agent = await _fresh_project_with_agent(
+            s, policy_yaml="version: 1\n# classic\n"
+        )
+        await pm.upsert_module(
+            s,
+            project_id=proj.id,
+            tier="capability",
+            path="read_only",
+            content=READ_ONLY,
+        )
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["read_only"]})
+        assert await asvc.recompile_project(s, proj.id, _dummy_sign) == 1
+        assert "roles:" in captured[-1]  # modular: compiled from resolved YAML
+
+        await pm.set_roles(s, project_id=proj.id, roles={})  # unbind -> classic
+        assert await pm.is_modular(s, proj.id) is False
+        assert await asvc.recompile_project(s, proj.id, _dummy_sign) == 1
+        assert captured[-1] == "version: 1\n# classic\n"  # back to policy_yaml
+
+
+@needs_opa
+async def test_modular_bundle_matches_compile_of_resolved_yaml(session_factory, client):
+    import hexgate_api.features.agents.service as asvc
+    from hexgate_api.features.agents.compiler import compile_bundle
+    from hexgate_api.features.policy_modules import service as pm
+
+    sign = keystore_mod.keystore.sign
+    async with session_factory() as s:
+        proj, agent = await _fresh_project_with_agent(s)
+        await pm.upsert_module(
+            s,
+            project_id=proj.id,
+            tier="capability",
+            path="read_only",
+            content=READ_ONLY,
+        )
+        await pm.set_roles(s, project_id=proj.id, roles={"default": ["read_only"]})
+
+        got = await asvc.bundle_for_agent(s, agent, sign)
+        expected = compile_bundle(await pm.resolved_policy_yaml(s, proj.id), sign)
+
+    assert got is not None and expected is not None
+    assert got[0] == expected[0]  # identical wasm bytes -> same enforced policy
+
+
+async def test_classic_recompile_nulls_bundle_when_policy_fails_to_compile(
+    session_factory, monkeypatch
+):
+    # A classic agent whose own policy_yaml no longer compiles must DROP its
+    # stale bundle (fall back to pydantic), never keep serving a wrong one — the
+    # Agent.compiled_wasm invariant, and the worst case after a modular->classic
+    # unbind. (The other recompile tests stub compile to always succeed.)
+    import hexgate_api.features.agents.service as asvc
+
+    monkeypatch.setattr(asvc, "compile_bundle", lambda py, sign: None)
+    async with session_factory() as s:
+        proj, agent = await _fresh_project_with_agent(s, bundle=(b"STALE", "M", b"S"))
+        # no role bindings -> classic branch
+        n = await asvc.recompile_project(s, proj.id, _dummy_sign)
+        assert n == 1
+        await s.refresh(agent)
+        assert agent.compiled_wasm is None
+        assert agent.bundle_manifest is None
+        assert agent.bundle_signature is None
+
+
+def test_identical_role_put_skips_recompile(client: TestClient, monkeypatch) -> None:
+    # An idempotent PUT /policy-roles (re-saving the same bindings) must not pay
+    # a resolve + opa compile; a real change still recompiles.
+    import hexgate_api.features.agents.service as asvc
+
+    calls = {"n": 0}
+    real = asvc.recompile_project
+
+    async def spy(session, project_id, sign):
+        calls["n"] += 1
+        return await real(session, project_id, sign)
+
+    monkeypatch.setattr(asvc, "recompile_project", spy)
+
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    body = {"roles": {"default": ["read_only"]}}
+    assert client.put(f"/v1/projects/{pid}/policy-roles", json=body).status_code == 200
+    after_change = calls["n"]
+    assert after_change >= 1  # a real change recompiled
+    # identical re-save -> no recompile
+    assert client.put(f"/v1/projects/{pid}/policy-roles", json=body).status_code == 200
+    assert calls["n"] == after_change

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -922,3 +922,29 @@ async def test_recompile_builds_distinct_bundles_per_agent(
         # billing_bot's bundle carries refund_order; triage_bot's does not.
         assert b"refund_order" in billing.compiled_wasm
         assert b"refund_order" not in triage.compiled_wasm
+
+
+def test_capability_deny_put_rejected_on_modular_project(client: TestClient) -> None:
+    # PUT-ing a capability with a deny into a modular project must 409 (the linker
+    # rejects it at resolve), not store an uncomposable module that silently keeps
+    # agents on the old bundle.
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    assert (
+        client.put(
+            f"/v1/projects/{pid}/policy-roles",
+            json={"roles": {"default": ["read_only"]}},
+        ).status_code
+        == 200
+    )
+    r = client.put(
+        f"/v1/projects/{pid}/policy-modules/capability/bad",
+        json={"content": "tools:\n  x: { mode: deny }\n"},
+    )
+    assert r.status_code == 409, r.text
+    # rolled back — the newly-created module was removed.
+    paths = {
+        (m["tier"], m["path"])
+        for m in client.get(f"/v1/projects/{pid}/policy-modules").json()
+    }
+    assert ("capability", "bad") not in paths

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -560,6 +560,32 @@ def test_identical_role_put_skips_recompile(client: TestClient, monkeypatch) -> 
     assert calls["n"] == after_change
 
 
+def test_reordered_role_put_skips_recompile(client: TestClient, monkeypatch) -> None:
+    # Re-saving the same imports in a different order is not a change -> no
+    # recompile (the comparison is order-insensitive).
+    import hexgate_api.features.agents.service as asvc
+
+    calls = {"n": 0}
+    real = asvc.recompile_project
+
+    async def spy(session, project_id, sign):
+        calls["n"] += 1
+        return await real(session, project_id, sign)
+
+    monkeypatch.setattr(asvc, "recompile_project", spy)
+
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    _put_module(client, pid, "capability", "payments", PAYMENTS)
+    b1 = {"roles": {"billing": ["read_only", "payments"]}}
+    assert client.put(f"/v1/projects/{pid}/policy-roles", json=b1).status_code == 200
+    after_change = calls["n"]
+    assert after_change >= 1
+    b2 = {"roles": {"billing": ["payments", "read_only"]}}  # same set, reordered
+    assert client.put(f"/v1/projects/{pid}/policy-roles", json=b2).status_code == 200
+    assert calls["n"] == after_change  # not recompiled
+
+
 # --- review fixes: fail-closed on modular flips / deletes -------------------
 
 

--- a/tests/security/test_analyzer.py
+++ b/tests/security/test_analyzer.py
@@ -481,6 +481,24 @@ def test_check_project_unknown_capability_is_a_link_error():
     assert [lint.code for lint in lints] == ["link-error"]
 
 
+def test_check_project_surfaces_named_agent_column_link_error():
+    # A named-agent column importing an unknown capability must show as a
+    # link-error lint (the "*" column alone would never touch it).
+    from hexgate.security import AgentBinding
+
+    read_only = _mod("read_only", "capability", {"view": _allow()})
+    roles = {
+        "member": {
+            "*": AgentBinding(capabilities=("read_only",)),
+            "billing_bot": AgentBinding(capabilities=("nonexistent",)),
+        }
+    }
+    lints = check_project([], [read_only], roles)
+    assert any(
+        lint.code == "link-error" and "billing_bot" in lint.message for lint in lints
+    )
+
+
 def test_no_roles_emit_no_project_lints():
     # None (no roles.yaml) -> one default importing everything. Nothing unused,
     # and the default is present, so neither project-level lint fires.

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -469,3 +469,55 @@ def test_default_role_synthesised_when_absent_is_deny_all():
     assert "default" in result.by_role
     assert result.policy_set.policy_for("default").tools == {}
     assert "x" in result.policy_set.policy_for("billing").tools
+
+
+# --- (role, agent) matrix: per-agent resolve (Path A) -----------------------
+
+
+def test_resolve_for_agent_uses_agent_cell_over_wildcard():
+    from hexgate.security import AgentBinding
+
+    read_only = _mod("read_only", "capability", {"view": _allow()})
+    payments = _mod("payments", "capability", {"refund": _allow()})
+    roles = {
+        "member": {
+            "*": AgentBinding(capabilities=("read_only",)),
+            "billing_bot": AgentBinding(capabilities=("read_only", "payments")),
+        }
+    }
+    lib = [read_only, payments]
+
+    # The named agent sees its own cell -> refund granted.
+    billing = resolve_for_project([], lib, roles, agent="billing_bot")
+    assert "refund" in billing.by_role["member"].effective["default"].tools
+
+    # An unnamed agent falls back to the "*" cell -> read_only only.
+    other = resolve_for_project([], lib, roles, agent="triage_bot")
+    other_tools = other.by_role["member"].effective["default"].tools
+    assert "view" in other_tools and "refund" not in other_tools
+
+
+def test_agent_cell_replaces_wildcard_so_agent_can_be_more_restricted():
+    from hexgate.security import AgentBinding
+
+    read_only = _mod("read_only", "capability", {"view": _allow()})
+    payments = _mod("payments", "capability", {"refund": _allow()})
+    roles = {
+        "member": {
+            "*": AgentBinding(capabilities=("read_only", "payments")),  # generic: both
+            "triage_bot": AgentBinding(capabilities=("read_only",)),  # restricted
+        }
+    }
+    triage = resolve_for_project([], [read_only, payments], roles, agent="triage_bot")
+    tools = triage.by_role["member"].effective["default"].tools
+    # Replace, not merge: triage_bot does NOT inherit payments from "*".
+    assert "view" in tools and "refund" not in tools
+
+
+def test_flat_roles_still_resolve_agent_independently():
+    # Legacy flat `role: [caps]` applies to every agent (the "*" cell).
+    read_only = _mod("read_only", "capability", {"view": _allow()})
+    roles = {"member": ["read_only"]}
+    for agent in ("main", "anything"):
+        res = resolve_for_project([], [read_only], roles, agent=agent)
+        assert "view" in res.by_role["member"].effective["default"].tools

--- a/tests/security/test_module_loader.py
+++ b/tests/security/test_module_loader.py
@@ -114,14 +114,40 @@ def test_nested_same_stem_modules_stay_distinct(tmp_path):
 
 
 def test_load_roles_reads_bindings(tmp_path):
+    from hexgate.security import AgentBinding
+
     _write(
         tmp_path,
         "roles.yaml",
         "version: 1\nroles:\n  default: [read_only]\n  billing: [read_only, payments]\n",
     )
+    # A flat `role: [caps]` normalizes to the generic "*" agent cell.
     assert load_roles(tmp_path) == {
-        "default": ["read_only"],
-        "billing": ["read_only", "payments"],
+        "default": {"*": AgentBinding(capabilities=("read_only",))},
+        "billing": {"*": AgentBinding(capabilities=("read_only", "payments"))},
+    }
+
+
+def test_load_roles_reads_agent_matrix(tmp_path):
+    from hexgate.security import AgentBinding
+
+    _write(
+        tmp_path,
+        "roles.yaml",
+        "version: 1\n"
+        "roles:\n"
+        "  member:\n"
+        "    '*': [read_only]\n"
+        "    billing_bot:\n"
+        "      capabilities: [read_only, payments]\n"
+        "    triage_bot: [read_only]\n",
+    )
+    assert load_roles(tmp_path) == {
+        "member": {
+            "*": AgentBinding(capabilities=("read_only",)),
+            "billing_bot": AgentBinding(capabilities=("read_only", "payments")),
+            "triage_bot": AgentBinding(capabilities=("read_only",)),
+        }
     }
 
 
@@ -160,7 +186,7 @@ def test_load_roles_rejects_non_mapping_document(tmp_path):
 
 def test_load_roles_rejects_non_list_value(tmp_path):
     _write(tmp_path, "roles.yaml", "roles:\n  default: read_only\n")
-    with pytest.raises(ValueError, match="list of capability names"):
+    with pytest.raises(ValueError, match="capability list or an agent mapping"):
         load_roles(tmp_path)
 
 


### PR DESCRIPTION
Compile a modular project's agent bundles from its resolved modules, so multi-module policy actually enforces. Until now the store + resolve/check (#116) were inspection-only; this wires the resolved role-keyed policy into the signed WASM bundle each agent serves.

**Stacked on #116** (the policy-module store). The base of this PR is that branch, so the diff here is just the enforcement wiring; it retargets to `main` once #116 merges. Review/merge #116 first.

Additive: no schema change, no migration, and classic single-file agents are untouched.

## Design (see `docs/adr/R-POL-002`)

- **Modular = the project has a role binding.** Inferred, not a `policy_mode` column — so no migration (the platform has no Alembic, and `create_all` can't add a column to a live DB). Binding a role is the deliberate opt-in; uploading a module alone doesn't flip enforcement.
- **One chokepoint.** `bundle_for_agent(session, agent, sign)` compiles from the resolved role-keyed policy for a modular project, or from `agent.policy_yaml` for a classic one. The three existing compile sites (`update_agent`, `register_manifest`, `backfill_bundles`) all route through it, so the whole lifecycle is mode-aware in one place.
- **Resolve → the YAML `build` already accepts.** `resolved_policy_yaml` serializes the `PolicySet` to the inline-`roles:` shape, so `build_signed_bundle` (the same helper the CLI and #116 use) is unchanged.
- **Fan-out.** Editing a module or role binding recompiles every agent in the project (`recompile_project`), resolving once and reusing the single bundle for all of them.
- **Fail-safe.** An unresolvable edit, or a resolve that can't compile (opa absent), leaves live bundles untouched — a work-in-progress or typo never blanks running agents. `check` still surfaces the problem.
- **Serve path unchanged.** The bundle stays on the `Agent` row; the SDK fetches it as today.

## Important files

| File | What to look at |
| --- | --- |
| `platform/api/hexgate_api/features/agents/service.py` | `bundle_for_agent` (the chokepoint) + `recompile_project` (fan-out); the 3 compile sites now route through it |
| `platform/api/hexgate_api/features/policy_modules/service.py` | `is_modular` + `resolved_policy_yaml` (serialize the resolved set to inline-roles YAML) |
| `platform/api/hexgate_api/features/policy_modules/router.py` | `_recompile_modular` wired into the module/role write endpoints |
| `docs/adr/R-POL-002-compile-agents-from-modules.md` | the decision + the fail-safe / infer-modular rationale |

## Test plan

Full platform-api suite green (464 passed, 4 skipped) against the post-#118 `main` SDK. New service-level tests cover: `is_modular` flips on the first role binding; `bundle_for_agent` compiles from resolved YAML when modular and from `policy_yaml` when classic; `recompile_project` fans out to every agent; an unresolvable edit (role importing an unknown capability) returns 0 and leaves the last-good bundle byte-for-byte unchanged. One `opa`-gated end-to-end asserts a modular agent's compiled WASM equals compiling the resolved YAML directly (identical bytes → same enforced policy). Logic tests monkeypatch the compiler so they don't need `opa`; the byte-match test skips without it.

## Notes

- For a modular agent, `agent.policy_yaml` is no longer what's enforced (the resolved modules are); the dashboard (3b) edits modules, not per-agent `policy_yaml`, for modular projects.
- Deferred: agent-scoped self-restriction modules; deduping the identical per-agent bundles into one per-project bundle; the dashboard itself (3b).
