### PR TITLE
feat(platform-api): add ClickHouse batch-insert functions for the enricher job

### DIFF
--- a/platform/api/hexgate_api/core/clickhouse.py
+++ b/platform/api/hexgate_api/core/clickhouse.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Sequence
+from dataclasses import KW_ONLY, dataclass
 from functools import lru_cache
-from typing import Protocol, TypeVar
+from typing import Generic, Protocol, TypeVar
 
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
@@ -57,18 +58,32 @@ def table_columns(client: Client, table: str) -> set[str]:
     return {row[name_index] for row in result.result_rows}
 
 
-_E = TypeVar("_E", contravariant=True)
+E = TypeVar("E")
+_E_contra = TypeVar("_E_contra", contravariant=True)
 
 
-class RowBuilder(Protocol[_E]):
-    """Shape one event into a row, in the caller's column order.
+@dataclass(frozen=True, slots=True)
+class BatchItem(Generic[E]):
+    """One event plus the ids it resolves to, for the ``insert_*_batch`` paths.
 
-    Keyword-only ids on purpose — the batch item is a bare tuple, and this
-    is where the two adjacent ``str`` fields get names again.
+    Both ids are keyword-only on purpose: they are two adjacent strings, and
+    a positional ``(event, agent_version_id, project_id)`` slip would land
+    every row with the ids transposed and nothing to catch it. This mirrors
+    the ``*, project_id, agent_version_id`` signature of the single-row
+    inserts, so the batch path is no easier to get wrong than they are.
     """
 
+    event: E
+    _: KW_ONLY
+    project_id: str
+    agent_version_id: str
+
+
+class RowBuilder(Protocol[_E_contra]):
+    """Shape one event into a row, in the caller's column order."""
+
     def __call__(
-        self, event: _E, *, project_id: str, agent_version_id: str
+        self, event: _E_contra, *, project_id: str, agent_version_id: str
     ) -> list: ...
 
 
@@ -87,18 +102,22 @@ def insert_batch(
     client: Client,
     table: str,
     columns: Sequence[str],
-    row_builder: RowBuilder[_E],
-    items: list[tuple[_E, str, str]],
+    row_builder: RowBuilder[E],
+    items: Sequence[BatchItem[E]],
 ) -> None:
-    """Insert ``items`` — ``(event, project_id, agent_version_id)`` each — as
-    one multi-row insert into ``table``, rows built by ``row_builder`` in
-    ``columns`` order. Retry semantics are the table engine's, not this
-    function's; see the per-table ``insert_*_batch`` docstrings.
+    """Insert ``items`` as one multi-row insert into ``table``, rows built by
+    ``row_builder`` in ``columns`` order. Retry semantics are the table
+    engine's, not this function's; see the per-table ``insert_*_batch``
+    docstrings.
     """
     if not items:
         return
     rows = [
-        row_builder(event, project_id=project_id, agent_version_id=agent_version_id)
-        for event, project_id, agent_version_id in items
+        row_builder(
+            item.event,
+            project_id=item.project_id,
+            agent_version_id=item.agent_version_id,
+        )
+        for item in items
     ]
     client.insert(table, rows, column_names=columns, settings=BATCH_INSERT_SETTINGS)

--- a/platform/api/hexgate_api/core/clickhouse.py
+++ b/platform/api/hexgate_api/core/clickhouse.py
@@ -6,7 +6,9 @@ Single shared Client — clickhouse-connect manages its own HTTP pool internally
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from functools import lru_cache
+from typing import Protocol, TypeVar
 
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
@@ -53,3 +55,50 @@ def table_columns(client: Client, table: str) -> set[str]:
     result = client.query(f"DESCRIBE TABLE {table}")
     name_index = result.column_names.index("name")
     return {row[name_index] for row in result.result_rows}
+
+
+_E = TypeVar("_E", contravariant=True)
+
+
+class RowBuilder(Protocol[_E]):
+    """Shape one event into a row, in the caller's column order.
+
+    Keyword-only ids on purpose — the batch item is a bare tuple, and this
+    is where the two adjacent ``str`` fields get names again.
+    """
+
+    def __call__(
+        self, event: _E, *, project_id: str, agent_version_id: str
+    ) -> list: ...
+
+
+# The one batch-insert contract, shared by every ``insert_*_batch``:
+# - Empty batch never touches ClickHouse.
+# - No async_insert, unlike the single-row paths: it exists to coalesce many
+#   small inserts, and this insert is already a batch — buffering it again
+#   would only add a server-side copy and a busy-timeout wait. A plain
+#   synchronous insert surfaces failures the same way (the call raises).
+#   Pinned to 0 rather than left to the server default so a cluster-wide
+#   async_insert=1 can't silently turn this into ack-before-durable.
+BATCH_INSERT_SETTINGS = {"async_insert": 0}
+
+
+def insert_batch(
+    client: Client,
+    table: str,
+    columns: Sequence[str],
+    row_builder: RowBuilder[_E],
+    items: list[tuple[_E, str, str]],
+) -> None:
+    """Insert ``items`` — ``(event, project_id, agent_version_id)`` each — as
+    one multi-row insert into ``table``, rows built by ``row_builder`` in
+    ``columns`` order. Retry semantics are the table engine's, not this
+    function's; see the per-table ``insert_*_batch`` docstrings.
+    """
+    if not items:
+        return
+    rows = [
+        row_builder(event, project_id=project_id, agent_version_id=agent_version_id)
+        for event, project_id, agent_version_id in items
+    ]
+    client.insert(table, rows, column_names=columns, settings=BATCH_INSERT_SETTINGS)

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -106,17 +106,14 @@ _DECISION_INSERT_SETTINGS = {
 }
 
 
-def insert_decision(
-    clickhouse_client: Client,
-    *,
-    event: DecisionEvent,
-    project_id: str,
-    agent_version_id: str,
-) -> None:
-    """Write one decision row to policy_decision.
+def _decision_row(
+    event: DecisionEvent, *, project_id: str, agent_version_id: str
+) -> list:
+    """Build one policy_decision row in ``_DECISION_COLUMNS`` order.
 
-    Raises AuditPayloadTooLarge on payload overflow and ClickHouseError on
-    insert failure; both propagate so the caller maps them to transport errors.
+    The single place the row-shaping rules live — payload serialization, the
+    falsy-attributes normalisation, the legacy ``role`` shim — shared by the
+    single-row and batch insert paths so the two cannot drift apart.
     """
     args_json = (
         json.dumps(event.arguments, default=str) if event.arguments is not None else ""
@@ -130,12 +127,6 @@ def insert_decision(
     attributes_json = (
         json.dumps(event.attributes, default=str) if event.attributes else ""
     )
-    if len(args_json.encode("utf-8")) > MAX_ARGS_BYTES:
-        raise AuditPayloadTooLarge("arguments", MAX_ARGS_BYTES)
-    if len(hint_json.encode("utf-8")) > MAX_HINT_BYTES:
-        raise AuditPayloadTooLarge("hint", MAX_HINT_BYTES)
-    if len(attributes_json.encode("utf-8")) > MAX_ATTRIBUTES_BYTES:
-        raise AuditPayloadTooLarge("attributes", MAX_ATTRIBUTES_BYTES)
 
     # ``role`` is an ingest-only compatibility shim, the single place the legacy
     # scalar still exists anywhere in the system. An SDK released before
@@ -146,7 +137,7 @@ def insert_decision(
     # This survives any database recreation, because the SDK is pip-installed.
     user_roles = list(event.user_roles) or ([event.role] if event.role else [])
 
-    row = [
+    return [
         event.event_id,
         event.occurred_at,
         project_id,  # bearer-resolved
@@ -165,11 +156,85 @@ def insert_decision(
         user_roles,
         event.deciding_role,
     ]
+
+
+# Caps live on the single-row path only: it serves direct external API callers,
+# who may send anything. The batch path's one planned caller (the span-enricher
+# job, OTel migration design doc PR 5) truncates and redacts server-side before
+# inserting, so the batch functions trust their input instead of re-checking.
+# Indices derived from the column list so a reorder cannot desynchronise them.
+_DECISION_PAYLOAD_CAPS = (
+    (_DECISION_COLUMNS.index("arguments"), "arguments", MAX_ARGS_BYTES),
+    (_DECISION_COLUMNS.index("hint"), "hint", MAX_HINT_BYTES),
+    (_DECISION_COLUMNS.index("attributes"), "attributes", MAX_ATTRIBUTES_BYTES),
+)
+
+
+def insert_decision(
+    clickhouse_client: Client,
+    *,
+    event: DecisionEvent,
+    project_id: str,
+    agent_version_id: str,
+) -> None:
+    """Write one decision row to policy_decision.
+
+    Raises AuditPayloadTooLarge on payload overflow and ClickHouseError on
+    insert failure; both propagate so the caller maps them to transport errors.
+    """
+    row = _decision_row(event, project_id=project_id, agent_version_id=agent_version_id)
+    for index, field, limit in _DECISION_PAYLOAD_CAPS:
+        if len(row[index].encode("utf-8")) > limit:
+            raise AuditPayloadTooLarge(field, limit)
+
     clickhouse_client.insert(
         DECISION_TABLE,
         [row],
         column_names=_DECISION_COLUMNS,
         settings=_DECISION_INSERT_SETTINGS,
+    )
+
+
+def insert_decisions_batch(
+    clickhouse_client: Client,
+    items: list[tuple[DecisionEvent, str, str]],
+) -> None:
+    """Write many decision rows in one atomic insert.
+
+    ``items`` is ``(event, project_id, agent_version_id)`` per event — both
+    ids resolved per item, because a consumer batch aggregates across Kafka
+    records and so can span projects and agents.
+
+    Contract with the caller (the span-enricher job): payloads arrive already
+    byte-capped and redacted — that job is the authoritative server-side
+    enforcement point, so unlike ``insert_decision`` there is no cap check
+    here.
+
+    Retry-safe rather than atomic: ClickHouse commits per block (and the
+    driver may re-send once on a dropped keep-alive), so a failed call can
+    have landed part of the batch. The caller's move on any failure is to
+    retry the whole batch — ReplacingMergeTree(received_at) collapses
+    re-inserted event_ids on merges, so duplicates cancel rather than
+    double-count. Two edges of that guarantee: dedup never crosses the
+    monthly received_at partition, so a retry that straddles a month
+    boundary can double-count (accepted — a seconds-wide window, and only at
+    most once a month); and a duplicate event_id *within* one batch
+    collapses at insert time, last occurrence winning.
+    """
+    if not items:
+        return
+    rows = [
+        _decision_row(event, project_id=project_id, agent_version_id=agent_version_id)
+        for event, project_id, agent_version_id in items
+    ]
+    # No async_insert here, unlike the single-row path: it exists to coalesce
+    # many small inserts, and this insert is already a batch — buffering it
+    # again would only add a server-side copy and a busy-timeout wait. A plain
+    # synchronous insert surfaces failures the same way (the call raises).
+    clickhouse_client.insert(
+        DECISION_TABLE,
+        rows,
+        column_names=_DECISION_COLUMNS,
     )
 
 
@@ -190,15 +255,12 @@ _BAN_ENFORCEMENT_COLUMNS = [
 ]
 
 
-def insert_ban_enforcement(
-    clickhouse_client: Client,
-    *,
-    event: BanEnforcementEvent,
-    project_id: str,
-    agent_version_id: str,
-) -> None:
-    """Write one row to ban_enforcement (no payload caps — no arguments/hint blobs)."""
-    row = [
+def _ban_enforcement_row(
+    event: BanEnforcementEvent, *, project_id: str, agent_version_id: str
+) -> list:
+    """Build one ban_enforcement row in ``_BAN_ENFORCEMENT_COLUMNS`` order,
+    shared by the single-row and batch insert paths."""
+    return [
         event.event_id,
         event.occurred_at,
         project_id,  # bearer-resolved
@@ -210,12 +272,51 @@ def insert_ban_enforcement(
         event.ban_id,
         event.reason,
     ]
+
+
+def insert_ban_enforcement(
+    clickhouse_client: Client,
+    *,
+    event: BanEnforcementEvent,
+    project_id: str,
+    agent_version_id: str,
+) -> None:
+    """Write one row to ban_enforcement (no payload caps — no arguments/hint blobs)."""
+    row = _ban_enforcement_row(
+        event, project_id=project_id, agent_version_id=agent_version_id
+    )
     clickhouse_client.insert(
         BAN_ENFORCEMENT_TABLE,
         [row],
         column_names=_BAN_ENFORCEMENT_COLUMNS,
         # Same async-insert-and-block semantics as decisions.
         settings=_DECISION_INSERT_SETTINGS,
+    )
+
+
+def insert_ban_enforcements_batch(
+    clickhouse_client: Client,
+    items: list[tuple[BanEnforcementEvent, str, str]],
+) -> None:
+    """Write many ban_enforcement rows in one batch insert.
+
+    Same shape and contract as ``insert_decisions_batch`` — per-item
+    ``(event, project_id, agent_version_id)``, retry-safe rather than atomic
+    (see that docstring for the guarantee and its edges) — minus the
+    payload-cap contract, since this table carries no blob columns at all.
+    """
+    if not items:
+        return
+    rows = [
+        _ban_enforcement_row(
+            event, project_id=project_id, agent_version_id=agent_version_id
+        )
+        for event, project_id, agent_version_id in items
+    ]
+    clickhouse_client.insert(
+        BAN_ENFORCEMENT_TABLE,
+        rows,
+        column_names=_BAN_ENFORCEMENT_COLUMNS,
     )
 
 

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -1,6 +1,7 @@
 """ClickHouse layer for audit events — both halves of the pipeline.
 
-Write path: validation caps + ``insert_decision`` (the SDK ingest).
+Write path: validation caps + ``insert_decision`` (the SDK ingest), plus
+the ``insert_*_batch`` twins (the span-enricher job, pre-capped input).
 Read path: ``summarize`` / ``timeseries`` / ``list_decisions`` (the
 dashboard aggregations). They stay in one module because they share the
 table contract (``_DECISION_COLUMNS``, windows, scope filters) — unlike

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -228,7 +228,15 @@ def insert_decisions_batch(
     crosses the monthly received_at partition, so a retry that straddles a
     month boundary double-counts permanently (accepted — a seconds-wide
     window, at most once a month); and a duplicate event_id *within* one
-    batch collapses at insert time, last occurrence winning.
+    batch is not reliably collapsed at insert time. ``optimize_on_insert``
+    applies the engine's merge to each inserted *block*, and the driver
+    splits a large batch into ~2MB blocks — so two copies in the same block
+    do collapse on the way in (observed: last occurrence wins, since both
+    carry the same server-stamped received_at), while copies that straddle a
+    block boundary land in separate parts and wait for a background merge
+    like any other duplicate. Callers that can see Kafka redeliveries within
+    one poll should dedup by event_id before building the batch rather than
+    rely on this.
     """
     if not items:
         return

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -17,11 +17,12 @@ import logging
 import re
 from datetime import datetime, timedelta
 from collections import deque
+from collections.abc import Sequence
 
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
 
-from hexgate_api.core.clickhouse import insert_batch, table_columns
+from hexgate_api.core.clickhouse import BatchItem, insert_batch, table_columns
 from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import (
     AnomalySeverity,
@@ -198,13 +199,13 @@ def insert_decision(
 
 def insert_decisions_batch(
     clickhouse_client: Client,
-    items: list[tuple[DecisionEvent, str, str]],
+    items: Sequence[BatchItem[DecisionEvent]],
 ) -> None:
     """Write many decision rows in one batch insert.
 
-    ``items`` is ``(event, project_id, agent_version_id)`` per event — both
-    ids resolved per item, because a consumer batch aggregates across Kafka
-    records and so can span projects and agents.
+    Each ``BatchItem`` carries its own ``project_id`` and ``agent_version_id``
+    (keyword-only, see ``BatchItem``) — resolved per item, because a consumer
+    batch aggregates across Kafka records and so can span projects and agents.
 
     Contract with the caller (the span-enricher job): payloads arrive already
     byte-capped and redacted — that job is the authoritative server-side
@@ -301,12 +302,12 @@ def insert_ban_enforcement(
 
 def insert_ban_enforcements_batch(
     clickhouse_client: Client,
-    items: list[tuple[BanEnforcementEvent, str, str]],
+    items: Sequence[BatchItem[BanEnforcementEvent]],
 ) -> None:
     """Write many ban_enforcement rows in one batch insert.
 
     Same shape and contract as ``insert_decisions_batch`` — per-item
-    ``(event, project_id, agent_version_id)``, retry-safe rather than atomic
+    ``BatchItem`` with its own ids, retry-safe rather than atomic
     (see that docstring for the guarantee and its edges) — minus the
     payload-cap contract, since this table carries no blob columns at all.
     """

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -21,7 +21,7 @@ from collections import deque
 from clickhouse_connect.driver.client import Client
 from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
 
-from hexgate_api.core.clickhouse import table_columns
+from hexgate_api.core.clickhouse import insert_batch, table_columns
 from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import (
     AnomalySeverity,
@@ -238,23 +238,8 @@ def insert_decisions_batch(
     one poll should dedup by event_id before building the batch rather than
     rely on this.
     """
-    if not items:
-        return
-    rows = [
-        _decision_row(event, project_id=project_id, agent_version_id=agent_version_id)
-        for event, project_id, agent_version_id in items
-    ]
-    # No async_insert here, unlike the single-row path: it exists to coalesce
-    # many small inserts, and this insert is already a batch — buffering it
-    # again would only add a server-side copy and a busy-timeout wait. A plain
-    # synchronous insert surfaces failures the same way (the call raises).
-    # Pinned to 0 rather than left to the server default so a cluster-wide
-    # async_insert=1 can't silently turn this into ack-before-durable.
-    clickhouse_client.insert(
-        DECISION_TABLE,
-        rows,
-        column_names=_DECISION_COLUMNS,
-        settings={"async_insert": 0},
+    insert_batch(
+        clickhouse_client, DECISION_TABLE, _DECISION_COLUMNS, _decision_row, items
     )
 
 
@@ -325,20 +310,12 @@ def insert_ban_enforcements_batch(
     (see that docstring for the guarantee and its edges) — minus the
     payload-cap contract, since this table carries no blob columns at all.
     """
-    if not items:
-        return
-    rows = [
-        _ban_enforcement_row(
-            event, project_id=project_id, agent_version_id=agent_version_id
-        )
-        for event, project_id, agent_version_id in items
-    ]
-    clickhouse_client.insert(
+    insert_batch(
+        clickhouse_client,
         BAN_ENFORCEMENT_TABLE,
-        rows,
-        column_names=_BAN_ENFORCEMENT_COLUMNS,
-        # Same synchronous-insert pin as insert_decisions_batch.
-        settings={"async_insert": 0},
+        _BAN_ENFORCEMENT_COLUMNS,
+        _ban_enforcement_row,
+        items,
     )
 
 

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -214,13 +214,21 @@ def insert_decisions_batch(
     Retry-safe rather than atomic: ClickHouse commits per block (and the
     driver may re-send once on a dropped keep-alive), so a failed call can
     have landed part of the batch. The caller's move on any failure is to
-    retry the whole batch — ReplacingMergeTree(received_at) collapses
-    re-inserted event_ids on merges, so duplicates cancel rather than
-    double-count. Two edges of that guarantee: dedup never crosses the
-    monthly received_at partition, so a retry that straddles a month
-    boundary can double-count (accepted — a seconds-wide window, and only at
-    most once a month); and a duplicate event_id *within* one batch
-    collapses at insert time, last occurrence winning.
+    retry the whole batch. What makes that safe is the table engine, and the
+    guarantee is *eventual*, not immediate: ReplacingMergeTree(received_at)
+    keeps every inserted row on disk and only collapses rows sharing a sort
+    key (project_id, occurred_at, event_id) — highest received_at wins — when
+    a background merge happens to cover the parts holding them. Merges are
+    opportunistic, with no upper bound on when they run, and the read paths
+    (``summarize``, ``timeseries``, ``list_decisions``) query without
+    ``FINAL``, so after a retry both copies of each event_id are counted
+    until that merge lands — typically seconds to minutes on these tables,
+    but not guaranteed. Only ``SELECT ... FINAL`` (or an argMax GROUP BY)
+    sees the collapsed view before then. Two further edges: dedup never
+    crosses the monthly received_at partition, so a retry that straddles a
+    month boundary double-counts permanently (accepted — a seconds-wide
+    window, at most once a month); and a duplicate event_id *within* one
+    batch collapses at insert time, last occurrence winning.
     """
     if not items:
         return

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -199,7 +199,7 @@ def insert_decisions_batch(
     clickhouse_client: Client,
     items: list[tuple[DecisionEvent, str, str]],
 ) -> None:
-    """Write many decision rows in one atomic insert.
+    """Write many decision rows in one batch insert.
 
     ``items`` is ``(event, project_id, agent_version_id)`` per event — both
     ids resolved per item, because a consumer batch aggregates across Kafka
@@ -231,10 +231,13 @@ def insert_decisions_batch(
     # many small inserts, and this insert is already a batch — buffering it
     # again would only add a server-side copy and a busy-timeout wait. A plain
     # synchronous insert surfaces failures the same way (the call raises).
+    # Pinned to 0 rather than left to the server default so a cluster-wide
+    # async_insert=1 can't silently turn this into ack-before-durable.
     clickhouse_client.insert(
         DECISION_TABLE,
         rows,
         column_names=_DECISION_COLUMNS,
+        settings={"async_insert": 0},
     )
 
 
@@ -317,6 +320,8 @@ def insert_ban_enforcements_batch(
         BAN_ENFORCEMENT_TABLE,
         rows,
         column_names=_BAN_ENFORCEMENT_COLUMNS,
+        # Same synchronous-insert pin as insert_decisions_batch.
+        settings={"async_insert": 0},
     )
 
 

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -2,6 +2,7 @@ from clickhouse_connect.driver.client import Client
 
 from datetime import datetime
 
+from hexgate_api.core.clickhouse import insert_batch
 from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import LlmInvocationEvent
 
@@ -96,23 +97,15 @@ def insert_llm_invocations_batch(
     features/audit/service.py: dedup stays within the monthly received_at
     partition, and an intra-batch duplicate collapses at insert time only if
     both copies fall in the same insert block — otherwise it waits for a
-    background merge. No async_insert, unlike the single-row path —
-    this insert is already a batch; pinned to 0 so a server-side default
-    change can't silently make it ack-before-durable.
+    background merge. No async_insert, unlike the single-row path — see
+    ``BATCH_INSERT_SETTINGS`` in core/clickhouse.py for why.
     """
-    if not items:
-        return
-    rows = [
-        _llm_invocation_row(
-            event, project_id=project_id, agent_version_id=agent_version_id
-        )
-        for event, project_id, agent_version_id in items
-    ]
-    clickhouse_client.insert(
+    insert_batch(
+        clickhouse_client,
         "llm_invocation",
-        rows,
-        column_names=_LLM_INVOCATION_COLUMNS,
-        settings={"async_insert": 0},
+        _LLM_INVOCATION_COLUMNS,
+        _llm_invocation_row,
+        items,
     )
 
 

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -1,8 +1,10 @@
+from collections.abc import Sequence
+
 from clickhouse_connect.driver.client import Client
 
 from datetime import datetime
 
-from hexgate_api.core.clickhouse import insert_batch
+from hexgate_api.core.clickhouse import BatchItem, insert_batch
 from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import LlmInvocationEvent
 
@@ -82,15 +84,16 @@ def insert_llm_invocation(
 
 def insert_llm_invocations_batch(
     clickhouse_client: Client,
-    items: list[tuple[LlmInvocationEvent, str, str]],
+    items: Sequence[BatchItem[LlmInvocationEvent]],
 ) -> None:
     """Write many llm_invocation rows in one batch insert.
 
-    ``items`` is ``(event, project_id, agent_version_id)`` per event — both
-    ids resolved per item, because a consumer batch aggregates across Kafka
-    records and so can span projects and agents. Retry-safe rather than
-    atomic: a failed call can have landed part of the batch (ClickHouse
-    commits per block), so the caller retries the whole batch — safe because
+    Each ``BatchItem`` carries its own ``project_id`` and ``agent_version_id``
+    (keyword-only, see ``BatchItem``) — resolved per item, because a consumer
+    batch aggregates across Kafka records and so can span projects and agents.
+    Retry-safe rather than atomic: a failed call can have landed part of the
+    batch (ClickHouse commits per block), so the caller retries the whole
+    batch — safe because
     ReplacingMergeTree(received_at) eventually collapses re-inserted
     event_ids on a background merge (both copies are visible to non-FINAL
     reads until then). Same guarantee edges as ``insert_decisions_batch`` in

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -95,7 +95,8 @@ def insert_llm_invocations_batch(
     features/audit/service.py: dedup stays within the monthly received_at
     partition, and an intra-batch duplicate collapses at insert time with the
     last occurrence winning. No async_insert, unlike the single-row path —
-    this insert is already a batch.
+    this insert is already a batch; pinned to 0 so a server-side default
+    change can't silently make it ack-before-durable.
     """
     if not items:
         return
@@ -109,6 +110,7 @@ def insert_llm_invocations_batch(
         "llm_invocation",
         rows,
         column_names=_LLM_INVOCATION_COLUMNS,
+        settings={"async_insert": 0},
     )
 
 

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -94,8 +94,9 @@ def insert_llm_invocations_batch(
     event_ids on a background merge (both copies are visible to non-FINAL
     reads until then). Same guarantee edges as ``insert_decisions_batch`` in
     features/audit/service.py: dedup stays within the monthly received_at
-    partition, and an intra-batch duplicate collapses at insert time with the
-    last occurrence winning. No async_insert, unlike the single-row path —
+    partition, and an intra-batch duplicate collapses at insert time only if
+    both copies fall in the same insert block — otherwise it waits for a
+    background merge. No async_insert, unlike the single-row path —
     this insert is already a batch; pinned to 0 so a server-side default
     change can't silently make it ack-before-durable.
     """

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -90,8 +90,9 @@ def insert_llm_invocations_batch(
     records and so can span projects and agents. Retry-safe rather than
     atomic: a failed call can have landed part of the batch (ClickHouse
     commits per block), so the caller retries the whole batch — safe because
-    ReplacingMergeTree(received_at) collapses re-inserted event_ids on
-    merges. Same guarantee edges as ``insert_decisions_batch`` in
+    ReplacingMergeTree(received_at) eventually collapses re-inserted
+    event_ids on a background merge (both copies are visible to non-FINAL
+    reads until then). Same guarantee edges as ``insert_decisions_batch`` in
     features/audit/service.py: dedup stays within the monthly received_at
     partition, and an intra-batch duplicate collapses at insert time with the
     last occurrence winning. No async_insert, unlike the single-row path —

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -34,19 +34,12 @@ _LLM_INVOCATION_INSERT_SETTINGS = {
 }
 
 
-def insert_llm_invocation(
-    clickhouse_client: Client,
-    *,
-    event: LlmInvocationEvent,
-    project_id: str,
-    agent_version_id: str,
-) -> None:
-    """Write one row to llm_invocation.
-
-    Raises ClickHouseError on insert failure; propagates so the caller maps
-    it to a transport error.
-    """
-    row = [
+def _llm_invocation_row(
+    event: LlmInvocationEvent, *, project_id: str, agent_version_id: str
+) -> list:
+    """Build one llm_invocation row in ``_LLM_INVOCATION_COLUMNS`` order,
+    shared by the single-row and batch insert paths."""
+    return [
         event.event_id,
         event.occurred_at,
         project_id,  # bearer-resolved
@@ -62,11 +55,60 @@ def insert_llm_invocation(
         event.error_code,
     ]
 
+
+def insert_llm_invocation(
+    clickhouse_client: Client,
+    *,
+    event: LlmInvocationEvent,
+    project_id: str,
+    agent_version_id: str,
+) -> None:
+    """Write one row to llm_invocation.
+
+    Raises ClickHouseError on insert failure; propagates so the caller maps
+    it to a transport error.
+    """
+    row = _llm_invocation_row(
+        event, project_id=project_id, agent_version_id=agent_version_id
+    )
     clickhouse_client.insert(
         "llm_invocation",
         [row],
         column_names=_LLM_INVOCATION_COLUMNS,
         settings=_LLM_INVOCATION_INSERT_SETTINGS,
+    )
+
+
+def insert_llm_invocations_batch(
+    clickhouse_client: Client,
+    items: list[tuple[LlmInvocationEvent, str, str]],
+) -> None:
+    """Write many llm_invocation rows in one batch insert.
+
+    ``items`` is ``(event, project_id, agent_version_id)`` per event — both
+    ids resolved per item, because a consumer batch aggregates across Kafka
+    records and so can span projects and agents. Retry-safe rather than
+    atomic: a failed call can have landed part of the batch (ClickHouse
+    commits per block), so the caller retries the whole batch — safe because
+    ReplacingMergeTree(received_at) collapses re-inserted event_ids on
+    merges. Same guarantee edges as ``insert_decisions_batch`` in
+    features/audit/service.py: dedup stays within the monthly received_at
+    partition, and an intra-batch duplicate collapses at insert time with the
+    last occurrence winning. No async_insert, unlike the single-row path —
+    this insert is already a batch.
+    """
+    if not items:
+        return
+    rows = [
+        _llm_invocation_row(
+            event, project_id=project_id, agent_version_id=agent_version_id
+        )
+        for event, project_id, agent_version_id in items
+    ]
+    clickhouse_client.insert(
+        "llm_invocation",
+        rows,
+        column_names=_LLM_INVOCATION_COLUMNS,
     )
 
 

--- a/platform/api/tests/core/test_clickhouse.py
+++ b/platform/api/tests/core/test_clickhouse.py
@@ -1,0 +1,30 @@
+"""Unit tests for the shared batch-insert helper in core/clickhouse.py."""
+
+from unittest.mock import MagicMock
+
+from hexgate_api.core.clickhouse import BATCH_INSERT_SETTINGS, insert_batch
+
+
+def _row(event: dict, *, project_id: str, agent_version_id: str) -> list:
+    return [event["id"], project_id, agent_version_id]
+
+
+def test_insert_batch_builds_rows_and_pins_synchronous_insert() -> None:
+    client = MagicMock()
+    items = [({"id": "e1"}, "proj_a", "ver_1"), ({"id": "e2"}, "proj_b", "ver_2")]
+
+    insert_batch(client, "some_table", ["event_id", "project_id", "agent"], _row, items)
+
+    client.insert.assert_called_once()
+    args, kwargs = client.insert.call_args
+    assert args[0] == "some_table"
+    assert args[1] == [["e1", "proj_a", "ver_1"], ["e2", "proj_b", "ver_2"]]
+    assert kwargs["column_names"] == ["event_id", "project_id", "agent"]
+    # The one place the batch contract is pinned; every insert_*_batch inherits it.
+    assert kwargs["settings"] == BATCH_INSERT_SETTINGS == {"async_insert": 0}
+
+
+def test_insert_batch_with_no_items_never_touches_clickhouse() -> None:
+    client = MagicMock()
+    insert_batch(client, "some_table", ["event_id"], _row, [])
+    client.insert.assert_not_called()

--- a/platform/api/tests/core/test_clickhouse.py
+++ b/platform/api/tests/core/test_clickhouse.py
@@ -2,7 +2,9 @@
 
 from unittest.mock import MagicMock
 
-from hexgate_api.core.clickhouse import BATCH_INSERT_SETTINGS, insert_batch
+import pytest
+
+from hexgate_api.core.clickhouse import BATCH_INSERT_SETTINGS, BatchItem, insert_batch
 
 
 def _row(event: dict, *, project_id: str, agent_version_id: str) -> list:
@@ -11,7 +13,10 @@ def _row(event: dict, *, project_id: str, agent_version_id: str) -> list:
 
 def test_insert_batch_builds_rows_and_pins_synchronous_insert() -> None:
     client = MagicMock()
-    items = [({"id": "e1"}, "proj_a", "ver_1"), ({"id": "e2"}, "proj_b", "ver_2")]
+    items = [
+        BatchItem({"id": "e1"}, project_id="proj_a", agent_version_id="ver_1"),
+        BatchItem({"id": "e2"}, project_id="proj_b", agent_version_id="ver_2"),
+    ]
 
     insert_batch(client, "some_table", ["event_id", "project_id", "agent"], _row, items)
 
@@ -28,3 +33,10 @@ def test_insert_batch_with_no_items_never_touches_clickhouse() -> None:
     client = MagicMock()
     insert_batch(client, "some_table", ["event_id"], _row, [])
     client.insert.assert_not_called()
+
+
+def test_batch_item_refuses_positional_ids() -> None:
+    """The whole point of BatchItem over a bare tuple: two adjacent str ids
+    can't be silently transposed, because they can't be passed positionally."""
+    with pytest.raises(TypeError):
+        BatchItem({"id": "e1"}, "proj_a", "ver_1")  # type: ignore[misc]

--- a/platform/api/tests/features/audit/test_audit.py
+++ b/platform/api/tests/features/audit/test_audit.py
@@ -36,6 +36,7 @@ from hexgate_api.query_scope import (
     RETENTION_WINDOW,
     prepare_date_range,
 )
+from hexgate_api.core.clickhouse import BatchItem
 from hexgate_api.core.keystore import FileKeyStore
 from hexgate_api.core.db import get_session
 from hexgate_api.deps.clickhouse import require_clickhouse
@@ -1370,7 +1371,14 @@ def test_insert_decisions_batch_happy_path() -> None:
     )
 
     clickhouse_client = MagicMock()
-    items = [(DecisionEvent(**_event()), f"proj_{i}", f"ver_{i}") for i in range(3)]
+    items = [
+        BatchItem(
+            DecisionEvent(**_event()),
+            project_id=f"proj_{i}",
+            agent_version_id=f"ver_{i}",
+        )
+        for i in range(3)
+    ]
 
     insert_decisions_batch(clickhouse_client, items)
 
@@ -1422,7 +1430,9 @@ def test_when_an_event_has_a_legacy_role_then_batch_and_single_rows_match() -> N
     single, batch = MagicMock(), MagicMock()
 
     insert_decision(single, event=event, project_id="p", agent_version_id="v")
-    insert_decisions_batch(batch, [(event, "p", "v")])
+    insert_decisions_batch(
+        batch, [BatchItem(event, project_id="p", agent_version_id="v")]
+    )
 
     single_row = single.insert.call_args.args[1][0]
     batch_row = batch.insert.call_args.args[1][0]
@@ -1444,7 +1454,9 @@ def test_when_a_batch_row_exceeds_the_caps_then_it_is_inserted_as_given() -> Non
     oversized = DecisionEvent(**_event(arguments={"blob": "x" * (MAX_ARGS_BYTES + 1)}))
     clickhouse_client = MagicMock()
 
-    insert_decisions_batch(clickhouse_client, [(oversized, "p", "v")])
+    insert_decisions_batch(
+        clickhouse_client, [BatchItem(oversized, project_id="p", agent_version_id="v")]
+    )
 
     clickhouse_client.insert.assert_called_once()
 
@@ -1458,7 +1470,11 @@ def test_insert_ban_enforcements_batch_happy_path() -> None:
 
     clickhouse_client = MagicMock()
     items = [
-        (BanEnforcementEvent(**_ban_enforcement()), f"proj_{i}", f"ver_{i}")
+        BatchItem(
+            BanEnforcementEvent(**_ban_enforcement()),
+            project_id=f"proj_{i}",
+            agent_version_id=f"ver_{i}",
+        )
         for i in range(2)
     ]
 
@@ -2018,9 +2034,21 @@ def test_real_clickhouse_batch_insert_lands_all_rows() -> None:
     project_a = f"test_proj_{uuid.uuid4().hex[:8]}"
     project_b = f"test_proj_{uuid.uuid4().hex[:8]}"
     items = [
-        (DecisionEvent(**_event(reason="batch-a1")), project_a, "ver_a"),
-        (DecisionEvent(**_event(reason="batch-a2")), project_a, "ver_a"),
-        (DecisionEvent(**_event(reason="batch-b1")), project_b, "ver_b"),
+        BatchItem(
+            DecisionEvent(**_event(reason="batch-a1")),
+            project_id=project_a,
+            agent_version_id="ver_a",
+        ),
+        BatchItem(
+            DecisionEvent(**_event(reason="batch-a2")),
+            project_id=project_a,
+            agent_version_id="ver_a",
+        ),
+        BatchItem(
+            DecisionEvent(**_event(reason="batch-b1")),
+            project_id=project_b,
+            agent_version_id="ver_b",
+        ),
     ]
 
     insert_decisions_batch(clickhouse_client, items)
@@ -2057,7 +2085,12 @@ def test_when_a_batch_is_reinserted_then_rows_collapse_to_one_per_event() -> Non
 
     clickhouse_client = real_get_clickhouse()
     project_id = f"test_proj_{uuid.uuid4().hex[:8]}"
-    items = [(DecisionEvent(**_event()), project_id, "ver_x") for _ in range(3)]
+    items = [
+        BatchItem(
+            DecisionEvent(**_event()), project_id=project_id, agent_version_id="ver_x"
+        )
+        for _ in range(3)
+    ]
 
     insert_decisions_batch(clickhouse_client, items)
     insert_decisions_batch(clickhouse_client, items)  # the retry

--- a/platform/api/tests/features/audit/test_audit.py
+++ b/platform/api/tests/features/audit/test_audit.py
@@ -1356,6 +1356,123 @@ def test_ban_enforcement_read_clamps_limit_to_200(
 
 
 # ---------------------------------------------------------------------------
+# Batch inserts (OTel migration design doc PR 4) — the span-enricher job's
+# write path. Nothing in the API calls these yet; the contract is exercised
+# directly with a MagicMock client capturing the insert call.
+# ---------------------------------------------------------------------------
+
+
+def test_insert_decisions_batch_happy_path() -> None:
+    """N per-item-resolved events become ONE insert call carrying N rows."""
+    from hexgate_api.features.audit.service import (
+        _DECISION_COLUMNS,
+        insert_decisions_batch,
+    )
+
+    clickhouse_client = MagicMock()
+    items = [(DecisionEvent(**_event()), f"proj_{i}", f"ver_{i}") for i in range(3)]
+
+    insert_decisions_batch(clickhouse_client, items)
+
+    clickhouse_client.insert.assert_called_once()
+    args, kwargs = clickhouse_client.insert.call_args
+    assert args[0] == "policy_decision"
+    rows = args[1]
+    assert len(rows) == 3
+    assert kwargs["column_names"] == _DECISION_COLUMNS
+    # No async_insert on the batch path — it coalesces small inserts, and this
+    # insert is already a batch; a plain synchronous insert raises on failure.
+    assert "settings" not in kwargs
+    # project_id / agent_version_id are per item, not hoisted batch-wide: a
+    # consumer batch aggregates across Kafka records and can span projects.
+    project_index = _DECISION_COLUMNS.index("project_id")
+    version_index = _DECISION_COLUMNS.index("agent_version_id")
+    assert [row[project_index] for row in rows] == ["proj_0", "proj_1", "proj_2"]
+    assert [row[version_index] for row in rows] == ["ver_0", "ver_1", "ver_2"]
+
+
+def test_when_the_batch_is_empty_then_clickhouse_is_not_called() -> None:
+    from hexgate_api.features.audit.service import (
+        insert_ban_enforcements_batch,
+        insert_decisions_batch,
+    )
+
+    clickhouse_client = MagicMock()
+
+    insert_decisions_batch(clickhouse_client, [])
+    insert_ban_enforcements_batch(clickhouse_client, [])
+
+    clickhouse_client.insert.assert_not_called()
+
+
+def test_when_an_event_has_a_legacy_role_then_batch_and_single_rows_match() -> None:
+    """The role→user_roles shim lives in the shared row builder, so the two
+    paths must produce identical rows for the same event — this is the guard
+    against the batch path drifting from the single-row serialization rules."""
+    from hexgate_api.features.audit.service import (
+        _DECISION_COLUMNS,
+        insert_decision,
+        insert_decisions_batch,
+    )
+
+    event = DecisionEvent(
+        **_event(role="billing", arguments={"path": "/tmp/x"}, attributes={})
+    )
+    single, batch = MagicMock(), MagicMock()
+
+    insert_decision(single, event=event, project_id="p", agent_version_id="v")
+    insert_decisions_batch(batch, [(event, "p", "v")])
+
+    single_row = single.insert.call_args.args[1][0]
+    batch_row = batch.insert.call_args.args[1][0]
+    assert batch_row == single_row
+    assert batch_row[_DECISION_COLUMNS.index("user_roles")] == ["billing"]
+    assert batch_row[_DECISION_COLUMNS.index("attributes")] == ""  # falsy → ""
+
+
+def test_when_a_batch_row_exceeds_the_caps_then_it_is_inserted_as_given() -> None:
+    """Deliberate contract, not an omission: the batch path's caller (the
+    span-enricher job) is the authoritative truncation/redaction point, so the
+    batch functions trust their input where ``insert_decision`` re-checks. A
+    change in this behavior is a change to that contract."""
+    from hexgate_api.features.audit.service import (
+        MAX_ARGS_BYTES,
+        insert_decisions_batch,
+    )
+
+    oversized = DecisionEvent(**_event(arguments={"blob": "x" * (MAX_ARGS_BYTES + 1)}))
+    clickhouse_client = MagicMock()
+
+    insert_decisions_batch(clickhouse_client, [(oversized, "p", "v")])
+
+    clickhouse_client.insert.assert_called_once()
+
+
+def test_insert_ban_enforcements_batch_happy_path() -> None:
+    from hexgate_api.features.audit.service import (
+        _BAN_ENFORCEMENT_COLUMNS,
+        insert_ban_enforcements_batch,
+    )
+    from hexgate_api.schemas import BanEnforcementEvent
+
+    clickhouse_client = MagicMock()
+    items = [
+        (BanEnforcementEvent(**_ban_enforcement()), f"proj_{i}", f"ver_{i}")
+        for i in range(2)
+    ]
+
+    insert_ban_enforcements_batch(clickhouse_client, items)
+
+    clickhouse_client.insert.assert_called_once()
+    args, kwargs = clickhouse_client.insert.call_args
+    assert args[0] == "ban_enforcement"
+    assert len(args[1]) == 2
+    assert kwargs["column_names"] == _BAN_ENFORCEMENT_COLUMNS
+    project_index = _BAN_ENFORCEMENT_COLUMNS.index("project_id")
+    assert [row[project_index] for row in args[1]] == ["proj_0", "proj_1"]
+
+
+# ---------------------------------------------------------------------------
 # Health (liveness) vs readiness split
 # ---------------------------------------------------------------------------
 
@@ -1883,3 +2000,79 @@ def test_audit_anomalies_clickhouse_error_returns_503(
     r = client.get("/v1/projects/proj_test/audit/anomalies")
     assert r.status_code == 503
     assert "unavailable" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Batch inserts — integration (real ClickHouse, opt-in via marker)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_real_clickhouse_batch_insert_lands_all_rows() -> None:
+    """One multi-row, multi-project insert through the real write path."""
+    from hexgate_api.core.clickhouse import get_clickhouse as real_get_clickhouse
+    from hexgate_api.features.audit.service import insert_decisions_batch
+
+    clickhouse_client = real_get_clickhouse()
+    project_a = f"test_proj_{uuid.uuid4().hex[:8]}"
+    project_b = f"test_proj_{uuid.uuid4().hex[:8]}"
+    items = [
+        (DecisionEvent(**_event(reason="batch-a1")), project_a, "ver_a"),
+        (DecisionEvent(**_event(reason="batch-a2")), project_a, "ver_a"),
+        (DecisionEvent(**_event(reason="batch-b1")), project_b, "ver_b"),
+    ]
+
+    insert_decisions_batch(clickhouse_client, items)
+
+    try:
+        rows = clickhouse_client.query(
+            "SELECT project_id, reason, agent_version_id FROM policy_decision "
+            "WHERE project_id IN ({a:String}, {b:String})",
+            parameters={"a": project_a, "b": project_b},
+        ).result_rows
+        assert sorted(rows) == sorted(
+            [
+                (project_a, "batch-a1", "ver_a"),
+                (project_a, "batch-a2", "ver_a"),
+                (project_b, "batch-b1", "ver_b"),
+            ]
+        )
+    finally:
+        for pid in (project_a, project_b):
+            clickhouse_client.command(
+                "ALTER TABLE policy_decision DELETE WHERE project_id = {pid:String}",
+                parameters={"pid": pid},
+            )
+
+
+@pytest.mark.integration
+def test_when_a_batch_is_reinserted_then_rows_collapse_to_one_per_event() -> None:
+    """The whole-batch-retry safety claim the enricher job will rely on:
+    re-inserting an already-landed batch deduplicates instead of
+    double-counting. ``SELECT ... FINAL`` applies ReplacingMergeTree's merge
+    semantics at read time, so this doesn't wait on a background merge."""
+    from hexgate_api.core.clickhouse import get_clickhouse as real_get_clickhouse
+    from hexgate_api.features.audit.service import insert_decisions_batch
+
+    clickhouse_client = real_get_clickhouse()
+    project_id = f"test_proj_{uuid.uuid4().hex[:8]}"
+    items = [(DecisionEvent(**_event()), project_id, "ver_x") for _ in range(3)]
+
+    insert_decisions_batch(clickhouse_client, items)
+    insert_decisions_batch(clickhouse_client, items)  # the retry
+
+    try:
+        counts = clickhouse_client.query(
+            "SELECT event_id, count() FROM policy_decision FINAL "
+            "WHERE project_id = {pid:String} GROUP BY event_id",
+            parameters={"pid": project_id},
+        ).result_rows
+        assert len(counts) == len(items), "every event must survive the retry"
+        assert all(int(n) == 1 for _, n in counts), (
+            "a retried batch must collapse to one row per event_id"
+        )
+    finally:
+        clickhouse_client.command(
+            "ALTER TABLE policy_decision DELETE WHERE project_id = {pid:String}",
+            parameters={"pid": project_id},
+        )

--- a/platform/api/tests/features/audit/test_audit.py
+++ b/platform/api/tests/features/audit/test_audit.py
@@ -1381,8 +1381,9 @@ def test_insert_decisions_batch_happy_path() -> None:
     assert len(rows) == 3
     assert kwargs["column_names"] == _DECISION_COLUMNS
     # No async_insert on the batch path — it coalesces small inserts, and this
-    # insert is already a batch; a plain synchronous insert raises on failure.
-    assert "settings" not in kwargs
+    # insert is already a batch; pinned to 0 so a server-default flip can't
+    # silently make the insert ack-before-durable.
+    assert kwargs["settings"] == {"async_insert": 0}
     # project_id / agent_version_id are per item, not hoisted batch-wide: a
     # consumer batch aggregates across Kafka records and can span projects.
     project_index = _DECISION_COLUMNS.index("project_id")

--- a/platform/api/tests/features/llm_invocations/test_llm_invocation.py
+++ b/platform/api/tests/features/llm_invocations/test_llm_invocation.py
@@ -50,6 +50,63 @@ def _llm_event(**overrides) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def test_insert_llm_invocations_batch_happy_path() -> None:
+    """N per-item-resolved events become ONE insert call carrying N rows;
+    project_id/agent_version_id stay per item (a consumer batch can span
+    projects). See the audit tests for the shared batch-insert contract."""
+    from hexgate_api.features.llm_invocations.service import (
+        _LLM_INVOCATION_COLUMNS,
+        insert_llm_invocations_batch,
+    )
+
+    clickhouse_client = MagicMock()
+    items = [
+        (LlmInvocationEvent(**_llm_event()), f"proj_{i}", f"ver_{i}") for i in range(3)
+    ]
+
+    insert_llm_invocations_batch(clickhouse_client, items)
+
+    clickhouse_client.insert.assert_called_once()
+    args, kwargs = clickhouse_client.insert.call_args
+    assert args[0] == "llm_invocation"
+    rows = args[1]
+    assert len(rows) == 3
+    assert kwargs["column_names"] == _LLM_INVOCATION_COLUMNS
+    # No async_insert on the batch path — see the audit batch tests.
+    assert "settings" not in kwargs
+    project_index = _LLM_INVOCATION_COLUMNS.index("project_id")
+    assert [row[project_index] for row in rows] == ["proj_0", "proj_1", "proj_2"]
+
+
+def test_when_the_batch_is_empty_then_clickhouse_is_not_called() -> None:
+    from hexgate_api.features.llm_invocations.service import (
+        insert_llm_invocations_batch,
+    )
+
+    clickhouse_client = MagicMock()
+
+    insert_llm_invocations_batch(clickhouse_client, [])
+
+    clickhouse_client.insert.assert_not_called()
+
+
+def test_when_an_event_is_batched_then_its_row_matches_the_single_insert() -> None:
+    """Single-row and batch paths share the row builder; identical input must
+    produce identical rows so the two cannot drift."""
+    from hexgate_api.features.llm_invocations.service import (
+        insert_llm_invocation,
+        insert_llm_invocations_batch,
+    )
+
+    event = LlmInvocationEvent(**_llm_event())
+    single, batch = MagicMock(), MagicMock()
+
+    insert_llm_invocation(single, event=event, project_id="p", agent_version_id="v")
+    insert_llm_invocations_batch(batch, [(event, "p", "v")])
+
+    assert batch.insert.call_args.args[1][0] == single.insert.call_args.args[1][0]
+
+
 def test_when_payload_is_minimal_then_defaults_are_applied() -> None:
     e = LlmInvocationEvent(**_llm_event())
     # Envelope defaults (agent_version_id is server-resolved, not in the wire model)

--- a/platform/api/tests/features/llm_invocations/test_llm_invocation.py
+++ b/platform/api/tests/features/llm_invocations/test_llm_invocation.py
@@ -19,6 +19,7 @@ from hexgate_api.deps.org import require_org_member
 from hexgate_api.deps.tokens import require_project
 from hexgate_api.features.llm_invocations import service as llm_invocations
 from hexgate_api.features.llm_invocations.service import summarize_llm_invocations
+from hexgate_api.core.clickhouse import BatchItem
 from hexgate_api.main import app
 from hexgate_api.schemas import LlmInvocationEvent
 
@@ -61,7 +62,12 @@ def test_insert_llm_invocations_batch_happy_path() -> None:
 
     clickhouse_client = MagicMock()
     items = [
-        (LlmInvocationEvent(**_llm_event()), f"proj_{i}", f"ver_{i}") for i in range(3)
+        BatchItem(
+            LlmInvocationEvent(**_llm_event()),
+            project_id=f"proj_{i}",
+            agent_version_id=f"ver_{i}",
+        )
+        for i in range(3)
     ]
 
     insert_llm_invocations_batch(clickhouse_client, items)
@@ -102,7 +108,9 @@ def test_when_an_event_is_batched_then_its_row_matches_the_single_insert() -> No
     single, batch = MagicMock(), MagicMock()
 
     insert_llm_invocation(single, event=event, project_id="p", agent_version_id="v")
-    insert_llm_invocations_batch(batch, [(event, "p", "v")])
+    insert_llm_invocations_batch(
+        batch, [BatchItem(event, project_id="p", agent_version_id="v")]
+    )
 
     assert batch.insert.call_args.args[1][0] == single.insert.call_args.args[1][0]
 

--- a/platform/api/tests/features/llm_invocations/test_llm_invocation.py
+++ b/platform/api/tests/features/llm_invocations/test_llm_invocation.py
@@ -72,8 +72,8 @@ def test_insert_llm_invocations_batch_happy_path() -> None:
     rows = args[1]
     assert len(rows) == 3
     assert kwargs["column_names"] == _LLM_INVOCATION_COLUMNS
-    # No async_insert on the batch path — see the audit batch tests.
-    assert "settings" not in kwargs
+    # No async_insert on the batch path (pinned to 0) — see the audit batch tests.
+    assert kwargs["settings"] == {"async_insert": 0}
     project_index = _LLM_INVOCATION_COLUMNS.index("project_id")
     assert [row[project_index] for row in rows] == ["proj_0", "proj_1", "proj_2"]
 


### PR DESCRIPTION
## What is changing

Adds three ClickHouse batch-insert functions: `insert_decisions_batch` and `insert_ban_enforcements_batch` in `features/audit/service.py`, and `insert_llm_invocations_batch` in `features/llm_invocations/service.py`. These are the write path the upcoming span-enricher job will call — nothing calls them yet, so this PR is functions plus tests only.

The existing single-row functions (`insert_decision`, `insert_ban_enforcement`, `insert_llm_invocation`) had their row-building extracted into shared helpers so the single and batch paths cannot drift apart. Their behavior is byte-for-byte unchanged: same row shape, same payload-cap boundary and check order (`arguments` → `hint` → `attributes`), same tables, same insert settings.

## Why is this change necessary

The enricher job needs to turn each Kafka poll (our broker is Redpanda — Kafka-wire-compatible, so "Kafka" throughout means the protocol) into one multi-row `clickhouse_client.insert()` instead of hundreds of single-row calls. These functions didn't exist anywhere yet — only the single-row inserts did — and they're pure Python with no Go/Kafka dependency, so they land as their own PR, independent of the Collector work (#127).

## Reviewer Notes

- **The live single-row paths are refactored but behavior-identical** — verified line-by-line against `main` by an adversarial review pass, plus an empirical boundary probe: exactly-8192-byte arguments insert, 8193 raises `AuditPayloadTooLarge` naming `arguments` first. A unit test pins single-vs-batch row equivalence for the same event.
- **Per-item `(event, project_id, agent_version_id)` tuples, not a batch-wide project.** Every Kafka record is single-project (the Collector keys them), but a consumer poll aggregates many records across partitions, so one insert batch can span projects and agents.
- **No payload-cap re-checks on the batch path — a deliberate contract, not an omission.** The enricher job truncates and redacts server-side before calling — it becomes the authoritative enforcement point, replacing today's client-side `_truncate_args()`/`_redact()` trust. A dedicated test pins the trust-the-caller contract so changing it is a visible decision. The single-row caps stay: they guard direct external API callers.
- **"Retry-safe", deliberately not "atomic".** ClickHouse commits per block and `clickhouse-connect` splits large batches into ~2MB blocks (and silently re-sends once on a dropped keep-alive), so a failed call can have landed part of the batch. The caller's move on any failure is to retry the whole batch; `ReplacingMergeTree(received_at)` collapses re-inserted `event_id`s. Two documented edges: dedup never crosses the monthly `received_at` partition (a retry straddling month-end midnight can double-count — accepted, seconds-wide window), and a duplicate `event_id` *within* one batch collapses at insert time, last occurrence winning (`optimize_on_insert` applies the collapse to the inserted block itself — observed against a real server).
- **The batch path drops `async_insert`.** It exists to coalesce many small inserts; these calls are already batches, so buffering again would only add a server-side copy and a busy-timeout wait per enricher poll. The single-row paths keep it.

## Tests

- **8 new unit tests** (MagicMock client): one insert call carrying N rows with per-item `project_id`/`agent_version_id`; empty batch never touches ClickHouse; single-vs-batch row equivalence including the legacy `role` → `user_roles` shim and the falsy-attributes rule; the over-cap-is-inserted contract pin; ban and LLM twins.
- **2 new integration tests** (`make platform-api-test-integration`, local ClickHouse): a multi-project batch lands every row; a re-inserted batch collapses to one row per `event_id` under `SELECT … FINAL` — the retry-safety property only a real `ReplacingMergeTree` can prove. Both clean up their randomly-named `test_proj_*` rows.
- **Empirical pass against a real local ClickHouse** (throwaway probes, not committed): a 10,000-row batch inserts in 0.13s with all rows intact; emoji/RTL/control-char/nested-dict payloads round-trip byte-identical; non-UTC `occurred_at` offsets normalize to the stored UTC instants; the cap-boundary regression above.
- `make fmt-check` and `make platform-api-check` pass (506 unit tests); the full integration suite passes (6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
