### PR TITLE
feat(sdk): agent-level policy model with admission/agents blocks

### DIFF
--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -20,12 +20,16 @@ from hexgate.security.bans import (
     resolve_ban_gate,
 )
 from hexgate.security.models import (
+    AGENT_RUN_TOOL,
     AgentPolicy,
+    AgentTargetPolicy,
+    AgentVia,
     BaseToolPolicy,
     FileScope,
     FileToolPolicy,
     PolicyMode,
     ToolPolicy,
+    agent_target_key,
 )
 from hexgate.security.constraints import (
     Constraint,
@@ -133,8 +137,12 @@ from hexgate.security.testing import (
 )
 
 __all__ = [
+    "AGENT_RUN_TOOL",
     "AgentBannedError",
     "AgentPolicy",
+    "AgentTargetPolicy",
+    "AgentVia",
+    "agent_target_key",
     "LayerKind",
     "LinkError",
     "LinkResult",

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -500,11 +500,15 @@ def check_default_role_exposure(policy_set: PolicySet) -> list[PolicyLint]:
             )
         )
 
-    for tool, tool_policy in sorted(default_policy.tools.items()):
+    # effective_tools, not tools: a default role that grants an admission or
+    # agents rule (lowered to an ``agent.*`` key) is reachable by any undefined
+    # role name too, and that is exactly the exposure this lint exists to catch.
+    for tool, tool_policy in sorted(default_policy.effective_tools.items()):
         if tool_policy.mode not in GRANT_MODES:
             continue
         if any(
-            tool in other.tools and other.tools[tool].mode in GRANT_MODES
+            tool in other.effective_tools
+            and other.effective_tools[tool].mode in GRANT_MODES
             for other in others
         ):
             continue

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -171,7 +171,7 @@ def link(
 ) -> tuple[AgentPolicy, RuleTrace]:
     """Fold one role's layers into a single :class:`AgentPolicy`. Pure; no I/O."""
     _reject_file_scope(boundaries, capabilities)
-    _reject_agent_blocks(boundaries, capabilities)
+    _reject_unsupported_module_fields(boundaries, capabilities)
     _reject_default_policy_constraints(boundaries, capabilities)
     consts = _merge_consts(boundaries, capabilities)
 
@@ -272,23 +272,32 @@ def _reject_file_scope(
                 )
 
 
-def _reject_agent_blocks(
+# The AgentPolicy fields the fold understands. Anything else a module sets is
+# rejected by _reject_unsupported_module_fields, so a field added to AgentPolicy
+# later fails closed here instead of being silently dropped by _fold_tool.
+_MODULE_COMPOSABLE_FIELDS = frozenset(
+    {"version", "inherits", "is_mixin", "default_policy", "tools", "consts"}
+)
+
+
+def _reject_unsupported_module_fields(
     boundaries: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> None:
-    """Reject ``admission`` / ``agents`` in a module — composing them isn't supported yet.
+    """Reject any top-level AgentPolicy field a module sets that the fold does not
+    compose (today: ``admission`` / ``agents``; tomorrow: whatever is added next).
 
-    Agent-level blocks lower into synthetic ``agent.*`` keys that the engines
-    enforce, but the module fold below only composes ``tools``. Silently dropping
-    an agent block would erase an ingress or egress rule an operator authored, the
-    same fail-open :func:`_reject_file_scope` guards against. Fail loud until module
-    composition understands agent blocks; author them in a single-file policy for
-    now."""
+    ``_fold_tool`` reads only ``.tools``, so an un-composed field would be silently
+    dropped, erasing a rule an operator authored — the same fail-open
+    :func:`_reject_file_scope` guards against, generalized. Allowlisting the fields
+    the fold understands means a new AgentPolicy field is rejected automatically
+    until composition learns it, rather than shipping fail-open by omission."""
     for module in (*boundaries, *capabilities):
-        if module.policy.admission is not None or module.policy.agents:
+        extra = module.policy.model_fields_set - _MODULE_COMPOSABLE_FIELDS
+        if extra:
             raise LinkError(
-                f"module {module.name!r} sets an agent-level block "
-                f"(admission/agents), which module composition does not support "
-                f"yet — keep it in a single-file policy ({module.source})"
+                f"module {module.name!r} sets {sorted(extra)}, which module "
+                f"composition does not support (the fold composes only tools); "
+                f"keep it in a single-file policy ({module.source})"
             )
 
 

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -171,6 +171,7 @@ def link(
 ) -> tuple[AgentPolicy, RuleTrace]:
     """Fold one role's layers into a single :class:`AgentPolicy`. Pure; no I/O."""
     _reject_file_scope(boundaries, capabilities)
+    _reject_agent_blocks(boundaries, capabilities)
     _reject_default_policy_constraints(boundaries, capabilities)
     consts = _merge_consts(boundaries, capabilities)
 
@@ -269,6 +270,26 @@ def _reject_file_scope(
                     f"which module composition does not support yet — keep it in a "
                     f"single-file policy or drop file_scope ({module.source})"
                 )
+
+
+def _reject_agent_blocks(
+    boundaries: list[ModuleContent], capabilities: list[ModuleContent]
+) -> None:
+    """Reject ``admission`` / ``agents`` in a module — composing them isn't supported yet.
+
+    Agent-level blocks lower into synthetic ``agent.*`` keys that the engines
+    enforce, but the module fold below only composes ``tools``. Silently dropping
+    an agent block would erase an ingress or egress rule an operator authored, the
+    same fail-open :func:`_reject_file_scope` guards against. Fail loud until module
+    composition understands agent blocks; author them in a single-file policy for
+    now."""
+    for module in (*boundaries, *capabilities):
+        if module.policy.admission is not None or module.policy.agents:
+            raise LinkError(
+                f"module {module.name!r} sets an agent-level block "
+                f"(admission/agents), which module composition does not support "
+                f"yet — keep it in a single-file policy ({module.source})"
+            )
 
 
 def _fold_tool(

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -52,6 +52,48 @@ class FileToolPolicy(BaseToolPolicy):
 
 ToolPolicy = BaseToolPolicy | FileToolPolicy
 
+AgentVia = Literal["tool", "handoff"]
+
+# Reserved synthetic tool keys that agent-level gating lowers to. Kept here so
+# the lowering and the agent gate (which builds the same keys at the seam) share
+# one definition. ``.`` and ``:`` are safe in a tool name: both engines treat the
+# name as an opaque string (the Rego compiler emits ``input.tool == "<name>"``),
+# exactly as the ``net.*`` egress tools already do.
+AGENT_RUN_TOOL = "agent.run"
+
+
+def agent_target_key(via: AgentVia, target: str) -> str:
+    """Synthetic tool key for reaching ``target`` in a given transfer mode."""
+    return f"agent.{via}:{target}"
+
+
+def _is_reserved_agent_key(name: str) -> bool:
+    return (
+        name == AGENT_RUN_TOOL
+        or name.startswith("agent.tool:")
+        or name.startswith("agent.handoff:")
+    )
+
+
+class AgentTargetPolicy(BaseToolPolicy):
+    """Authorize reaching one named target agent, per transfer mode.
+
+    ``via`` names the transfer modes this rule governs: ``tool`` (agent-as-tool,
+    the orchestrator keeps control) and/or ``handoff`` (control transfers). A
+    target listed for ``tool`` only cannot be handed off to, and the reverse.
+    ``mode`` and ``constraints`` behave exactly as on a tool policy.
+    """
+
+    via: list[AgentVia] = Field(default_factory=lambda: ["tool", "handoff"])
+
+    @field_validator("via")
+    @classmethod
+    def _validate_via(cls, value: list[AgentVia]) -> list[AgentVia]:
+        if not value:
+            raise ValueError("via must list at least one of 'tool', 'handoff'")
+        # De-dup, order-preserving.
+        return list(dict.fromkeys(value))
+
 
 class AgentPolicy(BaseModel):
     """Define an agent-wide tool authorization policy.
@@ -67,6 +109,21 @@ class AgentPolicy(BaseModel):
     ``consts`` names reusable values referenced from constraints as
     ``consts.<name>`` (e.g. ``args.amount <= consts.max_refund``). Merged
     through ``inherits`` like ``tools`` — put shared constants in a mixin.
+
+    Agent-level gating (all optional):
+
+    * ``admission`` — ingress. May this role start or enter *this* agent at all?
+    * ``agents`` — egress. Which *other* agents may this role reach, keyed by
+      target name, each an :class:`AgentTargetPolicy`.
+    * ``default_agent_policy`` — the fallback for a target not named in ``agents``.
+      Consumed by the agent gate at the seam, not by the engines directly; when a
+      target's synthetic key is absent it already falls to ``default_policy``
+      (deny by default), so a listed-``agents`` policy is closed-world for free
+      unless ``default_policy`` is permissive.
+
+    ``admission`` and ``agents`` lower into synthetic tool keys via
+    :attr:`effective_tools`, which both policy engines read, so agent-level rules
+    evaluate through the identical decision path as tools with no engine change.
     """
 
     version: int = 1
@@ -75,3 +132,56 @@ class AgentPolicy(BaseModel):
     default_policy: BaseToolPolicy = Field(default_factory=BaseToolPolicy)
     tools: dict[str, ToolPolicy] = Field(default_factory=dict)
     consts: dict[str, Any] = Field(default_factory=dict)
+    admission: BaseToolPolicy | None = None
+    agents: dict[str, AgentTargetPolicy] = Field(default_factory=dict)
+    default_agent_policy: BaseToolPolicy | None = None
+
+    @field_validator("tools")
+    @classmethod
+    def _reject_reserved_tool_names(
+        cls, value: dict[str, ToolPolicy]
+    ) -> dict[str, ToolPolicy]:
+        """Keep the ``agent.*`` key namespace for agent-level gating.
+
+        An authored tool named ``agent.run`` / ``agent.tool:x`` / ``agent.handoff:x``
+        would collide with a lowered agent rule in :attr:`effective_tools` and
+        silently shadow (or be shadowed by) it. Reject it at load."""
+        for name in value:
+            if _is_reserved_agent_key(name):
+                raise ValueError(
+                    f"tool name {name!r} is reserved for agent-level gating; "
+                    "use the 'admission'/'agents' blocks instead"
+                )
+        return value
+
+    def lowered_agent_tools(self) -> dict[str, BaseToolPolicy]:
+        """Expand ``admission``/``agents`` into synthetic tool entries.
+
+        ``admission`` → ``agent.run``; each ``agents`` target → one entry per
+        ``via`` mode (``agent.tool:<name>`` / ``agent.handoff:<name>``). Only the
+        *listed* rules are lowered; the fallback for an unlisted target is the
+        agent gate's concern, not this map's.
+        """
+        lowered: dict[str, BaseToolPolicy] = {}
+        if self.admission is not None:
+            lowered[AGENT_RUN_TOOL] = self.admission
+        for target, target_policy in self.agents.items():
+            base = BaseToolPolicy(
+                mode=target_policy.mode, constraints=target_policy.constraints
+            )
+            for via in target_policy.via:
+                lowered[agent_target_key(via, target)] = base
+        return lowered
+
+    @property
+    def effective_tools(self) -> dict[str, ToolPolicy]:
+        """Authored ``tools`` plus the lowered agent-level entries.
+
+        The single view both engines read (:func:`~hexgate.security.policy.get_tool_policy`
+        and the Rego compiler), so a lowered ``agent.*`` key evaluates byte-for-byte
+        the same on the pydantic and WASM paths.
+        """
+        lowered = self.lowered_agent_tools()
+        if not lowered:
+            return self.tools
+        return {**self.tools, **lowered}

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from hexgate.security.constraints import parse_constraint
 
@@ -110,21 +111,22 @@ class AgentPolicy(BaseModel):
     ``consts.<name>`` (e.g. ``args.amount <= consts.max_refund``). Merged
     through ``inherits`` like ``tools`` — put shared constants in a mixin.
 
-    Agent-level gating (all optional):
+    Agent-level gating (both optional):
 
     * ``admission`` — ingress. May this role start or enter *this* agent at all?
     * ``agents`` — egress. Which *other* agents may this role reach, keyed by
       target name, each an :class:`AgentTargetPolicy`.
-    * ``default_agent_policy`` — the fallback for a target not named in ``agents``.
-      Consumed by the agent gate at the seam, not by the engines directly; when a
-      target's synthetic key is absent it already falls to ``default_policy``
-      (deny by default), so a listed-``agents`` policy is closed-world for free
-      unless ``default_policy`` is permissive.
 
-    ``admission`` and ``agents`` lower into synthetic tool keys via
-    :attr:`effective_tools`, which both policy engines read, so agent-level rules
-    evaluate through the identical decision path as tools with no engine change.
+    Both lower into synthetic tool keys via :attr:`effective_tools`, which both
+    policy engines read, so agent-level rules evaluate through the identical
+    decision path as tools with no engine change. A target not named in ``agents``
+    falls to ``default_policy`` (deny by default), so a listed-``agents`` policy is
+    closed-world for free; the runtime gate refines that fallback in a later PR.
     """
+
+    # cached_property is a plain descriptor, not a field — tell pydantic to leave
+    # it alone so ``effective_tools`` can memoize on the enforcement hot path.
+    model_config = ConfigDict(ignored_types=(cached_property,))
 
     version: int = 1
     inherits: list[str] = Field(default_factory=list)
@@ -134,7 +136,6 @@ class AgentPolicy(BaseModel):
     consts: dict[str, Any] = Field(default_factory=dict)
     admission: BaseToolPolicy | None = None
     agents: dict[str, AgentTargetPolicy] = Field(default_factory=dict)
-    default_agent_policy: BaseToolPolicy | None = None
 
     @field_validator("tools")
     @classmethod
@@ -173,13 +174,15 @@ class AgentPolicy(BaseModel):
                 lowered[agent_target_key(via, target)] = base
         return lowered
 
-    @property
+    @cached_property
     def effective_tools(self) -> dict[str, ToolPolicy]:
         """Authored ``tools`` plus the lowered agent-level entries.
 
         The single view both engines read (:func:`~hexgate.security.policy.get_tool_policy`
         and the Rego compiler), so a lowered ``agent.*`` key evaluates byte-for-byte
-        the same on the pydantic and WASM paths.
+        the same on the pydantic and WASM paths. Memoized: ``get_tool_policy`` reads
+        this on every decision, and policies are immutable after load (inheritance
+        builds fresh instances), so the merge runs once per policy, not per call.
         """
         lowered = self.lowered_agent_tools()
         if not lowered:

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -68,9 +68,14 @@ def agent_target_key(via: AgentVia, target: str) -> str:
     return f"agent.{via}:{target}"
 
 
-def _is_reserved_agent_key(name: str) -> bool:
-    # Derive the reserved prefixes from AgentVia (via agent_target_key's shape),
-    # so a new via mode cannot be added without this guard covering it too.
+def is_agent_key(name: str) -> bool:
+    """True for a synthetic agent-level key (``agent.run`` / ``agent.tool:`` /
+    ``agent.handoff:``).
+
+    Used both to reserve the namespace from authored tools and to make agent reach
+    closed-world: an unlisted agent key denies regardless of ``default_policy``.
+    Derives the prefixes from :data:`AgentVia` so a new via mode is covered here
+    automatically."""
     if name == AGENT_RUN_TOOL:
         return True
     return any(name.startswith(f"agent.{via}:") for via in get_args(AgentVia))
@@ -150,7 +155,7 @@ class AgentPolicy(BaseModel):
         would collide with a lowered agent rule in :attr:`effective_tools` and
         silently shadow (or be shadowed by) it. Reject it at load."""
         for name in value:
-            if _is_reserved_agent_key(name):
+            if is_agent_key(name):
                 raise ValueError(
                     f"tool name {name!r} is reserved for agent-level gating; "
                     "use the 'admission'/'agents' blocks instead"

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -62,23 +62,34 @@ AgentVia = Literal["tool", "handoff"]
 # exactly as the ``net.*`` egress tools already do.
 AGENT_RUN_TOOL = "agent.run"
 
+# Prefixes for the reach keys (``agent.tool:<name>`` / ``agent.handoff:<name>``),
+# derived from AgentVia so a new via mode is covered everywhere automatically. One
+# source of truth for the namespace reservation and for both engines' closed-world
+# handling, so pydantic and Rego cannot drift on which names are agent keys.
+AGENT_REACH_PREFIXES = tuple(f"agent.{via}:" for via in get_args(AgentVia))
+
 
 def agent_target_key(via: AgentVia, target: str) -> str:
     """Synthetic tool key for reaching ``target`` in a given transfer mode."""
     return f"agent.{via}:{target}"
 
 
-def is_agent_key(name: str) -> bool:
-    """True for a synthetic agent-level key (``agent.run`` / ``agent.tool:`` /
-    ``agent.handoff:``).
+def is_agent_reach_key(name: str) -> bool:
+    """True for an ``agent.tool:`` / ``agent.handoff:`` reach key.
 
-    Used both to reserve the namespace from authored tools and to make agent reach
-    closed-world: an unlisted agent key denies regardless of ``default_policy``.
-    Derives the prefixes from :data:`AgentVia` so a new via mode is covered here
-    automatically."""
-    if name == AGENT_RUN_TOOL:
-        return True
-    return any(name.startswith(f"agent.{via}:") for via in get_args(AgentVia))
+    Reach is closed-world: an unlisted reach key denies regardless of
+    ``default_policy``. Admission (``agent.run``) is *not* a reach key — it is
+    opt-in, so its absence admits — hence the two are checked separately."""
+    return name.startswith(AGENT_REACH_PREFIXES)
+
+
+def is_agent_key(name: str) -> bool:
+    """True for any synthetic agent-level key (``agent.run`` or a reach key).
+
+    Used to reserve the ``agent.*`` namespace from authored tools. Enforcement
+    splits the two: :func:`is_agent_reach_key` for the closed-world reach keys,
+    ``agent.run`` for opt-in admission."""
+    return name == AGENT_RUN_TOOL or is_agent_reach_key(name)
 
 
 class AgentTargetPolicy(BaseToolPolicy):

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -69,11 +69,11 @@ def agent_target_key(via: AgentVia, target: str) -> str:
 
 
 def _is_reserved_agent_key(name: str) -> bool:
-    return (
-        name == AGENT_RUN_TOOL
-        or name.startswith("agent.tool:")
-        or name.startswith("agent.handoff:")
-    )
+    # Derive the reserved prefixes from AgentVia (via agent_target_key's shape),
+    # so a new via mode cannot be added without this guard covering it too.
+    if name == AGENT_RUN_TOOL:
+        return True
+    return any(name.startswith(f"agent.{via}:") for via in get_args(AgentVia))
 
 
 class AgentTargetPolicy(BaseToolPolicy):
@@ -124,9 +124,11 @@ class AgentPolicy(BaseModel):
     closed-world for free; the runtime gate refines that fallback in a later PR.
     """
 
-    # cached_property is a plain descriptor, not a field — tell pydantic to leave
-    # it alone so ``effective_tools`` can memoize on the enforcement hot path.
-    model_config = ConfigDict(ignored_types=(cached_property,))
+    # frozen: policies are immutable after load (inheritance builds fresh
+    # instances, nothing reassigns a field), which is what makes memoizing
+    # effective_tools safe. cached_property is a plain descriptor, not a field,
+    # so pydantic must leave it alone.
+    model_config = ConfigDict(frozen=True, ignored_types=(cached_property,))
 
     version: int = 1
     inherits: list[str] = Field(default_factory=list)
@@ -167,11 +169,11 @@ class AgentPolicy(BaseModel):
         if self.admission is not None:
             lowered[AGENT_RUN_TOOL] = self.admission
         for target, target_policy in self.agents.items():
-            base = BaseToolPolicy(
-                mode=target_policy.mode, constraints=target_policy.constraints
-            )
+            # Use the AgentTargetPolicy directly (it is a BaseToolPolicy): a bare
+            # rebuild would silently drop any field later added to BaseToolPolicy.
+            # via is an extra field the engines ignore.
             for via in target_policy.via:
-                lowered[agent_target_key(via, target)] = base
+                lowered[agent_target_key(via, target)] = target_policy
         return lowered
 
     @cached_property

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -13,16 +13,20 @@ from hexgate.security.decision import DecisionOutcome, Verdict
 from hexgate.security.errors import ApprovalRequiredError, PolicyDeniedError
 from hexgate.security.file_scope import build_file_scope_hint, is_path_allowed
 from hexgate.security.models import (
+    AGENT_RUN_TOOL,
     AgentPolicy,
     BaseToolPolicy,
     FileToolPolicy,
     ToolPolicy,
-    is_agent_key,
+    is_agent_reach_key,
 )
 
-# Unlisted agent-level keys are closed-world: they deny regardless of
-# default_policy, so a permissive tool default never silently grants agent reach.
-_AGENT_CLOSED_WORLD_DENY = BaseToolPolicy(mode="deny")
+# Reach keys are closed-world: an unlisted agent.tool:/agent.handoff: denies
+# regardless of default_policy, so a permissive tool default never silently grants
+# agent reach. Admission (agent.run) is the opposite: opt-in, so an unlisted
+# agent.run admits (a role that declares no admission does not restrict it).
+_AGENT_REACH_CLOSED_WORLD_DENY = BaseToolPolicy(mode="deny")
+_ADMISSION_OPT_IN_ALLOW = BaseToolPolicy(mode="allow")
 
 if TYPE_CHECKING:
     from hexgate.security.bundle import PolicyBundle
@@ -49,18 +53,27 @@ def get_tool_policy(policy: AgentPolicy, tool_name: str) -> ToolPolicy:
     """Resolve the effective policy for a tool name.
 
     Reads ``effective_tools`` (authored tools plus lowered ``agent.*`` keys) so a
-    synthetic agent-level key resolves through the same path as any tool. An
-    unlisted *agent* key denies unconditionally (agent reach is closed-world, so a
-    permissive ``default_policy`` cannot silently grant a handoff or sub-agent
-    call); any other unlisted tool falls to ``default_policy``. The Rego compiler
-    excludes ``agent.*`` from its permissive catch-all for the same reason, keeping
-    both engines in agreement.
+    synthetic agent-level key resolves through the same path as any tool. Fallbacks
+    for an unlisted key differ by kind:
+
+    * an unlisted **reach** key (``agent.tool:`` / ``agent.handoff:``) denies,
+      closed-world, so a permissive ``default_policy`` cannot silently grant a
+      handoff or sub-agent call;
+    * an unlisted ``agent.run`` **admits** (admission is opt-in — a role that
+      declares no admission does not restrict who may start the agent);
+    * any other unlisted tool falls to ``default_policy``.
+
+    The Rego compiler mirrors both (it excludes reach keys from its permissive
+    catch-all and emits an opt-in allow rule for ``agent.run``), keeping the engines
+    in agreement.
     """
     tool_policy = policy.effective_tools.get(tool_name)
     if tool_policy is not None:
         return tool_policy
-    if is_agent_key(tool_name):
-        return _AGENT_CLOSED_WORLD_DENY
+    if tool_name == AGENT_RUN_TOOL:
+        return _ADMISSION_OPT_IN_ALLOW
+    if is_agent_reach_key(tool_name):
+        return _AGENT_REACH_CLOSED_WORLD_DENY
     return policy.default_policy
 
 

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -36,8 +36,14 @@ def load_policy(policy: str | Path | AgentPolicy | None) -> AgentPolicy:
 
 
 def get_tool_policy(policy: AgentPolicy, tool_name: str) -> ToolPolicy:
-    """Resolve the effective policy for a tool name."""
-    return policy.tools.get(tool_name, policy.default_policy)
+    """Resolve the effective policy for a tool name.
+
+    Reads ``effective_tools`` (authored tools plus lowered ``agent.*`` keys) so
+    a synthetic agent-level key resolves through the same path as any tool, and
+    an unlisted key falls to ``default_policy`` — the same fallback the Rego
+    compiler emits, keeping both engines in agreement.
+    """
+    return policy.effective_tools.get(tool_name, policy.default_policy)
 
 
 def evaluate_tool_call(

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -12,7 +12,17 @@ from hexgate.security.constraints import check_constraints
 from hexgate.security.decision import DecisionOutcome, Verdict
 from hexgate.security.errors import ApprovalRequiredError, PolicyDeniedError
 from hexgate.security.file_scope import build_file_scope_hint, is_path_allowed
-from hexgate.security.models import AgentPolicy, FileToolPolicy, ToolPolicy
+from hexgate.security.models import (
+    AgentPolicy,
+    BaseToolPolicy,
+    FileToolPolicy,
+    ToolPolicy,
+    is_agent_key,
+)
+
+# Unlisted agent-level keys are closed-world: they deny regardless of
+# default_policy, so a permissive tool default never silently grants agent reach.
+_AGENT_CLOSED_WORLD_DENY = BaseToolPolicy(mode="deny")
 
 if TYPE_CHECKING:
     from hexgate.security.bundle import PolicyBundle
@@ -38,12 +48,20 @@ def load_policy(policy: str | Path | AgentPolicy | None) -> AgentPolicy:
 def get_tool_policy(policy: AgentPolicy, tool_name: str) -> ToolPolicy:
     """Resolve the effective policy for a tool name.
 
-    Reads ``effective_tools`` (authored tools plus lowered ``agent.*`` keys) so
-    a synthetic agent-level key resolves through the same path as any tool, and
-    an unlisted key falls to ``default_policy`` — the same fallback the Rego
-    compiler emits, keeping both engines in agreement.
+    Reads ``effective_tools`` (authored tools plus lowered ``agent.*`` keys) so a
+    synthetic agent-level key resolves through the same path as any tool. An
+    unlisted *agent* key denies unconditionally (agent reach is closed-world, so a
+    permissive ``default_policy`` cannot silently grant a handoff or sub-agent
+    call); any other unlisted tool falls to ``default_policy``. The Rego compiler
+    excludes ``agent.*`` from its permissive catch-all for the same reason, keeping
+    both engines in agreement.
     """
-    return policy.effective_tools.get(tool_name, policy.default_policy)
+    tool_policy = policy.effective_tools.get(tool_name)
+    if tool_policy is not None:
+        return tool_policy
+    if is_agent_key(tool_name):
+        return _AGENT_CLOSED_WORLD_DENY
+    return policy.default_policy
 
 
 def evaluate_tool_call(

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -332,6 +332,24 @@ def _resolve_inheritance(
     # user's intent is to override, and silently inheriting an ``allow`` from a
     # parent would be fail-open.
     merged_tools.update(own.tools)
+    # A per-target override replaces the parent's rule wholesale, so a child that
+    # DROPS a via the parent listed would silently un-list that mode (it falls
+    # through to default_policy, fail-open under a permissive default). One
+    # AgentTargetPolicy carries a single mode across its vias, so the parent's
+    # mode for the dropped via cannot be preserved in the merged entry; reject the
+    # narrowing loudly instead, the same stance as the admission merge above.
+    for target, own_rule in own.agents.items():
+        parent_rule = merged_agents.get(target)
+        if parent_rule is None:
+            continue
+        dropped = [via for via in parent_rule.via if via not in own_rule.via]
+        if dropped:
+            raise PolicySetError(
+                f"role {name!r} narrows agent target {target!r} to vias "
+                f"{own_rule.via}, dropping {dropped} that an inherited rule lists. "
+                "A child agent rule cannot silently un-list an inherited via mode. "
+                "Re-declare the full via set for this target."
+            )
     merged_agents.update(own.agents)
     merged_consts.update(own.consts)
     if "default_policy" in own.model_fields_set:

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -332,28 +332,14 @@ def _resolve_inheritance(
     # user's intent is to override, and silently inheriting an ``allow`` from a
     # parent would be fail-open.
     merged_tools.update(own.tools)
-    # A per-target override replaces the parent's rule wholesale, so a child that
-    # DROPS a via the parent listed would silently un-list that mode (it falls
-    # through to default_policy, fail-open under a permissive default). One
-    # AgentTargetPolicy carries a single mode across its vias, so the parent's
-    # mode for the dropped via cannot be preserved in the merged entry; reject the
-    # narrowing loudly instead, the same stance as the admission merge above.
-    for target, own_rule in own.agents.items():
-        parent_rule = merged_agents.get(target)
-        if parent_rule is None:
-            continue
-        dropped = [via for via in parent_rule.via if via not in own_rule.via]
-        if dropped:
-            raise PolicySetError(
-                f"role {name!r} narrows agent target {target!r} to vias "
-                f"{own_rule.via}, dropping {dropped} that an inherited rule lists. "
-                "A child agent rule cannot silently un-list an inherited via mode. "
-                "Re-declare the full via set for this target."
-            )
-    merged_agents.update(own.agents)
-    merged_consts.update(own.consts)
+    # Finalise the effective default before the narrowing guard: a dropped via
+    # resolves to *this* role's default_policy, so the guard must see the child's
+    # override, not the parent's.
     if "default_policy" in own.model_fields_set:
         merged_default = own.default_policy
+    _reject_fail_open_narrowing(name, own, merged_agents, merged_default)
+    merged_agents.update(own.agents)
+    merged_consts.update(own.consts)
     if "admission" in own.model_fields_set:
         merged_admission = own.admission
 
@@ -367,3 +353,40 @@ def _resolve_inheritance(
         admission=merged_admission,
         agents=merged_agents,
     )
+
+
+# How much access each mode grants, low to high.
+_PERMISSIVENESS = {"deny": 0, "approval_required": 1, "allow": 2}
+
+
+def _reject_fail_open_narrowing(
+    role: str,
+    own: AgentPolicy,
+    parent_agents: Mapping[str, AgentTargetPolicy],
+    effective_default: BaseToolPolicy,
+) -> None:
+    """Reject a child that drops an inherited via *and* thereby loosens it.
+
+    A per-target override replaces the parent's rule wholesale, and one
+    :class:`AgentTargetPolicy` carries a single mode across its vias, so the
+    parent's mode for a dropped via cannot be preserved in the merged entry. The
+    dropped via falls through to ``default_policy``. That is only a problem when the
+    default is MORE permissive than the parent's mode (e.g. parent ``deny``, child
+    default ``allow``): it silently loosens a restriction. Under a deny-by-default
+    child, dropping a via only tightens it, a common and safe intent (inherit a tool
+    grant, but never hand off), so it is allowed.
+    """
+    default_rank = _PERMISSIVENESS[effective_default.mode]
+    for target, own_rule in own.agents.items():
+        parent_rule = parent_agents.get(target)
+        if parent_rule is None:
+            continue
+        dropped = [via for via in parent_rule.via if via not in own_rule.via]
+        if dropped and default_rank > _PERMISSIVENESS[parent_rule.mode]:
+            raise PolicySetError(
+                f"role {role!r} drops via {dropped} from inherited agent target "
+                f"{target!r} (parent mode {parent_rule.mode!r}) under a more "
+                f"permissive default_policy ({effective_default.mode!r}), which "
+                "would silently loosen the parent's rule for that mode. Re-declare "
+                "the full via set, or tighten default_policy."
+            )

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -38,7 +38,12 @@ import yaml
 
 from hexgate.security.constraints import iter_const_refs, parse_constraint
 from hexgate.security.decision import Verdict
-from hexgate.security.models import AgentPolicy, BaseToolPolicy, ToolPolicy
+from hexgate.security.models import (
+    AgentPolicy,
+    AgentTargetPolicy,
+    BaseToolPolicy,
+    ToolPolicy,
+)
 
 
 DEFAULT_ROLE_NAME = "default"
@@ -135,7 +140,7 @@ def _validate_const_refs(policies: Mapping[str, AgentPolicy]) -> None:
     """
     for role, policy in policies.items():
         available = set(policy.consts)
-        for tool_policy in (*policy.tools.values(), policy.default_policy):
+        for tool_policy in (*policy.effective_tools.values(), policy.default_policy):
             for raw in tool_policy.constraints:
                 for name in iter_const_refs(parse_constraint(raw)):
                     if name not in available:
@@ -303,15 +308,27 @@ def _resolve_inheritance(
     if not own.inherits:
         return own
     merged_tools: dict[str, ToolPolicy] = {}
+    merged_agents: dict[str, AgentTargetPolicy] = {}
     merged_consts: dict[str, object] = {}
     merged_default: BaseToolPolicy = own.default_policy
+    merged_admission: BaseToolPolicy | None = own.admission
+    merged_default_agent: BaseToolPolicy | None = own.default_agent_policy
 
-    # Merge parents left-to-right (later parents override earlier).
+    # Merge parents left-to-right (later parents override earlier). ``agents``
+    # merges by target name like ``tools`` does. The optional agent-level scalars
+    # (``admission`` / ``default_agent_policy``) only overwrite when a parent
+    # actually sets one, so a later mixin that omits them can't null out an
+    # earlier parent's rule — dropping an agent gate silently would be fail-open.
     for parent_name in own.inherits:
         parent = _resolve_inheritance(parent_name, raw, chain + [name])
         merged_tools.update(parent.tools)
+        merged_agents.update(parent.agents)
         merged_consts.update(parent.consts)
         merged_default = parent.default_policy
+        if parent.admission is not None:
+            merged_admission = parent.admission
+        if parent.default_agent_policy is not None:
+            merged_default_agent = parent.default_agent_policy
 
     # Self overrides everything from parents. Check ``model_fields_set`` rather
     # than comparing against ``BaseToolPolicy()``: a child that explicitly says
@@ -319,9 +336,14 @@ def _resolve_inheritance(
     # user's intent is to override, and silently inheriting an ``allow`` from a
     # parent would be fail-open.
     merged_tools.update(own.tools)
+    merged_agents.update(own.agents)
     merged_consts.update(own.consts)
     if "default_policy" in own.model_fields_set:
         merged_default = own.default_policy
+    if "admission" in own.model_fields_set:
+        merged_admission = own.admission
+    if "default_agent_policy" in own.model_fields_set:
+        merged_default_agent = own.default_agent_policy
 
     return AgentPolicy(
         version=own.version,
@@ -330,4 +352,7 @@ def _resolve_inheritance(
         default_policy=merged_default,
         tools=merged_tools,
         consts=merged_consts,
+        admission=merged_admission,
+        agents=merged_agents,
+        default_agent_policy=merged_default_agent,
     )

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -332,14 +332,10 @@ def _resolve_inheritance(
     # user's intent is to override, and silently inheriting an ``allow`` from a
     # parent would be fail-open.
     merged_tools.update(own.tools)
-    # Finalise the effective default before the narrowing guard: a dropped via
-    # resolves to *this* role's default_policy, so the guard must see the child's
-    # override, not the parent's.
-    if "default_policy" in own.model_fields_set:
-        merged_default = own.default_policy
-    _reject_fail_open_narrowing(name, own, merged_agents, merged_default)
     merged_agents.update(own.agents)
     merged_consts.update(own.consts)
+    if "default_policy" in own.model_fields_set:
+        merged_default = own.default_policy
     if "admission" in own.model_fields_set:
         merged_admission = own.admission
 
@@ -353,60 +349,3 @@ def _resolve_inheritance(
         admission=merged_admission,
         agents=merged_agents,
     )
-
-
-# How much access each mode grants, low to high.
-_PERMISSIVENESS = {"deny": 0, "approval_required": 1, "allow": 2}
-
-
-def _reject_fail_open_narrowing(
-    role: str,
-    own: AgentPolicy,
-    parent_agents: Mapping[str, AgentTargetPolicy],
-    effective_default: BaseToolPolicy,
-) -> None:
-    """Reject a child that drops an inherited via *and* thereby loosens it.
-
-    A per-target override replaces the parent's rule wholesale, and one
-    :class:`AgentTargetPolicy` carries a single mode across its vias, so the
-    parent's rule for a dropped via cannot be preserved in the merged entry. The
-    dropped via falls through to ``default_policy``, which is a problem only when
-    the default is looser than the parent's rule for that via:
-
-    * a more permissive mode (e.g. parent ``deny``, child default ``allow``), or
-    * the same granting mode but *fewer constraints* (e.g. parent ``allow`` with
-      ``args.amount <= 100``, child default a bare ``allow`` — the cap vanishes).
-
-    Under a deny-by-default child, dropping a via only tightens it, a common and
-    safe intent (inherit a tool grant, but never hand off), so it is allowed.
-    """
-    for target, own_rule in own.agents.items():
-        parent_rule = parent_agents.get(target)
-        if parent_rule is None:
-            continue
-        dropped = [via for via in parent_rule.via if via not in own_rule.via]
-        if dropped and _default_loosens(effective_default, parent_rule):
-            raise PolicySetError(
-                f"role {role!r} drops via {dropped} from inherited agent target "
-                f"{target!r} (parent {parent_rule.mode!r}"
-                f"{' with constraints' if parent_rule.constraints else ''}) under a "
-                f"looser default_policy ({effective_default.mode!r}), which would "
-                "silently loosen the parent's rule for that mode. Re-declare the "
-                "full via set, or tighten default_policy."
-            )
-
-
-def _default_loosens(default: BaseToolPolicy, parent_rule: AgentTargetPolicy) -> bool:
-    """True if falling through to ``default`` is looser than ``parent_rule``.
-
-    Looser means a more permissive mode, or the same granting mode with a parent
-    constraint the default drops. ``deny`` ignores constraints, so a same-rank
-    ``deny`` tie is never looser."""
-    default_rank = _PERMISSIVENESS[default.mode]
-    parent_rank = _PERMISSIVENESS[parent_rule.mode]
-    if default_rank != parent_rank:
-        return default_rank > parent_rank
-    if parent_rule.mode == "deny":
-        return False
-    # Same granting mode: the default loosens if it drops any parent constraint.
-    return bool(set(parent_rule.constraints) - set(default.constraints))

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -369,24 +369,44 @@ def _reject_fail_open_narrowing(
 
     A per-target override replaces the parent's rule wholesale, and one
     :class:`AgentTargetPolicy` carries a single mode across its vias, so the
-    parent's mode for a dropped via cannot be preserved in the merged entry. The
-    dropped via falls through to ``default_policy``. That is only a problem when the
-    default is MORE permissive than the parent's mode (e.g. parent ``deny``, child
-    default ``allow``): it silently loosens a restriction. Under a deny-by-default
-    child, dropping a via only tightens it, a common and safe intent (inherit a tool
-    grant, but never hand off), so it is allowed.
+    parent's rule for a dropped via cannot be preserved in the merged entry. The
+    dropped via falls through to ``default_policy``, which is a problem only when
+    the default is looser than the parent's rule for that via:
+
+    * a more permissive mode (e.g. parent ``deny``, child default ``allow``), or
+    * the same granting mode but *fewer constraints* (e.g. parent ``allow`` with
+      ``args.amount <= 100``, child default a bare ``allow`` — the cap vanishes).
+
+    Under a deny-by-default child, dropping a via only tightens it, a common and
+    safe intent (inherit a tool grant, but never hand off), so it is allowed.
     """
-    default_rank = _PERMISSIVENESS[effective_default.mode]
     for target, own_rule in own.agents.items():
         parent_rule = parent_agents.get(target)
         if parent_rule is None:
             continue
         dropped = [via for via in parent_rule.via if via not in own_rule.via]
-        if dropped and default_rank > _PERMISSIVENESS[parent_rule.mode]:
+        if dropped and _default_loosens(effective_default, parent_rule):
             raise PolicySetError(
                 f"role {role!r} drops via {dropped} from inherited agent target "
-                f"{target!r} (parent mode {parent_rule.mode!r}) under a more "
-                f"permissive default_policy ({effective_default.mode!r}), which "
-                "would silently loosen the parent's rule for that mode. Re-declare "
-                "the full via set, or tighten default_policy."
+                f"{target!r} (parent {parent_rule.mode!r}"
+                f"{' with constraints' if parent_rule.constraints else ''}) under a "
+                f"looser default_policy ({effective_default.mode!r}), which would "
+                "silently loosen the parent's rule for that mode. Re-declare the "
+                "full via set, or tighten default_policy."
             )
+
+
+def _default_loosens(default: BaseToolPolicy, parent_rule: AgentTargetPolicy) -> bool:
+    """True if falling through to ``default`` is looser than ``parent_rule``.
+
+    Looser means a more permissive mode, or the same granting mode with a parent
+    constraint the default drops. ``deny`` ignores constraints, so a same-rank
+    ``deny`` tie is never looser."""
+    default_rank = _PERMISSIVENESS[default.mode]
+    parent_rank = _PERMISSIVENESS[parent_rule.mode]
+    if default_rank != parent_rank:
+        return default_rank > parent_rank
+    if parent_rule.mode == "deny":
+        return False
+    # Same granting mode: the default loosens if it drops any parent constraint.
+    return bool(set(parent_rule.constraints) - set(default.constraints))

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -312,12 +312,10 @@ def _resolve_inheritance(
     merged_consts: dict[str, object] = {}
     merged_default: BaseToolPolicy = own.default_policy
     merged_admission: BaseToolPolicy | None = own.admission
-    merged_default_agent: BaseToolPolicy | None = own.default_agent_policy
 
     # Merge parents left-to-right (later parents override earlier). ``agents``
-    # merges by target name like ``tools`` does. The optional agent-level scalars
-    # (``admission`` / ``default_agent_policy``) only overwrite when a parent
-    # actually sets one, so a later mixin that omits them can't null out an
+    # merges by target name like ``tools`` does. ``admission`` only overwrites when
+    # a parent actually sets one, so a later mixin that omits it can't null out an
     # earlier parent's rule — dropping an agent gate silently would be fail-open.
     for parent_name in own.inherits:
         parent = _resolve_inheritance(parent_name, raw, chain + [name])
@@ -327,8 +325,6 @@ def _resolve_inheritance(
         merged_default = parent.default_policy
         if parent.admission is not None:
             merged_admission = parent.admission
-        if parent.default_agent_policy is not None:
-            merged_default_agent = parent.default_agent_policy
 
     # Self overrides everything from parents. Check ``model_fields_set`` rather
     # than comparing against ``BaseToolPolicy()``: a child that explicitly says
@@ -342,8 +338,6 @@ def _resolve_inheritance(
         merged_default = own.default_policy
     if "admission" in own.model_fields_set:
         merged_admission = own.admission
-    if "default_agent_policy" in own.model_fields_set:
-        merged_default_agent = own.default_agent_policy
 
     return AgentPolicy(
         version=own.version,
@@ -354,5 +348,4 @@ def _resolve_inheritance(
         consts=merged_consts,
         admission=merged_admission,
         agents=merged_agents,
-        default_agent_policy=merged_default_agent,
     )

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -299,12 +299,14 @@ def _rules_for_role(
                 helpers,
             )
         )
-    if policy.agents and AGENT_RUN_TOOL not in effective:
-        # This role uses agent-level enforcement (has reach rules) but declares no
-        # admission, so admission is opt-in: an unlisted agent.run admits regardless
-        # of default_policy. Mirrors the _ADMISSION_OPT_IN_ALLOW fallback in the
-        # pydantic engine. Only emitted for agent-aware policies, so plain tool
-        # bundles are unchanged (agent.run is never queried on them anyway).
+    if AGENT_RUN_TOOL not in effective:
+        # Admission is opt-in: a role that declares no admission rule admits, so an
+        # unlisted agent.run allows regardless of default_policy. Emitted for every
+        # role (not gated on agent blocks) so it matches the unconditional
+        # _ADMISSION_OPT_IN_ALLOW fallback in the pydantic engine — otherwise a role
+        # without an admission rule would deny agent.run on the WASM path while
+        # allowing it on the pydantic path (the same non-monotonic lockout, one
+        # engine over).
         out.extend(
             _gated_rules(
                 role,

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -312,11 +312,13 @@ def _default_rules(
     """
     if default_policy.mode == "deny":
         return []
+    # agent.* keys are closed-world: a permissive default must not grant an unlisted
+    # agent reach, so exclude them from the catch-all (an unlisted agent key then
+    # matches no rule and denies). Mirrors get_tool_policy in the pydantic engine.
+    tool_guard = ['    not startswith(input.tool, "agent.")']
     if listed:
         members = ", ".join(json.dumps(name) for name in listed)
-        tool_guard = [f"    not input.tool in {{{members}}}"]
-    else:
-        tool_guard = []  # nothing listed → the default applies to every tool
+        tool_guard.append(f"    not input.tool in {{{members}}}")
     return _gated_rules(
         role, role_guard, tool_guard, default_policy, "<default>", helpers
     )

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -271,13 +271,15 @@ def _rules_for_role(
 ) -> list[str]:
     """Render rules for one resolved role (allow + violations per tool).
 
-    Explicitly-listed tools each get their own ``input.tool == "X"`` rule;
+    Explicitly-listed tools each get their own ``input.tool == "X"`` rule
+    (including the lowered ``agent.*`` keys in ``effective_tools``);
     ``default_policy`` (when not ``deny``) gets a catch-all for any tool *not*
     explicitly listed — mirroring the pydantic engine's
-    ``policy.tools.get(tool, default_policy)`` fallback so both engines agree
+    ``effective_tools.get(tool, default_policy)`` fallback so both engines agree
     on unlisted tools.
     """
-    listed = sorted(policy.tools)
+    effective = policy.effective_tools
+    listed = sorted(effective)
     out: list[str] = []
     for tool_name in listed:
         tool_guard = [f'    input.tool == "{_escape_string(tool_name)}"']
@@ -286,7 +288,7 @@ def _rules_for_role(
                 role,
                 role_guard,
                 tool_guard,
-                policy.tools[tool_name],
+                effective[tool_name],
                 tool_name,
                 helpers,
             )

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -85,7 +85,13 @@ from hexgate.security.constraints import (
     Ref,
     parse_constraint,
 )
-from hexgate.security.models import AgentPolicy, BaseToolPolicy, FileToolPolicy
+from hexgate.security.models import (
+    AGENT_REACH_PREFIXES,
+    AGENT_RUN_TOOL,
+    AgentPolicy,
+    BaseToolPolicy,
+    FileToolPolicy,
+)
 from hexgate.security.policy_set import (
     DEFAULT_ROLE_NAME,
     PolicySet,
@@ -293,6 +299,22 @@ def _rules_for_role(
                 helpers,
             )
         )
+    if policy.agents and AGENT_RUN_TOOL not in effective:
+        # This role uses agent-level enforcement (has reach rules) but declares no
+        # admission, so admission is opt-in: an unlisted agent.run admits regardless
+        # of default_policy. Mirrors the _ADMISSION_OPT_IN_ALLOW fallback in the
+        # pydantic engine. Only emitted for agent-aware policies, so plain tool
+        # bundles are unchanged (agent.run is never queried on them anyway).
+        out.extend(
+            _gated_rules(
+                role,
+                role_guard,
+                [f'    input.tool == "{_escape_string(AGENT_RUN_TOOL)}"'],
+                BaseToolPolicy(mode="allow"),
+                AGENT_RUN_TOOL,
+                helpers,
+            )
+        )
     out.extend(_default_rules(role, role_guard, policy.default_policy, listed, helpers))
     return out
 
@@ -312,10 +334,15 @@ def _default_rules(
     """
     if default_policy.mode == "deny":
         return []
-    # agent.* keys are closed-world: a permissive default must not grant an unlisted
-    # agent reach, so exclude them from the catch-all (an unlisted agent key then
-    # matches no rule and denies). Mirrors get_tool_policy in the pydantic engine.
-    tool_guard = ['    not startswith(input.tool, "agent.")']
+    # Reach keys are closed-world: a permissive default must not grant an unlisted
+    # agent.tool:/agent.handoff:, so exclude them from the catch-all (an unlisted
+    # reach key then matches no rule and denies). agent.run is deliberately NOT
+    # excluded — admission is opt-in and its own rule handles it. Mirrors
+    # get_tool_policy / is_agent_reach_key in the pydantic engine.
+    tool_guard = [
+        f"    not startswith(input.tool, {json.dumps(prefix)})"
+        for prefix in AGENT_REACH_PREFIXES
+    ]
     if listed:
         members = ", ".join(json.dumps(name) for name in listed)
         tool_guard.append(f"    not input.tool in {{{members}}}")

--- a/tests/security/golden/policy_fixture.rego
+++ b/tests/security/golden/policy_fixture.rego
@@ -111,10 +111,20 @@ violations contains `ctx.region in ["EU", "UK"]` if {
     not _p_b7b1e13455
 }
 
+allow if {
+    input.role == "billing"
+    input.tool == "agent.run"
+}
+
 # ---- role: default -----------------------------------------------------
 allow if {
     not input.role in {"billing", "support"}
     input.tool == "web_search"
+}
+
+allow if {
+    not input.role in {"billing", "support"}
+    input.tool == "agent.run"
 }
 
 # ---- role: support -----------------------------------------------------
@@ -139,6 +149,11 @@ violations contains `args.amount <= 500` if {
 allow if {
     input.role == "support"
     input.tool == "read_file"
+}
+
+allow if {
+    input.role == "support"
+    input.tool == "agent.run"
 }
 
 _p_066518c099 if {

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -277,6 +277,57 @@ def test_narrowing_via_under_deny_default_is_allowed() -> None:
     )
 
 
+def test_narrowing_that_drops_a_parent_constraint_is_rejected() -> None:
+    # Modes tie (both allow) but the parent's handoff rule carries a constraint the
+    # allow-default lacks; the dropped via would fall through to an *unconstrained*
+    # allow, silently losing the cap. Reject.
+    payload = {
+        "roles": {
+            "base": {
+                "is_mixin": True,
+                "agents": {
+                    "billing-bot": {
+                        "mode": "allow",
+                        "via": ["tool", "handoff"],
+                        "constraints": ["args.amount <= 100"],
+                    }
+                },
+            },
+            "support": {
+                "inherits": ["base"],
+                "default_policy": {"mode": "allow"},
+                "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
+            },
+        }
+    }
+    with pytest.raises(PolicySetError, match="silently loosen"):
+        load_policy_set_from_dict(payload)
+
+
+def test_narrowing_under_matching_unconstrained_allow_is_fine() -> None:
+    # Same shape but the parent rule has no constraint, so falling through to the
+    # allow-default loosens nothing. No error.
+    payload = {
+        "roles": {
+            "base": {
+                "is_mixin": True,
+                "agents": {
+                    "billing-bot": {"mode": "allow", "via": ["tool", "handoff"]}
+                },
+            },
+            "support": {
+                "inherits": ["base"],
+                "default_policy": {"mode": "allow"},
+                "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
+            },
+        }
+    }
+    policy_set = load_policy_set_from_dict(payload)
+    assert_allows(
+        policy_set, agent_target_key("handoff", "billing-bot"), role="support"
+    )
+
+
 def test_child_may_redeclare_target_with_the_full_via_set() -> None:
     # Re-declaring with the same (or wider) via set is a clean override; the
     # child's mode wins for every via.

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -226,3 +226,57 @@ def test_const_ref_in_agent_constraint_validated() -> None:
     }
     with pytest.raises(PolicySetError):
         load_policy_set_from_dict(payload)
+
+
+def test_child_narrowing_an_inherited_via_is_rejected() -> None:
+    # A child dropping a via the parent listed would silently un-list that mode
+    # (fail-open under a permissive default). Reject it loudly.
+    payload = {
+        "roles": {
+            "base": {
+                "is_mixin": True,
+                "agents": {"admin-bot": {"mode": "deny", "via": ["tool", "handoff"]}},
+            },
+            "support": {
+                "inherits": ["base"],
+                "default_policy": {"mode": "allow"},
+                "agents": {"admin-bot": {"mode": "allow", "via": ["tool"]}},
+            },
+        }
+    }
+    with pytest.raises(PolicySetError, match="narrows agent target"):
+        load_policy_set_from_dict(payload)
+
+
+def test_child_may_redeclare_target_with_the_full_via_set() -> None:
+    # Re-declaring with the same (or wider) via set is a clean override; the
+    # child's mode wins for every via.
+    payload = {
+        "roles": {
+            "base": {
+                "is_mixin": True,
+                "agents": {"admin-bot": {"mode": "deny", "via": ["tool", "handoff"]}},
+            },
+            "support": {
+                "inherits": ["base"],
+                "agents": {
+                    "admin-bot": {
+                        "mode": "approval_required",
+                        "via": ["tool", "handoff"],
+                    }
+                },
+            },
+        }
+    }
+    policy_set = load_policy_set_from_dict(payload)
+    assert_needs_approval(
+        policy_set, agent_target_key("handoff", "admin-bot"), role="support"
+    )
+
+
+def test_agent_policy_is_frozen() -> None:
+    # Immutability is what makes memoizing effective_tools safe; enforce it so
+    # the invariant the cache relies on is real, not just documented.
+    policy = AgentPolicy(tools={"t": BaseToolPolicy(mode="allow")})
+    with pytest.raises(ValidationError):
+        policy.tools = {}

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -228,9 +228,10 @@ def test_const_ref_in_agent_constraint_validated() -> None:
         load_policy_set_from_dict(payload)
 
 
-def test_child_narrowing_an_inherited_via_is_rejected() -> None:
-    # A child dropping a via the parent listed would silently un-list that mode
-    # (fail-open under a permissive default). Reject it loudly.
+def test_narrowing_that_loosens_a_deny_under_permissive_default_is_rejected() -> None:
+    # Parent denies both vias; child drops handoff under an allow-default, so
+    # handoff would fall through to allow and lose the parent's deny. Fail-open,
+    # so reject.
     payload = {
         "roles": {
             "base": {
@@ -244,8 +245,36 @@ def test_child_narrowing_an_inherited_via_is_rejected() -> None:
             },
         }
     }
-    with pytest.raises(PolicySetError, match="narrows agent target"):
+    with pytest.raises(PolicySetError, match="silently loosen"):
         load_policy_set_from_dict(payload)
+
+
+def test_narrowing_via_under_deny_default_is_allowed() -> None:
+    # Victor's case: inherit the mixin's grants, keep billing-bot callable as a
+    # tool, but never hand off. Under deny-by-default the dropped handoff via
+    # tightens to deny, which is exactly the intent, so this must NOT raise.
+    payload = {
+        "roles": {
+            "base": {
+                "is_mixin": True,
+                "tools": {"search_kb": {"mode": "allow"}},
+                "agents": {
+                    "billing-bot": {"mode": "allow", "via": ["tool", "handoff"]}
+                },
+            },
+            "support": {  # deny-by-default (no default_policy set)
+                "inherits": ["base"],
+                "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
+            },
+        }
+    }
+    policy_set = load_policy_set_from_dict(payload)
+    assert_allows(policy_set, "search_kb", role="support")
+    assert_allows(policy_set, agent_target_key("tool", "billing-bot"), role="support")
+    # handoff dropped → falls to support's deny-by-default → denied, as intended.
+    assert_denies(
+        policy_set, agent_target_key("handoff", "billing-bot"), role="support"
+    )
 
 
 def test_child_may_redeclare_target_with_the_full_via_set() -> None:

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -10,6 +10,8 @@ emits the same lowered keys, with no engine change.
 
 from __future__ import annotations
 
+import shutil
+
 import pytest
 from pydantic import ValidationError
 
@@ -26,6 +28,8 @@ from hexgate.security import (
     compile_to_rego,
     load_policy_set_from_dict,
 )
+
+needs_opa = pytest.mark.skipif(shutil.which("opa") is None, reason="opa not on PATH")
 
 # --- lowering --------------------------------------------------------------
 
@@ -183,6 +187,44 @@ def test_rego_compiler_emits_lowered_agent_keys() -> None:
     assert 'input.tool == "agent.handoff:billing-bot"' in rego
 
 
+def test_rego_permissive_default_excludes_agent_keys() -> None:
+    # Under an allow-default the catch-all must exclude agent.* so an unlisted
+    # agent reach denies (closed-world) on the WASM path too, matching get_tool_policy.
+    rego = compile_to_rego({"default_policy": {"mode": "allow"}})
+    assert 'not startswith(input.tool, "agent.")' in rego
+
+
+@needs_opa
+def test_closed_world_agent_parity_pydantic_vs_wasm() -> None:
+    # The closed-world exclusion must agree across engines: an allow-default grants
+    # unlisted tools but denies unlisted agent reach on both the pydantic and WASM
+    # paths.
+    from hexgate.security import compile_to_wasm, verdict_from_rego
+    from hexgate.security.wasm_engine import WasmPolicy
+
+    payload = {
+        "default_policy": {"mode": "allow"},
+        "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
+    }
+    ps = load_policy_set_from_dict(payload)
+    engine = WasmPolicy.from_bytes(compile_to_wasm(compile_to_rego(payload)).wasm)
+
+    cases = [
+        "some_unlisted_tool",  # ordinary tool → default allow
+        agent_target_key("tool", "billing-bot"),  # listed → allow
+        agent_target_key("handoff", "billing-bot"),  # via not listed → deny
+        agent_target_key("tool", "other-bot"),  # target not listed → deny
+    ]
+    for tool in cases:
+        pyd = ps.evaluate(role="default", tool=tool, args={})
+        wsm = verdict_from_rego(
+            engine.decide(role="default", tool=tool, args={}),
+            tool_name=tool,
+            role="default",
+        )
+        assert pyd.outcome is wsm.outcome, tool
+
+
 # --- inheritance -----------------------------------------------------------
 
 
@@ -228,59 +270,23 @@ def test_const_ref_in_agent_constraint_validated() -> None:
         load_policy_set_from_dict(payload)
 
 
-def test_narrowing_that_loosens_a_deny_under_permissive_default_is_rejected() -> None:
-    # Parent denies both vias; child drops handoff under an allow-default, so
-    # handoff would fall through to allow and lose the parent's deny. Fail-open,
-    # so reject.
-    payload = {
-        "roles": {
-            "base": {
-                "is_mixin": True,
-                "agents": {"admin-bot": {"mode": "deny", "via": ["tool", "handoff"]}},
-            },
-            "support": {
-                "inherits": ["base"],
-                "default_policy": {"mode": "allow"},
-                "agents": {"admin-bot": {"mode": "allow", "via": ["tool"]}},
-            },
-        }
-    }
-    with pytest.raises(PolicySetError, match="silently loosen"):
-        load_policy_set_from_dict(payload)
-
-
-def test_narrowing_via_under_deny_default_is_allowed() -> None:
-    # Victor's case: inherit the mixin's grants, keep billing-bot callable as a
-    # tool, but never hand off. Under deny-by-default the dropped handoff via
-    # tightens to deny, which is exactly the intent, so this must NOT raise.
-    payload = {
-        "roles": {
-            "base": {
-                "is_mixin": True,
-                "tools": {"search_kb": {"mode": "allow"}},
-                "agents": {
-                    "billing-bot": {"mode": "allow", "via": ["tool", "handoff"]}
-                },
-            },
-            "support": {  # deny-by-default (no default_policy set)
-                "inherits": ["base"],
-                "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
-            },
-        }
-    }
-    policy_set = load_policy_set_from_dict(payload)
-    assert_allows(policy_set, "search_kb", role="support")
-    assert_allows(policy_set, agent_target_key("tool", "billing-bot"), role="support")
-    # handoff dropped → falls to support's deny-by-default → denied, as intended.
-    assert_denies(
-        policy_set, agent_target_key("handoff", "billing-bot"), role="support"
+def test_agent_reach_is_closed_world_even_under_allow_default() -> None:
+    # A permissive default_policy grants unlisted *tools*, but never an unlisted
+    # *agent* reach: agent keys are closed-world regardless of the default.
+    policy = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="allow"),
+        agents={"billing-bot": AgentTargetPolicy(mode="allow", via=["tool"])},
     )
+    assert_allows(policy, "some_unlisted_tool")  # ordinary tool → default allow
+    assert_allows(policy, agent_target_key("tool", "billing-bot"))  # listed
+    assert_denies(policy, agent_target_key("handoff", "billing-bot"))  # via not listed
+    assert_denies(policy, agent_target_key("tool", "other-bot"))  # target not listed
 
 
-def test_narrowing_that_drops_a_parent_constraint_is_rejected() -> None:
-    # Modes tie (both allow) but the parent's handoff rule carries a constraint the
-    # allow-default lacks; the dropped via would fall through to an *unconstrained*
-    # allow, silently losing the cap. Reject.
+def test_dropped_via_denies_regardless_of_default() -> None:
+    # A child that narrows a target's vias: the dropped via denies whatever the
+    # default is (closed-world), so a permissive default cannot resurrect it. No
+    # error, no fail-open — the whole class the old guard chased is gone.
     payload = {
         "roles": {
             "base": {
@@ -300,31 +306,56 @@ def test_narrowing_that_drops_a_parent_constraint_is_rejected() -> None:
             },
         }
     }
-    with pytest.raises(PolicySetError, match="silently loosen"):
-        load_policy_set_from_dict(payload)
+    policy_set = load_policy_set_from_dict(payload)
+    assert_allows(policy_set, agent_target_key("tool", "billing-bot"), role="support")
+    # handoff dropped → closed-world deny even under an allow-default, cap and all.
+    assert_denies(
+        policy_set,
+        agent_target_key("handoff", "billing-bot"),
+        {"amount": 5000},
+        role="support",
+    )
 
 
-def test_narrowing_under_matching_unconstrained_allow_is_fine() -> None:
-    # Same shape but the parent rule has no constraint, so falling through to the
-    # allow-default loosens nothing. No error.
+def test_inherited_dropped_via_denies_under_later_permissive_default() -> None:
+    # The inheritance hazard: a mid role narrows to tool-only, then a descendant
+    # flips default_policy to allow without touching agents. The dropped handoff
+    # still denies (closed-world), so the descendant cannot silently resurrect it.
     payload = {
         "roles": {
             "base": {
                 "is_mixin": True,
                 "agents": {
-                    "billing-bot": {"mode": "allow", "via": ["tool", "handoff"]}
+                    "billing-bot": {
+                        "mode": "allow",
+                        "via": ["tool", "handoff"],
+                        "constraints": ["args.amount <= 100"],
+                    }
+                },
+            },
+            "mid": {
+                "is_mixin": True,
+                "inherits": ["base"],
+                "agents": {
+                    "billing-bot": {
+                        "mode": "allow",
+                        "via": ["tool"],
+                        "constraints": ["args.amount <= 100"],
+                    }
                 },
             },
             "support": {
-                "inherits": ["base"],
-                "default_policy": {"mode": "allow"},
-                "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
+                "inherits": ["mid"],
+                "default_policy": {"mode": "allow"},  # declares no agents
             },
         }
     }
     policy_set = load_policy_set_from_dict(payload)
-    assert_allows(
-        policy_set, agent_target_key("handoff", "billing-bot"), role="support"
+    assert_denies(
+        policy_set,
+        agent_target_key("handoff", "billing-bot"),
+        {"amount": 5000},
+        role="support",
     )
 
 

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -176,6 +176,29 @@ def test_unlisted_target_is_closed_world_under_deny_default() -> None:
     assert_denies(_policy(), agent_target_key("handoff", "evil-bot"))
 
 
+def test_admission_is_opt_in_when_unlisted_but_enforced_when_declared() -> None:
+    # agent.run is opt-in: a policy that declares no admission admits (even under a
+    # deny-default), so adding admission to one role never locks out roles without
+    # it. A declared admission still enforces.
+    no_admission = AgentPolicy(default_policy=BaseToolPolicy(mode="deny"))
+    assert_allows(no_admission, AGENT_RUN_TOOL)  # absent → admit, not deny-default
+    declared_deny = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"),
+        admission=BaseToolPolicy(mode="deny"),
+    )
+    assert_denies(declared_deny, AGENT_RUN_TOOL)
+
+
+def test_authored_agent_prefixed_tool_follows_default_not_closed_world() -> None:
+    # An authored tool whose name merely starts with "agent." (not a reserved key)
+    # follows default_policy, it is not swept into the closed-world reach handling.
+    policy = AgentPolicy(default_policy=BaseToolPolicy(mode="allow"))
+    assert_allows(policy, "agent.foo")  # not a key → default allow
+    assert_allows(policy, "agent.tool")  # no colon → not a reach key → default allow
+    assert_allows(policy, AGENT_RUN_TOOL)  # admission opt-in → allow
+    assert_denies(policy, agent_target_key("tool", "x"))  # real reach key → deny
+
+
 # --- parity: the Rego compiler emits the same lowered keys ------------------
 
 
@@ -187,18 +210,27 @@ def test_rego_compiler_emits_lowered_agent_keys() -> None:
     assert 'input.tool == "agent.handoff:billing-bot"' in rego
 
 
-def test_rego_permissive_default_excludes_agent_keys() -> None:
-    # Under an allow-default the catch-all must exclude agent.* so an unlisted
-    # agent reach denies (closed-world) on the WASM path too, matching get_tool_policy.
-    rego = compile_to_rego({"default_policy": {"mode": "allow"}})
-    assert 'not startswith(input.tool, "agent.")' in rego
+def test_rego_permissive_default_excludes_reach_keys_and_opts_in_admission() -> None:
+    # Reach keys are excluded from the permissive catch-all (so they deny), while
+    # admission opts in via its own rule. The old broad ``agent.`` exclusion is gone
+    # (it wrongly caught authored agent.* tool names).
+    rego = compile_to_rego(
+        {
+            "default_policy": {"mode": "allow"},
+            "agents": {"b": {"mode": "allow", "via": ["tool"]}},
+        }
+    )
+    assert 'not startswith(input.tool, "agent.tool:")' in rego
+    assert 'not startswith(input.tool, "agent.handoff:")' in rego
+    assert 'input.tool == "agent.run"' in rego  # opt-in admit rule
+    assert 'not startswith(input.tool, "agent.")' not in rego
 
 
 @needs_opa
 def test_closed_world_agent_parity_pydantic_vs_wasm() -> None:
-    # The closed-world exclusion must agree across engines: an allow-default grants
-    # unlisted tools but denies unlisted agent reach on both the pydantic and WASM
-    # paths.
+    # The fallbacks must agree across engines under an allow-default: ordinary tools
+    # and authored agent.*-named tools follow the default (allow), admission opts in
+    # (allow), and unlisted reach keys deny — on both the pydantic and WASM paths.
     from hexgate.security import compile_to_wasm, verdict_from_rego
     from hexgate.security.wasm_engine import WasmPolicy
 
@@ -211,6 +243,8 @@ def test_closed_world_agent_parity_pydantic_vs_wasm() -> None:
 
     cases = [
         "some_unlisted_tool",  # ordinary tool → default allow
+        "agent.foo",  # authored agent.*-named tool (not a key) → default allow
+        AGENT_RUN_TOOL,  # admission opt-in → allow
         agent_target_key("tool", "billing-bot"),  # listed → allow
         agent_target_key("handoff", "billing-bot"),  # via not listed → deny
         agent_target_key("tool", "other-bot"),  # target not listed → deny

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -1,0 +1,228 @@
+"""Tests for agent-level policy: the ``admission`` / ``agents`` blocks and their
+lowering into synthetic ``agent.*`` tool keys (``security/models.py``).
+
+The lowering is the parity-critical piece: ``admission`` / ``agents`` expand into
+ordinary tool entries in ``effective_tools`` so both policy engines gate an
+agent-level rule through the identical decision path as a tool. These tests drive
+the pydantic path via the ``assert_*`` helpers and check that the Rego compiler
+emits the same lowered keys, with no engine change.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from hexgate.security import (
+    AGENT_RUN_TOOL,
+    AgentPolicy,
+    AgentTargetPolicy,
+    BaseToolPolicy,
+    PolicySetError,
+    agent_target_key,
+    assert_allows,
+    assert_denies,
+    assert_needs_approval,
+    compile_to_rego,
+    load_policy_set_from_dict,
+)
+
+# --- lowering --------------------------------------------------------------
+
+
+def test_admission_lowers_to_agent_run() -> None:
+    policy = AgentPolicy(admission=BaseToolPolicy(mode="allow"))
+    lowered = policy.lowered_agent_tools()
+    assert set(lowered) == {AGENT_RUN_TOOL}
+    assert lowered[AGENT_RUN_TOOL].mode == "allow"
+
+
+def test_agents_lower_per_via_mode() -> None:
+    policy = AgentPolicy(
+        agents={
+            "billing-bot": AgentTargetPolicy(
+                mode="approval_required",
+                via=["tool", "handoff"],
+                constraints=["args.depth <= 2"],
+            ),
+            "refund-bot": AgentTargetPolicy(mode="allow", via=["tool"]),
+        }
+    )
+    lowered = policy.lowered_agent_tools()
+    assert set(lowered) == {
+        "agent.tool:billing-bot",
+        "agent.handoff:billing-bot",
+        "agent.tool:refund-bot",
+    }
+    # refund-bot is tool-only: no handoff key was minted.
+    assert "agent.handoff:refund-bot" not in lowered
+    # mode + constraints carry over to every via key.
+    assert lowered["agent.handoff:billing-bot"].mode == "approval_required"
+    assert lowered["agent.tool:billing-bot"].constraints == ["args.depth <= 2"]
+
+
+def test_via_defaults_to_both_modes() -> None:
+    policy = AgentPolicy(agents={"b": AgentTargetPolicy(mode="allow")})
+    assert set(policy.lowered_agent_tools()) == {"agent.tool:b", "agent.handoff:b"}
+
+
+def test_via_dedupes_order_preserving() -> None:
+    target = AgentTargetPolicy(mode="allow", via=["handoff", "tool", "handoff"])
+    assert target.via == ["handoff", "tool"]
+
+
+def test_empty_via_rejected() -> None:
+    with pytest.raises(ValidationError):
+        AgentTargetPolicy(mode="allow", via=[])
+
+
+def test_effective_tools_merges_authored_and_lowered() -> None:
+    policy = AgentPolicy(
+        tools={"refund": BaseToolPolicy(mode="allow")},
+        admission=BaseToolPolicy(mode="allow"),
+        agents={"b": AgentTargetPolicy(mode="deny", via=["handoff"])},
+    )
+    assert set(policy.effective_tools) == {
+        "refund",
+        AGENT_RUN_TOOL,
+        "agent.handoff:b",
+    }
+
+
+def test_effective_tools_returns_tools_when_no_agent_blocks() -> None:
+    tools = {"refund": BaseToolPolicy(mode="allow")}
+    policy = AgentPolicy(tools=tools)
+    # No agent blocks → the same authored map, untouched.
+    assert policy.effective_tools == tools
+
+
+# --- reserved namespace ----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "reserved",
+    ["agent.run", "agent.tool:x", "agent.handoff:x"],
+)
+def test_reserved_agent_tool_name_rejected(reserved: str) -> None:
+    with pytest.raises(ValidationError):
+        AgentPolicy(tools={reserved: BaseToolPolicy(mode="allow")})
+
+
+def test_non_reserved_dotted_tool_name_allowed() -> None:
+    # ``agent.foo`` is not a lowered key shape, and ``net.*`` egress tools must
+    # keep working — only the exact ``agent.run`` / ``agent.tool:`` / ``agent.handoff:``
+    # shapes are reserved.
+    policy = AgentPolicy(
+        tools={
+            "agent.foo": BaseToolPolicy(mode="allow"),
+            "net.http_request": BaseToolPolicy(mode="allow"),
+        }
+    )
+    assert "agent.foo" in policy.tools
+
+
+# --- enforcement through the real path -------------------------------------
+
+
+def _policy() -> AgentPolicy:
+    return AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"),
+        admission=BaseToolPolicy(mode="allow"),
+        agents={
+            "billing-bot": AgentTargetPolicy(
+                mode="approval_required",
+                via=["tool", "handoff"],
+                constraints=["args.depth <= 2"],
+            ),
+            "refund-bot": AgentTargetPolicy(mode="allow", via=["tool"]),
+            "admin-bot": AgentTargetPolicy(mode="deny"),
+        },
+    )
+
+
+def test_admission_allows() -> None:
+    assert_allows(_policy(), AGENT_RUN_TOOL, {"agent": "self"})
+
+
+def test_handoff_to_approval_target_needs_approval_within_depth() -> None:
+    assert_needs_approval(
+        _policy(), agent_target_key("handoff", "billing-bot"), {"depth": 1}
+    )
+
+
+def test_handoff_denied_when_constraint_fails() -> None:
+    # depth 3 fails ``args.depth <= 2`` → deny even though the target is listed.
+    assert_denies(_policy(), agent_target_key("handoff", "billing-bot"), {"depth": 3})
+
+
+def test_tool_only_target_allows_as_tool_but_denies_handoff() -> None:
+    policy = _policy()
+    assert_allows(policy, agent_target_key("tool", "refund-bot"))
+    # refund-bot minted no handoff key → falls to deny-by-default default_policy.
+    assert_denies(policy, agent_target_key("handoff", "refund-bot"))
+
+
+def test_denied_target_denies() -> None:
+    assert_denies(_policy(), agent_target_key("handoff", "admin-bot"))
+
+
+def test_unlisted_target_is_closed_world_under_deny_default() -> None:
+    # No rule for evil-bot; deny-by-default default_policy makes a listed-agents
+    # policy closed-world for free.
+    assert_denies(_policy(), agent_target_key("handoff", "evil-bot"))
+
+
+# --- parity: the Rego compiler emits the same lowered keys ------------------
+
+
+def test_rego_compiler_emits_lowered_agent_keys() -> None:
+    # ``compile_to_rego`` takes the parsed YAML document (flat single-policy here).
+    payload = {"agents": {"billing-bot": {"mode": "allow", "via": ["handoff"]}}}
+    rego = compile_to_rego(payload)
+    # The synthetic key is a plain string literal in the guard, ``:`` and all.
+    assert 'input.tool == "agent.handoff:billing-bot"' in rego
+
+
+# --- inheritance -----------------------------------------------------------
+
+
+def test_agent_blocks_survive_inheritance() -> None:
+    payload = {
+        "roles": {
+            "base": {
+                "is_mixin": True,
+                "admission": {"mode": "allow"},
+                "agents": {"shared-bot": {"mode": "allow", "via": ["tool"]}},
+            },
+            "support": {
+                "inherits": ["base"],
+                "agents": {"billing-bot": {"mode": "deny"}},
+            },
+        }
+    }
+    policy_set = load_policy_set_from_dict(payload)
+    support = policy_set.policy_for("support")
+    # Own agent target present, and inherited admission + inherited target both
+    # survived the merge (dropping either would be fail-open).
+    assert "agent.tool:shared-bot" in support.effective_tools
+    assert AGENT_RUN_TOOL in support.effective_tools
+    assert_denies(
+        policy_set, agent_target_key("handoff", "billing-bot"), role="support"
+    )
+    assert_allows(policy_set, agent_target_key("tool", "shared-bot"), role="support")
+
+
+def test_const_ref_in_agent_constraint_validated() -> None:
+    # A ``consts.<name>`` in an agent-block constraint must be cross-checked at
+    # PolicySet build, same as a tool constraint — an undefined const is an error.
+    payload = {
+        "roles": {
+            "default": {
+                "agents": {
+                    "b": {"mode": "allow", "constraints": ["args.depth <= consts.max"]}
+                },
+            }
+        }
+    }
+    with pytest.raises(PolicySetError):
+        load_policy_set_from_dict(payload)

--- a/tests/security/test_analyzer.py
+++ b/tests/security/test_analyzer.py
@@ -270,6 +270,26 @@ def test_permissive_default_flags_a_grant_no_named_role_has() -> None:
     assert lints[0].tool == "delete_everything"
 
 
+def test_permissive_default_flags_an_agent_grant_no_named_role_has() -> None:
+    """An admission/agents grant on `default` is reachable by any undefined role
+    name too, so it must lint via the lowered `agent.*` keys, not just `tools`."""
+    lints = check_default_role_exposure(
+        _policy_set(
+            {
+                "default": {"agents": {"admin-bot": {"mode": "allow"}}},
+                "support": {"tools": {"read_file": {"mode": "allow"}}},
+            }
+        )
+    )
+
+    codes = [lint.code for lint in lints]
+    assert codes == ["permissive-default", "permissive-default"]  # tool + handoff
+    assert {lint.tool for lint in lints} == {
+        "agent.tool:admin-bot",
+        "agent.handoff:admin-bot",
+    }
+
+
 def test_permissive_default_is_quiet_when_a_named_role_also_grants_it() -> None:
     """A shared grant is intentional (typically a mixin), not exposure."""
     lints = check_default_role_exposure(

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -291,6 +291,33 @@ def test_file_scope_in_module_raises():
         link([guard], [])
 
 
+def test_link_rejects_agents_block_in_module() -> None:
+    # An ``agents`` egress rule authored in a module would be silently dropped by
+    # the fold (which composes ``.tools`` only) — the same fail-open file_scope
+    # guards against. Fail loud instead.
+    mod = ModuleContent(
+        name="b",
+        kind="boundary",
+        policy=AgentPolicy(agents={"evil-bot": {"mode": "deny"}}),
+        source="b.yaml",
+        content_hash="hash-b",
+    )
+    with pytest.raises(LinkError, match="agent-level block"):
+        link([mod], [])
+
+
+def test_link_rejects_admission_block_in_module() -> None:
+    mod = ModuleContent(
+        name="c",
+        kind="capability",
+        policy=AgentPolicy(admission={"mode": "allow"}),
+        source="c.yaml",
+        content_hash="hash-c",
+    )
+    with pytest.raises(LinkError, match="agent-level block"):
+        link([], [mod])
+
+
 # --- provenance + policy-set wiring ---
 
 

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -302,7 +302,7 @@ def test_link_rejects_agents_block_in_module() -> None:
         source="b.yaml",
         content_hash="hash-b",
     )
-    with pytest.raises(LinkError, match="agent-level block"):
+    with pytest.raises(LinkError, match=r"\['agents'\]"):
         link([mod], [])
 
 
@@ -314,7 +314,7 @@ def test_link_rejects_admission_block_in_module() -> None:
         source="c.yaml",
         content_hash="hash-c",
     )
-    with pytest.raises(LinkError, match="agent-level block"):
+    with pytest.raises(LinkError, match=r"\['admission'\]"):
         link([], [mod])
 
 

--- a/tests/security/test_rego_compile.py
+++ b/tests/security/test_rego_compile.py
@@ -154,11 +154,13 @@ def test_emits_allow_rule_per_role_and_tool() -> None:
     rules = _allow_rules(rego)
     # support_bot: 3 roles (read_only is mixin, dropped) × 3 tools (web_search,
     # read_file each get an allow per role; refund_order is allow for support
-    # + billing, deny for default).
-    #   default  → web_search, read_file (refund_order is deny, no rule)
-    #   support  → web_search, read_file, refund_order (with 2 constraints)
-    #   billing  → web_search, read_file, refund_order (with 2 constraints)
-    assert len(rules) == 2 + 3 + 3
+    # + billing, deny for default). Plus one agent.run opt-in allow per role,
+    # since no role lists admission (admission is opt-in, so an absent agent.run
+    # admits — emitted on every role to match the pydantic engine).
+    #   default  → web_search, read_file, agent.run (refund_order is deny, no rule)
+    #   support  → web_search, read_file, refund_order (2 constraints), agent.run
+    #   billing  → web_search, read_file, refund_order (2 constraints), agent.run
+    assert len(rules) == (2 + 1) + (3 + 1) + (3 + 1)
 
 
 def test_mixin_role_omitted_from_output() -> None:
@@ -374,7 +376,9 @@ def test_approval_required_emits_separate_rule_head() -> None:
         },
     }
     rego = compile_to_rego(payload)
-    assert len(_allow_rules(rego)) == 0
+    # The only allow rule is the agent.run admission opt-in; issue_credit is an
+    # approval rule, not an allow rule.
+    assert all("agent.run" in rule for rule in _allow_rules(rego))
     [approval] = _approval_rules(rego)
     assert 'input.tool == "issue_credit"' in approval
     assert "input.args.amount <= 500" in approval
@@ -394,7 +398,8 @@ def test_flat_single_policy_compiles_as_default_role() -> None:
         },
     }
     rego = compile_to_rego(payload)
-    [rule] = _allow_rules(rego)
+    # web_search plus the agent.run admission opt-in; pick the web_search rule.
+    [rule] = [r for r in _allow_rules(rego) if "web_search" in r]
     assert 'input.tool == "web_search"' in rule
     # Only the default role exists → no role guard; it applies to every caller
     # (including unknown roles, per the default-role fallback).
@@ -511,7 +516,9 @@ def test_quantifier_emits_helper_rule() -> None:
     }
     rego = compile_to_rego(payload)
     assert re.search(r"_q_[0-9a-f]+ if \{\n\s+every __e_[0-9a-f]+ in ", rego)
-    [allow_body] = _allow_rules(rego)
+    # Two allow rules now: tool "t" and the agent.run admission opt-in. The
+    # quantifier body is on "t".
+    [allow_body] = [r for r in _allow_rules(rego) if "agent.run" not in r]
     assert re.search(r"_q_[0-9a-f]+", allow_body)  # allow references the helper
     assert re.search(r"not _q_[0-9a-f]+", rego)  # violation negates the helper
     assert "not every" not in rego and "not some" not in rego  # never inline-negated


### PR DESCRIPTION
Add the authoring surface for agent-level authorization: `admission` and `agents` blocks on `AgentPolicy`. This is PR-A1 of the agent-level enforcement series (gating who may run an agent, and who may hand off to another), and it is policy-side only: pure SDK, no platform change, no migration, no runtime wiring yet. It ships the model and the lowering so a policy can be authored and decided offline; the runtime gate, handoff interception, and depth cap follow in later PRs.

## Design

The key idea is that an agent-level rule reuses the tool decision path rather than adding a second one. `admission` and `agents` lower into synthetic tool keys through a computed `AgentPolicy.effective_tools`:

- `admission` becomes `agent.run`.
- each `agents` target becomes one key per `via` mode: `agent.tool:<name>` (agent-as-tool, orchestrator keeps control) and/or `agent.handoff:<name>` (control transfers).

Both engines read `effective_tools` (the pydantic `get_tool_policy` and the Rego compiler), so a lowered `agent.*` key evaluates identically on the pydantic and WASM paths with no engine or grammar change. Tool names are opaque strings in both engines (the Rego compiler emits `input.tool == "<name>"`), so the `.` and `:` in a key round-trip cleanly, the way the existing `net.*` egress tools already do.

Two decisions worth knowing:

- Only the listed rules lower. The fallback for an unlisted target is the runtime gate's job in a later PR, not this loader's. Folding a shared agent default into the single `default_policy` would make an existing agent (no `admission` block, deny-default) deny its own admission, a backward-compat break. Delegation closed-world still comes for free: an unlisted `agent.*` key hits the deny-by-default `default_policy`, so a listed-`agents` policy denies unlisted targets with no extra machinery.
- The `agent.*` key shapes are reserved. An authored tool that collides with `agent.run` / `agent.tool:` / `agent.handoff:` is rejected at load.

## Important files

| File | What to look at |
| --- | --- |
| `hexgate/security/models.py` | the core of the PR: the new fields, `AgentTargetPolicy` with its `via` list, and `lowered_agent_tools` / `effective_tools` |
| `hexgate/security/policy.py`, `hexgate/security/rego.py` | the parity-critical edits: each engine switches its tool lookup from `tools` to `effective_tools` |
| `hexgate/security/policy_set.py` | inheritance carry-through of the new fields, with a fail-open guard so a later mixin cannot null an earlier admission rule; const-ref validation over `effective_tools` |
| `tests/security/test_agent_policy.py` | the 20 cases pinning lowering, via modes, reserved names, enforcement, Rego parity, and inheritance |

## Test plan

Ran the full SDK unit suite: 2001 passed, 6 skipped (opt-in integration), no regressions. The live WASM engine tests are in that run, so the pydantic/WASM parity is exercised end to end, not just predicted. ruff check and ruff format are clean on all touched files.

Checked by hand through the `assert_*` helpers in the new suite:

- a listed handoff target with `approval_required` returns NEEDS_APPROVAL within its `args.depth <= 2` constraint and DENY past it;
- a `via: [tool]` target allows as a tool and denies handoff;
- an unlisted target denies under the deny-by-default policy (closed-world for free);
- inheritance keeps both an inherited `admission` rule and an inherited target after the merge.

A reviewer catches a parity regression if `test_rego_compiler_emits_lowered_agent_keys` or any WASM test fails, and a backward-compat regression if an agent with no agent blocks stops resolving its tools (`effective_tools` must equal `tools` in that case).

## Try it

```
# on this branch, from the repo root
uv run pytest tests/security/test_agent_policy.py -q
```

## Notes

- Blast radius: pure SDK, no platform change, no migration. `effective_tools` equals `tools` when no agent blocks are present, so existing policies are byte-for-byte unaffected.
- The agent default for an unlisted target is deferred to the runtime gate in PR-A2. Until then, closed-world falls out of the deny-by-default `default_policy`.
- A policy *module* (boundary/capability) that carries an agent block is rejected with a `LinkError` rather than silently dropped in the fold, mirroring the existing `file_scope` guard. Full agent-blocks-in-modules support is a later PR.
- Deferred to later PRs: the agent gate seam, admission and handoff interception across the four adapters, and the delegation depth cap.

Follow-up commit `8c19a7b` addressed the code review: the linker guard above, memoizing `effective_tools` off the hot path, and dropping an unused `default_agent_policy` field.
- Design doc: `agent-level-enforcement-design.md` (working note, not committed).
- Tooling: `uv` was not available in my environment, so I ran the equivalents (`ruff` and `pytest` via the project venv) rather than `make lint && make fmt-check && make coverage`. CI runs the make targets.
