### PR TITLE
feat(sdk): RunFacts accumulator and run scope

### DIFF
--- a/hexgate/adapters/_common.py
+++ b/hexgate/adapters/_common.py
@@ -20,10 +20,8 @@ from hexgate.tracing._senders import DEFAULT_DRAIN_TIMEOUT, pending_send_tasks
 # values are dropped too). Only bites on an unusually large role list.
 _MAX_METADATA_CHARS = 200
 
-# Fallback when a wrapped agent has no name. Shared so that a nameless agent's
-# audit events (agent_name=...) and its run facts (run.agent) agree on what it
-# is called — two independent literals drifting apart would silently split one
-# agent's trail across two labels.
+# Fallback when a wrapped agent has no name. Shared so a nameless agent's audit
+# events and its run facts agree on the label, rather than drifting apart.
 DEFAULT_AGENT_NAME = "default"
 
 
@@ -81,13 +79,10 @@ def langfuse_propagate_kwargs(context: HexgateContext, tag: str) -> dict[str, An
 async def abind(
     context: HexgateContext, agent_name: str, propagate_kwargs: dict[str, Any]
 ) -> AsyncIterator[None]:
-    """Async run boundary shared by every adapter proxy: identity scope, run
-    facts, then Langfuse propagation — in that order, so the run's facts are
-    live for the whole block a tool call executes in.
+    """Async run boundary shared by every adapter proxy: identity scope, run facts,
+    then Langfuse propagation, so the facts are live wherever a tool call executes.
 
-    ``propagate_kwargs`` is computed by the caller (via
-    :func:`langfuse_propagate_kwargs`), not here, since its ``tag`` embeds the
-    calling method's name.
+    The caller passes ``propagate_kwargs`` because its tag embeds their method name.
     """
     async with context:
         with run_scope(agent_name):

--- a/hexgate/adapters/_common.py
+++ b/hexgate/adapters/_common.py
@@ -20,10 +20,6 @@ from hexgate.tracing._senders import DEFAULT_DRAIN_TIMEOUT, pending_send_tasks
 # values are dropped too). Only bites on an unusually large role list.
 _MAX_METADATA_CHARS = 200
 
-# Fallback when a wrapped agent has no name. Shared so a nameless agent's audit
-# events and its run facts agree on the label, rather than drifting apart.
-DEFAULT_AGENT_NAME = "default"
-
 
 def drain_pending_tasks(
     loop: asyncio.AbstractEventLoop, *, drain_timeout: float = DEFAULT_DRAIN_TIMEOUT
@@ -77,25 +73,24 @@ def langfuse_propagate_kwargs(context: HexgateContext, tag: str) -> dict[str, An
 
 @asynccontextmanager
 async def abind(
-    context: HexgateContext, agent_name: str, propagate_kwargs: dict[str, Any]
+    context: HexgateContext, agent_name: str, tag: str
 ) -> AsyncIterator[None]:
     """Async run boundary shared by every adapter proxy: identity scope, run facts,
     then Langfuse propagation, so the facts are live wherever a tool call executes.
 
-    The caller passes ``propagate_kwargs`` because its tag embeds their method name.
+    Takes the span ``tag`` rather than the built kwargs — it embeds the caller's
+    method name, and resolving it here keeps the attributes read inside the scopes.
     """
     async with context:
         with run_scope(agent_name):
-            with propagate_attributes(**propagate_kwargs):
+            with propagate_attributes(**langfuse_propagate_kwargs(context, tag)):
                 yield
 
 
 @contextmanager
-def bind(
-    context: HexgateContext, agent_name: str, propagate_kwargs: dict[str, Any]
-) -> Iterator[None]:
+def bind(context: HexgateContext, agent_name: str, tag: str) -> Iterator[None]:
     """Sync mirror of :func:`abind`."""
     with context.sync_scope():
         with run_scope(agent_name):
-            with propagate_attributes(**propagate_kwargs):
+            with propagate_attributes(**langfuse_propagate_kwargs(context, tag)):
                 yield

--- a/hexgate/adapters/_common.py
+++ b/hexgate/adapters/_common.py
@@ -7,15 +7,24 @@ import surface.
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from contextlib import asynccontextmanager, contextmanager
+from typing import Any, AsyncIterator, Iterator
 
-from hexgate.runtime import HexgateContext
+from langfuse import propagate_attributes
+
+from hexgate.runtime import HexgateContext, run_scope
 from hexgate.tracing._senders import DEFAULT_DRAIN_TIMEOUT, pending_send_tasks
 
 # Langfuse silently drops a propagated metadata value over 200 chars, so the
 # joined role list is truncated to fit (with an ASCII ellipsis — non-ASCII
 # values are dropped too). Only bites on an unusually large role list.
 _MAX_METADATA_CHARS = 200
+
+# Fallback when a wrapped agent has no name. Shared so that a nameless agent's
+# audit events (agent_name=...) and its run facts (run.agent) agree on what it
+# is called — two independent literals drifting apart would silently split one
+# agent's trail across two labels.
+DEFAULT_AGENT_NAME = "default"
 
 
 def drain_pending_tasks(
@@ -66,3 +75,32 @@ def langfuse_propagate_kwargs(context: HexgateContext, tag: str) -> dict[str, An
         "session_id": context.session_id,
         "metadata": {"user_roles": roles},
     }
+
+
+@asynccontextmanager
+async def abind(
+    context: HexgateContext, agent_name: str, propagate_kwargs: dict[str, Any]
+) -> AsyncIterator[None]:
+    """Async run boundary shared by every adapter proxy: identity scope, run
+    facts, then Langfuse propagation — in that order, so the run's facts are
+    live for the whole block a tool call executes in.
+
+    ``propagate_kwargs`` is computed by the caller (via
+    :func:`langfuse_propagate_kwargs`), not here, since its ``tag`` embeds the
+    calling method's name.
+    """
+    async with context:
+        with run_scope(agent_name):
+            with propagate_attributes(**propagate_kwargs):
+                yield
+
+
+@contextmanager
+def bind(
+    context: HexgateContext, agent_name: str, propagate_kwargs: dict[str, Any]
+) -> Iterator[None]:
+    """Sync mirror of :func:`abind`."""
+    with context.sync_scope():
+        with run_scope(agent_name):
+            with propagate_attributes(**propagate_kwargs):
+                yield

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -17,7 +17,11 @@ from google.genai import types
 from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
-from hexgate.adapters._common import drain_pending_tasks, langfuse_propagate_kwargs
+from hexgate.adapters._common import (
+    DEFAULT_AGENT_NAME,
+    drain_pending_tasks,
+    langfuse_propagate_kwargs,
+)
 from hexgate.adapters.google.usage import HexgateUsagePlugin
 from hexgate.adapters.google.wrapper import wrap_google_agent
 from hexgate.approvals import ApprovalHandler
@@ -73,7 +77,7 @@ class HexgateRunner:
             session_service=session_service,
             **runner_kwargs,
         )
-        self._agent_name = getattr(agent, "name", "default")
+        self._agent_name = getattr(agent, "name", DEFAULT_AGENT_NAME)
         self._ban_gate = resolve_ban_gate(
             self._agent_name, api_key=self.api_key, client=client
         )

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -17,17 +17,13 @@ from google.genai import types
 from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
 
-from hexgate.adapters._common import (
-    DEFAULT_AGENT_NAME,
-    drain_pending_tasks,
-    langfuse_propagate_kwargs,
-)
+from hexgate.adapters._common import drain_pending_tasks, langfuse_propagate_kwargs
 from hexgate.adapters.google.usage import HexgateUsagePlugin
 from hexgate.adapters.google.wrapper import wrap_google_agent
 from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
-from hexgate.runtime import HexgateContext, run_scope
+from hexgate.runtime import DEFAULT_AGENT_NAME, HexgateContext, run_scope
 from hexgate.security.bans import resolve_ban_gate
 
 if TYPE_CHECKING:

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -23,7 +23,7 @@ from hexgate.adapters.google.wrapper import wrap_google_agent
 from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
-from hexgate.runtime import HexgateContext
+from hexgate.runtime import HexgateContext, run_scope
 from hexgate.security.bans import resolve_ban_gate
 
 if TYPE_CHECKING:
@@ -117,7 +117,11 @@ class HexgateRunner:
         self._binding.refresh()  # per-run policy pull; 304 when unchanged
         if self._ban_gate is not None:
             self._ban_gate.check(hexgate_context)
-        with hexgate_context.sync_scope(), self._propagate(hexgate_context):
+        with (
+            hexgate_context.sync_scope(),
+            run_scope(self._agent_name),
+            self._propagate(hexgate_context),
+        ):
             agen = self._runner.run_async(
                 user_id=hexgate_context.user_id,
                 session_id=hexgate_context.session_id,
@@ -155,7 +159,7 @@ class HexgateRunner:
         if self._ban_gate is not None:
             await self._ban_gate.check_async(hexgate_context)
         async with hexgate_context:
-            with self._propagate(hexgate_context):
+            with run_scope(self._agent_name), self._propagate(hexgate_context):
                 async for event in self._runner.run_async(
                     user_id=hexgate_context.user_id,
                     session_id=hexgate_context.session_id,

--- a/hexgate/adapters/langchain/agent.py
+++ b/hexgate/adapters/langchain/agent.py
@@ -2,17 +2,21 @@
 
 from __future__ import annotations
 
-from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Literal
 
 from langchain_core.runnables import RunnableConfig
-from langfuse import get_client, propagate_attributes
+from langfuse import get_client
 from langfuse.langchain import CallbackHandler
 from langgraph.graph.state import CompiledStateGraph
 
-from hexgate.adapters._common import langfuse_propagate_kwargs
+from hexgate.adapters._common import (
+    DEFAULT_AGENT_NAME,
+    abind,
+    bind,
+    langfuse_propagate_kwargs,
+)
 from hexgate.adapters.langchain.usage import HexgateUsageCallbackHandler
-from hexgate.runtime import HexgateContext, run_scope
+from hexgate.runtime import HexgateContext
 
 if TYPE_CHECKING:
     from hexgate.security.bans import BanGate
@@ -36,7 +40,7 @@ class HexgateLangchainAgent:
         agent: CompiledStateGraph,
         api_key: str,
         tool_names: list[str],
-        agent_name: str = "default",
+        agent_name: str = DEFAULT_AGENT_NAME,
         binding: PolicyBinding | None = None,
         ban_gate: BanGate | None = None,
     ) -> None:
@@ -74,21 +78,14 @@ class HexgateLangchainAgent:
     def _propagate_kwargs(self, context: HexgateContext, method: str) -> dict[str, Any]:
         return langfuse_propagate_kwargs(context, f"langchain.agent.{method}")
 
-    @asynccontextmanager
-    async def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
-        """Async run boundary — identity scope, run facts, Langfuse propagation."""
-        async with context:
-            with run_scope(self._agent_name):
-                with propagate_attributes(**self._propagate_kwargs(context, method)):
-                    yield
+    def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
+        """Async run boundary — identity scope, run facts, Langfuse propagation.
+        See :func:`hexgate.adapters._common.abind`."""
+        return abind(context, self._agent_name, self._propagate_kwargs(context, method))
 
-    @contextmanager
     def _bind(self, context: HexgateContext, method: str) -> Iterator[None]:
         """Sync mirror of :meth:`_abind`."""
-        with context.sync_scope():
-            with run_scope(self._agent_name):
-                with propagate_attributes(**self._propagate_kwargs(context, method)):
-                    yield
+        return bind(context, self._agent_name, self._propagate_kwargs(context, method))
 
     def _with_callbacks(self, config: RunnableConfig | None) -> RunnableConfig:
         """Append the Hexgate callback handlers to ``config['callbacks']``."""

--- a/hexgate/adapters/langchain/agent.py
+++ b/hexgate/adapters/langchain/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager, contextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Literal
 
 from langchain_core.runnables import RunnableConfig
@@ -11,7 +12,7 @@ from langgraph.graph.state import CompiledStateGraph
 
 from hexgate.adapters._common import langfuse_propagate_kwargs
 from hexgate.adapters.langchain.usage import HexgateUsageCallbackHandler
-from hexgate.runtime import HexgateContext
+from hexgate.runtime import HexgateContext, run_scope
 
 if TYPE_CHECKING:
     from hexgate.security.bans import BanGate
@@ -44,6 +45,7 @@ class HexgateLangchainAgent:
         self._ban_gate = ban_gate
         self._api_key = api_key
         self._tool_names = tool_names
+        self._agent_name = agent_name
         self._langfuse = get_client()
         self._callback_handler = CallbackHandler()
         self._usage_handler = HexgateUsageCallbackHandler(
@@ -72,6 +74,22 @@ class HexgateLangchainAgent:
     def _propagate_kwargs(self, context: HexgateContext, method: str) -> dict[str, Any]:
         return langfuse_propagate_kwargs(context, f"langchain.agent.{method}")
 
+    @asynccontextmanager
+    async def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
+        """Async run boundary — identity scope, run facts, Langfuse propagation."""
+        async with context:
+            with run_scope(self._agent_name):
+                with propagate_attributes(**self._propagate_kwargs(context, method)):
+                    yield
+
+    @contextmanager
+    def _bind(self, context: HexgateContext, method: str) -> Iterator[None]:
+        """Sync mirror of :meth:`_abind`."""
+        with context.sync_scope():
+            with run_scope(self._agent_name):
+                with propagate_attributes(**self._propagate_kwargs(context, method)):
+                    yield
+
     def _with_callbacks(self, config: RunnableConfig | None) -> RunnableConfig:
         """Append the Hexgate callback handlers to ``config['callbacks']``."""
         merged: RunnableConfig = dict(config) if config else {}
@@ -93,13 +111,10 @@ class HexgateLangchainAgent:
         """Invoke the agent asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
         await self._check_ban_async(hexgate_context)
-        async with hexgate_context:
-            with propagate_attributes(
-                **self._propagate_kwargs(hexgate_context, "ainvoke")
-            ):
-                return await self._agent.ainvoke(
-                    input, self._with_callbacks(config), **kwargs
-                )
+        async with self._abind(hexgate_context, "ainvoke"):
+            return await self._agent.ainvoke(
+                input, self._with_callbacks(config), **kwargs
+            )
 
     def invoke(
         self,
@@ -112,11 +127,8 @@ class HexgateLangchainAgent:
         """Invoke the agent synchronously inside a HexgateContext scope."""
         self._refresh()
         self._check_ban(hexgate_context)
-        with hexgate_context.sync_scope():
-            with propagate_attributes(
-                **self._propagate_kwargs(hexgate_context, "invoke")
-            ):
-                return self._agent.invoke(input, self._with_callbacks(config), **kwargs)
+        with self._bind(hexgate_context, "invoke"):
+            return self._agent.invoke(input, self._with_callbacks(config), **kwargs)
 
     async def astream(
         self,
@@ -129,14 +141,11 @@ class HexgateLangchainAgent:
         """Stream the agent asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
         await self._check_ban_async(hexgate_context)
-        async with hexgate_context:
-            with propagate_attributes(
-                **self._propagate_kwargs(hexgate_context, "astream")
+        async with self._abind(hexgate_context, "astream"):
+            async for chunk in self._agent.astream(
+                input, self._with_callbacks(config), **kwargs
             ):
-                async for chunk in self._agent.astream(
-                    input, self._with_callbacks(config), **kwargs
-                ):
-                    yield chunk
+                yield chunk
 
     def stream(
         self,
@@ -149,13 +158,8 @@ class HexgateLangchainAgent:
         """Stream the agent synchronously inside a HexgateContext scope."""
         self._refresh()
         self._check_ban(hexgate_context)
-        with hexgate_context.sync_scope():
-            with propagate_attributes(
-                **self._propagate_kwargs(hexgate_context, "stream")
-            ):
-                yield from self._agent.stream(
-                    input, self._with_callbacks(config), **kwargs
-                )
+        with self._bind(hexgate_context, "stream"):
+            yield from self._agent.stream(input, self._with_callbacks(config), **kwargs)
 
     async def astream_events(
         self,
@@ -169,17 +173,14 @@ class HexgateLangchainAgent:
         """Stream the agent events asynchronously inside a HexgateContext scope."""
         await self._refresh_async()
         await self._check_ban_async(hexgate_context)
-        async with hexgate_context:
-            with propagate_attributes(
-                **self._propagate_kwargs(hexgate_context, "astream_events")
+        async with self._abind(hexgate_context, "astream_events"):
+            async for event in self._agent.astream_events(
+                input,
+                config=self._with_callbacks(config),
+                version=version,
+                **kwargs,
             ):
-                async for event in self._agent.astream_events(
-                    input,
-                    config=self._with_callbacks(config),
-                    version=version,
-                    **kwargs,
-                ):
-                    yield event
+                yield event
 
     def __getattr__(self, name: str) -> Any:
         """Delegate unknown attributes to the wrapped agent.

--- a/hexgate/adapters/langchain/agent.py
+++ b/hexgate/adapters/langchain/agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator, Literal
 
 from langchain_core.runnables import RunnableConfig
@@ -9,14 +10,9 @@ from langfuse import get_client
 from langfuse.langchain import CallbackHandler
 from langgraph.graph.state import CompiledStateGraph
 
-from hexgate.adapters._common import (
-    DEFAULT_AGENT_NAME,
-    abind,
-    bind,
-    langfuse_propagate_kwargs,
-)
+from hexgate.adapters._common import abind, bind
 from hexgate.adapters.langchain.usage import HexgateUsageCallbackHandler
-from hexgate.runtime import HexgateContext
+from hexgate.runtime import DEFAULT_AGENT_NAME, HexgateContext
 
 if TYPE_CHECKING:
     from hexgate.security.bans import BanGate
@@ -75,17 +71,22 @@ class HexgateLangchainAgent:
         if self._ban_gate is not None:
             self._ban_gate.check(context)
 
-    def _propagate_kwargs(self, context: HexgateContext, method: str) -> dict[str, Any]:
-        return langfuse_propagate_kwargs(context, f"langchain.agent.{method}")
-
-    def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
+    def _abind(
+        self, context: HexgateContext, method: str
+    ) -> AbstractAsyncContextManager[None]:
         """Async run boundary — identity scope, run facts, Langfuse propagation.
         See :func:`hexgate.adapters._common.abind`."""
-        return abind(context, self._agent_name, self._propagate_kwargs(context, method))
+        return abind(context, self._agent_name, self._tag(method))
 
-    def _bind(self, context: HexgateContext, method: str) -> Iterator[None]:
+    def _bind(
+        self, context: HexgateContext, method: str
+    ) -> AbstractContextManager[None]:
         """Sync mirror of :meth:`_abind`."""
-        return bind(context, self._agent_name, self._propagate_kwargs(context, method))
+        return bind(context, self._agent_name, self._tag(method))
+
+    @staticmethod
+    def _tag(method: str) -> str:
+        return f"langchain.agent.{method}"
 
     def _with_callbacks(self, config: RunnableConfig | None) -> RunnableConfig:
         """Append the Hexgate callback handlers to ``config['callbacks']``."""

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -35,7 +35,7 @@ from hexgate.adapters.openai.wrapper import wrap_openai_agent
 from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
-from hexgate.runtime import HexgateContext
+from hexgate.runtime import HexgateContext, run_scope, use_run_facts
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -210,7 +210,7 @@ class HexgateRunner:
             guard_observer=self._guard_observer,
         )
         async with hexgate_context:
-            with self._propagate(hexgate_context, agent.name):
+            with run_scope(agent.name), self._propagate(hexgate_context, agent.name):
                 return await Runner.run(
                     wrapped_agent,
                     input,
@@ -244,7 +244,7 @@ class HexgateRunner:
             guard_observer=self._guard_observer,
         )
         with hexgate_context.sync_scope():
-            with self._propagate(hexgate_context, agent.name):
+            with run_scope(agent.name), self._propagate(hexgate_context, agent.name):
                 try:
                     return Runner.run_sync(
                         wrapped_agent,
@@ -314,22 +314,30 @@ class HexgateRunner:
         )
 
         with hexgate_context.sync_scope():
-            with self._propagate(hexgate_context, agent.name):
-                result = Runner.run_streamed(
-                    wrapped_agent,
-                    input,
-                    run_config=run_config,
-                    hooks=self._merge_hooks(hooks),
-                    **kwargs,
-                )
+            # The scope must be open around run_streamed(): it spawns the agent
+            # loop as a background task that snapshots the contextvars at
+            # creation, and that task is where tools fire. The task's snapshot
+            # keeps the facts alive after this block exits.
+            with run_scope(agent.name) as run_facts:
+                with self._propagate(hexgate_context, agent.name):
+                    result = Runner.run_streamed(
+                        wrapped_agent,
+                        input,
+                        run_config=run_config,
+                        hooks=self._merge_hooks(hooks),
+                        **kwargs,
+                    )
 
         original_stream_events = result.stream_events
 
         async def _stream_events_with_scope():
             async with hexgate_context:
-                with self._propagate(hexgate_context, agent.name):
-                    async for event in original_stream_events():
-                        yield event
+                # Re-bind the facts the background task snapshotted rather than
+                # minting a second run: one invocation must have one run id.
+                with use_run_facts(run_facts):
+                    with self._propagate(hexgate_context, agent.name):
+                        async for event in original_stream_events():
+                            yield event
 
         result.stream_events = _stream_events_with_scope
         return result

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -314,10 +314,9 @@ class HexgateRunner:
         )
 
         with hexgate_context.sync_scope():
-            # The scope must be open around run_streamed(): it spawns the agent
-            # loop as a background task that snapshots the contextvars at
-            # creation, and that task is where tools fire. The task's snapshot
-            # keeps the facts alive after this block exits.
+            # Scope must be open around run_streamed(): it snapshots the
+            # contextvars into the background task where tools fire, and that
+            # snapshot keeps the facts alive after this block exits.
             with run_scope(agent.name) as run_facts:
                 with self._propagate(hexgate_context, agent.name):
                     result = Runner.run_streamed(
@@ -332,8 +331,8 @@ class HexgateRunner:
 
         async def _stream_events_with_scope():
             async with hexgate_context:
-                # Re-bind the facts the background task snapshotted rather than
-                # minting a second run: one invocation must have one run id.
+                # Re-bind the snapshotted facts, not a second run: one
+                # invocation must have one run id.
                 with use_run_facts(run_facts):
                     with self._propagate(hexgate_context, agent.name):
                         async for event in original_stream_events():

--- a/hexgate/adapters/pydantic_ai/agent.py
+++ b/hexgate/adapters/pydantic_ai/agent.py
@@ -2,15 +2,19 @@
 
 from __future__ import annotations
 
-from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator
+from contextlib import (
+    AbstractAsyncContextManager,
+    AbstractContextManager,
+    asynccontextmanager,
+)
+from typing import TYPE_CHECKING, Any, AsyncIterator
 
 from langfuse import get_client
 from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRun, AgentRunResult
 from pydantic_ai.result import StreamedRunResult
 
-from hexgate.adapters._common import abind, bind, langfuse_propagate_kwargs
+from hexgate.adapters._common import abind, bind
 from hexgate.adapters.pydantic_ai.usage import emit_run_usage
 from hexgate.runtime import HexgateContext
 
@@ -70,17 +74,22 @@ class HexgatePydanticAgent:
         """Globally instrument all pydantic_ai Agents (idempotent)."""
         Agent.instrument_all()
 
-    def _propagate_kwargs(self, context: HexgateContext, method: str) -> dict[str, Any]:
-        return langfuse_propagate_kwargs(context, f"pydantic_ai.agent.{method}")
-
-    def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
+    def _abind(
+        self, context: HexgateContext, method: str
+    ) -> AbstractAsyncContextManager[None]:
         """Async HexgateContext scope + run facts + Langfuse propagation.
         See :func:`hexgate.adapters._common.abind`."""
-        return abind(context, self._agent_name, self._propagate_kwargs(context, method))
+        return abind(context, self._agent_name, self._tag(method))
 
-    def _bind(self, context: HexgateContext, method: str) -> Iterator[None]:
+    def _bind(
+        self, context: HexgateContext, method: str
+    ) -> AbstractContextManager[None]:
         """Sync mirror of :meth:`_abind`."""
-        return bind(context, self._agent_name, self._propagate_kwargs(context, method))
+        return bind(context, self._agent_name, self._tag(method))
+
+    @staticmethod
+    def _tag(method: str) -> str:
+        return f"pydantic_ai.agent.{method}"
 
     async def run(
         self,

--- a/hexgate/adapters/pydantic_ai/agent.py
+++ b/hexgate/adapters/pydantic_ai/agent.py
@@ -12,7 +12,7 @@ from pydantic_ai.result import StreamedRunResult
 
 from hexgate.adapters._common import langfuse_propagate_kwargs
 from hexgate.adapters.pydantic_ai.usage import emit_run_usage
-from hexgate.runtime import HexgateContext
+from hexgate.runtime import HexgateContext, run_scope
 
 if TYPE_CHECKING:
     from hexgate.security.bans import BanGate
@@ -75,17 +75,19 @@ class HexgatePydanticAgent:
 
     @asynccontextmanager
     async def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
-        """Async HexgateContext scope + Langfuse propagation."""
+        """Async HexgateContext scope + run facts + Langfuse propagation."""
         async with context:
-            with propagate_attributes(**self._propagate_kwargs(context, method)):
-                yield
+            with run_scope(self._agent_name):
+                with propagate_attributes(**self._propagate_kwargs(context, method)):
+                    yield
 
     @contextmanager
     def _bind(self, context: HexgateContext, method: str) -> Iterator[None]:
-        """Sync HexgateContext scope + Langfuse propagation."""
+        """Sync HexgateContext scope + run facts + Langfuse propagation."""
         with context.sync_scope():
-            with propagate_attributes(**self._propagate_kwargs(context, method)):
-                yield
+            with run_scope(self._agent_name):
+                with propagate_attributes(**self._propagate_kwargs(context, method)):
+                    yield
 
     async def run(
         self,

--- a/hexgate/adapters/pydantic_ai/agent.py
+++ b/hexgate/adapters/pydantic_ai/agent.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, AsyncIterator, Iterator
 
-from langfuse import get_client, propagate_attributes
+from langfuse import get_client
 from pydantic_ai import Agent
 from pydantic_ai.agent import AgentRun, AgentRunResult
 from pydantic_ai.result import StreamedRunResult
 
-from hexgate.adapters._common import langfuse_propagate_kwargs
+from hexgate.adapters._common import abind, bind, langfuse_propagate_kwargs
 from hexgate.adapters.pydantic_ai.usage import emit_run_usage
-from hexgate.runtime import HexgateContext, run_scope
+from hexgate.runtime import HexgateContext
 
 if TYPE_CHECKING:
     from hexgate.security.bans import BanGate
@@ -73,21 +73,14 @@ class HexgatePydanticAgent:
     def _propagate_kwargs(self, context: HexgateContext, method: str) -> dict[str, Any]:
         return langfuse_propagate_kwargs(context, f"pydantic_ai.agent.{method}")
 
-    @asynccontextmanager
-    async def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
-        """Async HexgateContext scope + run facts + Langfuse propagation."""
-        async with context:
-            with run_scope(self._agent_name):
-                with propagate_attributes(**self._propagate_kwargs(context, method)):
-                    yield
+    def _abind(self, context: HexgateContext, method: str) -> AsyncIterator[None]:
+        """Async HexgateContext scope + run facts + Langfuse propagation.
+        See :func:`hexgate.adapters._common.abind`."""
+        return abind(context, self._agent_name, self._propagate_kwargs(context, method))
 
-    @contextmanager
     def _bind(self, context: HexgateContext, method: str) -> Iterator[None]:
-        """Sync HexgateContext scope + run facts + Langfuse propagation."""
-        with context.sync_scope():
-            with run_scope(self._agent_name):
-                with propagate_attributes(**self._propagate_kwargs(context, method)):
-                    yield
+        """Sync mirror of :meth:`_abind`."""
+        return bind(context, self._agent_name, self._propagate_kwargs(context, method))
 
     async def run(
         self,

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -35,6 +35,7 @@ from langgraph.store.base import BaseStore
 from pydantic import BaseModel
 
 # BC re-export — canonical home is hexgate.approvals (framework-agnostic).
+from hexgate.adapters._common import DEFAULT_AGENT_NAME
 from hexgate.approvals import ApprovalHandler  # noqa: F401 — re-export
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import (
@@ -57,11 +58,6 @@ LangChainAgentGraph: TypeAlias = CompiledStateGraph
 ToolSpec: TypeAlias = BaseTool | Callable[..., Any] | dict[str, Any]
 AgentState: TypeAlias = dict[str, Any]
 AgentInput: TypeAlias = str | Sequence[object] | Mapping[str, object] | BaseModel
-# Fallback when the agent was built without a ``name``. Shared by the enforcer
-# (which stamps it on every audit event) and the run scope, so a nameless
-# agent's decisions and its run facts agree on what it is called.
-DEFAULT_AGENT_NAME = "default"
-
 DEFAULT_SYSTEM_PROMPT = (
     "You are a helpful assistant built on a tool-using agent runtime.\n\n"
     "Your job is to answer clearly and directly, using the tools available to "
@@ -378,7 +374,9 @@ class HexgateAgent:
         # (only hexgate_client, attached post-init by _bind_policy). If one is added,
         # thread it through here too, or usage events will keep silently resolving
         # from HEXGATE_API_KEY instead of the caller's explicit key.
-        self._usage_handler = HexgateUsageCallbackHandler(agent_name=name or "default")
+        self._usage_handler = HexgateUsageCallbackHandler(
+            agent_name=name or DEFAULT_AGENT_NAME
+        )
 
     def _with_usage_callback(self, config: dict[str, Any]) -> dict[str, Any]:
         """Append the usage callback handler to ``config['callbacks']``."""

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -42,6 +42,7 @@ from hexgate.runtime import (
     ToolUseContext,
     Workspace,
     reset_current_tool_use_context,
+    run_scope,
     set_current_tool_use_context,
 )
 from hexgate.streaming import StreamEvent, new_root_run_id, normalize_langchain_events
@@ -56,6 +57,11 @@ LangChainAgentGraph: TypeAlias = CompiledStateGraph
 ToolSpec: TypeAlias = BaseTool | Callable[..., Any] | dict[str, Any]
 AgentState: TypeAlias = dict[str, Any]
 AgentInput: TypeAlias = str | Sequence[object] | Mapping[str, object] | BaseModel
+# Fallback when the agent was built without a ``name``. Shared by the enforcer
+# (which stamps it on every audit event) and the run scope, so a nameless
+# agent's decisions and its run facts agree on what it is called.
+DEFAULT_AGENT_NAME = "default"
+
 DEFAULT_SYSTEM_PROMPT = (
     "You are a helpful assistant built on a tool-using agent runtime.\n\n"
     "Your job is to answer clearly and directly, using the tools available to "
@@ -396,9 +402,10 @@ class HexgateAgent:
         """
         await _refresh_policy_safely(self)
         await self._check_ban()
-        return await self._graph.ainvoke(
-            payload, config=self._with_usage_callback(config)
-        )
+        with run_scope(self.name or DEFAULT_AGENT_NAME):
+            return await self._graph.ainvoke(
+                payload, config=self._with_usage_callback(config)
+            )
 
     async def astream_events(
         self,
@@ -415,10 +422,11 @@ class HexgateAgent:
         """
         await _refresh_policy_safely(self)
         await self._check_ban()
-        async for event in self._graph.astream_events(
-            payload, config=self._with_usage_callback(config), version=version
-        ):
-            yield event
+        with run_scope(self.name or DEFAULT_AGENT_NAME):
+            async for event in self._graph.astream_events(
+                payload, config=self._with_usage_callback(config), version=version
+            ):
+                yield event
 
     async def _check_ban(self) -> None:
         """Refuse a banned agent/user before the graph runs, if a gate is
@@ -552,7 +560,7 @@ class HexgateAgent:
                 engine = load_policy_set(policy)
             enforcer = build_enforcer(
                 engine,
-                agent_name=self.name or "default",
+                agent_name=self.name or DEFAULT_AGENT_NAME,
                 decision_observer=decision_observer,
             )
 

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -35,10 +35,10 @@ from langgraph.store.base import BaseStore
 from pydantic import BaseModel
 
 # BC re-export — canonical home is hexgate.approvals (framework-agnostic).
-from hexgate.adapters._common import DEFAULT_AGENT_NAME
 from hexgate.approvals import ApprovalHandler  # noqa: F401 — re-export
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import (
+    DEFAULT_AGENT_NAME,
     LocalWorkspace,
     ToolUseContext,
     Workspace,

--- a/hexgate/runtime/__init__.py
+++ b/hexgate/runtime/__init__.py
@@ -24,6 +24,14 @@ from hexgate.runtime.roles import (
     distinct_roles,
     resolve_role_set,
 )
+from hexgate.runtime.run_facts import (
+    DETACHED,
+    KNOWN_RUN_PATHS,
+    RunFacts,
+    get_run_facts,
+    run_scope,
+    use_run_facts,
+)
 from hexgate.runtime.sandbox_runtime import build_sandbox_runtime_config
 from hexgate.runtime.srt import (
     SrtUnavailableError,
@@ -38,11 +46,14 @@ __all__ = [
     "Allowed",
     "CommandPolicyResult",
     "CommandResult",
+    "DETACHED",
     "FILE_OPS_COMMANDS",
+    "KNOWN_RUN_PATHS",
     "LocalWorkspace",
     "MAX_EVALUATED_ROLES",
     "MINIMAL_COMMANDS",
     "Rejected",
+    "RunFacts",
     "SHELL_BUILTINS",
     "ContextAttributeValue",
     "HexgateContext",
@@ -56,8 +67,11 @@ __all__ = [
     "find_srt",
     "get_current_context",
     "get_current_tool_use_context",
+    "get_run_facts",
     "reset_current_tool_use_context",
     "resolve_role_set",
+    "run_scope",
     "set_current_tool_use_context",
     "srt_version",
+    "use_run_facts",
 ]

--- a/hexgate/runtime/__init__.py
+++ b/hexgate/runtime/__init__.py
@@ -25,6 +25,7 @@ from hexgate.runtime.roles import (
     resolve_role_set,
 )
 from hexgate.runtime.run_facts import (
+    DEFAULT_AGENT_NAME,
     DETACHED,
     KNOWN_RUN_PATHS,
     RunFacts,
@@ -48,6 +49,7 @@ __all__ = [
     "CommandResult",
     "DETACHED",
     "FILE_OPS_COMMANDS",
+    "DEFAULT_AGENT_NAME",
     "KNOWN_RUN_PATHS",
     "LocalWorkspace",
     "MAX_EVALUATED_ROLES",

--- a/hexgate/runtime/run_facts.py
+++ b/hexgate/runtime/run_facts.py
@@ -1,27 +1,13 @@
-"""Per-invocation fact record — the ``run.*`` policy namespace.
+"""Per-invocation facts — the ``run.*`` policy namespace.
 
-``run.*`` is a fact family alongside the call-scope facts ``role`` / ``tool``
-(:mod:`hexgate.security.constraints`), the signed ``biscuit_facts``
-(:mod:`hexgate.cloud.biscuit`), and the advisory ``ctx.*`` bag
-(:attr:`~hexgate.runtime.context.HexgateContext.attributes`). It is the only
-one that is local *and* exact: the SDK accumulates it in-process, so it can
-never be unavailable and never needs a fail-soft path.
+A fourth fact family beside ``role`` / ``tool``, the signed ``biscuit_facts`` and
+the advisory ``ctx.*`` bag, and the only one local and exact. Records what happened,
+never limits: those stay in ``policy_yaml``, keeping ``PolicyEngine.evaluate`` a
+pure predicate.
 
-It records only what has happened — no limits, no thresholds, no pricing.
-Those live in ``policy_yaml`` and on the platform, which is what keeps
-``PolicyEngine.evaluate`` a pure predicate over its inputs.
-
-Every counter is monotone non-decreasing within a run, and elapsed comes off a
-monotonic clock. A ``<`` predicate over a non-decreasing value therefore
-*latches* — once a cap denies it keeps denying, which is what makes it a
-circuit breaker rather than a flapping gate.
-
-The contextvar distributes a *reference*, not a value. Sub-tasks that copy the
-context share one :class:`RunFacts`, so their writes reach the run that
-spawned them, while a ``set()`` inside a sub-task cannot rebind the parent's.
-Consequences, including the paths that do *not* propagate (raw threads, tasks
-created outside the scope), are in
-``plans/run-state/run-facts-phase1-implementation.md`` §0.4.
+Counters are monotone, so a ``<`` predicate latches once a cap trips. The contextvar
+holds a *reference*: sub-tasks sharing the context reach the parent run's record but
+cannot rebind it.
 """
 
 from __future__ import annotations
@@ -35,16 +21,10 @@ from dataclasses import dataclass, field
 from typing import Any, Final
 from uuid import uuid4
 
-# Every ``run.*`` path a policy may reference. One source of truth, shared by
-# :meth:`RunFacts.as_namespace` — which returns exactly these — and, from the
-# next change, the load-time linter that rejects anything else.
-#
-# A path is registered in the same change that starts *projecting* it, never
-# earlier. A registered path with no value behind it resolves to a permanent
-# zero, and ``run.tool_calls < 20`` against a permanent zero never fires: a
-# silently fail-open cap, shipped as a working feature. So the counters this
-# record already accumulates are deliberately absent below; each joins the
-# registry and the projection together, in the change that wires its writer.
+# Every ``run.*`` path a policy may reference; :meth:`RunFacts.as_namespace` returns
+# exactly these. Register a path only once something projects it: a registered path
+# with no value reads a permanent zero, and ``run.tool_calls < 20`` against zero
+# never fires — a fail-open cap that looks like it works.
 KNOWN_RUN_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_seconds"})
 
 
@@ -52,34 +32,19 @@ KNOWN_RUN_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_seco
 class RunFacts:
     """Mutable accumulator for one agent invocation.
 
-    Monotone by discipline, not by construction: the ``record_*`` methods are
-    the only monotone-preserving way in, and assigning a field directly
-    bypasses both the lock and the detached guard. Read through
-    :meth:`as_namespace`.
-
-    Not single-writer. Parallel tool calls run as separate asyncio tasks that
-    copy the context and therefore share one instance by reference, so several
-    writers are expected — that is what ``_lock`` is for.
+    Monotone by discipline: the ``record_*`` methods are the only safe way in, since
+    assigning a field bypasses both the lock and the detached guard. Several writers
+    are expected — parallel tool calls share one instance by reference.
     """
 
     id: str
     agent: str
-    # True only for DETACHED, where every mutator returns early. See DETACHED.
+    # True only for DETACHED, whose mutators all no-op.
     detached: bool = False
-    # Origin for ``elapsed_seconds``. Monotonic, not wall clock: an NTP step
-    # backwards would un-block a run that had already exceeded its time
-    # budget. Private and never a ``run.*`` path — only the derived elapsed is
-    # exposed, so there is no second time field to keep consistent.
-    #
-    # Wrapped in a lambda rather than passed as ``default_factory=
-    # time.monotonic``: the bare reference binds this function object at class
-    # definition, while :meth:`as_namespace` resolves ``time.monotonic`` at
-    # call time. The origin and the elapsed would then read different clocks
-    # whenever one is substituted, yielding a negative elapsed.
-    #
-    # Deliberately still an ``__init__`` parameter, unlike the internals below:
-    # it is the seam a caller substitutes to control the clock, so only the
-    # default is hard-wired.
+    # Monotonic, not wall clock: an NTP step backwards would un-block a run that had
+    # already exceeded its budget. The lambda matters — a bare ``time.monotonic``
+    # reference binds at class definition while :meth:`as_namespace` resolves it at
+    # call time, so a substituted clock would yield a negative elapsed.
     _started_monotonic: float = field(default_factory=lambda: time.monotonic())
 
     tool_calls: int = 0
@@ -90,30 +55,16 @@ class RunFacts:
     input_tokens: int = 0
     output_tokens: int = 0
 
-    # Per-tool call counts, which also give the first-use-ordered set of tools
-    # used: a dict preserves insertion order and an update to an existing key
-    # does not reorder it, so ``list(_calls_by_tool)`` is that set. Private
-    # because its keys are tool names, which may not be legal policy-path
-    # identifiers (MCP tool names are hyphenated), so exposing
-    # ``run.calls_by_tool.<name>`` needs a sanitisation scheme first.
-    #
-    # ``init=False`` here and on the lock: neither has a legitimate
-    # caller-supplied value, and a dataclass would otherwise expose them as
-    # constructor parameters — injectable by accident, which is worse than not
-    # being injectable. It keeps ``__init__`` a designed surface: identity, the
-    # detached flag, the clock origin, and the counters.
+    # Doubles as the first-use-ordered tool set (``list(...)``): dict preserves
+    # insertion order and re-keying does not reorder. Private — tool names are not
+    # always legal path identifiers, so ``run.calls_by_tool.<name>`` needs escaping.
+    # ``init=False`` here and on the lock: internals, not caller-supplied.
     _calls_by_tool: dict[str, int] = field(default_factory=dict, init=False)
-    # threading.Lock, not asyncio.Lock: the mutators are called from sync paths
-    # (``run_guarded_sync``, LangChain's sync callback handler) as well as
-    # async ones, and every critical section is a few integer increments.
+    # threading, not asyncio: the mutators run on sync paths too.
     _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
     def record_execution(self, tool_name: str) -> None:
-        """Count one tool call that actually executed.
-
-        Called after the tool returns *or* raises — a failed call consumed
-        budget just as a successful one did.
-        """
+        """Count one executed tool call, whether it returned or raised."""
         if self.detached:
             return
         with self._lock:
@@ -128,34 +79,24 @@ class RunFacts:
             self.errors += 1
 
     def record_denial(self) -> None:
-        """Count one refused call.
-
-        Deliberately not a ``tool_calls``: a denied call must not consume the
-        budget a legitimate caller is bounded by.
-        """
+        """Count one refused call. Deliberately not a ``tool_calls`` — a denial must
+        not consume a legitimate caller's budget."""
         if self.detached:
             return
         with self._lock:
             self.denials += 1
 
     def record_approval(self) -> None:
-        """Count one call gated on human approval.
-
-        Counted on the *decision*; whether it then executes is counted
-        separately by :meth:`record_execution`, so an approval never granted
-        consumes no tool budget.
-        """
+        """Count one call gated on approval. Execution is counted separately, so an
+        approval never granted consumes no budget."""
         if self.detached:
             return
         with self._lock:
             self.approvals += 1
 
     def record_llm_usage(self, input_tokens: int, output_tokens: int) -> None:
-        """Count one model request and its tokens.
-
-        ``input_tokens`` includes cached tokens, matching OpenTelemetry's
-        billed-count rule.
-        """
+        """Count one model request. ``input_tokens`` includes cached tokens, matching
+        OpenTelemetry's billed-count rule."""
         if self.detached:
             return
         with self._lock:
@@ -164,46 +105,29 @@ class RunFacts:
             self.output_tokens += output_tokens
 
     def as_namespace(self) -> dict[str, Any]:
-        """Build the ``run`` mapping the policy grammar evaluates against.
+        """The ``run`` mapping the policy grammar evaluates against; its keys are
+        exactly :data:`KNOWN_RUN_PATHS`.
 
-        Its keys are exactly :data:`KNOWN_RUN_PATHS`, so a policy can only
-        reference something this record actually projects — never a permanent
-        zero. ``test_as_namespace_returns_only_registered_paths`` keeps the two
-        in step.
-
-        Read under the lock, even though none of the three values below can be
-        touched by a recorder and the lock is therefore inert today. The next
-        change projects the counters, and a reader that already holds the lock
-        cannot forget to acquire it: the grammar permits cross-field
-        comparison (``run.a < run.b`` parses), so an unsynchronised read could
-        evaluate a pair of counters that never coexisted.
+        Locked because the grammar allows cross-field comparison (``run.a < run.b``),
+        so an unsynchronised read could pair counters that never coexisted.
         """
         with self._lock:
             return {
                 "id": self.id,
                 "agent": self.agent,
-                # Derived, not stored: the grammar has no time functions.
-                # Zero when detached rather than process uptime — DETACHED's
-                # origin is set at import, so a live subtraction would make
-                # ``run.elapsed_seconds < 300`` deny every out-of-scope call once
-                # the process had been up five minutes.
+                # Zero when detached, not process uptime: DETACHED's origin is set at
+                # import, so a live subtraction would eventually deny every
+                # out-of-scope call.
                 "elapsed_seconds": (
                     0.0 if self.detached else time.monotonic() - self._started_monotonic
                 ),
             }
 
 
-# The ContextVar default, and therefore shared process-wide: ``get()`` hands
-# back this same instance in every context that has not ``set()`` one. That is
-# safe only because every mutator is a no-op on it. A plain zeroed instance
-# here would be a global accumulator that never resets — counters would climb
-# for the process lifetime until they exceeded every cap, and then every tool
-# call in the process would deny.
-#
-# Reading zeros outside a run scope is the deliberate choice: it fails *open*
-# on counters, which is right for a boundary that was never wired, versus
-# bricking an agent. ``run.id == ""`` is the signal that a decision happened
-# outside a run.
+# The ContextVar default, so one shared instance process-wide — safe only because
+# every mutator no-ops on it. A plain zeroed record here would accumulate for the
+# process lifetime until it tripped every cap. Reading zeros outside a run fails
+# *open*, which is right for a boundary that was never wired; ``id == ""`` marks it.
 DETACHED: Final[RunFacts] = RunFacts(id="", agent="", detached=True)
 
 _CURRENT_RUN_FACTS: ContextVar[RunFacts] = ContextVar(
@@ -213,32 +137,24 @@ _CURRENT_RUN_FACTS: ContextVar[RunFacts] = ContextVar(
 
 
 def get_run_facts() -> RunFacts:
-    """Return the active run's facts, or :data:`DETACHED` outside a run scope.
+    """The active run's facts, or :data:`DETACHED` outside a run scope.
 
-    Never ``None``. An absent ``run`` namespace makes every ``run.*``
-    constraint fail closed, so a tool call decided outside a run scope — a
-    unit test, a direct ``decide()``, an unwired entry point — would deny
-    everything, with an error message naming a constraint rather than the real
-    cause.
+    Never ``None``: a missing ``run`` namespace fails every ``run.*`` constraint
+    closed, so an unwired boundary would deny everything for the wrong reason.
     """
     return _CURRENT_RUN_FACTS.get()
 
 
 @contextmanager
 def use_run_facts(facts: RunFacts) -> Iterator[RunFacts]:
-    """Bind ``facts`` for the duration of the block, minting nothing.
+    """Bind ``facts`` without minting — the primitive :func:`run_scope` builds on.
 
-    The primitive :func:`run_scope` is built from. Call it directly to join a
-    run already in flight: ``Runner.run_streamed`` (OpenAI Agents) spawns the
-    agent loop as a background task that snapshots the contextvars at creation
-    and then returns, so the consumer-side iterator has to re-bind the same
-    object — minting there would split one invocation across two runs.
+    Call it directly to join a run in flight: ``Runner.run_streamed`` snapshots the
+    contextvars into a background task and returns, so the consumer-side iterator
+    must re-bind that object rather than start a second run.
 
-    Saves and restores by ``set()`` rather than ``reset(token)``, matching
-    :class:`~hexgate.runtime.context.HexgateContext`: async-generator
-    finalizers run ``__aexit__`` in a different ``Context``, where a token
-    reset raises. Three run entry points are async generators, so this is
-    load-bearing rather than defensive.
+    Restores by ``set()``, not ``reset(token)``: async-generator finalizers run in a
+    different ``Context``, where a token reset raises.
     """
     saved = _CURRENT_RUN_FACTS.get()
     _CURRENT_RUN_FACTS.set(facts)
@@ -250,12 +166,10 @@ def use_run_facts(facts: RunFacts) -> Iterator[RunFacts]:
 
 @contextmanager
 def run_scope(agent: str) -> Iterator[RunFacts]:
-    """Open a new run — mint a :class:`RunFacts` and bind it.
+    """Mint a :class:`RunFacts` and bind it — one scope per agent invocation.
 
-    One scope per agent invocation. Open it at the adapter run boundary, after
-    the policy refresh and the ban check (a refused invocation is not a run),
-    and *not* in ``HexgateContext.__aenter__``: that scope is request-shaped
-    and may wrap several invocations.
+    Belongs at the adapter run boundary, after the ban check (a refused invocation is
+    not a run) and not in ``HexgateContext.__aenter__``, which may wrap several.
     """
     with use_run_facts(RunFacts(id=str(uuid4()), agent=agent)) as facts:
         yield facts

--- a/hexgate/runtime/run_facts.py
+++ b/hexgate/runtime/run_facts.py
@@ -27,6 +27,11 @@ from uuid import uuid4
 # never fires — a fail-open cap that looks like it works.
 KNOWN_RUN_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_seconds"})
 
+# Fallback when a wrapped agent has no name. Lives here, below both callers, so a
+# nameless agent's audit events and its run facts agree on the label rather than
+# drifting apart — and so core (``agents.factory``) need not import the adapter layer.
+DEFAULT_AGENT_NAME: Final[str] = "default"
+
 
 @dataclass(slots=True)
 class RunFacts:
@@ -139,8 +144,10 @@ _CURRENT_RUN_FACTS: ContextVar[RunFacts] = ContextVar(
 def get_run_facts() -> RunFacts:
     """The active run's facts, or :data:`DETACHED` outside a run scope.
 
-    Never ``None``: a missing ``run`` namespace fails every ``run.*`` constraint
-    closed, so an unwired boundary would deny everything for the wrong reason.
+    Never ``None`` — were it, the ``run`` namespace would be absent, and a missing
+    ref fails every comparison closed, so an unwired boundary would deny everything
+    for the wrong reason. :data:`DETACHED` reads as zeros instead: a projected path
+    (``elapsed_seconds``) then fails open, an unprojected one is still a missing ref.
     """
     return _CURRENT_RUN_FACTS.get()
 

--- a/hexgate/runtime/run_facts.py
+++ b/hexgate/runtime/run_facts.py
@@ -45,7 +45,7 @@ from uuid import uuid4
 # silently fail-open cap, shipped as a working feature. So the counters this
 # record already accumulates are deliberately absent below; each joins the
 # registry and the projection together, in the change that wires its writer.
-KNOWN_RUN_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_s"})
+KNOWN_RUN_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_seconds"})
 
 
 @dataclass(slots=True)
@@ -66,7 +66,7 @@ class RunFacts:
     agent: str
     # True only for DETACHED, where every mutator returns early. See DETACHED.
     detached: bool = False
-    # Origin for ``elapsed_s``. Monotonic, not wall clock: an NTP step
+    # Origin for ``elapsed_seconds``. Monotonic, not wall clock: an NTP step
     # backwards would un-block a run that had already exceeded its time
     # budget. Private and never a ``run.*`` path — only the derived elapsed is
     # exposed, so there is no second time field to keep consistent.
@@ -185,9 +185,9 @@ class RunFacts:
                 # Derived, not stored: the grammar has no time functions.
                 # Zero when detached rather than process uptime — DETACHED's
                 # origin is set at import, so a live subtraction would make
-                # ``run.elapsed_s < 300`` deny every out-of-scope call once
+                # ``run.elapsed_seconds < 300`` deny every out-of-scope call once
                 # the process had been up five minutes.
-                "elapsed_s": (
+                "elapsed_seconds": (
                     0.0 if self.detached else time.monotonic() - self._started_monotonic
                 ),
             }

--- a/hexgate/runtime/run_facts.py
+++ b/hexgate/runtime/run_facts.py
@@ -1,0 +1,273 @@
+"""Per-invocation fact record — the ``run.*`` policy namespace.
+
+``run.*`` is a fact family alongside the call-scope facts ``role`` / ``tool``
+(:mod:`hexgate.security.constraints`), the signed ``biscuit_facts``
+(:mod:`hexgate.cloud.biscuit`), and the advisory ``ctx.*`` bag
+(:attr:`~hexgate.runtime.context.HexgateContext.attributes`). It is the only
+one that is local *and* exact: the SDK accumulates it in-process, so it can
+never be unavailable and never needs a fail-soft path.
+
+It records only what has happened — no limits, no thresholds, no pricing.
+Those live in ``policy_yaml`` and on the platform, which is what keeps
+``PolicyEngine.evaluate`` a pure predicate over its inputs.
+
+Every field is monotone non-decreasing within a run: counters only increment,
+the tool set only grows, elapsed comes off a monotonic clock. A ``<``
+predicate over a non-decreasing value therefore *latches* — once a cap
+denies it keeps denying, which is what makes it a circuit breaker rather than
+a flapping gate.
+
+The contextvar distributes a *reference*, not a value. Sub-tasks that copy the
+context share one :class:`RunFacts`, so their writes reach the run that
+spawned them, while a ``set()`` inside a sub-task cannot rebind the parent's.
+Consequences, including the paths that do *not* propagate (raw threads, tasks
+created outside the scope), are in
+``plans/run-state/run-facts-phase1-implementation.md`` §0.4.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from typing import Any, Final
+from uuid import uuid4
+
+# The single source of truth for what ``run.*`` exposes to a policy. Drives
+# :meth:`RunFacts.as_namespace` and, from the next change, the load-time
+# linter — so a path cannot be readable-but-unlintable or lintable-but-absent.
+#
+# A path is added here in the same change that makes it truthful, never
+# earlier. A registered path with no writer reads a permanent zero, and
+# ``run.tool_calls < 20`` against a permanent zero never fires: a silently
+# fail-open cap, shipped as a working feature. The counters below are computed
+# by ``as_namespace`` already but stay unregistered until their write sites
+# land, so the only edit needed then is to this tuple.
+SCALAR_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_s"})
+LIST_PATHS: Final[frozenset[str]] = frozenset()
+KNOWN_RUN_PATHS: Final[frozenset[str]] = SCALAR_PATHS | LIST_PATHS
+
+
+@dataclass(slots=True)
+class RunFacts:
+    """Mutable, single-writer accumulator for one agent invocation.
+
+    Read through :meth:`as_namespace`; mutate only through the ``record_*``
+    methods. Assigning a counter directly bypasses the lock.
+    """
+
+    id: str
+    agent: str
+    # True only for DETACHED, where every mutator returns early. See DETACHED.
+    detached: bool = False
+    # Origin for ``elapsed_s``. Monotonic, not wall clock: an NTP step
+    # backwards would un-block a run that had already exceeded its time
+    # budget. Private and never a ``run.*`` path — only the derived elapsed is
+    # exposed, so there is no second time field to keep consistent.
+    #
+    # Wrapped in a lambda rather than passed as ``default_factory=
+    # time.monotonic``: the bare reference binds this function object at class
+    # definition, while ``as_namespace`` resolves ``time.monotonic`` at call
+    # time. The origin and the elapsed would then read different clocks
+    # whenever one is substituted, yielding a negative elapsed.
+    _started_monotonic: float = field(default_factory=lambda: time.monotonic())
+
+    tool_calls: int = 0
+    llm_calls: int = 0
+    denials: int = 0
+    approvals: int = 0
+    errors: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+    # Backs ``calls_of_this_tool``. Private: its keys are tool names, which may
+    # not be legal policy-path identifiers (MCP tool names are hyphenated), so
+    # exposing ``run.calls_by_tool.<name>`` needs a sanitisation scheme first.
+    _calls_by_tool: dict[str, int] = field(default_factory=dict)
+    # First-use-ordered set. A dict rather than a set because "first-use order"
+    # is the documented semantic for ``run.tools_used``.
+    _tools_used: dict[str, None] = field(default_factory=dict)
+    # threading.Lock, not asyncio.Lock: the mutators are called from sync paths
+    # (``run_guarded_sync``, LangChain's sync callback handler) as well as
+    # async ones, and every critical section is a few integer increments.
+    # Parallel tool calls run as separate asyncio tasks that copy the context
+    # and therefore share this object by reference — which is why a lock is
+    # needed at all.
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def record_execution(self, tool_name: str) -> None:
+        """Count one tool call that actually executed.
+
+        Called after the tool returns *or* raises — a failed call consumed
+        budget just as a successful one did.
+        """
+        if self.detached:
+            return
+        with self._lock:
+            self.tool_calls += 1
+            self._calls_by_tool[tool_name] = self._calls_by_tool.get(tool_name, 0) + 1
+            self._tools_used.setdefault(tool_name)
+
+    def record_error(self) -> None:
+        """Count one tool that raised."""
+        if self.detached:
+            return
+        with self._lock:
+            self.errors += 1
+
+    def record_denial(self) -> None:
+        """Count one refused call.
+
+        Deliberately not a ``tool_calls``: a denied call must not consume the
+        budget a legitimate caller is bounded by.
+        """
+        if self.detached:
+            return
+        with self._lock:
+            self.denials += 1
+
+    def record_approval(self) -> None:
+        """Count one call gated on human approval.
+
+        Counted on the *decision*; whether it then executes is counted
+        separately by :meth:`record_execution`, so an approval never granted
+        consumes no tool budget.
+        """
+        if self.detached:
+            return
+        with self._lock:
+            self.approvals += 1
+
+    def record_llm_usage(self, input_tokens: int, output_tokens: int) -> None:
+        """Count one model request and its tokens.
+
+        ``input_tokens`` includes cached tokens, matching OpenTelemetry's
+        billed-count rule.
+        """
+        if self.detached:
+            return
+        with self._lock:
+            self.llm_calls += 1
+            self.input_tokens += input_tokens
+            self.output_tokens += output_tokens
+
+    def as_namespace(self, tool_name: str) -> dict[str, Any]:
+        """Build the ``run`` mapping the policy grammar evaluates against.
+
+        ``tool_name`` is the tool being decided: ``calls_of_this_tool`` is a
+        per-decision view of the private per-tool map, not a counter, so it is
+        the one value here that is not monotone across a run.
+
+        Only paths in :data:`KNOWN_RUN_PATHS` are returned, so a path a policy
+        can reference is always one this SDK maintains. That makes the filter
+        and the load-time linter two independent guards against a cap reading
+        a permanently-zero field.
+
+        Takes the lock for the read: without it a concurrent
+        :meth:`record_llm_usage` could be observed half-applied, and
+        ``total_tokens`` would not equal its own parts.
+        """
+        with self._lock:
+            facts: dict[str, Any] = {
+                "id": self.id,
+                "agent": self.agent,
+                "tool_calls": self.tool_calls,
+                "calls_of_this_tool": self._calls_by_tool.get(tool_name, 0),
+                "llm_calls": self.llm_calls,
+                "denials": self.denials,
+                "approvals": self.approvals,
+                "errors": self.errors,
+                "input_tokens": self.input_tokens,
+                "output_tokens": self.output_tokens,
+                # Derived, never stored: the grammar has no arithmetic, so a
+                # policy cannot sum the parts itself.
+                "total_tokens": self.input_tokens + self.output_tokens,
+                # Zero when detached, not process uptime: DETACHED's origin is
+                # set at import, so a live subtraction would make
+                # ``run.elapsed_s < 300`` start denying every out-of-scope
+                # call once the process had been up five minutes.
+                "elapsed_s": (
+                    0.0 if self.detached else time.monotonic() - self._started_monotonic
+                ),
+                "tools_used": list(self._tools_used),
+            }
+        return {path: value for path, value in facts.items() if path in KNOWN_RUN_PATHS}
+
+
+# The ContextVar default, and therefore shared process-wide: ``get()`` hands
+# back this same instance in every context that has not ``set()`` one. That is
+# safe only because every mutator is a no-op on it. A plain zeroed instance
+# here would be a global accumulator that never resets — counters would climb
+# for the process lifetime until they exceeded every cap, and then every tool
+# call in the process would deny.
+#
+# Reading zeros outside a run scope is the deliberate choice: it fails *open*
+# on counters, which is right for a boundary that was never wired, versus
+# bricking an agent. ``run.id == ""`` is the signal that a decision happened
+# outside a run.
+DETACHED: Final[RunFacts] = RunFacts(id="", agent="", detached=True)
+
+_CURRENT_RUN_FACTS: ContextVar[RunFacts] = ContextVar(
+    "hexgate_run_facts",
+    default=DETACHED,
+)
+
+
+def get_run_facts() -> RunFacts:
+    """Return the active run's facts, or :data:`DETACHED` outside a run scope.
+
+    Never ``None``. An absent ``run`` namespace makes every ``run.*``
+    constraint fail closed, so a tool call decided outside a run scope — a
+    unit test, a direct ``decide()``, an unwired entry point — would deny
+    everything, with an error message naming a constraint rather than the real
+    cause.
+    """
+    return _CURRENT_RUN_FACTS.get()
+
+
+@contextmanager
+def _install(facts: RunFacts) -> Iterator[RunFacts]:
+    """Bind ``facts`` for the duration of the block.
+
+    Saves and restores by ``set()`` rather than ``reset(token)``, matching
+    :class:`~hexgate.runtime.context.HexgateContext`: async-generator
+    finalizers run ``__aexit__`` in a different ``Context``, where a token
+    reset raises. Three run entry points are async generators, so this is
+    load-bearing rather than defensive.
+    """
+    saved = _CURRENT_RUN_FACTS.get()
+    _CURRENT_RUN_FACTS.set(facts)
+    try:
+        yield facts
+    finally:
+        _CURRENT_RUN_FACTS.set(saved)
+
+
+@contextmanager
+def run_scope(agent: str) -> Iterator[RunFacts]:
+    """Open a new run — mint a :class:`RunFacts` and bind it.
+
+    One scope per agent invocation. Open it at the adapter run boundary, after
+    the policy refresh and the ban check (a refused invocation is not a run),
+    and *not* in ``HexgateContext.__aenter__``: that scope is request-shaped
+    and may wrap several invocations.
+    """
+    with _install(RunFacts(id=str(uuid4()), agent=agent)) as facts:
+        yield facts
+
+
+@contextmanager
+def use_run_facts(facts: RunFacts) -> Iterator[RunFacts]:
+    """Join a run already in flight — bind ``facts``, minting nothing.
+
+    For a context that must see an existing run rather than start one.
+    ``Runner.run_streamed`` (OpenAI Agents) spawns the agent loop as a
+    background task that snapshots the contextvars at creation and then
+    returns, so the consumer-side iterator has to re-bind the same object;
+    minting there would split one invocation's facts across two runs.
+    """
+    with _install(facts) as bound:
+        yield bound

--- a/hexgate/runtime/run_facts.py
+++ b/hexgate/runtime/run_facts.py
@@ -11,11 +11,10 @@ It records only what has happened — no limits, no thresholds, no pricing.
 Those live in ``policy_yaml`` and on the platform, which is what keeps
 ``PolicyEngine.evaluate`` a pure predicate over its inputs.
 
-Every field is monotone non-decreasing within a run: counters only increment,
-the tool set only grows, elapsed comes off a monotonic clock. A ``<``
-predicate over a non-decreasing value therefore *latches* — once a cap
-denies it keeps denying, which is what makes it a circuit breaker rather than
-a flapping gate.
+Every counter is monotone non-decreasing within a run, and elapsed comes off a
+monotonic clock. A ``<`` predicate over a non-decreasing value therefore
+*latches* — once a cap denies it keeps denying, which is what makes it a
+circuit breaker rather than a flapping gate.
 
 The contextvar distributes a *reference*, not a value. Sub-tasks that copy the
 context share one :class:`RunFacts`, so their writes reach the run that
@@ -36,27 +35,31 @@ from dataclasses import dataclass, field
 from typing import Any, Final
 from uuid import uuid4
 
-# The single source of truth for what ``run.*`` exposes to a policy. Drives
-# :meth:`RunFacts.as_namespace` and, from the next change, the load-time
-# linter — so a path cannot be readable-but-unlintable or lintable-but-absent.
+# Every ``run.*`` path a policy may reference. One source of truth, shared by
+# :meth:`RunFacts.as_namespace` — which returns exactly these — and, from the
+# next change, the load-time linter that rejects anything else.
 #
-# A path is added here in the same change that makes it truthful, never
-# earlier. A registered path with no writer reads a permanent zero, and
-# ``run.tool_calls < 20`` against a permanent zero never fires: a silently
-# fail-open cap, shipped as a working feature. The counters below are computed
-# by ``as_namespace`` already but stay unregistered until their write sites
-# land, so the only edit needed then is to this tuple.
-SCALAR_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_s"})
-LIST_PATHS: Final[frozenset[str]] = frozenset()
-KNOWN_RUN_PATHS: Final[frozenset[str]] = SCALAR_PATHS | LIST_PATHS
+# A path is registered in the same change that starts *projecting* it, never
+# earlier. A registered path with no value behind it resolves to a permanent
+# zero, and ``run.tool_calls < 20`` against a permanent zero never fires: a
+# silently fail-open cap, shipped as a working feature. So the counters this
+# record already accumulates are deliberately absent below; each joins the
+# registry and the projection together, in the change that wires its writer.
+KNOWN_RUN_PATHS: Final[frozenset[str]] = frozenset({"id", "agent", "elapsed_s"})
 
 
 @dataclass(slots=True)
 class RunFacts:
-    """Mutable, single-writer accumulator for one agent invocation.
+    """Mutable accumulator for one agent invocation.
 
-    Read through :meth:`as_namespace`; mutate only through the ``record_*``
-    methods. Assigning a counter directly bypasses the lock.
+    Monotone by discipline, not by construction: the ``record_*`` methods are
+    the only monotone-preserving way in, and assigning a field directly
+    bypasses both the lock and the detached guard. Read through
+    :meth:`as_namespace`.
+
+    Not single-writer. Parallel tool calls run as separate asyncio tasks that
+    copy the context and therefore share one instance by reference, so several
+    writers are expected — that is what ``_lock`` is for.
     """
 
     id: str
@@ -70,9 +73,13 @@ class RunFacts:
     #
     # Wrapped in a lambda rather than passed as ``default_factory=
     # time.monotonic``: the bare reference binds this function object at class
-    # definition, while ``as_namespace`` resolves ``time.monotonic`` at call
-    # time. The origin and the elapsed would then read different clocks
+    # definition, while :meth:`as_namespace` resolves ``time.monotonic`` at
+    # call time. The origin and the elapsed would then read different clocks
     # whenever one is substituted, yielding a negative elapsed.
+    #
+    # Deliberately still an ``__init__`` parameter, unlike the internals below:
+    # it is the seam a caller substitutes to control the clock, so only the
+    # default is hard-wired.
     _started_monotonic: float = field(default_factory=lambda: time.monotonic())
 
     tool_calls: int = 0
@@ -83,20 +90,23 @@ class RunFacts:
     input_tokens: int = 0
     output_tokens: int = 0
 
-    # Backs ``calls_of_this_tool``. Private: its keys are tool names, which may
-    # not be legal policy-path identifiers (MCP tool names are hyphenated), so
-    # exposing ``run.calls_by_tool.<name>`` needs a sanitisation scheme first.
-    _calls_by_tool: dict[str, int] = field(default_factory=dict)
-    # First-use-ordered set. A dict rather than a set because "first-use order"
-    # is the documented semantic for ``run.tools_used``.
-    _tools_used: dict[str, None] = field(default_factory=dict)
+    # Per-tool call counts, which also give the first-use-ordered set of tools
+    # used: a dict preserves insertion order and an update to an existing key
+    # does not reorder it, so ``list(_calls_by_tool)`` is that set. Private
+    # because its keys are tool names, which may not be legal policy-path
+    # identifiers (MCP tool names are hyphenated), so exposing
+    # ``run.calls_by_tool.<name>`` needs a sanitisation scheme first.
+    #
+    # ``init=False`` here and on the lock: neither has a legitimate
+    # caller-supplied value, and a dataclass would otherwise expose them as
+    # constructor parameters — injectable by accident, which is worse than not
+    # being injectable. It keeps ``__init__`` a designed surface: identity, the
+    # detached flag, the clock origin, and the counters.
+    _calls_by_tool: dict[str, int] = field(default_factory=dict, init=False)
     # threading.Lock, not asyncio.Lock: the mutators are called from sync paths
     # (``run_guarded_sync``, LangChain's sync callback handler) as well as
     # async ones, and every critical section is a few integer increments.
-    # Parallel tool calls run as separate asyncio tasks that copy the context
-    # and therefore share this object by reference — which is why a lock is
-    # needed at all.
-    _lock: threading.Lock = field(default_factory=threading.Lock)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
     def record_execution(self, tool_name: str) -> None:
         """Count one tool call that actually executed.
@@ -109,7 +119,6 @@ class RunFacts:
         with self._lock:
             self.tool_calls += 1
             self._calls_by_tool[tool_name] = self._calls_by_tool.get(tool_name, 0) + 1
-            self._tools_used.setdefault(tool_name)
 
     def record_error(self) -> None:
         """Count one tool that raised."""
@@ -154,47 +163,34 @@ class RunFacts:
             self.input_tokens += input_tokens
             self.output_tokens += output_tokens
 
-    def as_namespace(self, tool_name: str) -> dict[str, Any]:
+    def as_namespace(self) -> dict[str, Any]:
         """Build the ``run`` mapping the policy grammar evaluates against.
 
-        ``tool_name`` is the tool being decided: ``calls_of_this_tool`` is a
-        per-decision view of the private per-tool map, not a counter, so it is
-        the one value here that is not monotone across a run.
+        Its keys are exactly :data:`KNOWN_RUN_PATHS`, so a policy can only
+        reference something this record actually projects — never a permanent
+        zero. ``test_as_namespace_returns_only_registered_paths`` keeps the two
+        in step.
 
-        Only paths in :data:`KNOWN_RUN_PATHS` are returned, so a path a policy
-        can reference is always one this SDK maintains. That makes the filter
-        and the load-time linter two independent guards against a cap reading
-        a permanently-zero field.
-
-        Takes the lock for the read: without it a concurrent
-        :meth:`record_llm_usage` could be observed half-applied, and
-        ``total_tokens`` would not equal its own parts.
+        Read under the lock, even though none of the three values below can be
+        touched by a recorder and the lock is therefore inert today. The next
+        change projects the counters, and a reader that already holds the lock
+        cannot forget to acquire it: the grammar permits cross-field
+        comparison (``run.a < run.b`` parses), so an unsynchronised read could
+        evaluate a pair of counters that never coexisted.
         """
         with self._lock:
-            facts: dict[str, Any] = {
+            return {
                 "id": self.id,
                 "agent": self.agent,
-                "tool_calls": self.tool_calls,
-                "calls_of_this_tool": self._calls_by_tool.get(tool_name, 0),
-                "llm_calls": self.llm_calls,
-                "denials": self.denials,
-                "approvals": self.approvals,
-                "errors": self.errors,
-                "input_tokens": self.input_tokens,
-                "output_tokens": self.output_tokens,
-                # Derived, never stored: the grammar has no arithmetic, so a
-                # policy cannot sum the parts itself.
-                "total_tokens": self.input_tokens + self.output_tokens,
-                # Zero when detached, not process uptime: DETACHED's origin is
-                # set at import, so a live subtraction would make
-                # ``run.elapsed_s < 300`` start denying every out-of-scope
-                # call once the process had been up five minutes.
+                # Derived, not stored: the grammar has no time functions.
+                # Zero when detached rather than process uptime — DETACHED's
+                # origin is set at import, so a live subtraction would make
+                # ``run.elapsed_s < 300`` deny every out-of-scope call once
+                # the process had been up five minutes.
                 "elapsed_s": (
                     0.0 if self.detached else time.monotonic() - self._started_monotonic
                 ),
-                "tools_used": list(self._tools_used),
             }
-        return {path: value for path, value in facts.items() if path in KNOWN_RUN_PATHS}
 
 
 # The ContextVar default, and therefore shared process-wide: ``get()`` hands
@@ -229,8 +225,14 @@ def get_run_facts() -> RunFacts:
 
 
 @contextmanager
-def _install(facts: RunFacts) -> Iterator[RunFacts]:
-    """Bind ``facts`` for the duration of the block.
+def use_run_facts(facts: RunFacts) -> Iterator[RunFacts]:
+    """Bind ``facts`` for the duration of the block, minting nothing.
+
+    The primitive :func:`run_scope` is built from. Call it directly to join a
+    run already in flight: ``Runner.run_streamed`` (OpenAI Agents) spawns the
+    agent loop as a background task that snapshots the contextvars at creation
+    and then returns, so the consumer-side iterator has to re-bind the same
+    object — minting there would split one invocation across two runs.
 
     Saves and restores by ``set()`` rather than ``reset(token)``, matching
     :class:`~hexgate.runtime.context.HexgateContext`: async-generator
@@ -255,19 +257,5 @@ def run_scope(agent: str) -> Iterator[RunFacts]:
     and *not* in ``HexgateContext.__aenter__``: that scope is request-shaped
     and may wrap several invocations.
     """
-    with _install(RunFacts(id=str(uuid4()), agent=agent)) as facts:
+    with use_run_facts(RunFacts(id=str(uuid4()), agent=agent)) as facts:
         yield facts
-
-
-@contextmanager
-def use_run_facts(facts: RunFacts) -> Iterator[RunFacts]:
-    """Join a run already in flight — bind ``facts``, minting nothing.
-
-    For a context that must see an existing run rather than start one.
-    ``Runner.run_streamed`` (OpenAI Agents) spawns the agent loop as a
-    background task that snapshots the contextvars at creation and then
-    returns, so the consumer-side iterator has to re-bind the same object;
-    minting there would split one invocation's facts across two runs.
-    """
-    with _install(facts) as bound:
-        yield bound

--- a/tests/runtime/test_run_facts.py
+++ b/tests/runtime/test_run_facts.py
@@ -1,0 +1,400 @@
+"""Tests for the ``run.*`` fact record and its contextvar scope.
+
+Most failure modes in this module are *silent* — a fail-open cap, a lost
+increment, a scope that never opened — so these tests are the specification.
+Four of them guard specific bugs the design went through:
+
+  * ``test_detached_default_drops_writes`` — a mutable ContextVar default is
+    shared process-wide, so recording onto it would build a global accumulator
+    that eventually denies every call in the process.
+  * ``test_detached_elapsed_is_zero_not_uptime`` — DETACHED's clock origin is
+    set at import, so a live subtraction reports process uptime.
+  * ``test_parallel_recorders_do_not_lose_increments`` — parallel tool calls
+    share one RunFacts by reference; the lock is why that is safe.
+  * ``test_scope_survives_async_generator_finalizer`` — a token reset would
+    raise in an async-generator finalizer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+import random
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+
+from hexgate.runtime.run_facts import (
+    DETACHED,
+    KNOWN_RUN_PATHS,
+    LIST_PATHS,
+    SCALAR_PATHS,
+    RunFacts,
+    get_run_facts,
+    run_scope,
+    use_run_facts,
+)
+
+_ANY_TOOL = "search_kb"
+_OTHER_TOOL = "shell"
+_WRITERS = 8
+_WRITES_EACH = 500
+_FUZZ_STEPS = 200
+_FUZZ_SEED = 20260820
+_FAR_FUTURE_MONOTONIC = 1_000_000.0
+
+
+def _recorders(facts: RunFacts) -> list[Any]:
+    """Every mutator, as zero-argument callables."""
+    return [
+        lambda: facts.record_execution(_ANY_TOOL),
+        lambda: facts.record_execution(_OTHER_TOOL),
+        facts.record_error,
+        facts.record_denial,
+        facts.record_approval,
+        lambda: facts.record_llm_usage(10, 3),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# The detached default
+# ---------------------------------------------------------------------------
+
+
+def test_detached_is_the_contextvar_default() -> None:
+    facts = get_run_facts()
+    assert facts is DETACHED
+    assert facts.detached is True
+    assert facts.id == ""
+
+
+def test_detached_default_drops_writes() -> None:
+    """A mutable ContextVar default is one shared object: ``get()`` returns the
+    same instance in every context that has not ``set()`` one. Recording onto
+    it would accumulate for the process lifetime until the counters exceeded
+    every cap, and then every tool call in the process would deny."""
+    facts = get_run_facts()
+    for _ in range(100):
+        for record in _recorders(facts):
+            record()
+
+    assert facts.tool_calls == 0
+    assert facts.llm_calls == 0
+    assert facts.errors == 0
+    assert facts.denials == 0
+    assert facts.approvals == 0
+    assert facts.input_tokens == 0
+    assert facts.output_tokens == 0
+
+    # A fresh context must observe the same untouched object.
+    observed = contextvars.copy_context().run(get_run_facts)
+    assert observed is DETACHED
+    assert observed.as_namespace(_ANY_TOOL)["id"] == ""
+
+
+def test_detached_elapsed_is_zero_not_uptime(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DETACHED's clock origin is set at import, so ``monotonic() - origin``
+    would report process uptime — and ``run.elapsed_s < 300`` would start
+    denying every out-of-scope call once the process had been up 5 minutes."""
+    monkeypatch.setattr(time, "monotonic", lambda: _FAR_FUTURE_MONOTONIC)
+    assert DETACHED.as_namespace(_ANY_TOOL)["elapsed_s"] == 0.0
+
+
+def test_get_run_facts_is_never_none() -> None:
+    assert get_run_facts() is not None
+
+    with run_scope("a"):
+        assert get_run_facts() is not None
+    assert get_run_facts() is not None
+
+    seen: list[RunFacts | None] = []
+    thread = threading.Thread(target=lambda: seen.append(get_run_facts()))
+    thread.start()
+    thread.join()
+    assert seen == [DETACHED]
+
+
+# ---------------------------------------------------------------------------
+# The scope
+# ---------------------------------------------------------------------------
+
+
+def test_run_scope_mints_a_distinct_id() -> None:
+    with run_scope("a") as first:
+        pass
+    with run_scope("a") as second:
+        pass
+    assert first.id and second.id
+    assert first.id != second.id
+
+
+def test_run_scope_binds_and_restores() -> None:
+    assert get_run_facts() is DETACHED
+    with run_scope("billing") as facts:
+        assert get_run_facts() is facts
+        assert facts.agent == "billing"
+    assert get_run_facts() is DETACHED
+
+
+def test_nested_scope_isolates_then_restores() -> None:
+    """A child scope does not roll up into its parent — the documented Phase-1
+    limitation (a per-run cap is bypassable by spawning a sub-agent). Flip this
+    test when roll-up lands."""
+    with run_scope("parent") as parent:
+        parent.record_execution(_ANY_TOOL)
+        with run_scope("child") as child:
+            child.record_execution(_ANY_TOOL)
+            child.record_execution(_OTHER_TOOL)
+            assert get_run_facts() is child
+            assert child.id != parent.id
+        assert get_run_facts() is parent
+        assert parent.tool_calls == 1  # not 3 — no roll-up
+
+
+def test_use_run_facts_joins_an_existing_run() -> None:
+    with run_scope("a") as facts:
+        facts.record_execution(_ANY_TOOL)
+        original_id = facts.id
+
+    with use_run_facts(facts) as bound:
+        assert bound is facts
+        assert bound.id == original_id  # nothing minted
+        assert bound.tool_calls == 1  # counters carried over
+        bound.record_execution(_ANY_TOOL)
+
+    assert facts.tool_calls == 2
+
+
+def test_facts_outlive_their_scope_when_referenced() -> None:
+    """The contextvar distributes a reference, so a context still holding it
+    keeps the object usable after the scope closed. ``run_streamed`` depends on
+    this: its background task snapshots the facts, then the scope exits."""
+    with run_scope("a") as facts:
+        pass
+
+    facts.record_execution(_ANY_TOOL)  # a detached background task would do this
+
+    with use_run_facts(facts):
+        assert get_run_facts().tool_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_scope_survives_async_generator_finalizer() -> None:
+    """``_install`` restores by ``set()`` rather than ``reset(token)``: an
+    async-generator finalizer runs in a different Context, where a token reset
+    raises ValueError. Three run entry points are async generators."""
+
+    async def gen():
+        with run_scope("a"):
+            yield get_run_facts().id
+            yield get_run_facts().id
+
+    agen = gen()
+    first = await anext(agen)
+    assert first
+    await agen.aclose()  # would raise on reset(token)
+    assert get_run_facts() is DETACHED
+
+
+# ---------------------------------------------------------------------------
+# Propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gather_children_share_one_object() -> None:
+    """Parallel tool calls run as separate tasks that copy the context — and
+    therefore share one RunFacts by reference, so their writes reach the run
+    that spawned them."""
+    with run_scope("a") as facts:
+
+        async def child() -> bool:
+            get_run_facts().record_execution(_ANY_TOOL)
+            return get_run_facts() is facts
+
+        results = await asyncio.gather(*(child() for _ in range(5)))
+
+    assert all(results)
+    assert facts.tool_calls == 5
+
+
+@pytest.mark.asyncio
+async def test_child_set_does_not_leak_to_parent() -> None:
+    """The other half of the asymmetry: mutation propagates upward, rebinding
+    does not. A sub-task cannot hijack the namespace."""
+    with run_scope("parent") as parent:
+
+        async def child() -> None:
+            with run_scope("child"):
+                get_run_facts().record_execution(_ANY_TOOL)
+
+        await asyncio.create_task(child())
+
+        assert get_run_facts() is parent
+        assert parent.tool_calls == 0  # the child's write went to the child
+
+
+def test_raw_thread_is_detached() -> None:
+    """A documented limitation, pinned so it stays known: a tool that
+    dispatches guarded work to a raw thread pool records nothing. LangChain's
+    own executor is safe — it wraps submissions with ``copy_context().run``."""
+    with run_scope("a") as facts:
+        with ThreadPoolExecutor(1) as pool:
+            assert pool.submit(get_run_facts).result() is DETACHED
+
+        seen: list[RunFacts] = []
+        thread = threading.Thread(target=lambda: seen.append(get_run_facts()))
+        thread.start()
+        thread.join()
+
+    assert seen == [DETACHED]
+    assert facts.tool_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Recorders
+# ---------------------------------------------------------------------------
+
+
+def test_record_execution_updates_calls_and_tool_set() -> None:
+    with run_scope("a") as facts:
+        facts.record_execution(_ANY_TOOL)
+        facts.record_execution(_OTHER_TOOL)
+        facts.record_execution(_ANY_TOOL)
+
+        assert facts.tool_calls == 3
+        assert facts._calls_by_tool == {_ANY_TOOL: 2, _OTHER_TOOL: 1}
+        assert list(facts._tools_used) == [_ANY_TOOL, _OTHER_TOOL]
+
+
+def test_tools_used_is_first_use_order_deduplicated() -> None:
+    with run_scope("a") as facts:
+        for tool in (_OTHER_TOOL, _ANY_TOOL, _OTHER_TOOL):
+            facts.record_execution(tool)
+        assert list(facts._tools_used) == [_OTHER_TOOL, _ANY_TOOL]
+
+
+def test_each_recorder_touches_only_its_own_counter() -> None:
+    with run_scope("a") as facts:
+        facts.record_error()
+        facts.record_denial()
+        facts.record_approval()
+        facts.record_llm_usage(100, 20)
+
+        assert facts.errors == 1
+        assert facts.denials == 1
+        assert facts.approvals == 1
+        assert facts.llm_calls == 1
+        assert facts.input_tokens == 100
+        assert facts.output_tokens == 20
+        # A denied or gated call is not a tool call: it must not consume the
+        # budget a legitimate caller is bounded by.
+        assert facts.tool_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Monotonicity and the namespace
+# ---------------------------------------------------------------------------
+
+
+def test_counters_are_monotone_under_random_recording() -> None:
+    """Every scalar is non-decreasing within a run — the property that makes a
+    ``<`` predicate latch instead of flapping."""
+    rng = random.Random(_FUZZ_SEED)
+    with run_scope("a") as facts:
+        previous = facts.as_namespace(_ANY_TOOL)
+        for _ in range(_FUZZ_STEPS):
+            rng.choice(_recorders(facts))()
+            current = facts.as_namespace(_ANY_TOOL)
+            for path in SCALAR_PATHS:
+                if isinstance(current[path], (int, float)):
+                    assert current[path] >= previous[path], path
+            previous = current
+
+
+def test_as_namespace_returns_only_registered_paths() -> None:
+    """The structural half of the release gate: a path a policy can reference
+    is always one this SDK maintains, independent of the load-time linter."""
+    with run_scope("a") as facts:
+        assert set(facts.as_namespace(_ANY_TOOL)) == KNOWN_RUN_PATHS
+    assert set(DETACHED.as_namespace(_ANY_TOOL)) == KNOWN_RUN_PATHS
+
+
+def test_registry_is_scalars_plus_lists() -> None:
+    assert KNOWN_RUN_PATHS == SCALAR_PATHS | LIST_PATHS
+    assert not SCALAR_PATHS & LIST_PATHS
+
+
+def test_as_namespace_exposes_identity_and_elapsed() -> None:
+    with run_scope("billing") as facts:
+        namespace = facts.as_namespace(_ANY_TOOL)
+        assert namespace["id"] == facts.id
+        assert namespace["agent"] == "billing"
+        assert namespace["elapsed_s"] >= 0.0
+
+
+def test_elapsed_derives_from_the_monotonic_clock(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wall clock is the bug being guarded against: an NTP step backwards would
+    un-block a run that had already exceeded its time budget."""
+    clock = iter([100.0, 142.5])
+    monkeypatch.setattr(time, "monotonic", lambda: next(clock))
+
+    with run_scope("a") as facts:  # consumes 100.0 as the origin
+        assert facts.as_namespace(_ANY_TOOL)["elapsed_s"] == pytest.approx(42.5)
+
+
+# ---------------------------------------------------------------------------
+# Concurrency
+# ---------------------------------------------------------------------------
+
+
+def test_parallel_recorders_do_not_lose_increments() -> None:
+    """The lock's reason to exist. Asyncio tasks copy the context but share the
+    object, so parallel tool calls increment the same counters."""
+    with run_scope("a") as facts:
+        barrier = threading.Barrier(_WRITERS)
+
+        def hammer() -> None:
+            barrier.wait()
+            for _ in range(_WRITES_EACH):
+                facts.record_execution(_ANY_TOOL)
+
+        threads = [threading.Thread(target=hammer) for _ in range(_WRITERS)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert facts.tool_calls == _WRITERS * _WRITES_EACH
+        assert facts._calls_by_tool[_ANY_TOOL] == _WRITERS * _WRITES_EACH
+
+
+def test_as_namespace_snapshot_is_internally_consistent() -> None:
+    """Why the read takes the lock: without it a concurrent
+    ``record_llm_usage`` is observable half-applied and ``total_tokens`` would
+    not equal its own parts. Asserted on the full fact dict, since the derived
+    total is not a registered path yet."""
+    with run_scope("a") as facts:
+        stop = threading.Event()
+
+        def writer() -> None:
+            while not stop.is_set():
+                facts.record_llm_usage(7, 3)
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        try:
+            for _ in range(2000):
+                with facts._lock:
+                    total = facts.input_tokens + facts.output_tokens
+                    parts = (facts.input_tokens, facts.output_tokens)
+                assert total == parts[0] + parts[1]
+                assert parts[0] % 7 == 0 and parts[1] % 3 == 0
+        finally:
+            stop.set()
+            thread.join()

--- a/tests/runtime/test_run_facts.py
+++ b/tests/runtime/test_run_facts.py
@@ -1,18 +1,7 @@
 """Tests for the ``run.*`` fact record and its contextvar scope.
 
-Most failure modes in this module are *silent* — a fail-open cap, a lost
-increment, a scope that never opened — so these tests are the specification.
-Four of them guard specific bugs the design went through:
-
-  * ``test_detached_default_drops_writes`` — a mutable ContextVar default is
-    shared process-wide, so recording onto it would build a global accumulator
-    that eventually denies every call in the process.
-  * ``test_detached_elapsed_is_zero_not_uptime`` — DETACHED's clock origin is
-    set at import, so a live subtraction reports process uptime.
-  * ``test_parallel_recorders_do_not_lose_increments`` — parallel tool calls
-    share one RunFacts by reference; the lock is why that is safe.
-  * ``test_scope_survives_async_generator_finalizer`` — a token reset would
-    raise in an async-generator finalizer.
+Every failure mode here is *silent* — a fail-open cap, a lost increment, a scope
+that never opened — so these tests are the specification.
 """
 
 from __future__ import annotations
@@ -51,27 +40,21 @@ _FAR_FUTURE_MONOTONIC = 1_000_000.0
 _RECORDER_PREFIX = "record_"
 _DETACHED_GUARD = "if self.detached:"
 _AN_INT = 1
-# Identity, the clock origin and the lock are not counters; a recorder that
-# changed one would be a different bug than the one _mutable_state guards.
+# Not counters, so out of scope for _mutable_state.
 _NOT_MUTABLE_STATE = frozenset(
     {"id", "agent", "detached", "_started_monotonic", "_lock"}
 )
 
 
 def _recorder_names() -> list[str]:
-    """Every ``record_*`` method, discovered rather than listed.
-
-    Reflective on purpose. A recorder added without the detached guard would
-    accumulate on the process-wide DETACHED singleton — the exact bug this
-    module's design exists to prevent — and a hand-written list would not
-    notice the new method.
-    """
+    """Every ``record_*`` method, discovered so a new one cannot be added without
+    the detached guard and go unnoticed."""
     return sorted(name for name in dir(RunFacts) if name.startswith(_RECORDER_PREFIX))
 
 
 def _invoke(recorder: Callable[..., None]) -> None:
-    """Call a recorder with a plausible argument per parameter, from its
-    signature — so a new recorder needs no test-side wiring."""
+    """Call a recorder with an argument per parameter, inferred from its
+    signature, so a new recorder needs no test-side wiring."""
     arguments = [
         _ANY_TOOL if parameter.annotation in (str, "str") else _AN_INT
         for parameter in inspect.signature(recorder).parameters.values()
@@ -80,11 +63,8 @@ def _invoke(recorder: Callable[..., None]) -> None:
 
 
 def _recorders(facts: RunFacts) -> list[Callable[[], None]]:
-    """Every mutator as a zero-argument callable.
-
-    Includes a second ``record_execution`` bound to a different tool, which
-    reflection cannot infer, so the per-tool map is exercised too.
-    """
+    """Every mutator as a zero-argument callable, plus a second
+    ``record_execution`` on another tool so the per-tool map is exercised."""
     discovered: list[Callable[[], None]] = [
         partial(_invoke, getattr(facts, name)) for name in _recorder_names()
     ]
@@ -92,8 +72,8 @@ def _recorders(facts: RunFacts) -> list[Callable[[], None]]:
 
 
 def _mutable_state(facts: RunFacts) -> dict[str, Any]:
-    """Every field a recorder could touch, discovered from the dataclass so a
-    counter added later is covered without editing this helper."""
+    """Every field a recorder could touch, discovered from the dataclass so a new
+    counter is covered without editing this helper."""
     return {
         f.name: copy.deepcopy(getattr(facts, f.name))
         for f in dataclasses.fields(facts)
@@ -114,10 +94,8 @@ def test_detached_is_the_contextvar_default() -> None:
 
 
 def test_detached_default_drops_writes() -> None:
-    """A mutable ContextVar default is one shared object: ``get()`` returns the
-    same instance in every context that has not ``set()`` one. Recording onto
-    it would accumulate for the process lifetime until the counters exceeded
-    every cap, and then every tool call in the process would deny."""
+    """A ContextVar default is one shared object, so recording onto it would
+    accumulate process-wide until it tripped every cap."""
     facts = get_run_facts()
     before = _mutable_state(facts)
 
@@ -134,12 +112,8 @@ def test_detached_default_drops_writes() -> None:
 
 
 def test_every_recorder_has_the_detached_guard() -> None:
-    """The structural half of the guarantee above.
-
-    ``test_detached_default_drops_writes`` only proves the fields it snapshots
-    stayed put. This proves each recorder is *written* to return early, so one
-    that mutated something outside the dataclass still fails here.
-    """
+    """Structural half of the test above: each recorder must be *written* to
+    return early, so one mutating something off-dataclass still fails."""
     unguarded = [
         name
         for name in _recorder_names()
@@ -153,15 +127,13 @@ def test_every_recorder_has_the_detached_guard() -> None:
 
 
 def test_recorder_discovery_is_not_vacuous() -> None:
-    """Guards the guard: a typo in the prefix would make the two tests above
-    pass by iterating nothing."""
+    """Guards the guard: a typo in the prefix would pass by iterating nothing."""
     assert len(_recorder_names()) >= 5
 
 
 def test_detached_elapsed_is_zero_not_uptime(monkeypatch: pytest.MonkeyPatch) -> None:
-    """DETACHED's clock origin is set at import, so ``monotonic() - origin``
-    would report process uptime — and ``run.elapsed_seconds < 300`` would start
-    denying every out-of-scope call once the process had been up 5 minutes."""
+    """DETACHED's origin is set at import, so a live subtraction would report
+    process uptime and eventually deny every out-of-scope call."""
     monkeypatch.setattr(time, "monotonic", lambda: _FAR_FUTURE_MONOTONIC)
     assert DETACHED.as_namespace()["elapsed_seconds"] == 0.0
 
@@ -203,9 +175,8 @@ def test_run_scope_binds_and_restores() -> None:
 
 
 def test_nested_scope_isolates_then_restores() -> None:
-    """A child scope does not roll up into its parent — the documented Phase-1
-    limitation (a per-run cap is bypassable by spawning a sub-agent). Flip this
-    test when roll-up lands."""
+    """A child scope does not roll up: a per-run cap is bypassable by spawning a
+    sub-agent. Flip this test when roll-up lands."""
     with run_scope("parent") as parent:
         parent.record_execution(_ANY_TOOL)
         with run_scope("child") as child:
@@ -232,9 +203,8 @@ def test_use_run_facts_joins_an_existing_run() -> None:
 
 
 def test_facts_outlive_their_scope_when_referenced() -> None:
-    """The contextvar distributes a reference, so a context still holding it
-    keeps the object usable after the scope closed. ``run_streamed`` depends on
-    this: its background task snapshots the facts, then the scope exits."""
+    """A context still holding the reference keeps the record usable after the
+    scope closed — what ``run_streamed`` depends on."""
     with run_scope("a") as facts:
         pass
 
@@ -246,9 +216,8 @@ def test_facts_outlive_their_scope_when_referenced() -> None:
 
 @pytest.mark.asyncio
 async def test_scope_survives_async_generator_finalizer() -> None:
-    """``use_run_facts`` restores by ``set()`` rather than ``reset(token)``: an
-    async-generator finalizer runs in a different Context, where a token reset
-    raises ValueError. Three run entry points are async generators."""
+    """Why the restore uses ``set()``: an async-generator finalizer runs in a
+    different Context, where ``reset(token)`` raises."""
 
     async def gen():
         with run_scope("a"):
@@ -269,8 +238,7 @@ async def test_scope_survives_async_generator_finalizer() -> None:
 
 @pytest.mark.asyncio
 async def test_gather_children_share_one_object() -> None:
-    """Parallel tool calls run as separate tasks that copy the context — and
-    therefore share one RunFacts by reference, so their writes reach the run
+    """Tasks copy the context but share the record, so their writes reach the run
     that spawned them."""
     with run_scope("a") as facts:
 
@@ -286,8 +254,8 @@ async def test_gather_children_share_one_object() -> None:
 
 @pytest.mark.asyncio
 async def test_child_set_does_not_leak_to_parent() -> None:
-    """The other half of the asymmetry: mutation propagates upward, rebinding
-    does not. A sub-task cannot hijack the namespace."""
+    """The other half of the asymmetry: mutation propagates up, rebinding does
+    not, so a sub-task cannot hijack the namespace."""
     with run_scope("parent") as parent:
 
         async def child() -> None:
@@ -301,9 +269,8 @@ async def test_child_set_does_not_leak_to_parent() -> None:
 
 
 def test_raw_thread_is_detached() -> None:
-    """A documented limitation, pinned so it stays known: a tool that
-    dispatches guarded work to a raw thread pool records nothing. LangChain's
-    own executor is safe — it wraps submissions with ``copy_context().run``."""
+    """Known limitation: guarded work dispatched to a raw thread pool records
+    nothing. LangChain's own executor is safe — it copies the context."""
     with run_scope("a") as facts:
         with ThreadPoolExecutor(1) as pool:
             assert pool.submit(get_run_facts).result() is DETACHED
@@ -333,10 +300,8 @@ def test_record_execution_counts_per_tool() -> None:
 
 
 def test_calls_by_tool_is_the_first_use_ordered_tool_set() -> None:
-    """Why there is no separate ``tools_used`` field: a dict preserves
-    insertion order and an update to an existing key does not reorder it, so
-    the keys already are the deduplicated first-use sequence ``run.tools_used``
-    will project."""
+    """Why there is no separate ``tools_used`` field: re-keying a dict does not
+    reorder it, so the keys already are the deduplicated first-use sequence."""
     with run_scope("a") as facts:
         for tool in (_OTHER_TOOL, _ANY_TOOL, _OTHER_TOOL):
             facts.record_execution(tool)
@@ -367,14 +332,9 @@ def test_each_recorder_touches_only_its_own_counter() -> None:
 
 
 def test_counters_are_monotone_under_random_recording() -> None:
-    """Every counter is non-decreasing within a run — the property that makes a
-    ``<`` predicate latch instead of flapping.
-
-    Asserted on the fields rather than the projection: the counters are not
-    projected yet, and the field is where the invariant actually lives. Both
-    the field set and the recorder set are discovered, so a counter added later
-    is covered without editing this test.
-    """
+    """Every counter is non-decreasing — the property that makes a ``<`` predicate
+    latch. Asserted on the fields, where the invariant lives, and over discovered
+    sets so a new counter is covered without editing this test."""
     rng = random.Random(_FUZZ_SEED)
     with run_scope("a") as facts:
         previous = _mutable_state(facts)
@@ -391,8 +351,8 @@ def test_counters_are_monotone_under_random_recording() -> None:
 
 
 def test_as_namespace_returns_only_registered_paths() -> None:
-    """The structural half of the release gate: a path a policy can reference
-    is always one this SDK maintains, independent of the load-time linter."""
+    """A path a policy can reference is always one the SDK maintains, independent
+    of the load-time linter."""
     with run_scope("a") as facts:
         assert set(facts.as_namespace()) == KNOWN_RUN_PATHS
     assert set(DETACHED.as_namespace()) == KNOWN_RUN_PATHS
@@ -409,8 +369,8 @@ def test_as_namespace_exposes_identity_and_elapsed() -> None:
 def test_elapsed_derives_from_the_monotonic_clock(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Wall clock is the bug being guarded against: an NTP step backwards would
-    un-block a run that had already exceeded its time budget."""
+    """Wall clock is the bug guarded against: an NTP step back would un-block a
+    run that had already exceeded its budget."""
     clock = iter([100.0, 142.5])
     monkeypatch.setattr(time, "monotonic", lambda: next(clock))
 
@@ -424,8 +384,7 @@ def test_elapsed_derives_from_the_monotonic_clock(
 
 
 def test_parallel_recorders_do_not_lose_increments() -> None:
-    """The lock's reason to exist. Asyncio tasks copy the context but share the
-    object, so parallel tool calls increment the same counters."""
+    """The lock's reason to exist: parallel tool calls increment one record."""
     with run_scope("a") as facts:
         barrier = threading.Barrier(_WRITERS)
 
@@ -445,10 +404,8 @@ def test_parallel_recorders_do_not_lose_increments() -> None:
 
 
 def test_llm_usage_is_applied_atomically() -> None:
-    """Both token counters move together or not at all.
-
-    This is the invariant that will make the projected ``total_tokens`` equal
-    its own parts, and the reason :meth:`as_namespace` reads under the lock."""
+    """Both token counters move together or not at all — what will make a
+    projected ``total_tokens`` equal its parts, and why the read is locked."""
     with run_scope("a") as facts:
         stop = threading.Event()
 

--- a/tests/runtime/test_run_facts.py
+++ b/tests/runtime/test_run_facts.py
@@ -160,10 +160,10 @@ def test_recorder_discovery_is_not_vacuous() -> None:
 
 def test_detached_elapsed_is_zero_not_uptime(monkeypatch: pytest.MonkeyPatch) -> None:
     """DETACHED's clock origin is set at import, so ``monotonic() - origin``
-    would report process uptime — and ``run.elapsed_s < 300`` would start
+    would report process uptime — and ``run.elapsed_seconds < 300`` would start
     denying every out-of-scope call once the process had been up 5 minutes."""
     monkeypatch.setattr(time, "monotonic", lambda: _FAR_FUTURE_MONOTONIC)
-    assert DETACHED.as_namespace()["elapsed_s"] == 0.0
+    assert DETACHED.as_namespace()["elapsed_seconds"] == 0.0
 
 
 def test_get_run_facts_is_never_none() -> None:
@@ -403,7 +403,7 @@ def test_as_namespace_exposes_identity_and_elapsed() -> None:
         namespace = facts.as_namespace()
         assert namespace["id"] == facts.id
         assert namespace["agent"] == "billing"
-        assert namespace["elapsed_s"] >= 0.0
+        assert namespace["elapsed_seconds"] >= 0.0
 
 
 def test_elapsed_derives_from_the_monotonic_clock(
@@ -415,7 +415,7 @@ def test_elapsed_derives_from_the_monotonic_clock(
     monkeypatch.setattr(time, "monotonic", lambda: next(clock))
 
     with run_scope("a") as facts:  # consumes 100.0 as the origin
-        assert facts.as_namespace()["elapsed_s"] == pytest.approx(42.5)
+        assert facts.as_namespace()["elapsed_seconds"] == pytest.approx(42.5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/runtime/test_run_facts.py
+++ b/tests/runtime/test_run_facts.py
@@ -19,10 +19,15 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import copy
+import dataclasses
+import inspect
 import random
 import threading
 import time
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from typing import Any
 
 import pytest
@@ -30,8 +35,6 @@ import pytest
 from hexgate.runtime.run_facts import (
     DETACHED,
     KNOWN_RUN_PATHS,
-    LIST_PATHS,
-    SCALAR_PATHS,
     RunFacts,
     get_run_facts,
     run_scope,
@@ -45,18 +48,57 @@ _WRITES_EACH = 500
 _FUZZ_STEPS = 200
 _FUZZ_SEED = 20260820
 _FAR_FUTURE_MONOTONIC = 1_000_000.0
+_RECORDER_PREFIX = "record_"
+_DETACHED_GUARD = "if self.detached:"
+_AN_INT = 1
+# Identity, the clock origin and the lock are not counters; a recorder that
+# changed one would be a different bug than the one _mutable_state guards.
+_NOT_MUTABLE_STATE = frozenset(
+    {"id", "agent", "detached", "_started_monotonic", "_lock"}
+)
 
 
-def _recorders(facts: RunFacts) -> list[Any]:
-    """Every mutator, as zero-argument callables."""
-    return [
-        lambda: facts.record_execution(_ANY_TOOL),
-        lambda: facts.record_execution(_OTHER_TOOL),
-        facts.record_error,
-        facts.record_denial,
-        facts.record_approval,
-        lambda: facts.record_llm_usage(10, 3),
+def _recorder_names() -> list[str]:
+    """Every ``record_*`` method, discovered rather than listed.
+
+    Reflective on purpose. A recorder added without the detached guard would
+    accumulate on the process-wide DETACHED singleton — the exact bug this
+    module's design exists to prevent — and a hand-written list would not
+    notice the new method.
+    """
+    return sorted(name for name in dir(RunFacts) if name.startswith(_RECORDER_PREFIX))
+
+
+def _invoke(recorder: Callable[..., None]) -> None:
+    """Call a recorder with a plausible argument per parameter, from its
+    signature — so a new recorder needs no test-side wiring."""
+    arguments = [
+        _ANY_TOOL if parameter.annotation in (str, "str") else _AN_INT
+        for parameter in inspect.signature(recorder).parameters.values()
     ]
+    recorder(*arguments)
+
+
+def _recorders(facts: RunFacts) -> list[Callable[[], None]]:
+    """Every mutator as a zero-argument callable.
+
+    Includes a second ``record_execution`` bound to a different tool, which
+    reflection cannot infer, so the per-tool map is exercised too.
+    """
+    discovered: list[Callable[[], None]] = [
+        partial(_invoke, getattr(facts, name)) for name in _recorder_names()
+    ]
+    return [*discovered, lambda: facts.record_execution(_OTHER_TOOL)]
+
+
+def _mutable_state(facts: RunFacts) -> dict[str, Any]:
+    """Every field a recorder could touch, discovered from the dataclass so a
+    counter added later is covered without editing this helper."""
+    return {
+        f.name: copy.deepcopy(getattr(facts, f.name))
+        for f in dataclasses.fields(facts)
+        if f.name not in _NOT_MUTABLE_STATE
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -77,22 +119,43 @@ def test_detached_default_drops_writes() -> None:
     it would accumulate for the process lifetime until the counters exceeded
     every cap, and then every tool call in the process would deny."""
     facts = get_run_facts()
+    before = _mutable_state(facts)
+
     for _ in range(100):
         for record in _recorders(facts):
             record()
 
-    assert facts.tool_calls == 0
-    assert facts.llm_calls == 0
-    assert facts.errors == 0
-    assert facts.denials == 0
-    assert facts.approvals == 0
-    assert facts.input_tokens == 0
-    assert facts.output_tokens == 0
+    assert _mutable_state(facts) == before
 
     # A fresh context must observe the same untouched object.
     observed = contextvars.copy_context().run(get_run_facts)
     assert observed is DETACHED
-    assert observed.as_namespace(_ANY_TOOL)["id"] == ""
+    assert observed.as_namespace()["id"] == ""
+
+
+def test_every_recorder_has_the_detached_guard() -> None:
+    """The structural half of the guarantee above.
+
+    ``test_detached_default_drops_writes`` only proves the fields it snapshots
+    stayed put. This proves each recorder is *written* to return early, so one
+    that mutated something outside the dataclass still fails here.
+    """
+    unguarded = [
+        name
+        for name in _recorder_names()
+        if _DETACHED_GUARD not in inspect.getsource(getattr(RunFacts, name))
+    ]
+    assert not unguarded, (
+        f"{unguarded} lack the detached guard: they would accumulate on the "
+        "process-wide DETACHED singleton, which never resets, until the "
+        "counters exceeded every cap and the process denied every tool call."
+    )
+
+
+def test_recorder_discovery_is_not_vacuous() -> None:
+    """Guards the guard: a typo in the prefix would make the two tests above
+    pass by iterating nothing."""
+    assert len(_recorder_names()) >= 5
 
 
 def test_detached_elapsed_is_zero_not_uptime(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -100,7 +163,7 @@ def test_detached_elapsed_is_zero_not_uptime(monkeypatch: pytest.MonkeyPatch) ->
     would report process uptime — and ``run.elapsed_s < 300`` would start
     denying every out-of-scope call once the process had been up 5 minutes."""
     monkeypatch.setattr(time, "monotonic", lambda: _FAR_FUTURE_MONOTONIC)
-    assert DETACHED.as_namespace(_ANY_TOOL)["elapsed_s"] == 0.0
+    assert DETACHED.as_namespace()["elapsed_s"] == 0.0
 
 
 def test_get_run_facts_is_never_none() -> None:
@@ -183,7 +246,7 @@ def test_facts_outlive_their_scope_when_referenced() -> None:
 
 @pytest.mark.asyncio
 async def test_scope_survives_async_generator_finalizer() -> None:
-    """``_install`` restores by ``set()`` rather than ``reset(token)``: an
+    """``use_run_facts`` restores by ``set()`` rather than ``reset(token)``: an
     async-generator finalizer runs in a different Context, where a token reset
     raises ValueError. Three run entry points are async generators."""
 
@@ -259,7 +322,7 @@ def test_raw_thread_is_detached() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_record_execution_updates_calls_and_tool_set() -> None:
+def test_record_execution_counts_per_tool() -> None:
     with run_scope("a") as facts:
         facts.record_execution(_ANY_TOOL)
         facts.record_execution(_OTHER_TOOL)
@@ -267,14 +330,17 @@ def test_record_execution_updates_calls_and_tool_set() -> None:
 
         assert facts.tool_calls == 3
         assert facts._calls_by_tool == {_ANY_TOOL: 2, _OTHER_TOOL: 1}
-        assert list(facts._tools_used) == [_ANY_TOOL, _OTHER_TOOL]
 
 
-def test_tools_used_is_first_use_order_deduplicated() -> None:
+def test_calls_by_tool_is_the_first_use_ordered_tool_set() -> None:
+    """Why there is no separate ``tools_used`` field: a dict preserves
+    insertion order and an update to an existing key does not reorder it, so
+    the keys already are the deduplicated first-use sequence ``run.tools_used``
+    will project."""
     with run_scope("a") as facts:
         for tool in (_OTHER_TOOL, _ANY_TOOL, _OTHER_TOOL):
             facts.record_execution(tool)
-        assert list(facts._tools_used) == [_OTHER_TOOL, _ANY_TOOL]
+        assert list(facts._calls_by_tool) == [_OTHER_TOOL, _ANY_TOOL]
 
 
 def test_each_recorder_touches_only_its_own_counter() -> None:
@@ -301,17 +367,26 @@ def test_each_recorder_touches_only_its_own_counter() -> None:
 
 
 def test_counters_are_monotone_under_random_recording() -> None:
-    """Every scalar is non-decreasing within a run — the property that makes a
-    ``<`` predicate latch instead of flapping."""
+    """Every counter is non-decreasing within a run — the property that makes a
+    ``<`` predicate latch instead of flapping.
+
+    Asserted on the fields rather than the projection: the counters are not
+    projected yet, and the field is where the invariant actually lives. Both
+    the field set and the recorder set are discovered, so a counter added later
+    is covered without editing this test.
+    """
     rng = random.Random(_FUZZ_SEED)
     with run_scope("a") as facts:
-        previous = facts.as_namespace(_ANY_TOOL)
+        previous = _mutable_state(facts)
         for _ in range(_FUZZ_STEPS):
             rng.choice(_recorders(facts))()
-            current = facts.as_namespace(_ANY_TOOL)
-            for path in SCALAR_PATHS:
-                if isinstance(current[path], (int, float)):
-                    assert current[path] >= previous[path], path
+            current = _mutable_state(facts)
+            for name, value in current.items():
+                if isinstance(value, int):
+                    assert value >= previous[name], name
+                elif isinstance(value, dict):
+                    for key, count in value.items():
+                        assert count >= previous[name].get(key, 0), f"{name}.{key}"
             previous = current
 
 
@@ -319,18 +394,13 @@ def test_as_namespace_returns_only_registered_paths() -> None:
     """The structural half of the release gate: a path a policy can reference
     is always one this SDK maintains, independent of the load-time linter."""
     with run_scope("a") as facts:
-        assert set(facts.as_namespace(_ANY_TOOL)) == KNOWN_RUN_PATHS
-    assert set(DETACHED.as_namespace(_ANY_TOOL)) == KNOWN_RUN_PATHS
-
-
-def test_registry_is_scalars_plus_lists() -> None:
-    assert KNOWN_RUN_PATHS == SCALAR_PATHS | LIST_PATHS
-    assert not SCALAR_PATHS & LIST_PATHS
+        assert set(facts.as_namespace()) == KNOWN_RUN_PATHS
+    assert set(DETACHED.as_namespace()) == KNOWN_RUN_PATHS
 
 
 def test_as_namespace_exposes_identity_and_elapsed() -> None:
     with run_scope("billing") as facts:
-        namespace = facts.as_namespace(_ANY_TOOL)
+        namespace = facts.as_namespace()
         assert namespace["id"] == facts.id
         assert namespace["agent"] == "billing"
         assert namespace["elapsed_s"] >= 0.0
@@ -345,7 +415,7 @@ def test_elapsed_derives_from_the_monotonic_clock(
     monkeypatch.setattr(time, "monotonic", lambda: next(clock))
 
     with run_scope("a") as facts:  # consumes 100.0 as the origin
-        assert facts.as_namespace(_ANY_TOOL)["elapsed_s"] == pytest.approx(42.5)
+        assert facts.as_namespace()["elapsed_s"] == pytest.approx(42.5)
 
 
 # ---------------------------------------------------------------------------
@@ -374,11 +444,11 @@ def test_parallel_recorders_do_not_lose_increments() -> None:
         assert facts._calls_by_tool[_ANY_TOOL] == _WRITERS * _WRITES_EACH
 
 
-def test_as_namespace_snapshot_is_internally_consistent() -> None:
-    """Why the read takes the lock: without it a concurrent
-    ``record_llm_usage`` is observable half-applied and ``total_tokens`` would
-    not equal its own parts. Asserted on the full fact dict, since the derived
-    total is not a registered path yet."""
+def test_llm_usage_is_applied_atomically() -> None:
+    """Both token counters move together or not at all.
+
+    This is the invariant that will make the projected ``total_tokens`` equal
+    its own parts, and the reason :meth:`as_namespace` reads under the lock."""
     with run_scope("a") as facts:
         stop = threading.Event()
 

--- a/tests/runtime/test_run_scope_behaviour.py
+++ b/tests/runtime/test_run_scope_behaviour.py
@@ -1,13 +1,11 @@
 """Behavioural companion to ``test_run_scope_coverage``.
 
-The coverage tests assert a ``run_scope(`` call exists in the right place.
-These assert what it *does* when an adapter actually runs: one run id per
-invocation, a fresh one next time, none at all when the run was refused, and
-none on the entry points that deliberately bypass the wrapper.
+Where those assert a ``run_scope(`` call exists, these assert what it does when an
+adapter runs: one run id per invocation, a fresh one next time, none when the run
+was refused, none on the entry points that bypass the wrapper.
 
-Uses the langchain proxy because it needs no framework fixture — a recording
-stand-in for the compiled graph is enough, and the graph body runs in the same
-context a guarded tool would.
+Uses the langchain proxy since it needs no framework fixture — a recording graph
+stand-in runs in the same context a guarded tool would.
 """
 
 from __future__ import annotations
@@ -30,11 +28,8 @@ def _context() -> HexgateContext:
 
 
 class _FactsRecordingGraph:
-    """Stands in for the compiled graph, capturing the run facts it ran under.
-
-    A guarded tool would see exactly this — the graph body executes inside the
-    scope the proxy opened.
-    """
+    """Stands in for the compiled graph, capturing the facts it ran under — what a
+    guarded tool would see, since the body runs inside the proxy's scope."""
 
     name = "facts-recording-graph"
 
@@ -143,8 +138,7 @@ def test_each_invocation_gets_a_distinct_run_id() -> None:
 
 
 def test_streaming_keeps_one_run_across_chunks() -> None:
-    """Every chunk of one stream belongs to the same run — a per-chunk id would
-    mean a cap reset itself mid-stream."""
+    """One run across every chunk; a per-chunk id would reset a cap mid-stream."""
     graph = _FactsRecordingGraph()
     list(_proxy(graph).stream({"messages": []}, hexgate_context=_context()))
 
@@ -171,8 +165,7 @@ def test_scope_closes_after_the_invocation() -> None:
 
 
 def test_ban_refusal_opens_no_scope() -> None:
-    """A refused invocation is not a run: the ban gate fires before the scope,
-    so nothing runs and no facts are minted."""
+    """A refused invocation is not a run: nothing runs, no facts are minted."""
     graph = _FactsRecordingGraph()
     proxy = _proxy(graph, ban_gate=_banning_gate())
 
@@ -184,9 +177,8 @@ def test_ban_refusal_opens_no_scope() -> None:
 
 
 def test_bypassed_methods_run_detached() -> None:
-    """``batch`` reaches the wrapped graph through ``__getattr__``, so it gets
-    neither the ban gate nor a run scope. Documented, not fixed — pinned here so
-    the bypass stays known."""
+    """``batch`` reaches the graph through ``__getattr__``, so it gets neither the
+    ban gate nor a scope. Pinned so the bypass stays known."""
     graph = _FactsRecordingGraph()
     _proxy(graph).batch([{"messages": []}])
 

--- a/tests/runtime/test_run_scope_behaviour.py
+++ b/tests/runtime/test_run_scope_behaviour.py
@@ -1,0 +1,196 @@
+"""Behavioural companion to ``test_run_scope_coverage``.
+
+The coverage tests assert a ``run_scope(`` call exists in the right place.
+These assert what it *does* when an adapter actually runs: one run id per
+invocation, a fresh one next time, none at all when the run was refused, and
+none on the entry points that deliberately bypass the wrapper.
+
+Uses the langchain proxy because it needs no framework fixture — a recording
+stand-in for the compiled graph is enough, and the graph body runs in the same
+context a guarded tool would.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Iterator
+
+import pytest
+
+from hexgate.adapters.langchain.agent import HexgateLangchainAgent
+from hexgate.runtime import HexgateContext
+from hexgate.runtime.run_facts import DETACHED, get_run_facts
+from hexgate.security.bans import BanEntry, BanGate, BanSet
+from hexgate.security.errors import AgentBannedError
+
+_AGENT_NAME = "run-scope-probe"
+
+
+def _context() -> HexgateContext:
+    return HexgateContext(user_id="u-1", session_id="s-1", user_roles=["developer"])
+
+
+class _FactsRecordingGraph:
+    """Stands in for the compiled graph, capturing the run facts it ran under.
+
+    A guarded tool would see exactly this — the graph body executes inside the
+    scope the proxy opened.
+    """
+
+    name = "facts-recording-graph"
+
+    def __init__(self) -> None:
+        self.seen: list[tuple[str, str, str]] = []
+
+    def _capture(self, method: str) -> None:
+        facts = get_run_facts()
+        self.seen.append((method, facts.id, facts.agent))
+
+    @property
+    def run_ids(self) -> list[str]:
+        return [run_id for _, run_id, _ in self.seen]
+
+    def invoke(self, payload: dict[str, Any], config: Any, **_: Any) -> dict[str, Any]:
+        self._capture("invoke")
+        return {"messages": ["ok"]}
+
+    async def ainvoke(
+        self, payload: dict[str, Any], config: Any, **_: Any
+    ) -> dict[str, Any]:
+        self._capture("ainvoke")
+        return {"messages": ["ok"]}
+
+    def stream(
+        self, payload: dict[str, Any], config: Any, **_: Any
+    ) -> Iterator[dict[str, Any]]:
+        self._capture("stream")
+        yield {"chunk": 1}
+        self._capture("stream")
+        yield {"chunk": 2}
+
+    async def astream(
+        self, payload: dict[str, Any], config: Any, **_: Any
+    ) -> AsyncIterator[dict[str, Any]]:
+        self._capture("astream")
+        yield {"chunk": 1}
+        self._capture("astream")
+        yield {"chunk": 2}
+
+    def batch(self, payloads: list[dict[str, Any]], **_: Any) -> list[dict[str, Any]]:
+        """Reached through ``__getattr__`` — deliberately unwrapped."""
+        self._capture("batch")
+        return [{"messages": ["ok"]}]
+
+
+def _proxy(graph: _FactsRecordingGraph, ban_gate: BanGate | None = None):
+    return HexgateLangchainAgent(
+        agent=graph,
+        api_key="k",
+        tool_names=[],
+        agent_name=_AGENT_NAME,
+        ban_gate=ban_gate,
+    )
+
+
+def _banning_gate() -> BanGate:
+    entry = BanEntry(
+        ban_id="b1",
+        ban_type="agent",
+        target_agent_name=_AGENT_NAME,
+        target_user_id=None,
+        reason="disabled",
+    )
+    return BanGate(_AGENT_NAME, _StaticBanSource(BanSet({_AGENT_NAME: entry}, {})))
+
+
+class _StaticBanSource:
+    def __init__(self, bans: BanSet) -> None:
+        self._bans = bans
+
+    def fetch(self) -> BanSet:
+        return self._bans
+
+
+def test_sync_invocation_runs_under_a_named_run() -> None:
+    graph = _FactsRecordingGraph()
+    _proxy(graph).invoke({"messages": []}, hexgate_context=_context())
+
+    ((method, run_id, agent),) = graph.seen
+    assert method == "invoke"
+    assert run_id  # a real id, not the detached ""
+    assert agent == _AGENT_NAME
+
+
+@pytest.mark.asyncio
+async def test_async_invocation_runs_under_a_named_run() -> None:
+    graph = _FactsRecordingGraph()
+    await _proxy(graph).ainvoke({"messages": []}, hexgate_context=_context())
+
+    assert graph.seen[0][0] == "ainvoke"
+    assert graph.run_ids[0]
+
+
+def test_each_invocation_gets_a_distinct_run_id() -> None:
+    """Catches a scope opened once at construction instead of per call."""
+    graph = _FactsRecordingGraph()
+    proxy = _proxy(graph)
+
+    proxy.invoke({"messages": []}, hexgate_context=_context())
+    proxy.invoke({"messages": []}, hexgate_context=_context())
+
+    first, second = graph.run_ids
+    assert first and second
+    assert first != second
+
+
+def test_streaming_keeps_one_run_across_chunks() -> None:
+    """Every chunk of one stream belongs to the same run — a per-chunk id would
+    mean a cap reset itself mid-stream."""
+    graph = _FactsRecordingGraph()
+    list(_proxy(graph).stream({"messages": []}, hexgate_context=_context()))
+
+    assert len(graph.run_ids) == 2
+    assert len(set(graph.run_ids)) == 1
+    assert graph.run_ids[0]
+
+
+@pytest.mark.asyncio
+async def test_async_streaming_keeps_one_run_across_chunks() -> None:
+    graph = _FactsRecordingGraph()
+    proxy = _proxy(graph)
+    async for _ in proxy.astream({"messages": []}, hexgate_context=_context()):
+        pass
+
+    assert len(set(graph.run_ids)) == 1
+    assert graph.run_ids[0]
+
+
+def test_scope_closes_after_the_invocation() -> None:
+    graph = _FactsRecordingGraph()
+    _proxy(graph).invoke({"messages": []}, hexgate_context=_context())
+    assert get_run_facts() is DETACHED
+
+
+def test_ban_refusal_opens_no_scope() -> None:
+    """A refused invocation is not a run: the ban gate fires before the scope,
+    so nothing runs and no facts are minted."""
+    graph = _FactsRecordingGraph()
+    proxy = _proxy(graph, ban_gate=_banning_gate())
+
+    with pytest.raises(AgentBannedError):
+        proxy.invoke({"messages": []}, hexgate_context=_context())
+
+    assert graph.seen == []
+    assert get_run_facts() is DETACHED
+
+
+def test_bypassed_methods_run_detached() -> None:
+    """``batch`` reaches the wrapped graph through ``__getattr__``, so it gets
+    neither the ban gate nor a run scope. Documented, not fixed — pinned here so
+    the bypass stays known."""
+    graph = _FactsRecordingGraph()
+    _proxy(graph).batch([{"messages": []}])
+
+    ((method, run_id, agent),) = graph.seen
+    assert method == "batch"
+    assert run_id == ""  # DETACHED
+    assert agent == ""

--- a/tests/runtime/test_run_scope_coverage.py
+++ b/tests/runtime/test_run_scope_coverage.py
@@ -1,19 +1,13 @@
 """Every run entry point must open a ``run_scope``.
 
-A missed boundary is a *silent fail-open*, not a loud failure: outside a scope
-``get_run_facts()`` returns ``DETACHED``, which reads zeros, so a policy
-carrying ``run.tool_calls < 20`` would pass forever. Nothing else in the suite
-would notice.
+A missed boundary is a *silent fail-open*: outside a scope ``get_run_facts()``
+returns ``DETACHED``, which reads zeros, so ``run.tool_calls < 20`` would pass
+forever and nothing else in the suite would notice.
 
-So this file has two halves. :func:`_boundaries` **derives** the expected set
-from method signatures, which is what catches an entry point added later
-without a scope. ``SCOPE_SITES`` then pins where each one opens it, since some
-boundaries delegate to a helper and the native ambient path has no
-``hexgate_context`` parameter to derive from.
-
-The source-text assertions are deliberate. A behavioural equivalent needs a
-live agent fixture per framework, and the thing being guarded against is a
-line of code that is missing.
+Hence two halves: :func:`_boundaries` derives the expected set from method
+signatures, catching an entry point added later; ``SCOPE_SITES`` pins where each
+opens it. The source-text assertions are deliberate — what is guarded against is a
+missing line of code.
 """
 
 from __future__ import annotations
@@ -27,16 +21,13 @@ import pytest
 _CONTEXT_PARAM = "hexgate_context"
 _OPENS_SCOPE = "run_scope("
 _JOINS_SCOPE = "use_run_facts("
-# The langchain and pydantic_ai adapters delegate _abind/_bind to these shared
-# helpers (hexgate.adapters._common) rather than calling run_scope() inline —
-# see test_shared_bind_helpers_open_a_scope, which pins that abind/bind
-# themselves call run_scope(), so a per-site check on either spelling is
-# still sufficient.
+# langchain and pydantic_ai delegate _abind/_bind to these shared helpers instead
+# of calling run_scope() inline; test_shared_bind_helpers_open_a_scope pins that
+# the helpers do open one.
 _DELEGATES_TO_SHARED_BIND = ("abind(", "bind(")
 
-# The four framework adapters take the caller's HexgateContext explicitly, so
-# their run boundaries are derivable (see _boundaries). The native HexgateAgent
-# is ambient — it reads the contextvar — so it is listed but excluded there.
+# These four take the caller's HexgateContext explicitly, so their boundaries are
+# derivable. The native HexgateAgent is ambient, so it is pinned but not derived.
 _DERIVABLE = [
     ("hexgate.adapters.langchain.agent", "HexgateLangchainAgent"),
     ("hexgate.adapters.openai.runner", "HexgateRunner"),
@@ -85,10 +76,8 @@ def _load(module_name: str, class_name: str) -> Any:
 
 def _boundaries(cls: type) -> set[str]:
     """Public methods taking a ``hexgate_context`` keyword — i.e. run boundaries.
-
-    Derived rather than listed so that adding an entry point without wiring a
-    scope fails, instead of quietly passing because nobody updated a constant.
-    """
+    Derived, not listed, so a new entry point cannot pass by nobody updating a
+    constant."""
     found: set[str] = set()
     for name, member in inspect.getmembers(cls, callable):
         if name.startswith("_"):
@@ -108,12 +97,9 @@ def _source_of(module_name: str, class_name: str, symbol: str) -> str:
 
 @pytest.mark.parametrize(("module_name", "class_name"), _DERIVABLE)
 def test_every_adapter_boundary_is_covered(module_name: str, class_name: str) -> None:
-    """The guard against a *future* unwired entry point.
-
-    If someone adds a run method taking ``hexgate_context`` and does not add it
-    to SCOPE_SITES, this fails — rather than the boundary silently running
-    detached, where every ``run.*`` cap reads zero and passes.
-    """
+    """The guard against a *future* unwired entry point: a new method taking
+    ``hexgate_context`` and missing from SCOPE_SITES fails here, rather than
+    silently running detached."""
     listed = {
         method
         for module, klass, method, _ in SCOPE_SITES
@@ -142,9 +128,8 @@ def test_scope_is_opened_for_every_boundary(
 
 
 def test_shared_bind_helpers_open_a_scope() -> None:
-    """Every boundary that delegates (``_DELEGATES_TO_SHARED_BIND`` above)
-    trusts that the helper it calls actually opens one. Pin that trust here,
-    once, instead of re-deriving it per call site."""
+    """Delegating boundaries trust the helper to open the scope; pin that once
+    here rather than per call site."""
     from hexgate.adapters import _common
 
     for name in ("abind", "bind"):
@@ -157,8 +142,7 @@ def test_shared_bind_helpers_open_a_scope() -> None:
 
 
 def test_scope_opens_after_the_ban_check() -> None:
-    """A refused invocation is not a run: the ban gate must fire before the
-    scope opens, or a banned caller mints run facts nothing ever reads."""
+    """A refused invocation is not a run, so the ban gate must fire first."""
     source = _source_of(
         "hexgate.adapters.langchain.agent", "HexgateLangchainAgent", "ainvoke"
     )
@@ -166,10 +150,9 @@ def test_scope_opens_after_the_ban_check() -> None:
 
 
 def test_run_streamed_rejoins_rather_than_mints() -> None:
-    """``Runner.run_streamed`` hands tools to a background task that snapshots
-    the contextvars, then returns. The consumer-side iterator has to re-bind
-    that same object; minting there would split one invocation across two run
-    ids, and every cap would read half the truth."""
+    """``run_streamed`` hands tools to a background task that snapshots the
+    contextvars, so the consumer-side iterator must re-bind the same object —
+    minting would split one invocation across two run ids."""
     source = _source_of(
         "hexgate.adapters.openai.runner", "HexgateRunner", "run_streamed"
     )
@@ -182,8 +165,7 @@ def test_run_streamed_rejoins_rather_than_mints() -> None:
 
 
 def test_run_sync_keeps_the_loop_drain_inside_the_scope() -> None:
-    """``_drain_default_loop`` exists to pump a late fire-and-forget audit or
-    usage send. Draining outside the scope would attribute those tokens to no
-    run at all."""
+    """The drain pumps a late fire-and-forget audit or usage send; outside the
+    scope those tokens would belong to no run."""
     source = _source_of("hexgate.adapters.openai.runner", "HexgateRunner", "run_sync")
     assert source.index(_OPENS_SCOPE) < source.index("_drain_default_loop()")

--- a/tests/runtime/test_run_scope_coverage.py
+++ b/tests/runtime/test_run_scope_coverage.py
@@ -27,6 +27,12 @@ import pytest
 _CONTEXT_PARAM = "hexgate_context"
 _OPENS_SCOPE = "run_scope("
 _JOINS_SCOPE = "use_run_facts("
+# The langchain and pydantic_ai adapters delegate _abind/_bind to these shared
+# helpers (hexgate.adapters._common) rather than calling run_scope() inline —
+# see test_shared_bind_helpers_open_a_scope, which pins that abind/bind
+# themselves call run_scope(), so a per-site check on either spelling is
+# still sufficient.
+_DELEGATES_TO_SHARED_BIND = ("abind(", "bind(")
 
 # The four framework adapters take the caller's HexgateContext explicitly, so
 # their run boundaries are derivable (see _boundaries). The native HexgateAgent
@@ -125,11 +131,29 @@ def test_scope_is_opened_for_every_boundary(
     module_name: str, class_name: str, method: str, symbol: str
 ) -> None:
     source = _source_of(module_name, class_name, symbol)
-    assert _OPENS_SCOPE in source, (
-        f"{module_name}.{class_name}.{method} does not open a run scope "
-        f"(expected it in {symbol!r}). An unscoped boundary reads DETACHED, "
-        f"so every run.* constraint silently passes."
+    opens_directly = _OPENS_SCOPE in source
+    delegates = any(marker in source for marker in _DELEGATES_TO_SHARED_BIND)
+    assert opens_directly or delegates, (
+        f"{module_name}.{class_name}.{method} does not open a run scope, "
+        f"directly or via the shared abind/bind helpers (expected it in "
+        f"{symbol!r}). An unscoped boundary reads DETACHED, so every run.* "
+        f"constraint silently passes."
     )
+
+
+def test_shared_bind_helpers_open_a_scope() -> None:
+    """Every boundary that delegates (``_DELEGATES_TO_SHARED_BIND`` above)
+    trusts that the helper it calls actually opens one. Pin that trust here,
+    once, instead of re-deriving it per call site."""
+    from hexgate.adapters import _common
+
+    for name in ("abind", "bind"):
+        source = inspect.getsource(getattr(_common, name))
+        assert _OPENS_SCOPE in source, (
+            f"hexgate.adapters._common.{name} no longer opens a run scope; "
+            f"every adapter boundary delegating to it would silently run "
+            f"detached."
+        )
 
 
 def test_scope_opens_after_the_ban_check() -> None:

--- a/tests/runtime/test_run_scope_coverage.py
+++ b/tests/runtime/test_run_scope_coverage.py
@@ -1,0 +1,165 @@
+"""Every run entry point must open a ``run_scope``.
+
+A missed boundary is a *silent fail-open*, not a loud failure: outside a scope
+``get_run_facts()`` returns ``DETACHED``, which reads zeros, so a policy
+carrying ``run.tool_calls < 20`` would pass forever. Nothing else in the suite
+would notice.
+
+So this file has two halves. :func:`_boundaries` **derives** the expected set
+from method signatures, which is what catches an entry point added later
+without a scope. ``SCOPE_SITES`` then pins where each one opens it, since some
+boundaries delegate to a helper and the native ambient path has no
+``hexgate_context`` parameter to derive from.
+
+The source-text assertions are deliberate. A behavioural equivalent needs a
+live agent fixture per framework, and the thing being guarded against is a
+line of code that is missing.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import Any
+
+import pytest
+
+_CONTEXT_PARAM = "hexgate_context"
+_OPENS_SCOPE = "run_scope("
+_JOINS_SCOPE = "use_run_facts("
+
+# The four framework adapters take the caller's HexgateContext explicitly, so
+# their run boundaries are derivable (see _boundaries). The native HexgateAgent
+# is ambient — it reads the contextvar — so it is listed but excluded there.
+_DERIVABLE = [
+    ("hexgate.adapters.langchain.agent", "HexgateLangchainAgent"),
+    ("hexgate.adapters.openai.runner", "HexgateRunner"),
+    ("hexgate.adapters.pydantic_ai.agent", "HexgatePydanticAgent"),
+    ("hexgate.adapters.google.runner", "HexgateRunner"),
+]
+
+# (module, class, run method, symbol that must open the scope). Keyed on
+# module *and* class because the OpenAI and Google adapters both export a
+# class named HexgateRunner. The symbol differs from the method wherever the
+# boundary delegates its scope to a shared helper.
+SCOPE_SITES: list[tuple[str, str, str, str]] = [
+    ("hexgate.adapters.langchain.agent", "HexgateLangchainAgent", "ainvoke", "_abind"),
+    ("hexgate.adapters.langchain.agent", "HexgateLangchainAgent", "invoke", "_bind"),
+    ("hexgate.adapters.langchain.agent", "HexgateLangchainAgent", "astream", "_abind"),
+    ("hexgate.adapters.langchain.agent", "HexgateLangchainAgent", "stream", "_bind"),
+    (
+        "hexgate.adapters.langchain.agent",
+        "HexgateLangchainAgent",
+        "astream_events",
+        "_abind",
+    ),
+    ("hexgate.adapters.openai.runner", "HexgateRunner", "run", "run"),
+    ("hexgate.adapters.openai.runner", "HexgateRunner", "run_sync", "run_sync"),
+    ("hexgate.adapters.openai.runner", "HexgateRunner", "run_streamed", "run_streamed"),
+    ("hexgate.adapters.pydantic_ai.agent", "HexgatePydanticAgent", "run", "_abind"),
+    ("hexgate.adapters.pydantic_ai.agent", "HexgatePydanticAgent", "run_sync", "_bind"),
+    (
+        "hexgate.adapters.pydantic_ai.agent",
+        "HexgatePydanticAgent",
+        "run_stream",
+        "_abind",
+    ),
+    ("hexgate.adapters.pydantic_ai.agent", "HexgatePydanticAgent", "iter", "_abind"),
+    ("hexgate.adapters.google.runner", "HexgateRunner", "run", "run"),
+    ("hexgate.adapters.google.runner", "HexgateRunner", "run_async", "run_async"),
+    # Ambient: no hexgate_context parameter, so _boundaries cannot derive these.
+    ("hexgate.agents.factory", "HexgateAgent", "ainvoke", "ainvoke"),
+    ("hexgate.agents.factory", "HexgateAgent", "astream_events", "astream_events"),
+]
+
+
+def _load(module_name: str, class_name: str) -> Any:
+    return getattr(importlib.import_module(module_name), class_name)
+
+
+def _boundaries(cls: type) -> set[str]:
+    """Public methods taking a ``hexgate_context`` keyword — i.e. run boundaries.
+
+    Derived rather than listed so that adding an entry point without wiring a
+    scope fails, instead of quietly passing because nobody updated a constant.
+    """
+    found: set[str] = set()
+    for name, member in inspect.getmembers(cls, callable):
+        if name.startswith("_"):
+            continue
+        try:
+            signature = inspect.signature(member)
+        except (TypeError, ValueError):  # pragma: no cover - builtins
+            continue
+        if _CONTEXT_PARAM in signature.parameters:
+            found.add(name)
+    return found
+
+
+def _source_of(module_name: str, class_name: str, symbol: str) -> str:
+    return inspect.getsource(getattr(_load(module_name, class_name), symbol))
+
+
+@pytest.mark.parametrize(("module_name", "class_name"), _DERIVABLE)
+def test_every_adapter_boundary_is_covered(module_name: str, class_name: str) -> None:
+    """The guard against a *future* unwired entry point.
+
+    If someone adds a run method taking ``hexgate_context`` and does not add it
+    to SCOPE_SITES, this fails — rather than the boundary silently running
+    detached, where every ``run.*`` cap reads zero and passes.
+    """
+    listed = {
+        method
+        for module, klass, method, _ in SCOPE_SITES
+        if (module, klass) == (module_name, class_name)
+    }
+    assert _boundaries(_load(module_name, class_name)) == listed
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name", "method", "symbol"),
+    SCOPE_SITES,
+    ids=[f"{m.rsplit('.', 1)[-1]}.{c}.{meth}" for m, c, meth, _ in SCOPE_SITES],
+)
+def test_scope_is_opened_for_every_boundary(
+    module_name: str, class_name: str, method: str, symbol: str
+) -> None:
+    source = _source_of(module_name, class_name, symbol)
+    assert _OPENS_SCOPE in source, (
+        f"{module_name}.{class_name}.{method} does not open a run scope "
+        f"(expected it in {symbol!r}). An unscoped boundary reads DETACHED, "
+        f"so every run.* constraint silently passes."
+    )
+
+
+def test_scope_opens_after_the_ban_check() -> None:
+    """A refused invocation is not a run: the ban gate must fire before the
+    scope opens, or a banned caller mints run facts nothing ever reads."""
+    source = _source_of(
+        "hexgate.adapters.langchain.agent", "HexgateLangchainAgent", "ainvoke"
+    )
+    assert source.index("_check_ban_async") < source.index("_abind")
+
+
+def test_run_streamed_rejoins_rather_than_mints() -> None:
+    """``Runner.run_streamed`` hands tools to a background task that snapshots
+    the contextvars, then returns. The consumer-side iterator has to re-bind
+    that same object; minting there would split one invocation across two run
+    ids, and every cap would read half the truth."""
+    source = _source_of(
+        "hexgate.adapters.openai.runner", "HexgateRunner", "run_streamed"
+    )
+    assert _OPENS_SCOPE in source
+    assert _JOINS_SCOPE in source
+    # The scope must wrap the run_streamed call itself, since that is where the
+    # background task snapshots the context.
+    assert source.index(_OPENS_SCOPE) < source.index("Runner.run_streamed(")
+    assert source.index("Runner.run_streamed(") < source.index(_JOINS_SCOPE)
+
+
+def test_run_sync_keeps_the_loop_drain_inside_the_scope() -> None:
+    """``_drain_default_loop`` exists to pump a late fire-and-forget audit or
+    usage send. Draining outside the scope would attribute those tokens to no
+    run at all."""
+    source = _source_of("hexgate.adapters.openai.runner", "HexgateRunner", "run_sync")
+    assert source.index(_OPENS_SCOPE) < source.index("_drain_default_loop()")


### PR DESCRIPTION
Foundation for `run.*` policy constraints (*block after K tool calls / Z seconds*). Adds the per-invocation fact record and opens a scope at every run boundary.

**No behaviour change** — nothing reads the contextvar yet; cost is one `uuid4()` + one `monotonic()` + two `ContextVar.set()` per invocation.

## Commits — review in order

| | |
|---|---|
| `d7e46e8` | `run_facts.py`: the `RunFacts` accumulator, `run_scope` / `use_run_facts`, `DETACHED`, path registry |
| `fa1555b` | Pure refactor — extract `_bind`/`_abind` on the langchain proxy, mirroring the pydantic_ai adapter. **No scope yet**; the 75 existing adapter tests pass untouched |
| `de29cca` | Wire `run_scope` at **11 sites / 16 entry points** (langchain 2, openai 3, pydantic_ai 2, google 2, factory 2) + coverage tests |
| `c7aa11d` | Simplification pass after self-review (−36 lines) |
| `9f9290c` | Rename `run.elapsed_s` → `run.elapsed_seconds` before release |

## Four decisions worth a look

**`DETACHED` drops writes.** A `ContextVar` default is *one process-wide object* — a plain zeroed instance would accumulate for the process lifetime until it exceeded every cap, then deny every tool call. Reads give zeros (fails open, correct for an unwired boundary); `run.id == ""` signals "decided outside a run".

**Scope is not in `HexgateContext.__aenter__`.** Tempting, since every adapter re-enters the context per call — but `HexgateAgent` (`factory.py`) is ambient, so a user's `async with HexgateContext(...)` around a loop of `ainvoke` calls would produce one `RunFacts` for all of them.

**`set()`, not `reset(token)`** in `use_run_facts` — same discipline and reason as `HexgateContext` (`context.py:125`): three entry points are async generators, whose finalizers run in a foreign `Context` where a token reset raises.

**`run_streamed` re-binds rather than mints.** `Runner.run_streamed` hands tools to a background task that snapshots the contextvars, then returns; the consumer-side iterator calls `use_run_facts(facts)` on the *same* object. Minting there would split one invocation across two run ids.

## Registry is `{id, agent, elapsed_seconds}`

`as_namespace()` returns **exactly** `KNOWN_RUN_PATHS`. Counters are accumulated and tested but deliberately **not projected**: a registered path with no writer reads a permanent zero, and `run.tool_calls < 20` against zero never fires — a fail-open cap shipped as a working feature. Each counter joins the registry and the projection together in the follow-up, with the test that reads it.

## Why `elapsed_seconds`, not `elapsed_s`

The unit in the name is load-bearing: the grammar rejects duration literals (`run.elapsed_seconds < 5m` → *"not a valid JSON literal"*), so a policy author writes a bare `300` and the field name is the only thing distinguishing seconds from milliseconds. `_s` was also the SDK's only single-letter unit suffix — `ttl_seconds` sits in the same module, alongside `timeout_seconds` and `call_timeout_seconds`, while `_ms` is reserved for the millisecond symbol. Renamed now because `run.*` paths are a public contract with policy authors.

## What guards what

Two reflective tests, both **verified by deliberately breaking them**:

- `test_run_scope_coverage.py` — derives expected boundaries from method signatures (a public method taking `hexgate_context`), so a *future* unwired entry point fails. Confirmed: removing one scope, and adding an unwired `abatch`, each fail.
- `test_run_facts.py` — discovers `record_*` methods reflectively and asserts each is a no-op on `DETACHED`. Confirmed: a sixth recorder without the guard fails both the behavioural and structural halves.

Plus `test_run_scope_behaviour.py`: one run id per invocation, fresh next time, none on a ban refusal, `DETACHED` on `__getattr__`-bypassed methods (`batch`).

## Not in scope

Engine threading, the `run` key in the constraint context, the load-time linter, and the recorder call sites — all follow-up. Egress is excluded by design: `egress_guard` is one-per-process with a fixed `HexgateContext`, so its decisions aren't inside any run and carry `run_id = ""` truthfully.

`make lint && make fmt-check && make coverage` → 2049 passed, 14 skipped. No existing test modified.
