### PR TITLE
feat(sdk): define otel span semconv, expose redaction pipeline

### DIFF
--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -141,6 +141,15 @@ def _truncate_json(payload: dict[str, Any], *, cap: int) -> dict[str, Any]:
         preview_bytes //= 2
 
 
+# Public aliases so server-side ingestion can import this pipeline instead of
+# keeping its own copy.
+redact = _redact
+truncate_json = _truncate_json
+bounded_violations = _bounded_violations
+SENSITIVE_ARG_KEY_RE = _SENSITIVE_ARG_KEY_RE
+SENSITIVE_ATTR_KEY_RE = _SENSITIVE_ATTR_KEY_RE
+
+
 @dataclass(frozen=True, slots=True)
 class AuditEvent:
     """Decision plus caller identity from the active HexgateContext scope.

--- a/hexgate/tracing/semconv.py
+++ b/hexgate/tracing/semconv.py
@@ -1,0 +1,75 @@
+"""Semantic conventions for Hexgate audit events carried as OTel spans.
+
+Single source of truth for the OTLP wire contract between the SDK's span
+emitter (future) and the platform's span-enricher job. Both sides import
+these names; neither hardcodes a string. String constants only — this
+module must stay importable with zero dependencies.
+
+Wire contract (normative — the enricher decodes by these rules, the emitter
+must produce by them):
+
+- One event = one span. The instrumentation scope name selects the event
+  type: ``SCOPE_AUDIT`` → DecisionEvent, ``SCOPE_USAGE`` → LlmInvocationEvent,
+  ``SCOPE_BANS`` → BanEnforcementEvent (platform schemas).
+- ``occurred_at`` travels as the span's ``start_time_unix_nano`` — the one
+  field OTLP already types as a timestamp. No separate attribute: a duplicate
+  would invite the two values disagreeing with no rule for which wins. These
+  are point-in-time events; the emitter sets start == end (or start ≈ end).
+  A zero start time is a rejected span.
+- ``event_id`` travels as the ``EVENT_ID`` string-UUID attribute, never as
+  span identity: ``span_id`` is 8 bytes and regenerates on a client retry,
+  so keying dedup on it would fail to collapse retries. ``EVENT_ID`` is the
+  ReplacingMergeTree idempotency key end-to-end.
+- ``project_id`` is NOT a span attribute. It is auth-derived by the
+  Collector's Biscuit extension and travels as the Kafka record key —
+  a self-declared project on the span body is never trusted.
+- List fields (``USER_ROLES``, ``VIOLATIONS``) are native OTLP string
+  arrays (AnyValue.array_value).
+- Dict fields (``HINT``, ``ARGUMENTS``, ``ATTRIBUTES``) are JSON-string
+  attributes, not kvlists and not flattened keys: their platform byte caps
+  are defined in serialized-JSON bytes, so a JSON string keeps the capped
+  quantity the measured quantity, and kvlist round-tripping is the least
+  supported AnyValue shape across third-party pipelines.
+- LLM usage reuses the official ``gen_ai.*`` names where they exist (model,
+  token counts) and never invents new ``gen_ai.*`` names; everything
+  Hexgate-specific lives under ``sec_ai.*``.
+"""
+
+from __future__ import annotations
+
+# --- Instrumentation scope names (one per event stream) -----------------------
+SCOPE_AUDIT = "hexgate.audit"
+SCOPE_USAGE = "hexgate.usage"
+SCOPE_BANS = "hexgate.bans"
+
+# --- Envelope attributes (all three scopes) -----------------------------------
+EVENT_ID = "sec_ai.event_id"
+AGENT_NAME = "sec_ai.agent_name"
+SESSION_ID = "sec_ai.session_id"
+USER_ID = "sec_ai.user_id"
+
+# --- Decision spans (SCOPE_AUDIT) ----------------------------------------------
+TOOL_NAME = "sec_ai.tool_name"
+OUTCOME = "sec_ai.outcome"
+USER_ROLES = "sec_ai.user_roles"
+DECIDING_ROLE = "sec_ai.deciding_role"
+ERROR_TYPE = "sec_ai.error_type"
+REASON = "sec_ai.reason"
+VIOLATIONS = "sec_ai.violations"
+HINT = "sec_ai.hint"
+ARGUMENTS = "sec_ai.arguments"
+ATTRIBUTES = "sec_ai.attributes"
+
+# --- LLM usage spans (SCOPE_USAGE) ----------------------------------------------
+# Official OTel GenAI semconv names — never coin new gen_ai.* names ourselves.
+GEN_AI_REQUEST_MODEL = "gen_ai.request.model"
+GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
+GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+# Hexgate-specific usage fields.
+LATENCY_MS = "sec_ai.latency_ms"
+STATUS = "sec_ai.status"
+ERROR_CODE = "sec_ai.error_code"
+
+# --- Ban enforcement spans (SCOPE_BANS) ------------------------------------------
+BAN_TYPE = "sec_ai.ban_type"
+BAN_ID = "sec_ai.ban_id"

--- a/tests/tracing/test_semconv.py
+++ b/tests/tracing/test_semconv.py
@@ -1,0 +1,45 @@
+"""Invariants of the OTel span wire contract (hexgate.tracing.semconv)."""
+
+from __future__ import annotations
+
+from hexgate.tracing import semconv
+
+_SCOPES = {"SCOPE_AUDIT", "SCOPE_USAGE", "SCOPE_BANS"}
+_GEN_AI = {
+    "GEN_AI_REQUEST_MODEL",
+    "GEN_AI_USAGE_INPUT_TOKENS",
+    "GEN_AI_USAGE_OUTPUT_TOKENS",
+}
+
+
+def _constants() -> dict[str, str]:
+    return {
+        name: value
+        for name, value in vars(semconv).items()
+        if not name.startswith("_") and isinstance(value, str)
+    }
+
+
+def test_when_all_values_are_collected_then_none_collide() -> None:
+    """Two constants sharing a wire string would silently merge two fields."""
+    values = list(_constants().values())
+    assert len(values) == len(set(values))
+
+
+def test_when_names_are_grouped_then_prefixes_match_their_namespace() -> None:
+    """Scopes name the emitting library; attributes name the shared vocabulary."""
+    for name, value in _constants().items():
+        if name in _SCOPES:
+            assert value.startswith("hexgate."), name
+        elif name in _GEN_AI:
+            assert value.startswith("gen_ai."), name
+        else:
+            assert value.startswith("sec_ai."), name
+
+
+def test_when_gen_ai_names_are_read_then_they_match_the_official_semconv() -> None:
+    """Inlined literals (not imported — see module docstring) must track the
+    official gen_ai convention verbatim."""
+    assert semconv.GEN_AI_REQUEST_MODEL == "gen_ai.request.model"
+    assert semconv.GEN_AI_USAGE_INPUT_TOKENS == "gen_ai.usage.input_tokens"
+    assert semconv.GEN_AI_USAGE_OUTPUT_TOKENS == "gen_ai.usage.output_tokens"


### PR DESCRIPTION
## What is Changing

- New `hexgate/tracing/semconv.py`: the OTLP wire contract for audit events carried as OTel spans — instrumentation scope names (`hexgate.audit` / `hexgate.usage` / `hexgate.bans`) and the `sec_ai.*` / `gen_ai.*` span attribute keys, with the contract rules (occurred_at = span start time, event_id as a string-UUID attribute, lists as native string arrays, dicts as JSON strings, project_id never on the span) documented in the module docstring.
- `hexgate/audit.py`: the redaction/truncation pipeline gains public names (`redact`, `truncate_json`, `bounded_violations`, the two sensitive-key regexes). Pure aliases — no behavior change.

## Why is this change necessary?

The upcoming span-enricher job (platform side) and the future SDK span emitter must agree byte-for-byte on scope names and attribute keys; this module is the single source both import, so neither hardcodes a string. The public aliases let server-side ingestion import the exact redaction/truncation rules instead of keeping its own copy that would drift. The `gen_ai.*` keys are inlined as literals rather than imported from `opentelemetry-semantic-conventions` because they only exist in its private `_incubating` namespace, which may rename them at any time — and these strings are a wire contract that must only change deliberately.

## Tests

- `tests/tracing/test_semconv.py` (new): no two constants share a wire string, prefixes match their namespace (scopes `hexgate.*`, vocabulary `sec_ai.*`, official keys `gen_ai.*`), and the inlined `gen_ai.*` literals match the official convention verbatim.
- Full SDK suite green: 1997 passed. `make lint && make fmt-check && make coverage` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)