### PR TITLE
feat(platform-api, dashboard): policy-module editor

### DIFF
--- a/platform/api/hexgate_api/core/ids.py
+++ b/platform/api/hexgate_api/core/ids.py
@@ -7,6 +7,7 @@ from hexgate_api.models import (
     AgentVersion,
     ApiKey,
     Ban,
+    PolicyFolder,
     PolicyModule,
     RoleBinding,
     Tool,
@@ -21,6 +22,7 @@ _ID_PREFIXES: dict[type, str] = {
     ApiKey: "tok",
     Ban: "ban",
     PolicyModule: "pmd",
+    PolicyFolder: "pfd",
     RoleBinding: "rbd",
 }
 

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -10,6 +10,7 @@ docs/adr/R-POL-002).
 
 from __future__ import annotations
 
+import json
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Response
@@ -25,6 +26,7 @@ from hexgate_api.schemas import (
     MoveModuleRequest,
     PolicyCheckResponse,
     PolicyDraft,
+    PolicyFolderRead,
     PolicyLintOut,
     PolicyModuleRead,
     PolicyModuleWrite,
@@ -216,6 +218,60 @@ async def api_delete_policy_module(
             raise HTTPException(status_code=404, detail="module not found")
         if await service.is_modular(session, project_id):
             await _recompile_project_agents(session, project_id)
+    return Response(status_code=204)
+
+
+# --- folders (persisted empty folders) ---------------------------------------
+# No recompile on folder writes: folders never reach resolve (they're not
+# modules), so they can't change any agent's enforced bundle.
+
+
+@router.get("/projects/{project_id}/policy-folders", tags=["policy"])
+async def api_list_policy_folders(
+    project_id: str,
+    _user: User = Depends(require_org_member),
+    session: AsyncSession = Depends(get_session),
+) -> list[PolicyFolderRead]:
+    """Persisted empty folders in the project's module library."""
+    rows = await service.list_folders(session, project_id)
+    return [PolicyFolderRead(tier=r.tier, path=r.path) for r in rows]
+
+
+@router.put("/projects/{project_id}/policy-folders/{tier}/{path:path}", tags=["policy"])
+async def api_put_policy_folder(
+    project_id: str,
+    tier: str,
+    path: str,
+    _membership: tuple[User, OrganizationMember] = Depends(require_project_admin),
+    session: AsyncSession = Depends(get_session),
+) -> PolicyFolderRead:
+    """Create an empty folder marker (idempotent). 422 if the tier is unknown."""
+    try:
+        row = await service.create_folder(
+            session, project_id=project_id, tier=tier, path=path
+        )
+    except service.InvalidModuleError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return PolicyFolderRead(tier=row.tier, path=row.path)
+
+
+@router.delete(
+    "/projects/{project_id}/policy-folders/{tier}/{path:path}",
+    status_code=204,
+    tags=["policy"],
+)
+async def api_delete_policy_folder(
+    project_id: str,
+    tier: str,
+    path: str,
+    _membership: tuple[User, OrganizationMember] = Depends(require_project_admin),
+    session: AsyncSession = Depends(get_session),
+) -> Response:
+    deleted = await service.delete_folder(
+        session, project_id=project_id, tier=tier, path=path
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="folder not found")
     return Response(status_code=204)
 
 
@@ -419,7 +475,9 @@ async def api_test_policy(
         outcome=_OUTCOME_WIRE.get(verdict.outcome.name, verdict.outcome.name.lower()),
         reason=verdict.reason,
         violations=[str(v) for v in (verdict.violations or [])],
-        hint=verdict.hint,
+        # Verdict.hint is a machine-readable dict (file-scope path hint); the wire
+        # field is a string, so serialize it rather than 500 on a dict.
+        hint=json.dumps(verdict.hint) if verdict.hint is not None else None,
     )
 
 

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -454,6 +454,7 @@ async def api_test_policy(
             session,
             project_id,
             role=body.role,
+            agent=body.agent,
             tool=body.tool,
             args=body.args,
             attributes=body.attributes,

--- a/platform/api/hexgate_api/features/policy_modules/router.py
+++ b/platform/api/hexgate_api/features/policy_modules/router.py
@@ -22,10 +22,16 @@ from hexgate_api.deps.project import require_project_admin
 from hexgate_api.features.policy_modules import service
 from hexgate_api.models import OrganizationMember, PolicyModule, User
 from hexgate_api.schemas import (
+    MoveModuleRequest,
     PolicyCheckResponse,
+    PolicyDraft,
     PolicyLintOut,
     PolicyModuleRead,
     PolicyModuleWrite,
+    PolicyPreviewRequest,
+    PolicyPreviewResponse,
+    PolicyTestRequest,
+    PolicyTestResponse,
     ResolvedPolicyResponse,
     RoleBindingsRead,
     RoleBindingsWrite,
@@ -44,6 +50,30 @@ def _norm(roles: dict[str, dict[str, list[str]]]) -> dict[str, dict[str, list[st
         role: {agent: sorted(caps) for agent, caps in cells.items()}
         for role, cells in roles.items()
     }
+
+
+def _lint_out(lint) -> PolicyLintOut:
+    return PolicyLintOut(
+        code=lint.code,
+        severity=lint.severity,
+        message=lint.message,
+        source=lint.source,
+        tier=lint.tier,
+        tool=lint.tool,
+        role=lint.role,
+    )
+
+
+def _unpack_draft(draft: PolicyDraft | None):
+    """PolicyDraft -> (draft_module tuple, draft_roles) for the service layer."""
+    if draft is None:
+        return None, None
+    module = (
+        (draft.module.tier, draft.module.path, draft.module.content)
+        if draft.module
+        else None
+    )
+    return module, draft.roles
 
 
 def _module_read(row: PolicyModule) -> PolicyModuleRead:
@@ -293,7 +323,12 @@ async def api_resolve_policy(
 
     try:
         result = await service.resolve(session, project_id, agent=agent)
-    except (LinkError, PolicySetError, ConstraintParseError) as exc:
+    except (
+        LinkError,
+        PolicySetError,
+        ConstraintParseError,
+        service.InvalidModuleError,
+    ) as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     if role is not None and role not in result.by_role:
@@ -315,17 +350,100 @@ async def api_check_policy(
     errors...). Diagnostics-as-data: always 200. ``ok`` is False if any lint is
     an error."""
     lints = await service.check(session, project_id)
-    out = [
-        PolicyLintOut(
-            code=lint.code,
-            severity=lint.severity,
-            message=lint.message,
-            source=lint.source,
-            tier=lint.tier,
-            tool=lint.tool,
-            role=lint.role,
-        )
-        for lint in lints
-    ]
     ok = not any(lint.severity == "error" for lint in lints)
-    return PolicyCheckResponse(ok=ok, lints=out)
+    return PolicyCheckResponse(ok=ok, lints=[_lint_out(x) for x in lints])
+
+
+# --- editor: preview, test, move (see policy-editor-plan.md) -----------------
+
+_OUTCOME_WIRE = {
+    "ALLOW": "allow",
+    "DENY": "deny",
+    "NEEDS_APPROVAL": "approval_required",
+}
+
+
+@router.post("/projects/{project_id}/policy/preview", tags=["policy"])
+async def api_preview_policy(
+    project_id: str,
+    body: PolicyPreviewRequest,
+    _user: User = Depends(require_org_member),
+    session: AsyncSession = Depends(get_session),
+) -> PolicyPreviewResponse:
+    """Resolve + lint the project with the editor's unsaved edit overlaid, without
+    writing. Powers the debounced live preview. Always 200 (diagnostics-as-data)."""
+    draft_module, draft_roles = _unpack_draft(body.draft)
+    resolved, lints = await service.preview(
+        session, project_id, draft_module=draft_module, draft_roles=draft_roles
+    )
+    return PolicyPreviewResponse(resolved=resolved, lints=[_lint_out(x) for x in lints])
+
+
+@router.post("/projects/{project_id}/policy/test", tags=["policy"])
+async def api_test_policy(
+    project_id: str,
+    body: PolicyTestRequest,
+    _user: User = Depends(require_org_member),
+    session: AsyncSession = Depends(get_session),
+) -> PolicyTestResponse:
+    """Evaluate one tool call against the whole resolved policy for a role — the
+    'would this be allowed?' probe. 422 if the modules don't compose; 404 for an
+    unknown role. Reflects the editor's unsaved edit via ``draft``."""
+    from hexgate.security import LinkError, PolicySetError
+    from hexgate.security.constraints import ConstraintParseError
+
+    draft_module, draft_roles = _unpack_draft(body.draft)
+    try:
+        verdict = await service.test_policy(
+            session,
+            project_id,
+            role=body.role,
+            tool=body.tool,
+            args=body.args,
+            attributes=body.attributes,
+            draft_module=draft_module,
+            draft_roles=draft_roles,
+        )
+    except service.InvalidModuleError as exc:
+        raise HTTPException(status_code=422, detail=f"draft is invalid: {exc}") from exc
+    except (LinkError, PolicySetError, ConstraintParseError) as exc:
+        raise HTTPException(
+            status_code=422, detail=f"policy does not compose: {exc}"
+        ) from exc
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"role {exc.args[0]!r} not defined"
+        ) from exc
+
+    return PolicyTestResponse(
+        outcome=_OUTCOME_WIRE.get(verdict.outcome.name, verdict.outcome.name.lower()),
+        reason=verdict.reason,
+        violations=[str(v) for v in (verdict.violations or [])],
+        hint=verdict.hint,
+    )
+
+
+@router.patch(
+    "/projects/{project_id}/policy-modules/{tier}/{path:path}", tags=["policy"]
+)
+async def api_move_policy_module(
+    project_id: str,
+    tier: str,
+    path: str,
+    body: MoveModuleRequest,
+    _membership: tuple[User, OrganizationMember] = Depends(require_project_admin),
+    session: AsyncSession = Depends(get_session),
+) -> PolicyModuleRead:
+    """Rename/move a module within its tier. A capability rename cascades to the
+    role bindings that imported it. 404 if absent, 409 if the target exists."""
+    try:
+        row = await service.move_module(
+            session, project_id=project_id, tier=tier, path=path, new_path=body.new_path
+        )
+    except service.ModulePathConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    if row is None:
+        raise HTTPException(status_code=404, detail="module not found")
+    if await service.is_modular(session, project_id):
+        await _recompile_project_agents(session, project_id)
+    return _module_read(row)

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -20,7 +20,7 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from hexgate_api.core.ids import new_id
-from hexgate_api.models import PolicyModule, RoleBinding, utcnow
+from hexgate_api.models import PolicyFolder, PolicyModule, RoleBinding, utcnow
 
 logger = logging.getLogger("hexgate.platform.policy_modules")
 
@@ -189,6 +189,75 @@ async def delete_module(
 ) -> bool:
     """Remove one module. Returns False if it didn't exist."""
     row = await _get_module(session, project_id, tier, path)
+    if row is None:
+        return False
+    await session.delete(row)
+    await session.commit()
+    return True
+
+
+# --- folders (persisted empty folders; see models.PolicyFolder) --------------
+# Folders are usually derived from module paths; these rows exist only to keep
+# an EMPTY folder visible before any module lands in it. They never reach
+# resolve/analyze (those read modules), so no recompile on folder writes.
+
+
+async def _get_folder(
+    session: AsyncSession, project_id: str, tier: str, path: str
+) -> PolicyFolder | None:
+    stmt = select(PolicyFolder).where(
+        PolicyFolder.project_id == project_id,
+        PolicyFolder.tier == tier,
+        PolicyFolder.path == path,
+    )
+    return (await session.exec(stmt)).first()
+
+
+async def list_folders(session: AsyncSession, project_id: str) -> list[PolicyFolder]:
+    """Every persisted empty folder in the project's library."""
+    stmt = (
+        select(PolicyFolder)
+        .where(PolicyFolder.project_id == project_id)
+        .order_by(PolicyFolder.tier, PolicyFolder.path)  # type: ignore[arg-type]
+    )
+    return list((await session.exec(stmt)).all())
+
+
+async def create_folder(
+    session: AsyncSession, *, project_id: str, tier: str, path: str
+) -> PolicyFolder:
+    """Create an empty folder marker. Idempotent: returns the existing row if
+    the folder is already present (so re-creating is a no-op, not a 409)."""
+    if tier not in VALID_TIERS:
+        raise InvalidModuleError(
+            f"unknown tier {tier!r} (expected one of {VALID_TIERS})"
+        )
+    existing = await _get_folder(session, project_id, tier, path)
+    if existing is not None:
+        return existing
+    row = PolicyFolder(
+        id=new_id(PolicyFolder), project_id=project_id, tier=tier, path=path
+    )
+    session.add(row)
+    try:
+        await session.commit()
+    except IntegrityError:
+        # A concurrent create won the unique constraint — return its row.
+        await session.rollback()
+        existing = await _get_folder(session, project_id, tier, path)
+        if existing is None:
+            raise
+        return existing
+    await session.refresh(row)
+    return row
+
+
+async def delete_folder(
+    session: AsyncSession, *, project_id: str, tier: str, path: str
+) -> bool:
+    """Remove an empty-folder marker. Returns False if it didn't exist. Modules
+    under the prefix (if any) are untouched — the folder then stays derived."""
+    row = await _get_folder(session, project_id, tier, path)
     if row is None:
         return False
     await session.delete(row)
@@ -606,6 +675,27 @@ async def _draft_inputs(
     stored path.
     """
     boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    return _overlay_draft(
+        boundaries,
+        capabilities,
+        roles,
+        draft_module=draft_module,
+        draft_roles=draft_roles,
+    )
+
+
+def _overlay_draft(
+    boundaries,
+    capabilities,
+    roles,
+    *,
+    draft_module: tuple[str, str, str] | None = None,
+    draft_roles: dict[str, list[str]] | None = None,
+):
+    """Overlay one unsaved edit onto resolved inputs — the draft-parse step,
+    split out so ``preview`` can attribute a *draft* parse failure to the draft,
+    not to a stored module that separately fails to load. Raises if the draft
+    module content doesn't parse/validate."""
     if draft_module is not None:
         tier, path, content = draft_module
         mc = _draft_module_content(tier, path, content)
@@ -639,10 +729,20 @@ async def preview(
     from hexgate.security.constraints import ConstraintParseError
 
     try:
-        boundaries, capabilities, roles = await _draft_inputs(
-            session, project_id, draft_module=draft_module, draft_roles=draft_roles
+        boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    except Exception as exc:  # noqa: BLE001 — a STORED module no longer parses
+        # Not the draft's fault — don't pin it to the edited file's path.
+        return {}, [PolicyLint("parse-error", "error", str(exc), source=None)]
+
+    try:
+        boundaries, capabilities, roles = _overlay_draft(
+            boundaries,
+            capabilities,
+            roles,
+            draft_module=draft_module,
+            draft_roles=draft_roles,
         )
-    except Exception as exc:  # noqa: BLE001 — a draft that doesn't parse is a lint
+    except Exception as exc:  # noqa: BLE001 — the draft itself doesn't parse
         src = draft_module[1] if draft_module else None
         return {}, [PolicyLint("parse-error", "error", str(exc), source=src)]
 

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -761,7 +761,7 @@ async def test_policy(
     *,
     role: str,
     tool: str,
-    agent: str = "main",
+    agent: str = DEFAULT_AGENT,
     args: dict,
     attributes: dict | None = None,
     draft_module: tuple[str, str, str] | None = None,
@@ -824,7 +824,11 @@ async def move_module(
                 # reassign (not in-place) so SQLAlchemy tracks the JSON change;
                 # rename the capability in every agent column that imports it.
                 b.capabilities = {
-                    agent: [new_path if c == path else c for c in caps]
+                    # dedupe (order-preserving): if a cell already imported
+                    # new_path, renaming path->new_path would double it.
+                    agent: list(
+                        dict.fromkeys(new_path if c == path else c for c in caps)
+                    )
                     for agent, caps in cells.items()
                 }
                 session.add(b)

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -40,32 +40,56 @@ class InvalidModuleError(Exception):
     """
 
 
-def _content_hash(content: str) -> str:
+def _hash_payload(payload) -> str:
     """sha256 of the module's canonical JSON — the SAME scheme the SDK loader
     uses (``hexgate.security.module_loader``), so a module authored on the
     platform and the same module loaded from a file hash identically regardless
     of YAML formatting. ``default=str`` matches the loader for scalars YAML can
     produce that JSON can't (e.g. an unquoted date)."""
-    payload = yaml.safe_load(content) or {}
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
-def _parse_policy(content: str):
-    """Parse a module's YAML into an AgentPolicy. The one place content is parsed,
-    shared by write-time validation and read-time ModuleContent building so they
-    can't drift."""
+def _content_hash(content: str) -> str:
+    """Parse raw YAML text and canonical-hash it."""
+    return _hash_payload(yaml.safe_load(content) or {})
+
+
+def _load(content: str):
+    """Parse a module's YAML once → ``(payload, AgentPolicy)``. Raises on invalid
+    YAML / schema; callers wrap into ``InvalidModuleError`` where a clean 4xx or a
+    lint is wanted, so the raw pydantic/YAML error never escapes as a 500."""
     from hexgate.security import AgentPolicy
 
-    return AgentPolicy.model_validate(yaml.safe_load(content) or {})
+    payload = yaml.safe_load(content) or {}
+    return payload, AgentPolicy.model_validate(payload)
 
 
-def _validate_policy_yaml(content: str) -> None:
-    """Reject content that isn't a valid AgentPolicy before it's stored."""
+def _parse_policy(content: str):
+    """Parse a module's YAML into an AgentPolicy (read paths that don't also need
+    the raw payload for hashing)."""
+    return _load(content)[1]
+
+
+def _validate_module(tier: str, path: str, content: str):
+    """Validate a module about to be stored — schema **and** tier semantics — and
+    return ``(payload, policy)`` so the caller hashes without re-parsing.
+
+    A capability that ``deny``s is rejected here (fail fast, clean 422) rather
+    than parsing cleanly and then poisoning the whole project's resolve via the
+    SDK's library-wide capability-deny check."""
     try:
-        _parse_policy(content)
+        payload, policy = _load(content)
     except Exception as exc:  # noqa: BLE001 — surface as a clean 422
         raise InvalidModuleError(f"module is not a valid policy: {exc}") from exc
+    if tier == "capability":
+        for tool, tp in policy.tools.items():
+            if tp.mode == "deny":
+                raise InvalidModuleError(
+                    f"capability {path!r} denies {tool!r}; capabilities may only "
+                    f"grant — move the deny to a boundary"
+                )
+    return payload, policy
 
 
 # --- module CRUD -------------------------------------------------------------
@@ -123,7 +147,8 @@ async def upsert_module(
         raise InvalidModuleError(
             f"unknown tier {tier!r} (expected one of {VALID_TIERS})"
         )
-    _validate_policy_yaml(content)
+    payload, _policy = _validate_module(tier, path, content)  # parses once
+    content_hash = _hash_payload(payload)
 
     existing = await _get_module(session, project_id, tier, path)
     if existing is None:
@@ -133,7 +158,7 @@ async def upsert_module(
             tier=tier,
             path=path,
             content=content,
-            content_hash=_content_hash(content),
+            content_hash=content_hash,
         )
         session.add(row)
         try:
@@ -151,7 +176,7 @@ async def upsert_module(
             return row
 
     existing.content = content
-    existing.content_hash = _content_hash(content)
+    existing.content_hash = content_hash
     existing.updated_at = utcnow()
     session.add(existing)
     await session.commit()
@@ -288,10 +313,20 @@ async def set_roles(
 def _to_module_content(row: PolicyModule):
     from hexgate.security import ModuleContent
 
+    # Modules are validated at write, but a stored one can still fail to parse
+    # after an SDK schema tightening or an out-of-band edit. Surface that as a
+    # clean InvalidModuleError (→ a lint on check, a 422 on resolve) rather than
+    # letting a raw pydantic error escape as a 500.
+    try:
+        policy = _parse_policy(row.content)
+    except Exception as exc:  # noqa: BLE001
+        raise InvalidModuleError(
+            f"stored module {row.tier}/{row.path} is invalid: {exc}"
+        ) from exc
     return ModuleContent(
         name=row.path,
         kind=row.tier,  # "boundary" | "capability" == LayerKind
-        policy=_parse_policy(row.content),
+        policy=policy,
         source=f"{row.tier}/{row.path}",
         content_hash=row.content_hash,
     )
@@ -339,11 +374,16 @@ async def resolve(session: AsyncSession, project_id: str, agent: str = DEFAULT_A
 
 
 async def check(session: AsyncSession, project_id: str):
-    """Lint the composed project. A hard link failure folds into a single
-    error lint inside the SDK, so this always returns a list."""
+    """Lint the composed project. Always returns a list: a hard link failure
+    folds into a link-error lint inside the SDK, and a stored module that no
+    longer parses becomes an ``invalid-module`` lint here — never a raise."""
     from hexgate.security import check_project
+    from hexgate.security.analyzer import PolicyLint
 
-    boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    try:
+        boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    except InvalidModuleError as exc:
+        return [PolicyLint("invalid-module", "error", str(exc))]
     return check_project(boundaries, capabilities, roles)
 
 
@@ -526,3 +566,167 @@ async def resolved_yaml_by_agent(
         result = resolve_for_project(boundaries, capabilities, roles, agent=agent)
         out[agent] = yaml.safe_dump({"roles": roles_json(result)}, sort_keys=False)
     return out
+
+
+# --- editor: preview, test, move (see policy-editor-plan.md) -----------------
+
+
+class ModulePathConflictError(Exception):
+    """A move/rename target path already exists in that tier. Routes -> HTTP 409."""
+
+
+def _draft_module_content(tier: str, path: str, content: str):
+    """A ModuleContent from an unsaved draft (hash recomputed, not stored)."""
+    from hexgate.security import ModuleContent
+
+    return ModuleContent(
+        name=path,
+        kind=tier,
+        policy=_parse_policy(content),  # raises on invalid YAML / schema
+        source=f"{tier}/{path}",
+        content_hash=_content_hash(content),
+    )
+
+
+async def _draft_inputs(
+    session: AsyncSession,
+    project_id: str,
+    *,
+    draft_module: tuple[str, str, str] | None = None,
+    draft_roles: RoleMatrixJson | dict[str, list[str]] | None = None,
+):
+    """:func:`_sdk_inputs` with an optional unsaved-edit overlay.
+
+    The editor edits one thing at a time, so at most one of ``draft_module``
+    ``(tier, path, content)`` or ``draft_roles`` is set. The overlaid module
+    replaces the stored one of the same ``(tier, path)`` (or is added if new);
+    ``draft_roles`` (the ``(role, agent)`` matrix, or a flat ``role: [caps]``)
+    replaces the stored bindings, collapsing ``{}`` to ``None`` so an emptied
+    ``roles.yaml`` behaves like "no bindings" (all-compose), consistent with the
+    stored path.
+    """
+    boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
+    if draft_module is not None:
+        tier, path, content = draft_module
+        mc = _draft_module_content(tier, path, content)
+        if tier == "boundary":
+            boundaries = [m for m in boundaries if m.name != path] + [mc]
+        else:
+            capabilities = [m for m in capabilities if m.name != path] + [mc]
+    if draft_roles is not None:
+        roles = _to_role_matrix({r: _normalize_cell(c) for r, c in draft_roles.items()})
+    return boundaries, capabilities, roles
+
+
+async def preview(
+    session: AsyncSession,
+    project_id: str,
+    *,
+    draft_module: tuple[str, str, str] | None = None,
+    draft_roles: dict[str, list[str]] | None = None,
+):
+    """Resolve + lint the project with an optional unsaved-edit overlay, without
+    writing. Returns ``(resolved_by_role, lints)`` — always, diagnostics-as-data:
+    a draft that won't parse or compose comes back as an error lint with an empty
+    resolution rather than raising."""
+    from hexgate.security import (
+        LinkError,
+        PolicySetError,
+        analyze_project,
+        resolve_for_project,
+    )
+    from hexgate.security.analyzer import PolicyLint
+    from hexgate.security.constraints import ConstraintParseError
+
+    try:
+        boundaries, capabilities, roles = await _draft_inputs(
+            session, project_id, draft_module=draft_module, draft_roles=draft_roles
+        )
+    except Exception as exc:  # noqa: BLE001 — a draft that doesn't parse is a lint
+        src = draft_module[1] if draft_module else None
+        return {}, [PolicyLint("parse-error", "error", str(exc), source=src)]
+
+    try:
+        result = resolve_for_project(boundaries, capabilities, roles)
+    except (LinkError, PolicySetError, ConstraintParseError) as exc:
+        return {}, [PolicyLint("link-error", "error", str(exc))]
+
+    lints = analyze_project(result, boundaries, capabilities, roles)
+    return roles_json(result), lints
+
+
+async def test_policy(
+    session: AsyncSession,
+    project_id: str,
+    *,
+    role: str,
+    tool: str,
+    args: dict,
+    attributes: dict | None = None,
+    draft_module: tuple[str, str, str] | None = None,
+    draft_roles: dict[str, list[str]] | None = None,
+):
+    """Evaluate one tool call against the whole resolved policy for ``role``.
+
+    Resolves the composed bundle (all boundaries + the role's capabilities), with
+    the same optional draft overlay as :func:`preview`, then runs the pydantic
+    engine. Returns the SDK ``Verdict``. Raises the SDK compose errors if the set
+    doesn't resolve, and ``KeyError`` (mapped to 404) for an unknown role.
+    """
+    from hexgate.security import resolve_for_project
+
+    boundaries, capabilities, roles = await _draft_inputs(
+        session, project_id, draft_module=draft_module, draft_roles=draft_roles
+    )
+    result = resolve_for_project(boundaries, capabilities, roles)
+    if role not in result.policy_set.roles:
+        raise KeyError(role)
+    return result.policy_set.evaluate(
+        role=role, tool=tool, args=dict(args), attributes=attributes
+    )
+
+
+async def move_module(
+    session: AsyncSession, *, project_id: str, tier: str, path: str, new_path: str
+) -> PolicyModule | None:
+    """Rename/move a module within its tier. Returns None if it doesn't exist.
+
+    A capability rename cascades to every role binding that imported it (roles
+    reference capabilities by name), all in one transaction, so a reorg never
+    leaves a dangling binding. Boundaries are not referenced by name, so no
+    cascade. Raises :class:`ModulePathConflictError` if ``new_path`` is taken.
+    """
+    row = await _get_module(session, project_id, tier, path)
+    if row is None:
+        return None
+    if new_path == path:
+        return row
+    if await _get_module(session, project_id, tier, new_path) is not None:
+        raise ModulePathConflictError(
+            f"a {tier} module {new_path!r} already exists in this project"
+        )
+
+    row.path = new_path
+    row.updated_at = utcnow()
+    session.add(row)
+
+    if tier == "capability":
+        bindings = (
+            await session.exec(
+                select(RoleBinding).where(RoleBinding.project_id == project_id)
+            )
+        ).all()
+        for b in bindings:
+            cells = _normalize_cell(b.capabilities)  # {agent: [caps]}
+            if any(path in caps for caps in cells.values()):
+                # reassign (not in-place) so SQLAlchemy tracks the JSON change;
+                # rename the capability in every agent column that imports it.
+                b.capabilities = {
+                    agent: [new_path if c == path else c for c in caps]
+                    for agent, caps in cells.items()
+                }
+                session.add(b)
+
+    await session.commit()
+    await session.refresh(row)
+    return row

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -761,24 +761,26 @@ async def test_policy(
     *,
     role: str,
     tool: str,
+    agent: str = "main",
     args: dict,
     attributes: dict | None = None,
     draft_module: tuple[str, str, str] | None = None,
-    draft_roles: dict[str, list[str]] | None = None,
+    draft_roles: RoleMatrixJson | dict[str, list[str]] | None = None,
 ):
-    """Evaluate one tool call against the whole resolved policy for ``role``.
+    """Evaluate one tool call against the resolved policy for ``role`` + ``agent``.
 
-    Resolves the composed bundle (all boundaries + the role's capabilities), with
-    the same optional draft overlay as :func:`preview`, then runs the pydantic
-    engine. Returns the SDK ``Verdict``. Raises the SDK compose errors if the set
-    doesn't resolve, and ``KeyError`` (mapped to 404) for an unknown role.
+    Resolves the executing ``agent``'s column of the ``(role, agent)`` matrix (all
+    boundaries + that cell's capabilities), with the same optional draft overlay
+    as :func:`preview`, then runs the pydantic engine. Returns the SDK ``Verdict``.
+    Raises the SDK compose errors if the set doesn't resolve, and ``KeyError``
+    (mapped to 404) for an unknown role.
     """
     from hexgate.security import resolve_for_project
 
     boundaries, capabilities, roles = await _draft_inputs(
         session, project_id, draft_module=draft_module, draft_roles=draft_roles
     )
-    result = resolve_for_project(boundaries, capabilities, roles)
+    result = resolve_for_project(boundaries, capabilities, roles, agent=agent)
     if role not in result.policy_set.roles:
         raise KeyError(role)
     return result.policy_set.evaluate(

--- a/platform/api/hexgate_api/features/policy_modules/service.py
+++ b/platform/api/hexgate_api/features/policy_modules/service.py
@@ -462,15 +462,17 @@ def compose_error_types() -> tuple[type[BaseException], ...]:
     The single source of truth shared by the write-time guard (:func:`resolves`)
     and the compile fail-safe (``agents.service``), so they can't drift on which
     errors fold to "keep the last-good bundle" versus escape as a 500 — the SDK
-    link/compose errors plus ``yaml.YAMLError`` / pydantic ``ValidationError``
-    from re-parsing a stored row. SDK imports stay lazy so this module loads
-    without the SDK."""
+    link/compose errors plus ``yaml.YAMLError`` / pydantic ``ValidationError``,
+    and ``InvalidModuleError`` (``_to_module_content`` wraps a stored row that no
+    longer parses in it). SDK imports stay lazy so this module loads without the
+    SDK."""
     from pydantic import ValidationError
 
     from hexgate.security import LinkError, PolicySetError
     from hexgate.security.constraints import ConstraintParseError
 
     return (
+        InvalidModuleError,
         LinkError,
         PolicySetError,
         ConstraintParseError,
@@ -551,10 +553,11 @@ async def resolves_with_module(
     edit (e.g. a capability with a deny) is rejected without a commit-then-rollback
     window a concurrent GET could observe.
 
-    Raises :class:`InvalidModuleError` if the content isn't a valid policy (the
-    caller maps that to 422); returns ``False`` only when the content is valid but
-    the project no longer composes with it (→ 409)."""
-    _validate_policy_yaml(content)  # → InvalidModuleError (422) on malformed content
+    Raises :class:`InvalidModuleError` if the content isn't a valid policy — or,
+    on this branch, a capability with a deny (the caller maps that to 422);
+    returns ``False`` only when the content is valid but the project no longer
+    composes with it (→ 409)."""
+    _validate_module(tier, path, content)  # → InvalidModuleError (422)
     try:
         boundaries, capabilities, roles = await _sdk_inputs(session, project_id)
         overlay = _draft_module_content(tier, path, content)

--- a/platform/api/hexgate_api/models.py
+++ b/platform/api/hexgate_api/models.py
@@ -369,6 +369,29 @@ class PolicyModule(SQLModel, table=True):
     )
 
 
+class PolicyFolder(SQLModel, table=True):
+    """A persisted empty folder in a project's module library.
+
+    Folders are normally *derived* from module paths (``team_a/payments`` implies
+    a ``team_a`` folder), so this row exists only to keep an **empty** folder
+    around before any module lands in it. Invisible to resolve/analyze — those
+    read modules, never folders. Unique per ``(project_id, tier, path)``.
+    """
+
+    __tablename__ = "policy_folder"
+    __table_args__ = (
+        UniqueConstraint("project_id", "tier", "path", name="uq_policy_folder_scope"),
+    )
+
+    id: str = Field(primary_key=True)  # new_id(PolicyFolder) -> "pfd_…"
+    project_id: str = Field(foreign_key="project.id", index=True)
+    tier: str = Field(index=True)  # "boundary" | "capability"
+    path: str  # the folder prefix, e.g. "team_a" or "team_a/payments"
+    updated_at: datetime = Field(
+        default_factory=utcnow, sa_type=DateTime(timezone=True)
+    )
+
+
 class RoleBinding(SQLModel, table=True):
     """A project role: the capabilities it imports, per executing agent.
 

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -413,6 +413,60 @@ class PolicyCheckResponse(BaseModel):
     lints: list[PolicyLintOut] = Field(default_factory=list)
 
 
+# --- Editor: preview, test, move (see policy-editor-plan.md) -----------------
+
+
+class PolicyModuleDraft(BaseModel):
+    """An unsaved edit of one module, overlaid before resolve/test."""
+
+    tier: str  # "boundary" | "capability"
+    path: str
+    content: str
+
+
+class PolicyDraft(BaseModel):
+    """The editor's unsaved state: one module OR the roles map (never both)."""
+
+    module: Optional[PolicyModuleDraft] = None
+    roles: Optional[dict[str, list[str]]] = None
+
+
+class PolicyPreviewRequest(BaseModel):
+    draft: Optional[PolicyDraft] = None
+
+
+class PolicyPreviewResponse(BaseModel):
+    """Resolved policy per role + lints for the (optionally draft-overlaid) project.
+
+    Always 200: an unresolvable or unparseable draft comes back with an empty
+    ``resolved`` and an error lint, so the editor renders it in place.
+    """
+
+    resolved: dict[str, dict] = Field(default_factory=dict)
+    lints: list[PolicyLintOut] = Field(default_factory=list)
+
+
+class PolicyTestRequest(BaseModel):
+    """A tool call to evaluate against the whole resolved policy for ``role``."""
+
+    role: str
+    tool: str
+    args: dict = Field(default_factory=dict)
+    attributes: Optional[dict] = None
+    draft: Optional[PolicyDraft] = None  # reflect an unsaved edit, like preview
+
+
+class PolicyTestResponse(BaseModel):
+    outcome: str  # "allow" | "deny" | "approval_required"
+    reason: Optional[str] = None
+    violations: list[str] = Field(default_factory=list)
+    hint: Optional[str] = None
+
+
+class MoveModuleRequest(BaseModel):
+    new_path: str
+
+
 # --- Agent manifest registration ---------------------------------------------
 # These mirror hexgate/manifest/models.py so SDK and platform stay in sync.
 

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -370,6 +370,13 @@ class PolicyModuleWrite(BaseModel):
     content: str
 
 
+class PolicyFolderRead(BaseModel):
+    """A persisted empty folder — tier + path prefix (see models.PolicyFolder)."""
+
+    tier: str
+    path: str
+
+
 class RoleBindingsRead(BaseModel):
     """A project's role bindings as the ``(role, agent)`` matrix:
     ``role -> agent-or-"*" -> capability names``. The ``"*"`` agent is the

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -457,7 +457,9 @@ class PolicyTestRequest(BaseModel):
     """A tool call to evaluate against the resolved policy for ``role`` + ``agent``."""
 
     role: str
-    agent: str = "main"  # the executing agent's column of the (role, agent) matrix
+    # The executing agent's column of the (role, agent) matrix; "*" (the generic
+    # column) by default, matching /policy/resolve, so the editor's panels agree.
+    agent: str = "*"
     tool: str
     args: dict = Field(default_factory=dict)
     attributes: Optional[dict] = None

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -454,9 +454,10 @@ class PolicyPreviewResponse(BaseModel):
 
 
 class PolicyTestRequest(BaseModel):
-    """A tool call to evaluate against the whole resolved policy for ``role``."""
+    """A tool call to evaluate against the resolved policy for ``role`` + ``agent``."""
 
     role: str
+    agent: str = "main"  # the executing agent's column of the (role, agent) matrix
     tool: str
     args: dict = Field(default_factory=dict)
     attributes: Optional[dict] = None

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -974,3 +974,161 @@ async def test_resolves_false_on_unparseable_stored_module(session_factory) -> N
         await pm.set_roles(s, project_id=proj.id, roles={"default": ["broken"]})
         await s.commit()
         assert await pm.resolves(s, proj.id) is False  # must not raise
+# --- editor endpoints: preview, test, move --------------------------------
+
+
+def test_preview_overlays_an_unsaved_draft(client: TestClient) -> None:
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)  # view_orders only
+    client.put(
+        f"/v1/projects/{pid}/policy-roles", json={"roles": {"default": ["read_only"]}}
+    )
+    # draft adds lookup_order to read_only, unsaved
+    draft = {
+        "module": {
+            "tier": "capability",
+            "path": "read_only",
+            "content": "tools:\n  view_orders: { mode: allow }\n  lookup_order: { mode: allow }\n",
+        }
+    }
+    body = client.post(
+        f"/v1/projects/{pid}/policy/preview", json={"draft": draft}
+    ).json()
+    tools = body["resolved"]["default"]["tools"]
+    assert "lookup_order" in tools  # reflects the draft, not the stored module
+    # stored resolve still doesn't have it
+    stored = client.get(f"/v1/projects/{pid}/policy/resolve").json()
+    assert "lookup_order" not in stored["roles"]["default"]["tools"]
+
+
+def test_preview_unparseable_draft_is_an_error_lint_not_500(client: TestClient) -> None:
+    pid = _project(client)
+    draft = {"module": {"tier": "capability", "path": "x", "content": "tools: [broken"}}
+    r = client.post(f"/v1/projects/{pid}/policy/preview", json={"draft": draft})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resolved"] == {}
+    assert any(lint["code"] == "parse-error" for lint in body["lints"])
+
+
+def test_test_policy_allow_then_deny(client: TestClient) -> None:
+    pid = _project(client)
+    _put_module(client, pid, "boundary", "org_core", BOUNDARY)  # refund <= 1000
+    _put_module(client, pid, "capability", "payments", PAYMENTS)  # refund allow
+    client.put(
+        f"/v1/projects/{pid}/policy-roles", json={"roles": {"billing": ["payments"]}}
+    )
+
+    allow = client.post(
+        f"/v1/projects/{pid}/policy/test",
+        json={"role": "billing", "tool": "refund_order", "args": {"amount": 800}},
+    ).json()
+    assert allow["outcome"] == "allow"
+
+    deny = client.post(
+        f"/v1/projects/{pid}/policy/test",
+        json={"role": "billing", "tool": "refund_order", "args": {"amount": 1500}},
+    ).json()
+    assert deny["outcome"] == "deny"
+    assert deny["reason"]  # explains why
+
+
+def test_test_policy_unknown_role_404(client: TestClient) -> None:
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    client.put(
+        f"/v1/projects/{pid}/policy-roles", json={"roles": {"default": ["read_only"]}}
+    )
+    r = client.post(
+        f"/v1/projects/{pid}/policy/test",
+        json={"role": "ghost", "tool": "view_orders", "args": {}},
+    )
+    assert r.status_code == 404
+
+
+def test_move_capability_cascades_to_role_bindings(client: TestClient) -> None:
+    pid = _project(client)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    client.put(
+        f"/v1/projects/{pid}/policy-roles", json={"roles": {"billing": ["read_only"]}}
+    )
+    r = client.patch(
+        f"/v1/projects/{pid}/policy-modules/capability/read_only",
+        json={"new_path": "team/read_only"},
+    )
+    assert r.status_code == 200, r.text
+    paths = {
+        (m["tier"], m["path"])
+        for m in client.get(f"/v1/projects/{pid}/policy-modules").json()
+    }
+    assert ("capability", "team/read_only") in paths
+    assert ("capability", "read_only") not in paths
+    # the binding followed the rename
+    roles = client.get(f"/v1/projects/{pid}/policy-roles").json()["roles"]
+    assert roles["billing"] == ["team/read_only"]
+
+
+def test_move_conflict_is_409(client: TestClient) -> None:
+    pid = _project(client)
+    _put_module(client, pid, "capability", "a", READ_ONLY)
+    _put_module(client, pid, "capability", "b", PAYMENTS)
+    r = client.patch(
+        f"/v1/projects/{pid}/policy-modules/capability/a", json={"new_path": "b"}
+    )
+    assert r.status_code == 409
+
+
+def test_move_missing_module_is_404(client: TestClient) -> None:
+    pid = _project(client)
+    r = client.patch(
+        f"/v1/projects/{pid}/policy-modules/capability/ghost", json={"new_path": "x"}
+    )
+    assert r.status_code == 404
+
+
+def test_capability_with_deny_rejected_at_write(client: TestClient) -> None:
+    # A capability that denies must fail fast at write (422), not save (200) and
+    # then poison the whole project's resolve via the SDK's library-wide check.
+    pid = _project(client)
+    r = client.put(
+        f"/v1/projects/{pid}/policy-modules/capability/bad",
+        json={"content": "tools:\n  x: { mode: deny }\n"},
+    )
+    assert r.status_code == 422
+    assert "deny" in r.json()["detail"].lower()
+
+
+async def test_stored_invalid_module_is_diagnostic_not_500(session_factory) -> None:
+    # A stored module that no longer parses (schema drift / out-of-band edit)
+    # must surface as an invalid-module lint on check and a 422-mapped error on
+    # resolve, never a raw 500.
+    import uuid
+
+    from hexgate_api.constants import DEFAULT_ORG_ID
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.features.policy_modules import service as pm
+    from hexgate_api.models import PolicyModule, Project
+
+    async with session_factory() as s:
+        proj = Project(
+            id=str(uuid.uuid4()),
+            org_id=DEFAULT_ORG_ID,
+            name=f"inv-{uuid.uuid4().hex[:8]}",
+        )
+        s.add(proj)
+        s.add(
+            PolicyModule(
+                id=new_id(PolicyModule),
+                project_id=proj.id,
+                tier="capability",
+                path="broken",
+                content="tools: {x: {mode: bogus}}",  # bad mode -> won't validate
+                content_hash="x",
+            )
+        )
+        await s.commit()
+
+        lints = await pm.check(s, proj.id)
+        assert any(lint.code == "invalid-module" for lint in lints)
+        with pytest.raises(pm.InvalidModuleError):
+            await pm.resolve(s, proj.id)

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -1132,3 +1132,78 @@ async def test_stored_invalid_module_is_diagnostic_not_500(session_factory) -> N
         assert any(lint.code == "invalid-module" for lint in lints)
         with pytest.raises(pm.InvalidModuleError):
             await pm.resolve(s, proj.id)
+
+
+def test_folder_crud_and_separate_from_modules(client: TestClient) -> None:
+    # Persisted empty folders live in their own table — create/list/delete, and
+    # they are NOT modules (so resolve/analyze never see them).
+    pid = _project(client)
+    r = client.put(f"/v1/projects/{pid}/policy-folders/capability/team_a")
+    assert r.status_code == 200, r.text
+    assert r.json() == {"tier": "capability", "path": "team_a"}
+    # idempotent create (no 409)
+    assert (
+        client.put(f"/v1/projects/{pid}/policy-folders/capability/team_a").status_code
+        == 200
+    )
+    assert client.get(f"/v1/projects/{pid}/policy-folders").json() == [
+        {"tier": "capability", "path": "team_a"}
+    ]
+    # a folder is not a module
+    assert client.get(f"/v1/projects/{pid}/policy-modules").json() == []
+    # delete, then 404 on the second delete
+    assert (
+        client.delete(
+            f"/v1/projects/{pid}/policy-folders/capability/team_a"
+        ).status_code
+        == 204
+    )
+    assert client.get(f"/v1/projects/{pid}/policy-folders").json() == []
+    assert (
+        client.delete(
+            f"/v1/projects/{pid}/policy-folders/capability/team_a"
+        ).status_code
+        == 404
+    )
+
+
+def test_folder_unknown_tier_is_422(client: TestClient) -> None:
+    pid = _project(client)
+    assert client.put(f"/v1/projects/{pid}/policy-folders/bogus/x").status_code == 422
+
+
+async def test_preview_stored_error_not_attributed_to_draft(session_factory) -> None:
+    # A broken STORED module surfaces with source=None on preview — it must NOT
+    # be pinned to the currently-edited (valid) draft's path.
+    import uuid
+
+    from hexgate_api.constants import DEFAULT_ORG_ID
+    from hexgate_api.core.ids import new_id
+    from hexgate_api.features.policy_modules import service as pm
+    from hexgate_api.models import PolicyModule, Project
+
+    async with session_factory() as s:
+        proj = Project(
+            id=str(uuid.uuid4()),
+            org_id=DEFAULT_ORG_ID,
+            name=f"pv-{uuid.uuid4().hex[:6]}",
+        )
+        s.add(proj)
+        s.add(
+            PolicyModule(
+                id=new_id(PolicyModule),
+                project_id=proj.id,
+                tier="capability",
+                path="broken",
+                content="tools: {x: {mode: bogus}}",  # invalid stored module
+                content_hash="x",
+            )
+        )
+        await s.commit()
+
+        resolved, lints = await pm.preview(
+            s, proj.id, draft_module=("capability", "team_a/new", "tools: {}\n")
+        )
+        assert resolved == {}
+        err = next(lint for lint in lints if lint.severity == "error")
+        assert err.source is None  # the stored module's fault, not the draft's

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -911,9 +911,10 @@ async def test_recompile_builds_distinct_bundles_per_agent(
 
 
 def test_capability_deny_put_rejected_on_modular_project(client: TestClient) -> None:
-    # PUT-ing a capability with a deny into a modular project must 409 (the linker
-    # rejects it at resolve), not store an uncomposable module that silently keeps
-    # agents on the old bundle.
+    # PUT-ing a capability with a deny must be rejected, not stored as an
+    # uncomposable module that silently keeps agents on the old bundle. This
+    # branch rejects it at WRITE time (422, `_validate_module`), earlier than the
+    # resolvability guard (409); either way it must not land.
     pid = _project(client)
     _put_module(client, pid, "capability", "read_only", READ_ONLY)
     assert (
@@ -927,8 +928,8 @@ def test_capability_deny_put_rejected_on_modular_project(client: TestClient) -> 
         f"/v1/projects/{pid}/policy-modules/capability/bad",
         json={"content": "tools:\n  x: { mode: deny }\n"},
     )
-    assert r.status_code == 409, r.text
-    # rolled back — the newly-created module was removed.
+    assert r.status_code in (422, 409), r.text
+    # not stored.
     paths = {
         (m["tier"], m["path"])
         for m in client.get(f"/v1/projects/{pid}/policy-modules").json()

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -960,6 +960,8 @@ async def test_resolves_false_on_unparseable_stored_module(session_factory) -> N
         await pm.set_roles(s, project_id=proj.id, roles={"default": ["broken"]})
         await s.commit()
         assert await pm.resolves(s, proj.id) is False  # must not raise
+
+
 # --- editor endpoints: preview, test, move --------------------------------
 
 
@@ -1193,3 +1195,35 @@ async def test_preview_stored_error_not_attributed_to_draft(session_factory) -> 
         assert resolved == {}
         err = next(lint for lint in lints if lint.severity == "error")
         assert err.source is None  # the stored module's fault, not the draft's
+
+
+def test_policy_test_evaluates_per_agent(client: TestClient) -> None:
+    # /policy/test resolves the EXECUTING agent's column: billing_bot (payments)
+    # allows a refund; an agent falling back to "*" (read_only) does not.
+    pid = _project(client)
+    _put_module(client, pid, "boundary", "org_core", BOUNDARY)
+    _put_module(client, pid, "capability", "read_only", READ_ONLY)
+    _put_module(client, pid, "capability", "payments", PAYMENTS)
+    assert (
+        client.put(
+            f"/v1/projects/{pid}/policy-roles",
+            json={
+                "roles": {
+                    "member": {
+                        "*": ["read_only"],
+                        "billing_bot": ["read_only", "payments"],
+                    }
+                }
+            },
+        ).status_code
+        == 200
+    )
+    call = {"role": "member", "tool": "refund_order", "args": {"amount": 500}}
+    billing = client.post(
+        f"/v1/projects/{pid}/policy/test", json={**call, "agent": "billing_bot"}
+    ).json()
+    assert billing["outcome"] == "allow"
+    generic = client.post(
+        f"/v1/projects/{pid}/policy/test", json={**call, "agent": "triage_bot"}
+    ).json()
+    assert generic["outcome"] == "deny"  # "*" -> read_only only, no refund grant

--- a/platform/api/tests/features/policy_modules/test_policy_modules.py
+++ b/platform/api/tests/features/policy_modules/test_policy_modules.py
@@ -159,20 +159,6 @@ def test_check_clean_bundle_is_ok(client: TestClient) -> None:
     assert all(lint["severity"] != "error" for lint in body["lints"])
 
 
-def test_capability_deny_is_link_error_on_check_and_422_on_resolve(
-    client: TestClient,
-) -> None:
-    pid = _project(client)
-    _put_module(client, pid, "capability", "bad", "tools:\n  x: { mode: deny }\n")
-    client.put(f"/v1/projects/{pid}/policy-roles", json={"roles": {"default": ["bad"]}})
-
-    check = client.get(f"/v1/projects/{pid}/policy/check").json()
-    assert check["ok"] is False
-    assert any(lint["code"] == "link-error" for lint in check["lints"])
-
-    assert client.get(f"/v1/projects/{pid}/policy/resolve").status_code == 422
-
-
 def test_invalid_content_and_tier_are_422(client: TestClient) -> None:
     pid = _project(client)
     # not a policy document
@@ -1063,9 +1049,9 @@ def test_move_capability_cascades_to_role_bindings(client: TestClient) -> None:
     }
     assert ("capability", "team/read_only") in paths
     assert ("capability", "read_only") not in paths
-    # the binding followed the rename
+    # the binding followed the rename (in the (role, agent) matrix)
     roles = client.get(f"/v1/projects/{pid}/policy-roles").json()["roles"]
-    assert roles["billing"] == ["team/read_only"]
+    assert roles["billing"] == {"*": ["team/read_only"]}
 
 
 def test_move_conflict_is_409(client: TestClient) -> None:

--- a/platform/dashboard/src/App.tsx
+++ b/platform/dashboard/src/App.tsx
@@ -13,6 +13,7 @@ import { OrgSettingsPage } from "@/routes/OrgSettings";
 import { OrgsPage } from "@/routes/Orgs";
 import { PlaygroundPage } from "@/routes/Playground";
 import { PoliciesPage } from "@/routes/Policies";
+import { PolicyModulesPage } from "@/routes/PolicyModules";
 import { ResetPasswordPage } from "@/routes/ResetPassword";
 import { SettingsPage } from "@/routes/Settings";
 import { SignInPage } from "@/routes/SignIn";
@@ -59,6 +60,7 @@ export default function App() {
           <Route index element={<Navigate to="/agents" replace />} />
           <Route path="agents" element={<AgentsPage />} />
           <Route path="policies" element={<PoliciesPage />} />
+          <Route path="policy-modules" element={<PolicyModulesPage />} />
           <Route path="graph" element={<GraphPage />} />
           <Route path="playground" element={<PlaygroundPage />} />
           <Route path="audit" element={<AuditPage />} />

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -10,6 +10,7 @@ import {
   LogOut,
   MessageSquareCode,
   Network,
+  PanelLeft,
   ScrollText,
   Settings2,
   ShieldCheck,
@@ -17,6 +18,14 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { OrgProjectSwitcher } from "@/components/OrgProjectSwitcher";
 import { PreviewBanner } from "@/components/PreviewBanner";
 import { VerifyEmailBanner } from "@/components/VerifyEmailBanner";
@@ -24,6 +33,7 @@ import { useActive } from "@/lib/active";
 import { useLogout, useUser } from "@/lib/auth";
 import { useOrgs } from "@/lib/orgs";
 import { useProjects } from "@/lib/projects";
+import { useUi } from "@/lib/ui";
 import { cn } from "@/lib/utils";
 
 /**
@@ -106,6 +116,7 @@ function NavItem({
   end,
   badge,
   status,
+  collapsed,
 }: {
   to: string;
   label: string;
@@ -113,14 +124,17 @@ function NavItem({
   end?: boolean;
   badge?: string;
   status?: string;
+  collapsed?: boolean;
 }) {
   return (
     <NavLink
       to={to}
       end={end}
+      title={collapsed ? label : undefined}
       className={({ isActive }) =>
         cn(
-          "flex h-9 items-center justify-between rounded-md px-3 text-sm transition-colors",
+          "flex h-9 items-center rounded-md text-sm transition-colors",
+          collapsed ? "justify-center px-0" : "justify-between px-2",
           isActive
             ? "bg-primary/15 text-primary font-medium"
             : "text-muted-foreground hover:bg-accent hover:text-foreground",
@@ -128,13 +142,13 @@ function NavItem({
       }
     >
       <span className="flex items-center gap-2.5">
-        <Icon className="size-4" />
-        {label}
+        <Icon className="size-4 shrink-0" />
+        {!collapsed && label}
       </span>
-      {badge && (
+      {!collapsed && badge && (
         <span className="text-[11px] text-muted-foreground">{badge}</span>
       )}
-      {status && (
+      {!collapsed && status && (
         <span className="rounded-full bg-allow/15 px-1.5 py-0.5 text-[10px] font-medium text-allow">
           {status}
         </span>
@@ -148,49 +162,72 @@ export function AppShell() {
   // shows something usable instead of "Pick an organization" empty
   // state. Idempotent — won't overwrite an existing valid selection.
   useActiveBootstrap();
+  const { sidebarCollapsed, toggleSidebar } = useUi();
+
+  // Cmd/Ctrl-B toggles the sidebar (standard editor shortcut). toggleSidebar is
+  // a stable zustand action, so this binds once.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {
+        e.preventDefault();
+        toggleSidebar();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [toggleSidebar]);
 
   return (
     <div className="flex h-screen bg-background text-foreground">
-      <aside className="flex w-[220px] flex-col border-r border-border bg-card">
-        <div className="flex h-14 items-center gap-2 px-4 border-b border-border">
-          <img src="/icon.svg" alt="" className="size-7" />
-          <span className="text-sm font-semibold">Hexgate</span>
+      <aside
+        className={cn(
+          // No hard right border — the card-vs-background shade separates the
+          // sidebar from the content (VSCode "shades, not rules"). The whole
+          // shell lives in the sidebar (switcher on top, account on the
+          // bottom) so the content column reclaims the old header's height.
+          "flex flex-col bg-card transition-[width] duration-200",
+          sidebarCollapsed ? "w-14" : "w-[240px]",
+        )}
+      >
+        {/* Top: project/org switcher (two lines) + the collapse toggle,
+            top-aligned so it sits level with the project line. */}
+        <div
+          className={cn(
+            "flex items-start gap-1 overflow-hidden py-2",
+            sidebarCollapsed ? "justify-center px-0" : "px-2",
+          )}
+        >
+          {!sidebarCollapsed && (
+            <div className="min-w-0 flex-1">
+              <OrgProjectSwitcher />
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0 text-muted-foreground"
+            title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            aria-label={
+              sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"
+            }
+            onClick={toggleSidebar}
+          >
+            <PanelLeft className="size-4" />
+          </Button>
         </div>
 
-        <nav className="flex-1 overflow-y-auto p-3 scrollbar-thin">
-          <div className="mb-4">
-            <div className="px-3 pb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-              Workspace
-            </div>
-            <div className="flex flex-col gap-0.5">
-              {workspaceLinks.map((l) => (
-                <NavItem key={l.to} {...l} />
-              ))}
-            </div>
+        <nav className="flex-1 overflow-y-auto px-2 py-2 scrollbar-thin">
+          <div className="flex flex-col gap-0.5">
+            {workspaceLinks.map((l) => (
+              <NavItem key={l.to} {...l} collapsed={sidebarCollapsed} />
+            ))}
           </div>
         </nav>
 
-        <div className="border-t border-border p-3 text-[11px] text-muted-foreground space-y-1">
-          <div className="flex items-center gap-1.5">
-            <span className="relative flex size-1.5">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-50" />
-              <span className="relative inline-flex size-1.5 rounded-full bg-primary" />
-            </span>
-            Serving bundle <span className="font-mono text-foreground">v1</span>
-          </div>
-          <div>Pushed just now</div>
-          <div>local · 1 region</div>
-        </div>
+        <AccountChip collapsed={sidebarCollapsed} />
       </aside>
 
       <div className="flex flex-1 flex-col">
-        <header className="flex h-14 items-center justify-between border-b border-border px-6">
-          <div className="flex items-center gap-3">
-            <OrgProjectSwitcher />
-          </div>
-          <UserMenu />
-        </header>
-
         <PreviewBanner />
         <VerifyEmailBanner />
 
@@ -202,40 +239,77 @@ export function AppShell() {
   );
 }
 
-/** Top-right corner: shows the signed-in user's initial + a sign-out
- * button. Phase 5 will replace this with a proper dropdown menu (and
- * an org switcher next to it); for now a flat layout is enough. */
-function UserMenu() {
+/**
+ * Bottom-of-sidebar account chip — the signed-in user, opening a menu
+ * upward with settings shortcuts and sign-out (OpenAI-style). The project
+ * and org now live in the top switcher, so this is purely the user's
+ * identity. When the sidebar is collapsed it shrinks to just the avatar.
+ */
+function AccountChip({ collapsed }: { collapsed: boolean }) {
   const { user } = useUser();
   const logout = useLogout();
   const navigate = useNavigate();
 
   if (!user) return null;
 
-  const initial = user.email.slice(0, 1).toUpperCase();
+  const username = user.email.split("@")[0] || user.email;
+  const initial = (user.email.slice(0, 1) || "?").toUpperCase();
 
   return (
-    <div className="flex items-center gap-3 text-muted-foreground">
-      <div className="flex items-center gap-2">
-        <span className="size-8 rounded-full bg-primary/20 text-primary grid place-items-center text-xs font-medium">
-          {initial}
-        </span>
-        <span className="hidden text-xs text-foreground sm:inline">
-          {user.email}
-        </span>
-      </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        title="Sign out"
-        disabled={logout.isPending}
-        onClick={async () => {
-          await logout.mutateAsync().catch(() => undefined);
-          navigate("/sign-in", { replace: true });
-        }}
-      >
-        <LogOut className="h-4 w-4" />
-      </Button>
+    <div className="p-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            title={collapsed ? user.email : undefined}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              collapsed && "justify-center",
+            )}
+          >
+            <span className="grid size-7 shrink-0 place-items-center rounded-full bg-primary/20 text-xs font-medium text-primary">
+              {initial}
+            </span>
+            {!collapsed && (
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">
+                  {username}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {user.email}
+                </span>
+              </span>
+            )}
+          </button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="start" side="top" className="min-w-[240px]">
+          <DropdownMenuLabel className="truncate text-xs font-normal text-muted-foreground">
+            {user.email}
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => navigate("/settings")}>
+            <Settings2 className="size-4" />
+            <span>Settings</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => navigate("/orgs")}>
+            <Building2 className="size-4" />
+            <span>Organizations</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={logout.isPending}
+            onSelect={async () => {
+              await logout.mutateAsync().catch(() => undefined);
+              navigate("/sign-in", { replace: true });
+            }}
+          >
+            <LogOut className="size-4" />
+            <span>Log out</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { useNavigate, NavLink, Outlet } from "react-router-dom";
 import {
   Ban,
   BarChart3,
+  Boxes,
   Building2,
   FileCode,
   KeyRound,
@@ -87,6 +88,7 @@ function useActiveBootstrap(): void {
 const workspaceLinks = [
   { to: "/agents", label: "Agents", icon: FileCode },
   { to: "/policies", label: "Policies", icon: ShieldCheck },
+  { to: "/policy-modules", label: "Modules", icon: Boxes },
   { to: "/graph", label: "Graph", icon: Network },
   { to: "/playground", label: "Playground", icon: MessageSquareCode },
   { to: "/audit", label: "Audit", icon: ScrollText },

--- a/platform/dashboard/src/components/OrgProjectSwitcher.tsx
+++ b/platform/dashboard/src/components/OrgProjectSwitcher.tsx
@@ -1,11 +1,5 @@
 import { useState } from "react";
-import {
-  Building2,
-  Check,
-  ChevronsUpDown,
-  FolderPlus,
-  Plus,
-} from "lucide-react";
+import { Check, ChevronsUpDown, FolderPlus, Plus } from "lucide-react";
 
 import { CreateOrgDialog } from "@/components/CreateOrgDialog";
 import { CreateProjectDialog } from "@/components/CreateProjectDialog";
@@ -23,10 +17,14 @@ import { useProjects, type ProjectRead } from "@/lib/projects";
 import { cn } from "@/lib/utils";
 
 /**
- * The pill that lives in the AppShell header. Reads the active org +
+ * The workspace switcher at the top of the sidebar. Reads the active org +
  * project from the store, lists all the user's orgs (with their
  * projects nested) in a single dropdown. "+ New project" /
  * "+ New organization" footer actions open the corresponding dialogs.
+ *
+ * Renders as a two-line block — project name on top, org name beneath — so
+ * the project reads as the primary context (OpenAI-style) even though one
+ * dropdown still switches both.
  *
  * Two state pieces:
  *   - which orgs/projects exist (from React Query)
@@ -48,6 +46,7 @@ export function OrgProjectSwitcher() {
   const projects: ProjectRead[] = projectsQuery.data ?? [];
   const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? null;
   const activeProject = projects.find((p) => p.id === activeProjectId) ?? null;
+  const label = switcherLabel(activeOrg, activeProject, orgsQuery.isLoading);
 
   return (
     <>
@@ -56,18 +55,22 @@ export function OrgProjectSwitcher() {
           <button
             type="button"
             className={cn(
-              "inline-flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1 text-xs",
-              "transition-colors hover:border-primary hover:bg-primary/5",
+              "flex w-full flex-col gap-0.5 rounded-md px-2 py-1 text-left",
+              "transition-colors hover:bg-accent",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             )}
           >
-            <Building2 className="h-3.5 w-3.5 text-primary" />
-            <SwitcherLabel
-              activeOrg={activeOrg}
-              activeProject={activeProject}
-              loading={orgsQuery.isLoading}
-            />
-            <ChevronsUpDown className="h-3 w-3 text-muted-foreground" />
+            <span className="flex w-full items-center gap-1">
+              <span className="truncate text-sm font-medium text-foreground">
+                {label.project}
+              </span>
+              <ChevronsUpDown className="ml-auto size-3 shrink-0 text-muted-foreground" />
+            </span>
+            {label.org && (
+              <span className="truncate text-xs text-muted-foreground">
+                {label.org}
+              </span>
+            )}
           </button>
         </DropdownMenuTrigger>
 
@@ -154,37 +157,16 @@ export function OrgProjectSwitcher() {
   );
 }
 
-interface SwitcherLabelProps {
-  activeOrg: OrgWithRole | null;
-  activeProject: ProjectRead | null;
-  loading: boolean;
-}
-
-function SwitcherLabel({
-  activeOrg,
-  activeProject,
-  loading,
-}: SwitcherLabelProps) {
-  if (loading) {
-    return <span className="text-muted-foreground">Loading…</span>;
-  }
-  if (!activeOrg) {
-    return <span className="text-muted-foreground">Pick an organization</span>;
-  }
-  return (
-    <span className="flex items-center gap-1.5">
-      <span className="text-foreground">{activeOrg.name}</span>
-      {activeProject && (
-        <>
-          <span className="text-muted-foreground">/</span>
-          <span className="font-mono text-foreground">
-            {activeProject.name}
-          </span>
-        </>
-      )}
-      {!activeProject && (
-        <span className="text-muted-foreground">· no project</span>
-      )}
-    </span>
-  );
+/** Project (primary line) + org (secondary line) for the two-line trigger. */
+function switcherLabel(
+  activeOrg: OrgWithRole | null,
+  activeProject: ProjectRead | null,
+  loading: boolean,
+): { project: string; org: string } {
+  if (loading) return { project: "Loading…", org: "" };
+  if (!activeOrg) return { project: "Pick an organization", org: "" };
+  return {
+    project: activeProject?.name ?? "No project",
+    org: activeOrg.name,
+  };
 }

--- a/platform/dashboard/src/components/PolicyEditor/theme.ts
+++ b/platform/dashboard/src/components/PolicyEditor/theme.ts
@@ -24,20 +24,27 @@
 import { EditorView } from "@codemirror/view";
 import { tokyoNightStormInit } from "@uiw/codemirror-theme-tokyo-night-storm";
 
-const tokyoNight = tokyoNightStormInit({
-  settings: {
-    // Mono face — Tokyo Night Storm's default is a stack we don't use.
-    fontFamily: "var(--font-mono)",
-    // Match the dashboard's text-sm (14px).
-    fontSize: "14px",
-    // Blend the editor into the dashboard surface — Tokyo Night Storm's
-    // default `#24283b` was slightly bluer than `--background`; using
-    // the dashboard var instead means no seam between the editor and the
-    // surrounding chrome.
-    background: "hsl(var(--background))",
-    gutterBackground: "hsl(var(--background))",
-  },
-});
+/**
+ * Tokyo Night Storm with our mono face + a caller-chosen background.
+ * `background` is the editor surface: `hsl(var(--background))` for the
+ * standalone editor (a visible code-pane), or `transparent` for editors
+ * embedded in a translucent pane, where any solid fill would read as a
+ * darker inset seam.
+ */
+function tokyoNightWith(background: string) {
+  return tokyoNightStormInit({
+    settings: {
+      // Mono face — Tokyo Night Storm's default is a stack we don't use.
+      fontFamily: "var(--font-mono)",
+      // Match the dashboard's text-sm (14px).
+      fontSize: "14px",
+      background,
+      gutterBackground: background,
+    },
+  });
+}
+
+const tokyoNight = tokyoNightWith("hsl(var(--background))");
 
 /**
  * Editor chrome + semantic decoration colors. Kept here (in
@@ -65,3 +72,13 @@ const chromeAndDecorationsTheme = EditorView.theme({
 });
 
 export const policyEditorTheme = [tokyoNight, chromeAndDecorationsTheme];
+
+/**
+ * Same theme with a transparent editor surface — for CodeMirror instances
+ * embedded in a translucent pane (e.g. the Test panel's JSON box), so the
+ * editor inherits the pane's shade instead of painting its own.
+ */
+export const policyEditorThemeTransparent = [
+  tokyoNightWith("transparent"),
+  chromeAndDecorationsTheme,
+];

--- a/platform/dashboard/src/components/policy_modules/EditorPane.tsx
+++ b/platform/dashboard/src/components/policy_modules/EditorPane.tsx
@@ -45,11 +45,14 @@ function parseRoles(text: string): RoleBindings {
   if (typeof doc !== "object" || Array.isArray(doc)) {
     throw new Error("roles.yaml must be a mapping of role -> capabilities");
   }
-  // The SDK wrapper is `{version, roles: {...}}`; a bare map is `{role: ...}`.
-  // Detect the wrapper by whether `.roles` is itself a mapping — so a bare map
-  // that legitimately has a role literally named `roles` is not misread.
-  const maybeRoles = (doc as Record<string, unknown>).roles;
+  // The SDK wrapper is `{version: <number>, roles: {...}}`. Require a NUMERIC
+  // `version` to detect it — otherwise a bare map whose role is literally named
+  // `roles` and bound to a per-agent mapping would be misread as the wrapper (a
+  // role value can now be a mapping, so "roles is a mapping" alone is ambiguous).
+  const d = doc as Record<string, unknown>;
+  const maybeRoles = d.roles;
   const wrapped =
+    typeof d.version === "number" &&
     typeof maybeRoles === "object" &&
     maybeRoles !== null &&
     !Array.isArray(maybeRoles);

--- a/platform/dashboard/src/components/policy_modules/EditorPane.tsx
+++ b/platform/dashboard/src/components/policy_modules/EditorPane.tsx
@@ -177,13 +177,14 @@ export function EditorPane({
     if (parse.error) {
       out.push({
         role: null,
+        tool: null,
         line: parse.error.line,
         message: parse.error.message,
       });
     }
     for (const l of fileLints) {
       const line = lintToLine(draft, l);
-      if (line) out.push({ role: l.role, line, message: l.message });
+      if (line) out.push({ role: l.role, tool: l.tool, line, message: l.message });
     }
     return out;
   }, [parse.error, fileLints, draft]);

--- a/platform/dashboard/src/components/policy_modules/EditorPane.tsx
+++ b/platform/dashboard/src/components/policy_modules/EditorPane.tsx
@@ -29,7 +29,10 @@ function dumpRoles(roles: RoleBindings): string {
     rendered[role] =
       agents.length === 1 && agents[0] === "*" ? cells["*"] : cells;
   }
-  return dump({ version: 1, roles: rendered }, { flowLevel: 3, lineWidth: 100 });
+  return dump(
+    { version: 1, roles: rendered },
+    { flowLevel: 3, lineWidth: 100 },
+  );
 }
 
 /** Parse the roles.yaml buffer back to the (role, agent) matrix. Accepts the SDK
@@ -63,13 +66,18 @@ function parseRoles(text: string): RoleBindings {
 
 /** One role's value → `{agent: [caps]}`. A bare list is the generic `"*"` agent;
  * a mapping is the per-agent matrix, each agent's value a capability list. */
-function parseRoleValue(role: string, value: unknown): Record<string, string[]> {
+function parseRoleValue(
+  role: string,
+  value: unknown,
+): Record<string, string[]> {
   const isCapList = (v: unknown): v is string[] =>
     Array.isArray(v) && v.every((c) => typeof c === "string");
   if (isCapList(value)) return { "*": value };
   if (typeof value === "object" && value !== null && !Array.isArray(value)) {
     const cells: Record<string, string[]> = {};
-    for (const [agent, caps] of Object.entries(value as Record<string, unknown>)) {
+    for (const [agent, caps] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
       if (!isCapList(caps)) {
         throw new Error(
           `role ${role}, agent ${agent}: capabilities must be a list of names`,
@@ -213,7 +221,8 @@ export function EditorPane({
     }
     for (const l of fileLints) {
       const line = lintToLine(draft, l);
-      if (line) out.push({ role: l.role, tool: l.tool, line, message: l.message });
+      if (line)
+        out.push({ role: l.role, tool: l.tool, line, message: l.message });
     }
     return out;
   }, [parse.error, fileLints, draft]);

--- a/platform/dashboard/src/components/policy_modules/EditorPane.tsx
+++ b/platform/dashboard/src/components/policy_modules/EditorPane.tsx
@@ -1,0 +1,305 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { dump, load, YAMLException } from "js-yaml";
+import { FileText, RotateCcw, Save, ScrollText } from "lucide-react";
+
+import {
+  ApiError,
+  type PolicyDraft,
+  type PolicyLint,
+  type PolicyModuleRead,
+  type PolicyValidationError,
+  type RoleBindings,
+} from "@/lib/api";
+import { useSetRoles, useUpsertModule } from "@/lib/policy_modules";
+import { lintToLine, type Selection } from "@/lib/module_tree";
+import { PolicyEditor } from "@/components/PolicyEditor";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/** Serialize role bindings as the SDK's on-disk `roles.yaml` (version + map). */
+function dumpRoles(roles: RoleBindings): string {
+  return dump({ version: 1, roles }, { flowLevel: 2, lineWidth: 100 });
+}
+
+/** Parse the roles.yaml buffer back to bindings. Accepts the SDK shape
+ * (`{version, roles: {...}}`) or a bare `role: [caps]` map. Throws on a
+ * non-mapping or a non-string-list value so Save can block. */
+function parseRoles(text: string): RoleBindings {
+  const doc = load(text);
+  if (doc === null || doc === undefined) return {};
+  if (typeof doc !== "object" || Array.isArray(doc)) {
+    throw new Error("roles.yaml must be a mapping of role -> capabilities");
+  }
+  // The SDK wrapper is `{version, roles: {...}}`; a bare map is `{role: [...]}`.
+  // Detect the wrapper by whether `.roles` is itself a mapping — so a bare map
+  // that legitimately has a role literally named `roles` (value is a list) is
+  // not misread as the wrapper.
+  const maybeRoles = (doc as Record<string, unknown>).roles;
+  const wrapped =
+    typeof maybeRoles === "object" &&
+    maybeRoles !== null &&
+    !Array.isArray(maybeRoles);
+  const raw = wrapped ? maybeRoles : doc;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error("`roles` must be a mapping of role -> capabilities");
+  }
+  const out: RoleBindings = {};
+  for (const [role, caps] of Object.entries(raw as Record<string, unknown>)) {
+    if (!Array.isArray(caps) || caps.some((c) => typeof c !== "string")) {
+      throw new Error(`role ${role}: capabilities must be a list of names`);
+    }
+    out[role] = caps as string[];
+  }
+  return out;
+}
+
+const selKey = (sel: Selection) =>
+  sel.kind === "roles" ? "roles" : `${sel.tier}:${sel.path}`;
+
+interface ClientParse {
+  ok: boolean;
+  /** 1-based line of the parse error, when the exception carries a mark. */
+  error: { line: number | null; message: string } | null;
+}
+
+function clientParse(text: string): ClientParse {
+  try {
+    load(text);
+    return { ok: true, error: null };
+  } catch (e) {
+    if (e instanceof YAMLException) {
+      const line = e.mark ? e.mark.line + 1 : null;
+      return { ok: false, error: { line, message: e.reason || e.message } };
+    }
+    return { ok: false, error: { line: null, message: String(e) } };
+  }
+}
+
+export function EditorPane({
+  projectId,
+  selection,
+  modules,
+  roles,
+  lints,
+  canManage,
+  onDraftChange,
+}: {
+  projectId: string;
+  selection: Selection;
+  modules: PolicyModuleRead[];
+  roles: RoleBindings;
+  lints: PolicyLint[];
+  canManage: boolean;
+  onDraftChange: (draft: PolicyDraft | null, parses: boolean) => void;
+}) {
+  const upsert = useUpsertModule(projectId);
+  const setRoles = useSetRoles(projectId);
+
+  // Authoritative stored text for the open node.
+  const saved = useMemo(() => {
+    if (selection.kind === "roles") return dumpRoles(roles);
+    const mod = modules.find(
+      (m) => m.tier === selection.tier && m.path === selection.path,
+    );
+    return mod?.content ?? "";
+  }, [selection, modules, roles]);
+
+  const [draft, setDraft] = useState(saved);
+
+  // Re-sync the buffer via the render-phase "adjust state when a prop changes"
+  // pattern (no effect, so the reset lands in the same render as the switch).
+  // On a file switch, always load the newly-selected file's stored text. On a
+  // background refetch of the SAME file (React Query focus/invalidation), only
+  // adopt the new server copy when the buffer is clean — never clobber unsaved
+  // edits out from under the user. A dirty buffer keeps its edits and the
+  // 'unsaved' badge; Save then resolves it last-write-wins.
+  const nodeKey = selKey(selection);
+  const [syncKey, setSyncKey] = useState(nodeKey);
+  const [syncSaved, setSyncSaved] = useState(saved);
+  if (nodeKey !== syncKey) {
+    setSyncKey(nodeKey);
+    setSyncSaved(saved);
+    setDraft(saved);
+  } else if (saved !== syncSaved) {
+    const wasClean = draft === syncSaved;
+    setSyncSaved(saved);
+    if (wasClean) setDraft(saved);
+  }
+
+  const dirty = draft !== saved;
+  const parse = useMemo(() => clientParse(draft), [draft]);
+
+  // Publish the live overlay up so the inspector previews the unsaved edit.
+  // Clean or unparseable → no overlay (the inspector shows stored state; the
+  // parse error renders inline here). Parseable roles must extract to a map.
+  useEffect(() => {
+    if (!dirty || !parse.ok) {
+      onDraftChange(null, parse.ok);
+      return;
+    }
+    if (selection.kind === "roles") {
+      try {
+        onDraftChange({ roles: parseRoles(draft) }, true);
+      } catch {
+        onDraftChange(null, false);
+      }
+    } else {
+      onDraftChange(
+        {
+          module: {
+            tier: selection.tier,
+            path: selection.path,
+            content: draft,
+          },
+        },
+        true,
+      );
+    }
+  }, [draft, dirty, parse.ok, selection, onDraftChange]);
+
+  const handleChange = useCallback((next: string) => setDraft(next), []);
+
+  // Semantic lints for THIS module, anchored to the tool's line. Whole-module
+  // and cross-role lints have no line and surface in the inspector's Lints tab.
+  const fileLints = useMemo<PolicyLint[]>(() => {
+    if (selection.kind !== "module") return [];
+    return lints.filter(
+      (l) =>
+        l.source === selection.path ||
+        l.source === `${selection.tier}/${selection.path}`,
+    );
+  }, [lints, selection]);
+
+  const diagnostics = useMemo<PolicyValidationError[]>(() => {
+    const out: PolicyValidationError[] = [];
+    if (parse.error) {
+      out.push({
+        role: null,
+        line: parse.error.line,
+        message: parse.error.message,
+      });
+    }
+    for (const l of fileLints) {
+      const line = lintToLine(draft, l);
+      if (line) out.push({ role: l.role, line, message: l.message });
+    }
+    return out;
+  }, [parse.error, fileLints, draft]);
+
+  // Everything to list in the inline banner: the client parse error plus ALL
+  // this-file lints — including semantic ones that can't be pinned to a line
+  // (shown without a line number), so a file-level error is visible next to the
+  // code, not only in the inspector's Lints tab. The gutter still underlines
+  // only the line-anchored `diagnostics` above.
+  const bannerItems = useMemo(() => {
+    const out: { line: number | null; message: string }[] = [];
+    if (parse.error) {
+      out.push({ line: parse.error.line, message: parse.error.message });
+    }
+    for (const l of fileLints) {
+      out.push({ line: lintToLine(draft, l), message: l.message });
+    }
+    return out;
+  }, [parse.error, fileLints, draft]);
+
+  const hasError = !parse.ok || fileLints.some((l) => l.severity === "error");
+
+  function handleSave() {
+    if (selection.kind === "roles") {
+      let parsed: RoleBindings;
+      try {
+        parsed = parseRoles(draft);
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : "roles.yaml is invalid");
+        return;
+      }
+      setRoles.mutate(parsed, {
+        onSuccess: () => toast.success("Saved roles.yaml"),
+        onError: (e) =>
+          toast.error(
+            e instanceof ApiError ? e.message : "Could not save roles",
+          ),
+      });
+      return;
+    }
+    upsert.mutate(
+      { tier: selection.tier, path: selection.path, content: draft },
+      {
+        onSuccess: () => toast.success(`Saved ${selection.path}`),
+        onError: (e) =>
+          toast.error(e instanceof ApiError ? e.message : "Could not save"),
+      },
+    );
+  }
+
+  const saving = upsert.isPending || setRoles.isPending;
+  const title =
+    selection.kind === "roles"
+      ? "roles.yaml"
+      : `${selection.tier === "boundary" ? "boundaries" : "capabilities"}/${selection.path}`;
+  const Icon = selection.kind === "roles" ? ScrollText : FileText;
+
+  return (
+    <div className="h-full flex flex-col">
+      <header className="flex items-center justify-between gap-2 px-4 py-2 border-b border-border">
+        <div className="flex items-center gap-2 text-sm min-w-0">
+          <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="font-mono truncate">{title}</span>
+          {dirty && <Badge variant="approval">unsaved</Badge>}
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setDraft(saved)}
+            disabled={!dirty || saving}
+            className="gap-1.5 h-8"
+            title="Discard unsaved changes"
+          >
+            <RotateCcw className="size-3.5" />
+            Discard
+          </Button>
+          {canManage && (
+            <Button
+              size="sm"
+              onClick={handleSave}
+              disabled={!dirty || saving}
+              className="gap-1.5 h-8"
+            >
+              <Save className="size-3.5" />
+              {saving ? "Saving…" : "Save"}
+            </Button>
+          )}
+        </div>
+      </header>
+      <PolicyEditor
+        value={draft}
+        onChange={handleChange}
+        diagnostics={diagnostics}
+        readOnly={!canManage}
+        className="flex-1 overflow-hidden"
+      />
+      {/* Diagnostics as a bottom status bar (VSCode "problems"), so appearing/
+          clearing them never shifts the editor content down from the top. */}
+      {bannerItems.length > 0 && (
+        <div
+          className={cn(
+            "shrink-0 max-h-28 overflow-y-auto scrollbar-thin px-4 py-1.5 text-xs border-t font-mono space-y-0.5",
+            hasError
+              ? "bg-deny/5 border-deny/30 text-deny"
+              : "bg-approval/5 border-approval/30 text-approval",
+          )}
+        >
+          {bannerItems.map((d, i) => (
+            <div key={i}>
+              {d.line ? `L${d.line} — ` : ""}
+              {d.message}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/platform/dashboard/src/components/policy_modules/EditorPane.tsx
+++ b/platform/dashboard/src/components/policy_modules/EditorPane.tsx
@@ -18,24 +18,33 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-/** Serialize role bindings as the SDK's on-disk `roles.yaml` (version + map). */
+/** Serialize the (role, agent) matrix as the SDK's on-disk `roles.yaml`.
+ * A role whose only agent is the generic `"*"` renders as the flat
+ * `role: [caps]` shorthand (cleaner for the common single-agent case); a role
+ * with named agents renders the full `role: {agent: [caps]}` mapping. */
 function dumpRoles(roles: RoleBindings): string {
-  return dump({ version: 1, roles }, { flowLevel: 2, lineWidth: 100 });
+  const rendered: Record<string, string[] | Record<string, string[]>> = {};
+  for (const [role, cells] of Object.entries(roles)) {
+    const agents = Object.keys(cells);
+    rendered[role] =
+      agents.length === 1 && agents[0] === "*" ? cells["*"] : cells;
+  }
+  return dump({ version: 1, roles: rendered }, { flowLevel: 3, lineWidth: 100 });
 }
 
-/** Parse the roles.yaml buffer back to bindings. Accepts the SDK shape
- * (`{version, roles: {...}}`) or a bare `role: [caps]` map. Throws on a
- * non-mapping or a non-string-list value so Save can block. */
+/** Parse the roles.yaml buffer back to the (role, agent) matrix. Accepts the SDK
+ * wrapper (`{version, roles: {...}}`) or a bare map, and — per role — either a
+ * flat `[caps]` list (the generic `"*"` agent) or an `{agent: [caps]}` mapping.
+ * Throws on a non-mapping or a non-string-list value so Save can block. */
 function parseRoles(text: string): RoleBindings {
   const doc = load(text);
   if (doc === null || doc === undefined) return {};
   if (typeof doc !== "object" || Array.isArray(doc)) {
     throw new Error("roles.yaml must be a mapping of role -> capabilities");
   }
-  // The SDK wrapper is `{version, roles: {...}}`; a bare map is `{role: [...]}`.
+  // The SDK wrapper is `{version, roles: {...}}`; a bare map is `{role: ...}`.
   // Detect the wrapper by whether `.roles` is itself a mapping — so a bare map
-  // that legitimately has a role literally named `roles` (value is a list) is
-  // not misread as the wrapper.
+  // that legitimately has a role literally named `roles` is not misread.
   const maybeRoles = (doc as Record<string, unknown>).roles;
   const wrapped =
     typeof maybeRoles === "object" &&
@@ -46,13 +55,33 @@ function parseRoles(text: string): RoleBindings {
     throw new Error("`roles` must be a mapping of role -> capabilities");
   }
   const out: RoleBindings = {};
-  for (const [role, caps] of Object.entries(raw as Record<string, unknown>)) {
-    if (!Array.isArray(caps) || caps.some((c) => typeof c !== "string")) {
-      throw new Error(`role ${role}: capabilities must be a list of names`);
-    }
-    out[role] = caps as string[];
+  for (const [role, value] of Object.entries(raw as Record<string, unknown>)) {
+    out[role] = parseRoleValue(role, value);
   }
   return out;
+}
+
+/** One role's value → `{agent: [caps]}`. A bare list is the generic `"*"` agent;
+ * a mapping is the per-agent matrix, each agent's value a capability list. */
+function parseRoleValue(role: string, value: unknown): Record<string, string[]> {
+  const isCapList = (v: unknown): v is string[] =>
+    Array.isArray(v) && v.every((c) => typeof c === "string");
+  if (isCapList(value)) return { "*": value };
+  if (typeof value === "object" && value !== null && !Array.isArray(value)) {
+    const cells: Record<string, string[]> = {};
+    for (const [agent, caps] of Object.entries(value as Record<string, unknown>)) {
+      if (!isCapList(caps)) {
+        throw new Error(
+          `role ${role}, agent ${agent}: capabilities must be a list of names`,
+        );
+      }
+      cells[agent] = caps;
+    }
+    return cells;
+  }
+  throw new Error(
+    `role ${role}: must be a capability list or an { agent: [caps] } mapping`,
+  );
 }
 
 const selKey = (sel: Selection) =>

--- a/platform/dashboard/src/components/policy_modules/EditorPane.tsx
+++ b/platform/dashboard/src/components/policy_modules/EditorPane.tsx
@@ -216,7 +216,13 @@ export function EditorPane({
         return;
       }
       setRoles.mutate(parsed, {
-        onSuccess: () => toast.success("Saved roles.yaml"),
+        onSuccess: () => {
+          // Re-sync the buffer to the canonical dump the server now echoes, so
+          // a bare/reordered roles.yaml doesn't read as perpetually "unsaved"
+          // (dumpRoles rarely equals the user's typed text byte-for-byte).
+          setDraft(dumpRoles(parsed));
+          toast.success("Saved roles.yaml");
+        },
         onError: (e) =>
           toast.error(
             e instanceof ApiError ? e.message : "Could not save roles",

--- a/platform/dashboard/src/components/policy_modules/InspectorTabs.tsx
+++ b/platform/dashboard/src/components/policy_modules/InspectorTabs.tsx
@@ -1,0 +1,324 @@
+import { useMemo, useState } from "react";
+import { dump } from "js-yaml";
+import { AlertTriangle, FlaskConical, Info, ListChecks } from "lucide-react";
+
+import type {
+  PolicyDraft,
+  PolicyLint,
+  ResolvedPolicy,
+  RoleBindings,
+} from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { TestPanel } from "./TestPanel";
+import { cn } from "@/lib/utils";
+
+type Tab = "resolved" | "lints" | "test";
+
+function modeBadge(mode: string | undefined) {
+  if (mode === "allow") return "allow" as const;
+  if (mode === "deny") return "deny" as const;
+  if (mode === "approval_required") return "approval" as const;
+  return "default" as const;
+}
+
+/**
+ * Right pane: the composed policy (Resolved), analyzer lints (Lints), and the
+ * decision tester (Test). Resolved + Lints reflect the unsaved draft when one
+ * is active (the page feeds preview results through); otherwise stored state.
+ */
+export function InspectorTabs({
+  projectId,
+  resolved,
+  lints,
+  roles,
+  draft,
+  resolves,
+  previewing,
+}: {
+  projectId: string;
+  resolved: ResolvedPolicy | undefined;
+  lints: PolicyLint[];
+  roles: RoleBindings;
+  draft: PolicyDraft | null;
+  resolves: boolean;
+  previewing: boolean;
+}) {
+  const [tab, setTab] = useState<Tab>("resolved");
+  const errorCount = lints.filter((l) => l.severity === "error").length;
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center gap-1 px-2 py-2 border-b border-border">
+        <TabButton
+          active={tab === "resolved"}
+          onClick={() => setTab("resolved")}
+          Icon={ListChecks}
+          label="Resolved"
+        />
+        <TabButton
+          active={tab === "lints"}
+          onClick={() => setTab("lints")}
+          Icon={AlertTriangle}
+          label="Lints"
+          count={lints.length}
+          danger={errorCount > 0}
+        />
+        <TabButton
+          active={tab === "test"}
+          onClick={() => setTab("test")}
+          Icon={FlaskConical}
+          label="Test"
+        />
+        {previewing && (
+          <span className="ml-auto text-[10px] text-muted-foreground animate-pulse">
+            previewing…
+          </span>
+        )}
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {tab === "resolved" && (
+          <ResolvedTab resolved={resolved} resolves={resolves} />
+        )}
+        {tab === "lints" && <LintsTab lints={lints} />}
+        {tab === "test" && (
+          <TestPanel
+            projectId={projectId}
+            roles={roles}
+            draft={draft}
+            resolves={resolves}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  Icon,
+  label,
+  count,
+  danger,
+}: {
+  active: boolean;
+  onClick: () => void;
+  Icon: typeof Info;
+  label: string;
+  count?: number;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors",
+        active
+          ? "bg-primary text-primary-foreground"
+          : "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon className="size-3" />
+      {label}
+      {count !== undefined && count > 0 && (
+        <span
+          className={cn(
+            "rounded-full px-1.5 text-[10px]",
+            danger ? "bg-deny/20 text-deny" : "bg-muted text-muted-foreground",
+          )}
+        >
+          {count}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function ResolvedTab({
+  resolved,
+  resolves,
+}: {
+  resolved: ResolvedPolicy | undefined;
+  resolves: boolean;
+}) {
+  const roleNames = useMemo(
+    () => (resolved ? Object.keys(resolved).sort() : []),
+    [resolved],
+  );
+  const [role, setRole] = useState<string>("");
+  const [view, setView] = useState<"table" | "yaml">("table");
+  const active = roleNames.includes(role) ? role : (roleNames[0] ?? "");
+
+  if (!resolves || !resolved || roleNames.length === 0) {
+    return (
+      <div className="h-full grid place-items-center px-6 text-center">
+        <p className="text-xs text-muted-foreground">
+          {resolves
+            ? "No roles bound yet — bind one in roles.yaml to see the composed policy."
+            : "The modules don't compose. See the Lints tab."}
+        </p>
+      </div>
+    );
+  }
+
+  const policy = resolved[active];
+  const tools = policy?.tools ?? {};
+  const toolNames = Object.keys(tools).sort();
+  const defaultMode = policy?.default_policy?.mode;
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-border">
+        <div className="flex flex-wrap items-center gap-1 min-w-0">
+          {roleNames.map((r) => (
+            <button
+              key={r}
+              onClick={() => setRole(r)}
+              className={cn(
+                "rounded px-2 py-0.5 text-xs font-mono",
+                r === active
+                  ? "bg-primary/15 text-primary font-medium"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {r}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center rounded-md border border-border p-0.5 shrink-0">
+          {(["table", "yaml"] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setView(v)}
+              className={cn(
+                "rounded px-2 py-0.5 text-[11px] font-medium capitalize transition-colors",
+                view === v
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+      </div>
+      {view === "yaml" ? (
+        <div className="flex-1 overflow-auto scrollbar-thin p-3">
+          {/* The composed / "compiled" policy for this role as one document —
+              boundaries + the role's capabilities merged (hexgate policy
+              resolve). Read-only; edits happen in the module files. */}
+          <pre className="text-[11px] font-mono leading-relaxed whitespace-pre">
+            {dumpPolicy(policy)}
+          </pre>
+        </div>
+      ) : (
+        <div className="flex-1 overflow-y-auto scrollbar-thin p-3 space-y-1">
+          {defaultMode && (
+            <div className="flex items-center justify-between gap-2 py-1 text-xs border-b border-border/50">
+              <span className="text-muted-foreground italic">default</span>
+              <Badge variant={modeBadge(defaultMode)}>{defaultMode}</Badge>
+            </div>
+          )}
+          {toolNames.length === 0 ? (
+            <p className="text-xs text-muted-foreground pt-2">
+              No tools granted for this role.
+            </p>
+          ) : (
+            toolNames.map((t) => {
+              const tp = tools[t];
+              const constraints = tp?.constraints ?? [];
+              return (
+                <div
+                  key={t}
+                  className="flex items-start justify-between gap-2 py-1 text-xs border-b border-border/50"
+                >
+                  <div className="min-w-0">
+                    <span className="font-mono">{t}</span>
+                    {constraints.length > 0 && (
+                      <ul className="mt-0.5 text-[11px] text-muted-foreground font-mono space-y-0.5">
+                        {constraints.map((c, i) => (
+                          <li key={i}>{c}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  <Badge variant={modeBadge(tp?.mode)}>{tp?.mode ?? "—"}</Badge>
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** The resolved policy for one role, as a single YAML document. Drops the
+ * catch-all `[key: string]` passthrough so only the real policy fields show. */
+function dumpPolicy(policy: ResolvedPolicy[string] | undefined): string {
+  if (!policy) return "# no policy for this role\n";
+  const { default_policy, tools } = policy;
+  const doc: Record<string, unknown> = {};
+  if (default_policy) doc.default_policy = default_policy;
+  doc.tools = tools ?? {};
+  return dump(doc, { sortKeys: false, lineWidth: 100 });
+}
+
+function LintsTab({ lints }: { lints: PolicyLint[] }) {
+  if (lints.length === 0) {
+    return (
+      <div className="h-full grid place-items-center px-6 text-center">
+        <p className="text-xs text-muted-foreground">
+          No lints — the policy composes cleanly.
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="h-full overflow-y-auto scrollbar-thin p-3 space-y-1.5">
+      {lints.map((l, i) => (
+        <div
+          key={i}
+          className={cn(
+            "rounded border p-2 text-xs",
+            l.severity === "error"
+              ? "border-deny/30 bg-deny/5"
+              : l.severity === "warning"
+                ? "border-approval/30 bg-approval/5"
+                : "border-border bg-muted/30",
+          )}
+        >
+          <div className="flex items-center gap-1.5">
+            <span
+              className={cn(
+                "font-mono text-[10px] uppercase",
+                l.severity === "error"
+                  ? "text-deny"
+                  : l.severity === "warning"
+                    ? "text-approval"
+                    : "text-muted-foreground",
+              )}
+            >
+              {l.severity}
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {l.code}
+            </span>
+          </div>
+          <p className="mt-0.5 text-foreground/90">{l.message}</p>
+          {(l.source || l.role || l.tool) && (
+            <p className="mt-0.5 text-[10px] text-muted-foreground font-mono">
+              {[
+                l.role && `role:${l.role}`,
+                l.source,
+                l.tool && `tool:${l.tool}`,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/platform/dashboard/src/components/policy_modules/InspectorTabs.tsx
+++ b/platform/dashboard/src/components/policy_modules/InspectorTabs.tsx
@@ -33,6 +33,7 @@ export function InspectorTabs({
   roles,
   draft,
   resolves,
+  modular,
   previewing,
 }: {
   projectId: string;
@@ -41,6 +42,7 @@ export function InspectorTabs({
   roles: RoleBindings;
   draft: PolicyDraft | null;
   resolves: boolean;
+  modular: boolean;
   previewing: boolean;
 }) {
   const [tab, setTab] = useState<Tab>("resolved");
@@ -77,7 +79,11 @@ export function InspectorTabs({
       </div>
       <div className="flex-1 overflow-hidden">
         {tab === "resolved" && (
-          <ResolvedTab resolved={resolved} resolves={resolves} />
+          <ResolvedTab
+            resolved={resolved}
+            resolves={resolves}
+            modular={modular}
+          />
         )}
         {tab === "lints" && <LintsTab lints={lints} />}
         {tab === "test" && (
@@ -137,9 +143,11 @@ function TabButton({
 function ResolvedTab({
   resolved,
   resolves,
+  modular,
 }: {
   resolved: ResolvedPolicy | undefined;
   resolves: boolean;
+  modular: boolean;
 }) {
   const roleNames = useMemo(
     () => (resolved ? Object.keys(resolved).sort() : []),
@@ -149,13 +157,16 @@ function ResolvedTab({
   const [view, setView] = useState<"table" | "yaml">("table");
   const active = roleNames.includes(role) ? role : (roleNames[0] ?? "");
 
-  if (!resolves || !resolved || roleNames.length === 0) {
+  // A classic project (no role bindings) resolves to a synthetic `default`
+  // importing every capability — but no agent enforces it in classic mode, so
+  // don't show it here (it would contradict the "classic" banner).
+  if (!modular || !resolves || !resolved || roleNames.length === 0) {
     return (
       <div className="h-full grid place-items-center px-6 text-center">
         <p className="text-xs text-muted-foreground">
-          {resolves
-            ? "No roles bound yet — bind one in roles.yaml to see the composed policy."
-            : "The modules don't compose. See the Lints tab."}
+          {!resolves
+            ? "The modules don't compose. See the Lints tab."
+            : "Bind a role in roles.yaml to see the composed policy. (Classic projects enforce each agent's own policy.)"}
         </p>
       </div>
     );

--- a/platform/dashboard/src/components/policy_modules/ModularBanner.tsx
+++ b/platform/dashboard/src/components/policy_modules/ModularBanner.tsx
@@ -1,0 +1,31 @@
+import { Info, Layers } from "lucide-react";
+
+/**
+ * Classic-vs-modular banner. A project is modular once it has at least one
+ * role binding; until then agents enforce their own `policy.yaml` and the
+ * module library changes nothing. Reused verbatim from the resolve semantics
+ * server-side (no `policy_mode` column — bindings are the signal).
+ */
+export function ModularBanner({ modular }: { modular: boolean }) {
+  if (modular) {
+    return (
+      <div className="flex items-center gap-2 px-6 py-2 text-xs border-b border-primary/30 bg-primary/5 text-primary">
+        <Layers className="size-3.5 shrink-0" />
+        <span>
+          Modular policy is <span className="font-medium">active</span>. Agents
+          in this project enforce the composed bundle below.
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 px-6 py-2 text-xs border-b border-approval/30 bg-approval/5 text-approval">
+      <Info className="size-3.5 shrink-0" />
+      <span>
+        Classic project — agents enforce their own policy. Bind a role in{" "}
+        <span className="font-mono">roles.yaml</span> to switch this project to
+        the modular library.
+      </span>
+    </div>
+  );
+}

--- a/platform/dashboard/src/components/policy_modules/ModularBanner.tsx
+++ b/platform/dashboard/src/components/policy_modules/ModularBanner.tsx
@@ -1,31 +1,52 @@
+import type { ReactNode } from "react";
 import { Info, Layers } from "lucide-react";
 
+import { cn } from "@/lib/utils";
+
 /**
- * Classic-vs-modular banner. A project is modular once it has at least one
- * role binding; until then agents enforce their own `policy.yaml` and the
- * module library changes nothing. Reused verbatim from the resolve semantics
- * server-side (no `policy_mode` column — bindings are the signal).
+ * Classic-vs-modular status bar — doubles as the page's top bar (there's no
+ * separate title; the sidebar already says "Modules"). A project is modular
+ * once it has at least one role binding; until then agents enforce their own
+ * `policy.yaml` and the module library changes nothing (no `policy_mode`
+ * column — bindings are the signal). `trailing` holds right-aligned actions
+ * (e.g. the docs link).
  */
-export function ModularBanner({ modular }: { modular: boolean }) {
-  if (modular) {
-    return (
-      <div className="flex items-center gap-2 px-6 py-2 text-xs border-b border-primary/30 bg-primary/5 text-primary">
-        <Layers className="size-3.5 shrink-0" />
-        <span>
-          Modular policy is <span className="font-medium">active</span>. Agents
-          in this project enforce the composed bundle below.
-        </span>
-      </div>
-    );
-  }
+export function ModularBanner({
+  modular,
+  trailing,
+}: {
+  modular: boolean;
+  trailing?: ReactNode;
+}) {
   return (
-    <div className="flex items-center gap-2 px-6 py-2 text-xs border-b border-approval/30 bg-approval/5 text-approval">
-      <Info className="size-3.5 shrink-0" />
-      <span>
-        Classic project — agents enforce their own policy. Bind a role in{" "}
-        <span className="font-mono">roles.yaml</span> to switch this project to
-        the modular library.
+    <div
+      className={cn(
+        "flex items-center gap-2 px-6 py-2 text-xs border-b",
+        modular
+          ? "border-primary/30 bg-primary/5 text-primary"
+          : "border-approval/30 bg-approval/5 text-approval",
+      )}
+    >
+      {modular ? (
+        <Layers className="size-3.5 shrink-0" />
+      ) : (
+        <Info className="size-3.5 shrink-0" />
+      )}
+      <span className="min-w-0 flex-1">
+        {modular ? (
+          <>
+            Modular policy is <span className="font-medium">active</span>.
+            Agents in this project enforce the composed bundle below.
+          </>
+        ) : (
+          <>
+            Classic project — agents enforce their own policy. Bind a role in{" "}
+            <span className="font-mono">roles.yaml</span> to switch this project
+            to the modular library.
+          </>
+        )}
       </span>
+      {trailing && <div className="shrink-0">{trailing}</div>}
     </div>
   );
 }

--- a/platform/dashboard/src/components/policy_modules/ModuleTree.tsx
+++ b/platform/dashboard/src/components/policy_modules/ModuleTree.tsx
@@ -14,8 +14,11 @@ import {
 
 import { ApiError, type PolicyModuleRead, type PolicyTier } from "@/lib/api";
 import {
+  useCreateFolder,
+  useDeleteFolder,
   useDeleteModule,
   useMoveModule,
+  usePolicyFolders,
   useUpsertModule,
 } from "@/lib/policy_modules";
 import {
@@ -82,6 +85,9 @@ export function ModuleTree({
   const upsert = useUpsertModule(projectId);
   const move = useMoveModule(projectId);
   const del = useDeleteModule(projectId);
+  const folders = usePolicyFolders(projectId);
+  const createFolder = useCreateFolder(projectId);
+  const deleteFolder = useDeleteFolder(projectId);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   // Drag-to-move: the leaf being dragged + the folder key currently hovered.
   // Drops are same-tier only (the PATCH move endpoint is same-tier), so a
@@ -101,14 +107,18 @@ export function ModuleTree({
   // Bumped on every open so the dialog remounts fresh — otherwise it reopens
   // showing the previously-typed value.
   const [dialogSeq, setDialogSeq] = useState(0);
-  // UI-only empty subfolders (the store has no folder entity — folders are
-  // otherwise derived from module paths). Reset on reload until a module lands.
-  const [emptyFolders, setEmptyFolders] = useState<EmptyFolder[]>([]);
-
   function openDialog(next: NonNullable<typeof dialog>) {
     setDialog(next);
     setDialogSeq((s) => s + 1);
   }
+
+  // Persisted empty folders (from the store), mapped to the tree builder's
+  // {tier, prefix} shape. A folder with modules renders from those paths; these
+  // rows only keep an EMPTY folder visible.
+  const emptyFolders = useMemo<EmptyFolder[]>(
+    () => (folders.data ?? []).map((f) => ({ tier: f.tier, prefix: f.path })),
+    [folders.data],
+  );
 
   const roots = useMemo(
     () => buildModuleTree(modules, emptyFolders),
@@ -142,19 +152,43 @@ export function ModuleTree({
       return next;
     });
 
-  // Add a UI-only empty subfolder so it renders before any module lives in it.
+  // Persist an empty subfolder so it renders before any module lives in it.
   function addEmptyFolder(tier: PolicyTier, prefix: string) {
-    setEmptyFolders((prev) =>
-      prev.some((f) => f.tier === tier && f.prefix === prefix)
-        ? prev
-        : [...prev, { tier, prefix }],
+    createFolder.mutate(
+      { tier, path: prefix },
+      {
+        onSuccess: () => {
+          setCollapsed((prev) => {
+            const n = new Set(prev);
+            n.delete(`${tier}:${prefix}`); // keep it expanded
+            return n;
+          });
+          toast.success(`Created folder ${tier}/${prefix}`);
+        },
+        onError: (e) =>
+          toast.error(
+            e instanceof ApiError
+              ? e.message
+              : `Could not create folder ${prefix}`,
+          ),
+      },
     );
-    setCollapsed((prev) => {
-      const n = new Set(prev);
-      n.delete(`${tier}:${prefix}`); // keep it expanded
-      return n;
-    });
-    toast.success(`Created folder ${tier}/${prefix}`);
+  }
+
+  // Delete an empty folder marker (only offered for folders with no children).
+  function handleDeleteFolder(tier: PolicyTier, prefix: string) {
+    deleteFolder.mutate(
+      { tier, path: prefix },
+      {
+        onSuccess: () => toast.success(`Deleted folder ${tier}/${prefix}`),
+        onError: (e) =>
+          toast.error(
+            e instanceof ApiError
+              ? e.message
+              : `Could not delete folder ${prefix}`,
+          ),
+      },
+    );
   }
 
   // Create a module from the dialog's validated (trimmed, non-duplicate) path.
@@ -319,6 +353,15 @@ export function ModuleTree({
                 >
                   <FolderPlus className="size-3.5" />
                 </button>
+                {node.prefix !== "" && node.children.length === 0 && (
+                  <button
+                    title="Delete empty folder"
+                    onClick={() => handleDeleteFolder(node.tier, node.prefix)}
+                    className="hover:text-deny"
+                  >
+                    <Trash2 className="size-3.5" />
+                  </button>
+                )}
               </span>
             )}
           </div>
@@ -427,10 +470,11 @@ export function ModuleTree({
           }
           description={
             dialog.subfolder
-              ? "Creates an empty subfolder. Add modules to it afterward. (Folders are UI-only until a module lands, so an empty one resets on reload.)"
-              : "Use / to nest in a subfolder, e.g. team_a/payments."
+              ? "Create an empty subfolder here; add modules to it afterward."
+              : "Name the module. Use / to nest further, e.g. payments or team_b/payments."
           }
-          initial={dialog.prefix ? `${dialog.prefix}/` : ""}
+          fixedPrefix={dialog.prefix}
+          initial=""
           existingPaths={dialog.subfolder ? existingFolders : existingPaths}
           confirmLabel={dialog.subfolder ? "Create folder" : "Create"}
           onClose={() => setDialog(null)}
@@ -462,19 +506,21 @@ export function ModuleTree({
   );
 }
 
-/** Modal for a module path — used to create (new module / subfolder) and to
- * rename/move. Trims the path (whitespace + edge slashes) and blocks
- * duplicates against the full tier+path; `selfPath` excludes the entry's own
- * path (so an unchanged rename is a no-op, not a "duplicate"); `requireSlash`
- * enforces nesting in subfolder mode. */
+/** Modal for a module path — used to create (module / folder) and to
+ * rename/move. `fixedPrefix` (create mode) is the immutable parent folder shown
+ * as a label, so the typed value is only the name *within* it — the parent
+ * can't be accidentally cleared, and nesting works at any depth. Rename passes
+ * no `fixedPrefix`, so the input is the full path. Trims the input (whitespace
+ * + edge slashes) and blocks duplicates against the full tier+path; `selfPath`
+ * excludes the entry's own path (so an unchanged rename is a no-op). */
 function ModulePathDialog({
   tier,
   title,
   description,
+  fixedPrefix,
   initial,
   existingPaths,
   selfPath,
-  requireSlash,
   confirmLabel,
   onClose,
   onSubmit,
@@ -482,24 +528,24 @@ function ModulePathDialog({
   tier: PolicyTier;
   title: string;
   description: string;
+  fixedPrefix?: string;
   initial: string;
   existingPaths: Set<string>;
   selfPath?: string;
-  requireSlash?: boolean;
   confirmLabel: string;
   onClose: () => void;
   onSubmit: (path: string) => void;
 }) {
   const [value, setValue] = useState(initial);
-  const path = normalizePath(value);
+  const rel = normalizePath(value);
+  // Combine the fixed parent (if any) with the typed name into the full path.
+  const path = fixedPrefix ? (rel ? `${fixedPrefix}/${rel}` : "") : rel;
   const isSelf = selfPath !== undefined && path === selfPath;
-  const error = !path
+  const error = !rel
     ? "Enter a name."
     : existingPaths.has(`${tier}:${path}`) && !isSelf
       ? `A ${tier} already exists at ${path}.`
-      : requireSlash && !path.includes("/")
-        ? "Use folder/name to create a subfolder."
-        : null;
+      : null;
   // isSelf = an unchanged rename: valid input, but nothing to do -> disabled.
   const disabled = !!error || isSelf;
 
@@ -515,15 +561,23 @@ function ModulePathDialog({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
         <div className="space-y-2">
-          <Label htmlFor="module-path">Path</Label>
-          <Input
-            id="module-path"
-            autoFocus
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && submit()}
-            placeholder={tier === "capability" ? "team_a/payments" : "org_core"}
-          />
+          <Label htmlFor="module-path">{fixedPrefix ? "Name" : "Path"}</Label>
+          <div className="flex items-center gap-1">
+            {fixedPrefix && (
+              <span className="shrink-0 font-mono text-xs text-muted-foreground">
+                {fixedPrefix}/
+              </span>
+            )}
+            <Input
+              id="module-path"
+              autoFocus
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+              placeholder={tier === "capability" ? "payments" : "org_core"}
+              className="flex-1"
+            />
+          </div>
           {error && value.trim() !== "" && (
             <p className="text-xs text-deny">{error}</p>
           )}

--- a/platform/dashboard/src/components/policy_modules/ModuleTree.tsx
+++ b/platform/dashboard/src/components/policy_modules/ModuleTree.tsx
@@ -1,0 +1,542 @@
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import {
+  ChevronDown,
+  ChevronRight,
+  FilePlus,
+  FileText,
+  Folder,
+  FolderPlus,
+  Pencil,
+  ScrollText,
+  Trash2,
+} from "lucide-react";
+
+import { ApiError, type PolicyModuleRead, type PolicyTier } from "@/lib/api";
+import {
+  useDeleteModule,
+  useMoveModule,
+  useUpsertModule,
+} from "@/lib/policy_modules";
+import {
+  buildModuleTree,
+  reparent,
+  type EmptyFolder,
+  type FolderNode,
+  type Selection,
+  type TreeNode,
+} from "@/lib/module_tree";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+// Starter content for a freshly-created module — a VALID minimal policy (empty
+// tool map), so upsert doesn't reject it. `tools:` with only a comment parses
+// to null, which AgentPolicy rejects ("tools must be a dictionary").
+const TEMPLATE: Record<PolicyTier, string> = {
+  boundary:
+    "# Boundary: ceilings + hard denies (applies to every role).\n" +
+    "# e.g.  delete_database: { mode: deny }\n" +
+    "default_policy: { mode: allow }\n" +
+    "tools: {}\n",
+  capability:
+    "# Capability: grants a role imports (grants only).\n" +
+    "# e.g.  refund_order: { mode: allow }\n" +
+    "tools: {}\n",
+};
+
+/** Normalize a typed module path: trim whitespace and strip leading/trailing
+ * slashes so " team_a/payments/ " -> "team_a/payments". */
+function normalizePath(raw: string): string {
+  return raw.trim().replace(/^\/+|\/+$/g, "");
+}
+
+function isSelected(sel: Selection, leaf: { tier: PolicyTier; path: string }) {
+  return (
+    sel.kind === "module" && sel.tier === leaf.tier && sel.path === leaf.path
+  );
+}
+
+export function ModuleTree({
+  modules,
+  selection,
+  onSelect,
+  projectId,
+  canManage,
+}: {
+  modules: PolicyModuleRead[];
+  selection: Selection;
+  onSelect: (sel: Selection) => void;
+  projectId: string;
+  canManage: boolean;
+}) {
+  const upsert = useUpsertModule(projectId);
+  const move = useMoveModule(projectId);
+  const del = useDeleteModule(projectId);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  // Drag-to-move: the leaf being dragged + the folder key currently hovered.
+  // Drops are same-tier only (the PATCH move endpoint is same-tier), so a
+  // capability can't land in boundaries/ and vice versa.
+  const [dragged, setDragged] = useState<{
+    tier: PolicyTier;
+    path: string;
+  } | null>(null);
+  const [dropTarget, setDropTarget] = useState<string | null>(null);
+  // Open state for the path dialog (null = closed): create a module/subfolder,
+  // or rename/move an existing one. Both share ModulePathDialog.
+  const [dialog, setDialog] = useState<
+    | { kind: "new"; tier: PolicyTier; prefix: string; subfolder: boolean }
+    | { kind: "rename"; tier: PolicyTier; path: string }
+    | null
+  >(null);
+  // Bumped on every open so the dialog remounts fresh — otherwise it reopens
+  // showing the previously-typed value.
+  const [dialogSeq, setDialogSeq] = useState(0);
+  // UI-only empty subfolders (the store has no folder entity — folders are
+  // otherwise derived from module paths). Reset on reload until a module lands.
+  const [emptyFolders, setEmptyFolders] = useState<EmptyFolder[]>([]);
+
+  function openDialog(next: NonNullable<typeof dialog>) {
+    setDialog(next);
+    setDialogSeq((s) => s + 1);
+  }
+
+  const roots = useMemo(
+    () => buildModuleTree(modules, emptyFolders),
+    [modules, emptyFolders],
+  );
+  // Full-path keys for the module duplicate check.
+  const existingPaths = useMemo(
+    () => new Set(modules.map((m) => `${m.tier}:${m.path}`)),
+    [modules],
+  );
+  // Folder prefixes (from module paths + UI-only folders) for the folder dup check.
+  const existingFolders = useMemo(() => {
+    const s = new Set<string>();
+    for (const m of modules) {
+      const segs = m.path.split("/").filter(Boolean);
+      let p = "";
+      for (let i = 0; i < segs.length - 1; i++) {
+        p = p ? `${p}/${segs[i]}` : segs[i];
+        s.add(`${m.tier}:${p}`);
+      }
+    }
+    for (const f of emptyFolders) s.add(`${f.tier}:${f.prefix}`);
+    return s;
+  }, [modules, emptyFolders]);
+
+  const toggle = (key: string) =>
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+
+  // Add a UI-only empty subfolder so it renders before any module lives in it.
+  function addEmptyFolder(tier: PolicyTier, prefix: string) {
+    setEmptyFolders((prev) =>
+      prev.some((f) => f.tier === tier && f.prefix === prefix)
+        ? prev
+        : [...prev, { tier, prefix }],
+    );
+    setCollapsed((prev) => {
+      const n = new Set(prev);
+      n.delete(`${tier}:${prefix}`); // keep it expanded
+      return n;
+    });
+    toast.success(`Created folder ${tier}/${prefix}`);
+  }
+
+  // Create a module from the dialog's validated (trimmed, non-duplicate) path.
+  function createModule(tier: PolicyTier, path: string) {
+    upsert.mutate(
+      { tier, path, content: TEMPLATE[tier] },
+      {
+        onSuccess: () => {
+          onSelect({ kind: "module", tier, path });
+          toast.success(`Created ${tier}/${path}`);
+        },
+        onError: (e) =>
+          toast.error(
+            e instanceof ApiError ? e.message : `Could not create ${path}`,
+          ),
+      },
+    );
+  }
+
+  // Shared by Rename (type a path) and drag-to-move (drop into a folder).
+  // No-ops when the path is unchanged so an accidental drop-in-place is free.
+  function moveTo(leaf: { tier: PolicyTier; path: string }, newPath: string) {
+    if (!newPath || newPath === leaf.path) return;
+    move.mutate(
+      { tier: leaf.tier, path: leaf.path, newPath },
+      {
+        onSuccess: () => {
+          if (isSelected(selection, leaf)) {
+            onSelect({ kind: "module", tier: leaf.tier, path: newPath });
+          }
+          toast.success(`Moved to ${newPath}`, {
+            action: {
+              label: "Undo",
+              onClick: () =>
+                move.mutate({
+                  tier: leaf.tier,
+                  path: newPath,
+                  newPath: leaf.path,
+                }),
+            },
+          });
+        },
+        onError: (e) =>
+          toast.error(
+            e instanceof ApiError && e.status === 409
+              ? `A ${leaf.tier} already exists at ${newPath}`
+              : e instanceof ApiError
+                ? e.message
+                : `Could not move ${leaf.path}`,
+          ),
+      },
+    );
+  }
+
+  function handleRename(leaf: { tier: PolicyTier; path: string }) {
+    openDialog({ kind: "rename", tier: leaf.tier, path: leaf.path });
+  }
+
+  function handleDelete(leaf: { tier: PolicyTier; path: string }) {
+    const saved = modules.find(
+      (m) => m.tier === leaf.tier && m.path === leaf.path,
+    );
+    del.mutate(
+      { tier: leaf.tier, path: leaf.path },
+      {
+        onSuccess: () => {
+          if (isSelected(selection, leaf)) onSelect({ kind: "roles" });
+          toast.success(`Deleted ${leaf.tier}/${leaf.path}`, {
+            action: saved
+              ? {
+                  label: "Undo",
+                  onClick: () =>
+                    upsert.mutate({
+                      tier: saved.tier,
+                      path: saved.path,
+                      content: saved.content,
+                    }),
+                }
+              : undefined,
+          });
+        },
+        onError: (e) =>
+          toast.error(
+            e instanceof ApiError ? e.message : `Could not delete ${leaf.path}`,
+          ),
+      },
+    );
+  }
+
+  const renderNode = (node: TreeNode, depth: number) => {
+    if (node.type === "folder") {
+      const folderKey = `${node.tier}:${node.prefix}`;
+      const isOpen = !collapsed.has(folderKey);
+      const canDrop = !!dragged && dragged.tier === node.tier;
+      return (
+        <div key={`${node.tier}:${node.prefix || node.name}`}>
+          <div
+            className={cn(
+              "group flex items-center gap-1 rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-accent",
+              dropTarget === folderKey && "ring-1 ring-primary bg-primary/10",
+            )}
+            style={{ paddingLeft: `${depth * 12 + 6}px` }}
+            onDragOver={(e) => {
+              if (!canDrop) return;
+              e.preventDefault();
+              setDropTarget(folderKey);
+            }}
+            onDragLeave={() =>
+              setDropTarget((k) => (k === folderKey ? null : k))
+            }
+            onDrop={(e) => {
+              e.preventDefault();
+              setDropTarget(null);
+              if (canDrop && dragged) {
+                moveTo(
+                  { tier: dragged.tier, path: dragged.path },
+                  reparent(node.prefix, dragged.path),
+                );
+              }
+              setDragged(null);
+            }}
+          >
+            <button
+              onClick={() => toggle(`${node.tier}:${node.prefix}`)}
+              className="flex items-center gap-1 flex-1 min-w-0"
+            >
+              {isOpen ? (
+                <ChevronDown className="size-3 shrink-0" />
+              ) : (
+                <ChevronRight className="size-3 shrink-0" />
+              )}
+              <Folder className="size-3.5 shrink-0" />
+              <span className="truncate font-medium">{node.name}</span>
+            </button>
+            {canManage && (
+              <span className="flex items-center gap-1.5 opacity-0 group-hover:opacity-100">
+                <button
+                  title="New module"
+                  onClick={() =>
+                    openDialog({
+                      kind: "new",
+                      tier: node.tier,
+                      prefix: node.prefix,
+                      subfolder: false,
+                    })
+                  }
+                  className="hover:text-foreground"
+                >
+                  <FilePlus className="size-3.5" />
+                </button>
+                <button
+                  title="New subfolder"
+                  onClick={() =>
+                    openDialog({
+                      kind: "new",
+                      tier: node.tier,
+                      prefix: node.prefix,
+                      subfolder: true,
+                    })
+                  }
+                  className="hover:text-foreground"
+                >
+                  <FolderPlus className="size-3.5" />
+                </button>
+              </span>
+            )}
+          </div>
+          {isOpen &&
+            (node.children.length ? (
+              node.children.map((c) => renderNode(c, depth + 1))
+            ) : (
+              <div
+                className="text-[11px] italic text-muted-foreground/60 py-0.5"
+                style={{ paddingLeft: `${(depth + 1) * 12 + 24}px` }}
+              >
+                empty
+              </div>
+            ))}
+        </div>
+      );
+    }
+
+    const active = isSelected(selection, node);
+    const dragging = dragged?.tier === node.tier && dragged?.path === node.path;
+    return (
+      <div
+        key={`${node.tier}:${node.path}`}
+        draggable={canManage}
+        onDragStart={(e) => {
+          setDragged({ tier: node.tier, path: node.path });
+          e.dataTransfer.effectAllowed = "move";
+        }}
+        onDragEnd={() => {
+          setDragged(null);
+          setDropTarget(null);
+        }}
+        className={cn(
+          "group flex items-center gap-1 rounded px-1.5 py-1 text-xs cursor-pointer",
+          active
+            ? "bg-primary/15 text-primary font-medium"
+            : "text-foreground hover:bg-accent",
+          dragging && "opacity-50",
+        )}
+        style={{ paddingLeft: `${depth * 12 + 22}px` }}
+        onClick={() =>
+          onSelect({ kind: "module", tier: node.tier, path: node.path })
+        }
+      >
+        <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="truncate flex-1 font-mono">{node.name}</span>
+        {canManage && (
+          <span className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
+            <button
+              title="Move / rename"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleRename(node);
+              }}
+              className="hover:text-foreground text-muted-foreground"
+            >
+              <Pencil className="size-3" />
+            </button>
+            <button
+              title="Delete"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDelete(node);
+              }}
+              className="hover:text-deny text-muted-foreground"
+            >
+              <Trash2 className="size-3" />
+            </button>
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-full flex flex-col text-sm">
+      <div className="flex items-center justify-between px-3 py-2 border-b border-border">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          Modules
+        </span>
+      </div>
+      <div className="flex-1 overflow-y-auto p-1.5 scrollbar-thin space-y-0.5">
+        {/* roles.yaml is a synthetic, always-present node at the root. */}
+        <div
+          className={cn(
+            "flex items-center gap-1.5 rounded px-1.5 py-1 text-xs cursor-pointer",
+            selection.kind === "roles"
+              ? "bg-primary/15 text-primary font-medium"
+              : "text-foreground hover:bg-accent",
+          )}
+          onClick={() => onSelect({ kind: "roles" })}
+        >
+          <ScrollText className="size-3.5 shrink-0 text-muted-foreground" />
+          <span className="font-mono">roles.yaml</span>
+        </div>
+        {roots.map((root: FolderNode) => renderNode(root, 0))}
+      </div>
+      {dialog?.kind === "new" && (
+        <ModulePathDialog
+          key={dialogSeq}
+          tier={dialog.tier}
+          title={
+            dialog.subfolder
+              ? `New ${dialog.tier} folder`
+              : `New ${dialog.tier}`
+          }
+          description={
+            dialog.subfolder
+              ? "Creates an empty subfolder. Add modules to it afterward. (Folders are UI-only until a module lands, so an empty one resets on reload.)"
+              : "Use / to nest in a subfolder, e.g. team_a/payments."
+          }
+          initial={dialog.prefix ? `${dialog.prefix}/` : ""}
+          existingPaths={dialog.subfolder ? existingFolders : existingPaths}
+          confirmLabel={dialog.subfolder ? "Create folder" : "Create"}
+          onClose={() => setDialog(null)}
+          onSubmit={(path) => {
+            if (dialog.subfolder) addEmptyFolder(dialog.tier, path);
+            else createModule(dialog.tier, path);
+            setDialog(null);
+          }}
+        />
+      )}
+      {dialog?.kind === "rename" && (
+        <ModulePathDialog
+          key={dialogSeq}
+          tier={dialog.tier}
+          title={`Move / rename ${dialog.tier}`}
+          description="Rename in place, or move it by changing the folder path (use / to nest). Renaming a capability updates the roles that import it."
+          initial={dialog.path}
+          existingPaths={existingPaths}
+          selfPath={dialog.path}
+          confirmLabel="Save"
+          onClose={() => setDialog(null)}
+          onSubmit={(path) => {
+            moveTo({ tier: dialog.tier, path: dialog.path }, path);
+            setDialog(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Modal for a module path — used to create (new module / subfolder) and to
+ * rename/move. Trims the path (whitespace + edge slashes) and blocks
+ * duplicates against the full tier+path; `selfPath` excludes the entry's own
+ * path (so an unchanged rename is a no-op, not a "duplicate"); `requireSlash`
+ * enforces nesting in subfolder mode. */
+function ModulePathDialog({
+  tier,
+  title,
+  description,
+  initial,
+  existingPaths,
+  selfPath,
+  requireSlash,
+  confirmLabel,
+  onClose,
+  onSubmit,
+}: {
+  tier: PolicyTier;
+  title: string;
+  description: string;
+  initial: string;
+  existingPaths: Set<string>;
+  selfPath?: string;
+  requireSlash?: boolean;
+  confirmLabel: string;
+  onClose: () => void;
+  onSubmit: (path: string) => void;
+}) {
+  const [value, setValue] = useState(initial);
+  const path = normalizePath(value);
+  const isSelf = selfPath !== undefined && path === selfPath;
+  const error = !path
+    ? "Enter a name."
+    : existingPaths.has(`${tier}:${path}`) && !isSelf
+      ? `A ${tier} already exists at ${path}.`
+      : requireSlash && !path.includes("/")
+        ? "Use folder/name to create a subfolder."
+        : null;
+  // isSelf = an unchanged rename: valid input, but nothing to do -> disabled.
+  const disabled = !!error || isSelf;
+
+  const submit = () => {
+    if (!disabled) onSubmit(path);
+  };
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-2">
+          <Label htmlFor="module-path">Path</Label>
+          <Input
+            id="module-path"
+            autoFocus
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && submit()}
+            placeholder={tier === "capability" ? "team_a/payments" : "org_core"}
+          />
+          {error && value.trim() !== "" && (
+            <p className="text-xs text-deny">{error}</p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button disabled={disabled} onClick={submit}>
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/platform/dashboard/src/components/policy_modules/ModuleTree.tsx
+++ b/platform/dashboard/src/components/policy_modules/ModuleTree.tsx
@@ -407,7 +407,7 @@ export function ModuleTree({
         }
       >
         <FileText className="size-3.5 shrink-0 text-muted-foreground" />
-        <span className="truncate flex-1 font-mono">{node.name}</span>
+        <span className="truncate flex-1">{node.name}</span>
         {canManage && (
           <span className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
             <button
@@ -440,7 +440,7 @@ export function ModuleTree({
     <div className="h-full flex flex-col text-sm">
       <div className="flex items-center justify-between px-3 py-2 border-b border-border">
         <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-          Modules
+          Files
         </span>
       </div>
       <div className="flex-1 overflow-y-auto p-1.5 scrollbar-thin space-y-0.5">
@@ -455,7 +455,7 @@ export function ModuleTree({
           onClick={() => onSelect({ kind: "roles" })}
         >
           <ScrollText className="size-3.5 shrink-0 text-muted-foreground" />
-          <span className="font-mono">roles.yaml</span>
+          <span>roles.yaml</span>
         </div>
         {roots.map((root: FolderNode) => renderNode(root, 0))}
       </div>

--- a/platform/dashboard/src/components/policy_modules/TestPanel.tsx
+++ b/platform/dashboard/src/components/policy_modules/TestPanel.tsx
@@ -1,4 +1,6 @@
 import { useMemo, useState } from "react";
+import CodeMirror from "@uiw/react-codemirror";
+import { yaml } from "@codemirror/lang-yaml";
 import { CheckCircle2, MinusCircle, Play, ShieldAlert } from "lucide-react";
 
 import {
@@ -9,8 +11,22 @@ import {
   type RoleBindings,
 } from "@/lib/api";
 import { useTestPolicy } from "@/lib/policy_modules";
+import { policyEditorThemeTransparent } from "@/components/PolicyEditor/theme";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+
+// JSON is a subset of YAML, so the YAML grammar highlights the call JSON
+// (keys / strings / numbers) without pulling in a separate lang-json dep.
+const JSON_EXTENSIONS = [yaml()];
+const JSON_BASIC_SETUP = {
+  lineNumbers: false,
+  foldGutter: false,
+  highlightActiveLine: false,
+  highlightActiveLineGutter: false,
+  autocompletion: false,
+  bracketMatching: true,
+  closeBrackets: true,
+} as const;
 
 const SAMPLE = '{\n  "tool": "refund_order",\n  "args": { "amount": 50 }\n}';
 
@@ -125,16 +141,26 @@ export function TestPanel({
         </select>
       </label>
 
-      <label className="flex flex-col gap-1 text-xs flex-1 min-h-[120px]">
+      <div className="flex flex-col gap-1 text-xs flex-1 min-h-[120px]">
         <span className="text-muted-foreground">Call (JSON)</span>
-        <textarea
-          value={call}
-          onChange={(e) => setCall(e.target.value)}
-          disabled={disabled}
-          spellCheck={false}
-          className="flex-1 rounded-md border border-border bg-background p-2 text-xs font-mono resize-none focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
-        />
-      </label>
+        <div
+          className={cn(
+            "flex-1 overflow-auto rounded-md border border-border scrollbar-thin",
+            disabled && "opacity-50 pointer-events-none",
+          )}
+        >
+          <CodeMirror
+            value={call}
+            onChange={setCall}
+            editable={!disabled}
+            extensions={JSON_EXTENSIONS}
+            theme={policyEditorThemeTransparent}
+            basicSetup={JSON_BASIC_SETUP}
+            height="100%"
+            className="text-xs"
+          />
+        </div>
+      </div>
 
       {parseError && (
         <p className="text-xs text-deny font-mono">{parseError}</p>

--- a/platform/dashboard/src/components/policy_modules/TestPanel.tsx
+++ b/platform/dashboard/src/components/policy_modules/TestPanel.tsx
@@ -70,12 +70,22 @@ export function TestPanel({
 }) {
   const roleNames = useMemo(() => Object.keys(roles).sort(), [roles]);
   const [role, setRole] = useState<string>(roleNames[0] ?? "");
+  const [agent, setAgent] = useState<string>("main");
   const [call, setCall] = useState<string>(SAMPLE);
   const [parseError, setParseError] = useState<string | null>(null);
   const test = useTestPolicy(projectId);
 
   // Keep a valid role selected as bindings load / change.
   const effectiveRole = roleNames.includes(role) ? role : (roleNames[0] ?? "");
+
+  // Agent names the bindings mention (besides the generic "*"), for autocomplete.
+  const knownAgents = useMemo(() => {
+    const names = new Set<string>(["main"]);
+    for (const cells of Object.values(roles)) {
+      for (const a of Object.keys(cells)) if (a !== "*") names.add(a);
+    }
+    return [...names].sort();
+  }, [roles]);
 
   function run() {
     let parsed: { tool?: unknown; args?: unknown; attributes?: unknown };
@@ -106,6 +116,7 @@ export function TestPanel({
     setParseError(null);
     test.mutate({
       role: effectiveRole,
+      agent: agent.trim() || "main",
       tool: parsed.tool,
       args: (parsed.args as Record<string, unknown>) ?? {},
       attributes: (parsed.attributes as Record<string, unknown>) ?? null,
@@ -139,6 +150,28 @@ export function TestPanel({
             </option>
           ))}
         </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="text-muted-foreground">
+          Executing agent{" "}
+          <span className="text-muted-foreground/70">
+            (falls back to <span className="font-mono">*</span> if unnamed)
+          </span>
+        </span>
+        <input
+          value={agent}
+          onChange={(e) => setAgent(e.target.value)}
+          disabled={disabled}
+          list="test-known-agents"
+          placeholder="main"
+          className="h-8 rounded-md border border-border bg-background px-2 text-sm font-mono focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+        />
+        <datalist id="test-known-agents">
+          {knownAgents.map((a) => (
+            <option key={a} value={a} />
+          ))}
+        </datalist>
       </label>
 
       <div className="flex flex-col gap-1 text-xs flex-1 min-h-[120px]">

--- a/platform/dashboard/src/components/policy_modules/TestPanel.tsx
+++ b/platform/dashboard/src/components/policy_modules/TestPanel.tsx
@@ -1,0 +1,189 @@
+import { useMemo, useState } from "react";
+import { CheckCircle2, MinusCircle, Play, ShieldAlert } from "lucide-react";
+
+import {
+  ApiError,
+  type PolicyDraft,
+  type PolicyTestOutcome,
+  type PolicyTestResponse,
+  type RoleBindings,
+} from "@/lib/api";
+import { useTestPolicy } from "@/lib/policy_modules";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const SAMPLE = '{\n  "tool": "refund_order",\n  "args": { "amount": 50 }\n}';
+
+const OUTCOME: Record<
+  PolicyTestOutcome,
+  { label: string; className: string; Icon: typeof CheckCircle2 }
+> = {
+  allow: {
+    label: "ALLOW",
+    className: "bg-allow/10 border-allow/40 text-allow",
+    Icon: CheckCircle2,
+  },
+  deny: {
+    label: "DENY",
+    className: "bg-deny/10 border-deny/40 text-deny",
+    Icon: MinusCircle,
+  },
+  approval_required: {
+    label: "APPROVAL REQUIRED",
+    className: "bg-approval/10 border-approval/40 text-approval",
+    Icon: ShieldAlert,
+  },
+};
+
+/**
+ * Decision tester — "would this call be allowed?". A role + a JSON call
+ * (`{tool, args, attributes?}`) evaluated against the WHOLE resolved policy
+ * (boundaries + that role's capabilities composed), not the open module. The
+ * unsaved `draft` is overlaid so the verdict matches the resolved preview.
+ */
+export function TestPanel({
+  projectId,
+  roles,
+  draft,
+  resolves,
+}: {
+  projectId: string;
+  roles: RoleBindings;
+  draft: PolicyDraft | null;
+  resolves: boolean;
+}) {
+  const roleNames = useMemo(() => Object.keys(roles).sort(), [roles]);
+  const [role, setRole] = useState<string>(roleNames[0] ?? "");
+  const [call, setCall] = useState<string>(SAMPLE);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const test = useTestPolicy(projectId);
+
+  // Keep a valid role selected as bindings load / change.
+  const effectiveRole = roleNames.includes(role) ? role : (roleNames[0] ?? "");
+
+  function run() {
+    let parsed: { tool?: unknown; args?: unknown; attributes?: unknown };
+    try {
+      parsed = JSON.parse(call);
+    } catch (e) {
+      setParseError(e instanceof Error ? e.message : "invalid JSON");
+      return;
+    }
+    if (!parsed || typeof parsed.tool !== "string" || !parsed.tool) {
+      setParseError('the call must include a string "tool"');
+      return;
+    }
+    const isObj = (v: unknown) =>
+      typeof v === "object" && v !== null && !Array.isArray(v);
+    if (parsed.args !== undefined && !isObj(parsed.args)) {
+      setParseError('"args" must be a JSON object');
+      return;
+    }
+    if (
+      parsed.attributes !== undefined &&
+      parsed.attributes !== null &&
+      !isObj(parsed.attributes)
+    ) {
+      setParseError('"attributes" must be a JSON object');
+      return;
+    }
+    setParseError(null);
+    test.mutate({
+      role: effectiveRole,
+      tool: parsed.tool,
+      args: (parsed.args as Record<string, unknown>) ?? {},
+      attributes: (parsed.attributes as Record<string, unknown>) ?? null,
+      draft,
+    });
+  }
+
+  const disabled = !resolves || roleNames.length === 0;
+
+  return (
+    <div className="h-full flex flex-col gap-3 p-4 overflow-y-auto scrollbar-thin">
+      {disabled && (
+        <p className="text-xs text-muted-foreground">
+          {roleNames.length === 0
+            ? "Bind a role in roles.yaml to test a call."
+            : "The policy doesn't currently resolve — fix the lints, then test."}
+        </p>
+      )}
+
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="text-muted-foreground">Role</span>
+        <select
+          value={effectiveRole}
+          onChange={(e) => setRole(e.target.value)}
+          disabled={disabled}
+          className="h-8 rounded-md border border-border bg-background px-2 text-sm font-mono focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+        >
+          {roleNames.map((r) => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs flex-1 min-h-[120px]">
+        <span className="text-muted-foreground">Call (JSON)</span>
+        <textarea
+          value={call}
+          onChange={(e) => setCall(e.target.value)}
+          disabled={disabled}
+          spellCheck={false}
+          className="flex-1 rounded-md border border-border bg-background p-2 text-xs font-mono resize-none focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
+        />
+      </label>
+
+      {parseError && (
+        <p className="text-xs text-deny font-mono">{parseError}</p>
+      )}
+
+      <Button
+        size="sm"
+        onClick={run}
+        disabled={disabled || test.isPending}
+        className="gap-1.5 h-8 self-start"
+      >
+        <Play className="size-3.5" />
+        {test.isPending ? "Checking…" : "Check"}
+      </Button>
+
+      {test.isError && (
+        <p className="text-xs text-deny">
+          {test.error instanceof ApiError
+            ? test.error.message
+            : "Could not evaluate the call."}
+        </p>
+      )}
+      {test.data && <Verdict verdict={test.data} />}
+    </div>
+  );
+}
+
+function Verdict({ verdict }: { verdict: PolicyTestResponse }) {
+  const spec = OUTCOME[verdict.outcome];
+  const { Icon } = spec;
+  return (
+    <div className={cn("rounded-md border p-3 space-y-2", spec.className)}>
+      <div className="flex items-center gap-1.5 text-sm font-semibold">
+        <Icon className="size-4" />
+        {spec.label}
+      </div>
+      {verdict.reason && (
+        <p className="text-xs text-foreground/80">{verdict.reason}</p>
+      )}
+      {verdict.violations.length > 0 && (
+        <ul className="text-xs font-mono text-foreground/80 space-y-0.5">
+          {verdict.violations.map((v, i) => (
+            <li key={i}>· {v}</li>
+          ))}
+        </ul>
+      )}
+      {verdict.hint && (
+        <p className="text-[11px] text-muted-foreground">{verdict.hint}</p>
+      )}
+    </div>
+  );
+}

--- a/platform/dashboard/src/components/policy_modules/TestPanel.tsx
+++ b/platform/dashboard/src/components/policy_modules/TestPanel.tsx
@@ -70,7 +70,7 @@ export function TestPanel({
 }) {
   const roleNames = useMemo(() => Object.keys(roles).sort(), [roles]);
   const [role, setRole] = useState<string>(roleNames[0] ?? "");
-  const [agent, setAgent] = useState<string>("main");
+  const [agent, setAgent] = useState<string>("*");
   const [call, setCall] = useState<string>(SAMPLE);
   const [parseError, setParseError] = useState<string | null>(null);
   const test = useTestPolicy(projectId);
@@ -78,11 +78,11 @@ export function TestPanel({
   // Keep a valid role selected as bindings load / change.
   const effectiveRole = roleNames.includes(role) ? role : (roleNames[0] ?? "");
 
-  // Agent names the bindings mention (besides the generic "*"), for autocomplete.
+  // The generic "*" column plus every agent the bindings name, for autocomplete.
   const knownAgents = useMemo(() => {
-    const names = new Set<string>(["main"]);
+    const names = new Set<string>(["*"]);
     for (const cells of Object.values(roles)) {
-      for (const a of Object.keys(cells)) if (a !== "*") names.add(a);
+      for (const a of Object.keys(cells)) names.add(a);
     }
     return [...names].sort();
   }, [roles]);
@@ -116,7 +116,7 @@ export function TestPanel({
     setParseError(null);
     test.mutate({
       role: effectiveRole,
-      agent: agent.trim() || "main",
+      agent: agent.trim() || "*",
       tool: parsed.tool,
       args: (parsed.args as Record<string, unknown>) ?? {},
       attributes: (parsed.attributes as Record<string, unknown>) ?? null,
@@ -156,7 +156,8 @@ export function TestPanel({
         <span className="text-muted-foreground">
           Executing agent{" "}
           <span className="text-muted-foreground/70">
-            (falls back to <span className="font-mono">*</span> if unnamed)
+            (<span className="font-mono">*</span> = the generic column; a named
+            agent uses its own)
           </span>
         </span>
         <input
@@ -164,7 +165,7 @@ export function TestPanel({
           onChange={(e) => setAgent(e.target.value)}
           disabled={disabled}
           list="test-known-agents"
-          placeholder="main"
+          placeholder="*"
           className="h-8 rounded-md border border-border bg-background px-2 text-sm font-mono focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-50"
         />
         <datalist id="test-known-agents">

--- a/platform/dashboard/src/lib/api.ts
+++ b/platform/dashboard/src/lib/api.ts
@@ -226,6 +226,13 @@ export interface PolicyModuleRead {
   updated_at: string;
 }
 
+/** A persisted empty folder (tier + path prefix). Folders are otherwise derived
+ * from module paths; these keep an empty one visible before a module lands. */
+export interface PolicyFolder {
+  tier: PolicyTier;
+  path: string;
+}
+
 /** Role -> the capability names it imports. Boundaries always apply, so they
  * carry no binding. An empty map means the project is still classic. */
 export type RoleBindings = Record<string, string[]>;
@@ -627,6 +634,21 @@ export const api = {
     request<PolicyModuleRead>(
       `/v1/projects/${projectId}/policy-modules/${tier}/${encodePath(path)}`,
       { method: "PATCH", body: JSON.stringify({ new_path: newPath }) },
+    ),
+
+  listPolicyFolders: (projectId: string) =>
+    request<PolicyFolder[]>(`/v1/projects/${projectId}/policy-folders`),
+
+  createPolicyFolder: (projectId: string, tier: PolicyTier, path: string) =>
+    request<PolicyFolder>(
+      `/v1/projects/${projectId}/policy-folders/${tier}/${encodePath(path)}`,
+      { method: "PUT" },
+    ),
+
+  deletePolicyFolder: (projectId: string, tier: PolicyTier, path: string) =>
+    request<void>(
+      `/v1/projects/${projectId}/policy-folders/${tier}/${encodePath(path)}`,
+      { method: "DELETE" },
     ),
 
   getPolicyRoles: (projectId: string) =>

--- a/platform/dashboard/src/lib/api.ts
+++ b/platform/dashboard/src/lib/api.ts
@@ -212,6 +212,78 @@ export interface ValidatePolicyResponse {
   warnings: PolicyValidationError[];
 }
 
+// --- Policy modules (multi-module editor; mirrors platform/api/schemas.py) ---
+
+export type PolicyTier = "boundary" | "capability";
+
+/** One stored module — a boundary (ceiling/deny) or capability (grant). The
+ * `path` may contain slashes for subfolders (e.g. `team_a/payments`). */
+export interface PolicyModuleRead {
+  tier: PolicyTier;
+  path: string;
+  content: string;
+  content_hash: string;
+  updated_at: string;
+}
+
+/** Role -> the capability names it imports. Boundaries always apply, so they
+ * carry no binding. An empty map means the project is still classic. */
+export type RoleBindings = Record<string, string[]>;
+
+/** One analyzer lint over the composed project. `source`/`tier`/`tool`/`role`
+ * locate it; a null `role` is a project-wide concern. */
+export interface PolicyLint {
+  code: string;
+  severity: "error" | "warning" | "info";
+  message: string;
+  source: string | null;
+  tier: string | null;
+  tool: string | null;
+  role: string | null;
+}
+
+/** The effective policy for one role: a tool map plus the catch-all default.
+ * Loosely typed — it's an AgentPolicy dump the editor only renders. */
+export interface ResolvedRolePolicy {
+  default_policy?: { mode?: string } | null;
+  tools?: Record<
+    string,
+    { mode?: string; constraints?: string[] | null } | null
+  >;
+  [key: string]: unknown;
+}
+
+export type ResolvedPolicy = Record<string, ResolvedRolePolicy>;
+
+/** The editor's unsaved edit, overlaid before resolve/test. One module OR the
+ * roles map, never both (matches PolicyDraft server-side). */
+export interface PolicyDraft {
+  module?: { tier: PolicyTier; path: string; content: string };
+  roles?: RoleBindings;
+}
+
+export interface PolicyPreviewResponse {
+  resolved: ResolvedPolicy;
+  lints: PolicyLint[];
+}
+
+export type PolicyTestOutcome = "allow" | "deny" | "approval_required";
+
+export interface PolicyTestRequest {
+  role: string;
+  tool: string;
+  args?: Record<string, unknown>;
+  attributes?: Record<string, unknown> | null;
+  draft?: PolicyDraft | null;
+}
+
+export interface PolicyTestResponse {
+  outcome: PolicyTestOutcome;
+  reason: string | null;
+  violations: string[];
+  hint: string | null;
+}
+
 // --- Audit dashboard (mirrors platform/api/schemas.py) ----------------------
 
 export type AuditWindow = "24h" | "7d" | "30d" | "90d";
@@ -413,6 +485,14 @@ export interface LlmUsageScope {
   end_date?: string;
 }
 
+/** Encode a module path for a URL while preserving the `/` separators the
+ * `{path:path}` route depends on: each segment is percent-encoded, slashes
+ * kept. A path typed into a prompt may hold `?`, `#`, `%`, or spaces, which
+ * would otherwise be parsed as query/fragment/escape and hit the wrong route. */
+function encodePath(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
 function qs(params: Record<string, string | number | undefined>): string {
   const search = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
@@ -513,4 +593,72 @@ export const api = {
     request<LlmInvocationSummary>(
       `/v1/projects/${projectId}/llm/summary${qs({ ...scope })}`,
     ),
+
+  // --- policy modules (multi-module editor) --------------------------------
+  // `path` may contain slashes (subfolders); the route's `{path:path}` keeps
+  // them, so `encodePath` encodes each segment but preserves the separators.
+
+  listPolicyModules: (projectId: string) =>
+    request<PolicyModuleRead[]>(`/v1/projects/${projectId}/policy-modules`),
+
+  upsertPolicyModule: (
+    projectId: string,
+    tier: PolicyTier,
+    path: string,
+    content: string,
+  ) =>
+    request<PolicyModuleRead>(
+      `/v1/projects/${projectId}/policy-modules/${tier}/${encodePath(path)}`,
+      { method: "PUT", body: JSON.stringify({ content }) },
+    ),
+
+  deletePolicyModule: (projectId: string, tier: PolicyTier, path: string) =>
+    request<void>(
+      `/v1/projects/${projectId}/policy-modules/${tier}/${encodePath(path)}`,
+      { method: "DELETE" },
+    ),
+
+  movePolicyModule: (
+    projectId: string,
+    tier: PolicyTier,
+    path: string,
+    newPath: string,
+  ) =>
+    request<PolicyModuleRead>(
+      `/v1/projects/${projectId}/policy-modules/${tier}/${encodePath(path)}`,
+      { method: "PATCH", body: JSON.stringify({ new_path: newPath }) },
+    ),
+
+  getPolicyRoles: (projectId: string) =>
+    request<{ roles: RoleBindings }>(
+      `/v1/projects/${projectId}/policy-roles`,
+    ).then((r) => r.roles),
+
+  setPolicyRoles: (projectId: string, roles: RoleBindings) =>
+    request<{ roles: RoleBindings }>(`/v1/projects/${projectId}/policy-roles`, {
+      method: "PUT",
+      body: JSON.stringify({ roles }),
+    }).then((r) => r.roles),
+
+  resolvePolicy: (projectId: string, role?: string) =>
+    request<{ roles: ResolvedPolicy }>(
+      `/v1/projects/${projectId}/policy/resolve${qs({ role })}`,
+    ).then((r) => r.roles),
+
+  checkPolicy: (projectId: string) =>
+    request<{ ok: boolean; lints: PolicyLint[] }>(
+      `/v1/projects/${projectId}/policy/check`,
+    ),
+
+  previewPolicy: (projectId: string, draft?: PolicyDraft | null) =>
+    request<PolicyPreviewResponse>(`/v1/projects/${projectId}/policy/preview`, {
+      method: "POST",
+      body: JSON.stringify({ draft: draft ?? null }),
+    }),
+
+  testPolicy: (projectId: string, body: PolicyTestRequest) =>
+    request<PolicyTestResponse>(`/v1/projects/${projectId}/policy/test`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 };

--- a/platform/dashboard/src/lib/api.ts
+++ b/platform/dashboard/src/lib/api.ts
@@ -233,9 +233,11 @@ export interface PolicyFolder {
   path: string;
 }
 
-/** Role -> the capability names it imports. Boundaries always apply, so they
+/** The (role, agent) matrix: role -> agent-or-"*" -> the capability names it
+ * imports. `"*"` is the generic agent (applies to any agent not named); a named
+ * agent's cell replaces `"*"` for that agent. Boundaries always apply, so they
  * carry no binding. An empty map means the project is still classic. */
-export type RoleBindings = Record<string, string[]>;
+export type RoleBindings = Record<string, Record<string, string[]>>;
 
 /** One analyzer lint over the composed project. `source`/`tier`/`tool`/`role`
  * locate it; a null `role` is a project-wide concern. */
@@ -278,6 +280,8 @@ export type PolicyTestOutcome = "allow" | "deny" | "approval_required";
 
 export interface PolicyTestRequest {
   role: string;
+  /** The executing agent whose column to test against; defaults to "main". */
+  agent?: string;
   tool: string;
   args?: Record<string, unknown>;
   attributes?: Record<string, unknown> | null;

--- a/platform/dashboard/src/lib/api_policy_modules.test.ts
+++ b/platform/dashboard/src/lib/api_policy_modules.test.ts
@@ -142,3 +142,32 @@ describe("policy-module api requests", () => {
     });
   });
 });
+
+describe("policy-folder api requests", () => {
+  it("lists folders", async () => {
+    const calls = capture([]);
+    await api.listPolicyFolders(P);
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy-folders",
+      method: "GET",
+    });
+  });
+
+  it("creates a folder via PUT, encoding path segments", async () => {
+    const calls = capture({ tier: "capability", path: "team a/x" });
+    await api.createPolicyFolder(P, "capability", "team a/x");
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy-folders/capability/team%20a/x",
+      method: "PUT",
+    });
+  });
+
+  it("deletes a folder", async () => {
+    const calls = capture(null, 204);
+    await api.deletePolicyFolder(P, "boundary", "team_a");
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy-folders/boundary/team_a",
+      method: "DELETE",
+    });
+  });
+});

--- a/platform/dashboard/src/lib/api_policy_modules.test.ts
+++ b/platform/dashboard/src/lib/api_policy_modules.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Request-shape tests for the policy-module API surface: right verb, right
+ * URL (nested paths stay un-encoded so `{path:path}` keeps the slashes),
+ * right body, and the `.roles` unwrapping on the roles/resolve reads.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "./api";
+
+interface Captured {
+  url: string;
+  method: string;
+  body: unknown;
+}
+
+function capture(responseBody: unknown, status = 200): Captured[] {
+  const calls: Captured[] = [];
+  vi.spyOn(window, "fetch").mockImplementation(async (input, init) => {
+    calls.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    });
+    if (status === 204) return new Response(null, { status });
+    return new Response(JSON.stringify(responseBody), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return calls;
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+const P = "p1";
+
+describe("policy-module api requests", () => {
+  it("lists modules", async () => {
+    const calls = capture([]);
+    await api.listPolicyModules(P);
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy-modules",
+      method: "GET",
+    });
+  });
+
+  it("upserts a nested capability without encoding the slash", async () => {
+    const calls = capture({});
+    await api.upsertPolicyModule(P, "capability", "team_a/payments", "yaml");
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy-modules/capability/team_a/payments",
+      method: "PUT",
+      body: { content: "yaml" },
+    });
+  });
+
+  it("percent-encodes path segments but keeps the slash separators", async () => {
+    const calls = capture({});
+    await api.upsertPolicyModule(P, "capability", "team a/pay #1", "y");
+    expect(calls[0].url).toBe(
+      "/v1/projects/p1/policy-modules/capability/team%20a/pay%20%231",
+    );
+  });
+
+  it("moves a module via PATCH with new_path", async () => {
+    const calls = capture({});
+    await api.movePolicyModule(P, "capability", "old", "team_a/new");
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy-modules/capability/old",
+      method: "PATCH",
+      body: { new_path: "team_a/new" },
+    });
+  });
+
+  it("deletes a module", async () => {
+    const calls = capture(null, 204);
+    await api.deletePolicyModule(P, "boundary", "org_core");
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy-modules/boundary/org_core",
+      method: "DELETE",
+    });
+  });
+
+  it("unwraps .roles on get + put", async () => {
+    const calls = capture({ roles: { default: ["read_only"] } });
+    const got = await api.getPolicyRoles(P);
+    expect(got).toEqual({ default: ["read_only"] });
+
+    const put = await api.setPolicyRoles(P, { billing: ["payments"] });
+    expect(put).toEqual({ default: ["read_only"] }); // echoed stub body
+    expect(calls[1]).toMatchObject({
+      url: "/v1/projects/p1/policy-roles",
+      method: "PUT",
+      body: { roles: { billing: ["payments"] } },
+    });
+  });
+
+  it("passes role as a query param on resolve and unwraps .roles", async () => {
+    const calls = capture({ roles: { billing: { tools: {} } } });
+    const resolved = await api.resolvePolicy(P, "billing");
+    expect(resolved).toEqual({ billing: { tools: {} } });
+    expect(calls[0].url).toBe("/v1/projects/p1/policy/resolve?role=billing");
+  });
+
+  it("omits the query string when no role is given", async () => {
+    const calls = capture({ roles: {} });
+    await api.resolvePolicy(P);
+    expect(calls[0].url).toBe("/v1/projects/p1/policy/resolve");
+  });
+
+  it("posts a preview with the draft overlay", async () => {
+    const calls = capture({ resolved: {}, lints: [] });
+    await api.previewPolicy(P, {
+      module: { tier: "capability", path: "x", content: "c" },
+    });
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy/preview",
+      method: "POST",
+      body: {
+        draft: { module: { tier: "capability", path: "x", content: "c" } },
+      },
+    });
+  });
+
+  it("posts a test call", async () => {
+    const calls = capture({
+      outcome: "allow",
+      reason: null,
+      violations: [],
+      hint: null,
+    });
+    await api.testPolicy(P, {
+      role: "billing",
+      tool: "refund_order",
+      args: { amount: 50 },
+    });
+    expect(calls[0]).toMatchObject({
+      url: "/v1/projects/p1/policy/test",
+      method: "POST",
+      body: { role: "billing", tool: "refund_order", args: { amount: 50 } },
+    });
+  });
+});

--- a/platform/dashboard/src/lib/api_policy_modules.test.ts
+++ b/platform/dashboard/src/lib/api_policy_modules.test.ts
@@ -83,16 +83,16 @@ describe("policy-module api requests", () => {
   });
 
   it("unwraps .roles on get + put", async () => {
-    const calls = capture({ roles: { default: ["read_only"] } });
+    const calls = capture({ roles: { default: { "*": ["read_only"] } } });
     const got = await api.getPolicyRoles(P);
-    expect(got).toEqual({ default: ["read_only"] });
+    expect(got).toEqual({ default: { "*": ["read_only"] } });
 
-    const put = await api.setPolicyRoles(P, { billing: ["payments"] });
-    expect(put).toEqual({ default: ["read_only"] }); // echoed stub body
+    const put = await api.setPolicyRoles(P, { billing: { "*": ["payments"] } });
+    expect(put).toEqual({ default: { "*": ["read_only"] } }); // echoed stub body
     expect(calls[1]).toMatchObject({
       url: "/v1/projects/p1/policy-roles",
       method: "PUT",
-      body: { roles: { billing: ["payments"] } },
+      body: { roles: { billing: { "*": ["payments"] } } },
     });
   });
 

--- a/platform/dashboard/src/lib/module_tree.test.ts
+++ b/platform/dashboard/src/lib/module_tree.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Pure tests for the module-tree builder + lint line anchoring. These back
+ * the left pane (rows rendered as the SDK's on-disk layout) and the inline
+ * gutter markers, so they're worth pinning without a DOM.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { PolicyLint, PolicyModuleRead } from "./api";
+import { buildModuleTree, lintToLine, reparent } from "./module_tree";
+
+function mod(tier: PolicyModuleRead["tier"], path: string): PolicyModuleRead {
+  return {
+    tier,
+    path,
+    content: "",
+    content_hash: "h",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("buildModuleTree", () => {
+  it("always returns the two tier roots, even when empty", () => {
+    const [boundaries, capabilities] = buildModuleTree([]);
+    expect(boundaries.name).toBe("boundaries");
+    expect(boundaries.tier).toBe("boundary");
+    expect(boundaries.children).toEqual([]);
+    expect(capabilities.name).toBe("capabilities");
+    expect(capabilities.children).toEqual([]);
+  });
+
+  it("nests a slashed capability path into folders", () => {
+    const [, capabilities] = buildModuleTree([
+      mod("capability", "team_a/payments"),
+    ]);
+    expect(capabilities.children).toHaveLength(1);
+    const folder = capabilities.children[0];
+    expect(folder.type).toBe("folder");
+    if (folder.type !== "folder") throw new Error("expected folder");
+    expect(folder.name).toBe("team_a");
+    expect(folder.prefix).toBe("team_a");
+    const leaf = folder.children[0];
+    expect(leaf).toMatchObject({
+      type: "file",
+      name: "payments",
+      path: "team_a/payments",
+    });
+  });
+
+  it("sorts folders before files, each group alphabetically", () => {
+    const [, capabilities] = buildModuleTree([
+      mod("capability", "zed"),
+      mod("capability", "team_b/x"),
+      mod("capability", "alpha"),
+      mod("capability", "team_a/y"),
+    ]);
+    const names = capabilities.children.map((n) => n.name);
+    expect(names).toEqual(["team_a", "team_b", "alpha", "zed"]);
+  });
+
+  it("injects a UI-only empty folder even with no modules", () => {
+    const [, capabilities] = buildModuleTree(
+      [],
+      [{ tier: "capability", prefix: "team_a" }],
+    );
+    expect(capabilities.children).toHaveLength(1);
+    const folder = capabilities.children[0];
+    expect(folder).toMatchObject({
+      type: "folder",
+      name: "team_a",
+      prefix: "team_a",
+    });
+    if (folder.type === "folder") expect(folder.children).toEqual([]);
+  });
+
+  it("routes modules to their own tier root", () => {
+    const [boundaries, capabilities] = buildModuleTree([
+      mod("boundary", "org_core"),
+      mod("capability", "read_only"),
+    ]);
+    expect(boundaries.children.map((n) => n.name)).toEqual(["org_core"]);
+    expect(capabilities.children.map((n) => n.name)).toEqual(["read_only"]);
+  });
+});
+
+describe("reparent (drag-to-move target path)", () => {
+  it("reparents a top-level module under a folder, keeping the basename", () => {
+    expect(reparent("team_a", "payments")).toBe("team_a/payments");
+  });
+
+  it("keeps the basename when moving between folders", () => {
+    expect(reparent("team_b", "team_a/payments")).toBe("team_b/payments");
+  });
+
+  it("moves back to the top level at a tier root (empty prefix)", () => {
+    expect(reparent("", "team_a/payments")).toBe("payments");
+  });
+});
+
+describe("lintToLine", () => {
+  const content =
+    "default_policy: { mode: allow }\ntools:\n  refund_order: { mode: allow }\n";
+
+  function lint(tool: string | null): PolicyLint {
+    return {
+      code: "dead-grant",
+      severity: "warning",
+      message: "x",
+      source: "cap",
+      tier: "capability",
+      tool,
+      role: null,
+    };
+  }
+
+  it("anchors a tool-scoped lint to the tool's line (1-based)", () => {
+    expect(lintToLine(content, lint("refund_order"))).toBe(3);
+  });
+
+  it("returns null for a lint with no tool", () => {
+    expect(lintToLine(content, lint(null))).toBeNull();
+  });
+
+  it("returns null when the tool isn't in the buffer", () => {
+    expect(lintToLine(content, lint("delete_database"))).toBeNull();
+  });
+
+  it("skips a same-named top-level key and anchors to the nested tool", () => {
+    const c = "refund_order: junk\ntools:\n  refund_order: { mode: allow }\n";
+    expect(lintToLine(c, lint("refund_order"))).toBe(3);
+  });
+});

--- a/platform/dashboard/src/lib/module_tree.ts
+++ b/platform/dashboard/src/lib/module_tree.ts
@@ -1,0 +1,169 @@
+/**
+ * Pure helpers backing the module tree — the left pane renders the DB rows
+ * (`policy_module`) as the SDK's on-disk layout: `boundaries/`, `capabilities/`
+ * (nestable), and a synthetic `roles.yaml` at the root. Folders are derived
+ * from module paths; there is no folder entity.
+ */
+
+import type { PolicyLint, PolicyModuleRead, PolicyTier } from "./api";
+
+/** Which node the editor has open. `roles` is the synthetic roles.yaml. */
+export type Selection =
+  | { kind: "module"; tier: PolicyTier; path: string }
+  | { kind: "roles" };
+
+export interface FileLeaf {
+  type: "file";
+  /** Last path segment — the display name. */
+  name: string;
+  tier: PolicyTier;
+  /** Full module path (may contain slashes). */
+  path: string;
+}
+
+export interface FolderNode {
+  type: "folder";
+  name: string;
+  /** Path prefix this folder represents, "" at a tier root. */
+  prefix: string;
+  tier: PolicyTier;
+  children: TreeNode[];
+}
+
+export type TreeNode = FolderNode | FileLeaf;
+
+const TIER_FOLDER: Record<PolicyTier, string> = {
+  boundary: "boundaries",
+  capability: "capabilities",
+};
+
+/** Insert one module into a tier's child list, creating folders as needed. */
+function insert(children: TreeNode[], mod: PolicyModuleRead): void {
+  const segments = mod.path.split("/").filter(Boolean);
+  let level = children;
+  let prefix = "";
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
+    const last = i === segments.length - 1;
+    if (last) {
+      level.push({ type: "file", name: seg, tier: mod.tier, path: mod.path });
+      return;
+    }
+    prefix = prefix ? `${prefix}/${seg}` : seg;
+    let folder = level.find(
+      (n): n is FolderNode => n.type === "folder" && n.name === seg,
+    );
+    if (!folder) {
+      folder = {
+        type: "folder",
+        name: seg,
+        prefix,
+        tier: mod.tier,
+        children: [],
+      };
+      level.push(folder);
+    }
+    level = folder.children;
+  }
+}
+
+/** Sort folders before files, each group alphabetically, recursively. */
+function sortTree(nodes: TreeNode[]): void {
+  nodes.sort((a, b) => {
+    if (a.type !== b.type) return a.type === "folder" ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  });
+  for (const n of nodes) if (n.type === "folder") sortTree(n.children);
+}
+
+/** Ensure the folder chain for `prefix` exists in `children`, creating empty
+ * FolderNodes as needed. Used to render UI-only empty subfolders (the store has
+ * no folder entity — folders are otherwise derived from module paths). */
+function ensureFolderChain(
+  children: TreeNode[],
+  prefix: string,
+  tier: PolicyTier,
+): void {
+  let level = children;
+  let p = "";
+  for (const seg of prefix.split("/").filter(Boolean)) {
+    p = p ? `${p}/${seg}` : seg;
+    let folder = level.find(
+      (n): n is FolderNode => n.type === "folder" && n.name === seg,
+    );
+    if (!folder) {
+      folder = { type: "folder", name: seg, prefix: p, tier, children: [] };
+      level.push(folder);
+    }
+    level = folder.children;
+  }
+}
+
+/** A UI-only empty subfolder to render even though no module lives in it yet. */
+export interface EmptyFolder {
+  tier: PolicyTier;
+  prefix: string;
+}
+
+/**
+ * Build the two tier roots (always present, even when empty) from the flat
+ * module list. Each root is a folder whose children are the modules of that
+ * tier, nested by their path segments. `emptyFolders` injects UI-only empty
+ * subfolders (client-side; they vanish on reload until a module lands in them).
+ */
+export function buildModuleTree(
+  modules: PolicyModuleRead[],
+  emptyFolders: EmptyFolder[] = [],
+): FolderNode[] {
+  const roots: Record<PolicyTier, FolderNode> = {
+    boundary: {
+      type: "folder",
+      name: TIER_FOLDER.boundary,
+      prefix: "",
+      tier: "boundary",
+      children: [],
+    },
+    capability: {
+      type: "folder",
+      name: TIER_FOLDER.capability,
+      prefix: "",
+      tier: "capability",
+      children: [],
+    },
+  };
+  for (const mod of modules) insert(roots[mod.tier].children, mod);
+  for (const f of emptyFolders) {
+    ensureFolderChain(roots[f.tier].children, f.prefix, f.tier);
+  }
+  sortTree(roots.boundary.children);
+  sortTree(roots.capability.children);
+  return [roots.boundary, roots.capability];
+}
+
+/**
+ * The path a module takes when reparented under `folderPrefix` (drag-to-move
+ * keeps the basename, swaps the parent). `folderPrefix` is "" at a tier root,
+ * which moves the module back to the top level.
+ */
+export function reparent(folderPrefix: string, path: string): string {
+  const base = path.split("/").pop() as string;
+  return folderPrefix ? `${folderPrefix}/${base}` : base;
+}
+
+/**
+ * 1-based line of a lint within the open module, or null. The loader doesn't
+ * track exact positions yet, so anchor a tool-scoped lint to the line where
+ * that tool key is declared (a `  <tool>:` entry under `tools:`). Whole-module
+ * lints (no tool) stay unanchored and surface in the list instead.
+ */
+export function lintToLine(content: string, lint: PolicyLint): number | null {
+  if (!lint.tool) return null;
+  const lines = content.split("\n");
+  const key = `${lint.tool}:`;
+  for (let i = 0; i < lines.length; i++) {
+    // Tool entries are always nested under `tools:`, so they're indented —
+    // require leading whitespace to avoid matching a same-named top-level key.
+    if (/^\s/.test(lines[i]) && lines[i].trim().startsWith(key)) return i + 1;
+  }
+  return null;
+}

--- a/platform/dashboard/src/lib/policy_modules.ts
+++ b/platform/dashboard/src/lib/policy_modules.ts
@@ -1,0 +1,207 @@
+/**
+ * Policy-module editor hooks. React Query reads + mutations over the
+ * `api.*PolicyModule*` / `api.*PolicyRoles` / `api.resolvePolicy` calls (all
+ * through the shared `request()` helper, so a 401 bounces to /sign-in and
+ * error detail is extracted centrally).
+ *
+ * The store is the source of truth; the resolved policy + lints are derived.
+ * Every write invalidates the resolve + check reads so the inspector reconciles
+ * to stored state after a Save. The live preview (`usePolicyPreview`) is a
+ * separate, debounced read of an unsaved draft — it never writes.
+ */
+
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useActive } from "./active";
+import {
+  api,
+  type PolicyDraft,
+  type PolicyTier,
+  type RoleBindings,
+} from "./api";
+import { useOrgs } from "./orgs";
+
+// Re-export the wire types so component imports (`@/lib/policy_modules`)
+// resolve without also reaching into `@/lib/api`.
+export type { PolicyLint, PolicyTier, RoleBindings } from "./api";
+
+const modulesKey = (pid: string) => ["policy-modules", pid] as const;
+const rolesKey = (pid: string) => ["policy-roles", pid] as const;
+const resolveKey = (pid: string, role: string | null) =>
+  ["policy-resolve", pid, role] as const;
+const checkKey = (pid: string) => ["policy-check", pid] as const;
+
+/** Bust every derived read for a project after a write. The store row is
+ * authoritative; resolve/check/preview all recompute from it. */
+function invalidateDerived(qc: ReturnType<typeof useQueryClient>, pid: string) {
+  qc.invalidateQueries({ queryKey: ["policy-resolve", pid] });
+  qc.invalidateQueries({ queryKey: checkKey(pid) });
+  qc.invalidateQueries({ queryKey: ["policy-preview", pid] });
+}
+
+/** Every boundary + capability module in the project's library. Disabled
+ * while `projectId` is null so pages pass the resolved scope id directly. */
+export function usePolicyModules(projectId: string | null) {
+  return useQuery({
+    queryKey: modulesKey(projectId as string),
+    queryFn: () => api.listPolicyModules(projectId as string),
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+}
+
+/** The project's role bindings (role -> imported capability names). */
+export function usePolicyRoles(projectId: string | null) {
+  return useQuery({
+    queryKey: rolesKey(projectId as string),
+    queryFn: () => api.getPolicyRoles(projectId as string),
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+}
+
+/** The composed effective policy, per role (all roles, or just `role`). */
+export function useResolvedPolicy(projectId: string | null, role?: string) {
+  return useQuery({
+    queryKey: resolveKey(projectId as string, role ?? null),
+    queryFn: () => api.resolvePolicy(projectId as string, role),
+    enabled: !!projectId,
+    // 422 when the modules don't compose — surfaced via `useCheck`; don't
+    // hammer the endpoint retrying an unresolvable set.
+    retry: false,
+    staleTime: 15_000,
+  });
+}
+
+/** Lints over the composed project (diagnostics-as-data, always 200). */
+export function usePolicyCheck(projectId: string | null) {
+  return useQuery({
+    queryKey: checkKey(projectId as string),
+    queryFn: () => api.checkPolicy(projectId as string),
+    enabled: !!projectId,
+    staleTime: 15_000,
+  });
+}
+
+interface UpsertInput {
+  tier: PolicyTier;
+  path: string;
+  content: string;
+}
+
+export function useUpsertModule(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpsertInput) =>
+      api.upsertPolicyModule(projectId, input.tier, input.path, input.content),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: modulesKey(projectId) });
+      invalidateDerived(qc, projectId);
+    },
+  });
+}
+
+interface DeleteInput {
+  tier: PolicyTier;
+  path: string;
+}
+
+export function useDeleteModule(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: DeleteInput) =>
+      api.deletePolicyModule(projectId, input.tier, input.path),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: modulesKey(projectId) });
+      invalidateDerived(qc, projectId);
+    },
+  });
+}
+
+interface MoveInput {
+  tier: PolicyTier;
+  path: string;
+  newPath: string;
+}
+
+export function useMoveModule(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: MoveInput) =>
+      api.movePolicyModule(projectId, input.tier, input.path, input.newPath),
+    onSuccess: () => {
+      // A capability move cascades to role bindings server-side, so refresh
+      // roles too — not just the module list.
+      qc.invalidateQueries({ queryKey: modulesKey(projectId) });
+      qc.invalidateQueries({ queryKey: rolesKey(projectId) });
+      invalidateDerived(qc, projectId);
+    },
+  });
+}
+
+export function useSetRoles(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (roles: RoleBindings) => api.setPolicyRoles(projectId, roles),
+    onSuccess: (roles) => {
+      qc.setQueryData(rolesKey(projectId), roles);
+      invalidateDerived(qc, projectId);
+    },
+  });
+}
+
+/** Evaluate one tool call against the whole resolved policy. A mutation, not
+ * a query: it's fired on demand by the tester's Check button. */
+export function useTestPolicy(projectId: string) {
+  return useMutation({
+    mutationFn: (body: Parameters<typeof api.testPolicy>[1]) =>
+      api.testPolicy(projectId, body),
+  });
+}
+
+/**
+ * Debounced live preview: resolve + lint the project with `draft` overlaid,
+ * without writing. Keyed on the (already debounced) draft so a new keystroke
+ * supersedes an in-flight request; `enabled` lets the caller skip the round
+ * trip while the draft doesn't parse client-side. `placeholderData` keeps the
+ * previous result on screen during a refetch so lints don't flicker.
+ */
+export function usePolicyPreview(
+  projectId: string | null,
+  draft: PolicyDraft | null,
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: ["policy-preview", projectId, JSON.stringify(draft ?? null)],
+    queryFn: () => api.previewPolicy(projectId as string, draft),
+    enabled: !!projectId && enabled,
+    retry: false,
+    placeholderData: (prev) => prev,
+    staleTime: 5_000,
+  });
+}
+
+/**
+ * Value that lags `value` by `ms`, resetting the timer on every change. Only
+ * the debounced value should be a query dependency, so the expensive preview
+ * round-trip fires after the user pauses, not per keystroke.
+ */
+export function useDebouncedValue<T>(value: T, ms: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(value), ms);
+    return () => clearTimeout(t);
+  }, [value, ms]);
+  return debounced;
+}
+
+/** Whether the caller may edit policy in the active org — the module write
+ * endpoints are `require_project_admin` server-side, so this gates the Save /
+ * tree-edit affordances. Mirrors `useCanManageBans`; false while orgs load. */
+export function useCanManagePolicy(): boolean {
+  const activeOrgId = useActive((s) => s.activeOrgId);
+  const orgsQuery = useOrgs();
+  const org = orgsQuery.data?.find((o) => o.id === activeOrgId) ?? null;
+  return org?.role === "owner" || org?.role === "admin";
+}

--- a/platform/dashboard/src/lib/policy_modules.ts
+++ b/platform/dashboard/src/lib/policy_modules.ts
@@ -51,6 +51,41 @@ export function usePolicyModules(projectId: string | null) {
   });
 }
 
+const foldersKey = (pid: string) => ["policy-folders", pid] as const;
+
+/** Persisted empty folders in the project's library (see PolicyFolder). */
+export function usePolicyFolders(projectId: string | null) {
+  return useQuery({
+    queryKey: foldersKey(projectId as string),
+    queryFn: () => api.listPolicyFolders(projectId as string),
+    enabled: !!projectId,
+    staleTime: 30_000,
+  });
+}
+
+interface FolderInput {
+  tier: PolicyTier;
+  path: string;
+}
+
+export function useCreateFolder(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: FolderInput) =>
+      api.createPolicyFolder(projectId, input.tier, input.path),
+    onSuccess: () => qc.invalidateQueries({ queryKey: foldersKey(projectId) }),
+  });
+}
+
+export function useDeleteFolder(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: FolderInput) =>
+      api.deletePolicyFolder(projectId, input.tier, input.path),
+    onSuccess: () => qc.invalidateQueries({ queryKey: foldersKey(projectId) }),
+  });
+}
+
 /** The project's role bindings (role -> imported capability names). */
 export function usePolicyRoles(projectId: string | null) {
   return useQuery({

--- a/platform/dashboard/src/lib/ui.ts
+++ b/platform/dashboard/src/lib/ui.ts
@@ -1,0 +1,27 @@
+/**
+ * Small persisted UI-preference store (separate from `active`, which holds the
+ * org/project scope). Currently just the workspace-sidebar collapsed state, so
+ * a collapse survives a reload.
+ */
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface UiState {
+  sidebarCollapsed: boolean;
+  toggleSidebar: () => void;
+}
+
+export const useUi = create<UiState>()(
+  persist(
+    (set) => ({
+      sidebarCollapsed: false,
+      toggleSidebar: () =>
+        set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+    }),
+    {
+      name: "hexgate-ui",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);

--- a/platform/dashboard/src/routes/PolicyModules.test.tsx
+++ b/platform/dashboard/src/routes/PolicyModules.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Tests for the /policy-modules editor page.
+ *
+ * Invariants:
+ *   1. no-project scope -> the empty state, no policy fetch.
+ *   2. Modules render in the tree; roles present -> the modular banner.
+ *   3. No role bindings -> the classic banner.
+ *   4. A /check error lint surfaces in the Lints tab.
+ *
+ * The CodeMirror editor is mocked to a textarea so the page's own logic
+ * (tree, banner, inspector tabs) is what's under test, not the editor.
+ */
+
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PolicyLint } from "@/lib/api";
+import { useActive } from "@/lib/active";
+import { PolicyModulesPage } from "@/routes/PolicyModules";
+import { renderWithProviders } from "@/test/render";
+
+vi.mock("@/components/PolicyEditor", () => ({
+  PolicyEditor: ({ value }: { value: string }) => (
+    <textarea data-testid="policy-editor" defaultValue={value} />
+  ),
+}));
+
+const PROJECT = "p1";
+
+interface StubOptions {
+  role?: string;
+  modules?: { tier: string; path: string }[];
+  roles?: Record<string, string[]>;
+  lints?: PolicyLint[];
+  resolveStatus?: number;
+  resolved?: Record<string, unknown>;
+}
+
+function stubFetch({
+  role = "owner",
+  modules = [],
+  roles = {},
+  lints = [],
+  resolveStatus = 200,
+  resolved = {},
+}: StubOptions = {}) {
+  const json = (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  vi.spyOn(window, "fetch").mockImplementation(
+    async (input: RequestInfo | URL) => {
+      const raw = typeof input === "string" ? input : input.toString();
+      const url = new URL(raw, "http://localhost");
+      const p = url.pathname;
+      switch (true) {
+        case p === "/v1/orgs":
+          return json([{ id: "org-1", slug: "acme", name: "Acme", role }]);
+        case p === "/v1/orgs/org-1/projects":
+          return json([{ id: PROJECT, org_id: "org-1", name: "demo" }]);
+        case p === `/v1/projects/${PROJECT}/policy-modules`:
+          return json(
+            modules.map((m) => ({
+              ...m,
+              content: "tools: {}\n",
+              content_hash: "h",
+              updated_at: "2026-01-01T00:00:00Z",
+            })),
+          );
+        case p === `/v1/projects/${PROJECT}/policy-roles`:
+          return json({ roles });
+        case p === `/v1/projects/${PROJECT}/policy/resolve`:
+          return resolveStatus === 200
+            ? json({ roles: resolved })
+            : json({ detail: "does not compose" }, resolveStatus);
+        case p === `/v1/projects/${PROJECT}/policy/check`:
+          return json({
+            ok: lints.every((l) => l.severity !== "error"),
+            lints,
+          });
+        default:
+          return new Response("not found", { status: 404 });
+      }
+    },
+  );
+}
+
+describe("PolicyModulesPage", () => {
+  beforeEach(() => {
+    act(() => {
+      useActive.setState({ activeOrgId: "org-1", activeProjectId: PROJECT });
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders the no-project empty state and skips the policy fetch", async () => {
+    act(() => {
+      useActive.setState({ activeOrgId: "org-1", activeProjectId: null });
+    });
+    stubFetch();
+    renderWithProviders(<PolicyModulesPage />, {
+      initialRoute: "/policy-modules",
+    });
+    expect(await screen.findByText("No project selected")).toBeInTheDocument();
+  });
+
+  it("lists modules in the tree and shows the modular banner", async () => {
+    stubFetch({
+      modules: [
+        { tier: "boundary", path: "org_core" },
+        { tier: "capability", path: "read_only" },
+      ],
+      roles: { default: ["read_only"] },
+    });
+    renderWithProviders(<PolicyModulesPage />, {
+      initialRoute: "/policy-modules",
+    });
+
+    expect(await screen.findByText("org_core")).toBeInTheDocument();
+    expect(screen.getByText("read_only")).toBeInTheDocument();
+    expect(screen.getByText(/Modular policy is/i)).toBeInTheDocument();
+  });
+
+  it("shows the classic banner when no role is bound", async () => {
+    stubFetch({ modules: [{ tier: "capability", path: "read_only" }] });
+    renderWithProviders(<PolicyModulesPage />, {
+      initialRoute: "/policy-modules",
+    });
+    expect(await screen.findByText(/Classic project/i)).toBeInTheDocument();
+  });
+
+  it("shows the composed policy as a YAML document when toggled", async () => {
+    stubFetch({
+      modules: [{ tier: "capability", path: "read_only" }],
+      roles: { default: ["read_only"] },
+      resolved: {
+        default: {
+          default_policy: { mode: "deny" },
+          tools: { view_orders: { mode: "allow" } },
+        },
+      },
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<PolicyModulesPage />, {
+      initialRoute: "/policy-modules",
+    });
+
+    // Resolved is the default tab; flip Table -> YAML.
+    const yamlToggle = await screen.findByRole("button", { name: /^yaml$/i });
+    await user.click(yamlToggle);
+    // `default_policy` is a YAML-only key (the table renders a "default"
+    // label + badge instead), so it proves the composed document rendered.
+    expect(await screen.findByText(/default_policy/)).toBeInTheDocument();
+  });
+
+  it("surfaces a /check error lint in the Lints tab", async () => {
+    stubFetch({
+      roles: { default: ["ghost"] },
+      resolveStatus: 422,
+      lints: [
+        {
+          code: "link-error",
+          severity: "error",
+          message: "role default imports unknown capability 'ghost'",
+          source: null,
+          tier: null,
+          tool: null,
+          role: "default",
+        },
+      ],
+    });
+    const user = userEvent.setup();
+    renderWithProviders(<PolicyModulesPage />, {
+      initialRoute: "/policy-modules",
+    });
+
+    // Lint count badge rides on the tab; open it to see the message.
+    const lintsTab = await screen.findByRole("button", { name: /lints/i });
+    await user.click(lintsTab);
+    await waitFor(() =>
+      expect(
+        screen.getByText(/imports unknown capability 'ghost'/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/platform/dashboard/src/routes/PolicyModules.tsx
+++ b/platform/dashboard/src/routes/PolicyModules.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useMemo, useState } from "react";
-import { Boxes } from "lucide-react";
 
 import type { PolicyDraft } from "@/lib/api";
 import { useProjectScoped } from "@/lib/active";
@@ -81,59 +80,63 @@ export function PolicyModulesPage() {
   const loading = modules.isLoading || roles.isLoading;
 
   return (
-    <div className="-mx-8 -my-6 h-[calc(100vh-56px)] flex flex-col overflow-hidden">
-      <header className="flex items-center justify-between gap-4 px-6 py-3 border-b border-border bg-card">
-        <div className="flex items-center gap-2">
-          <Boxes className="size-4 text-muted-foreground" />
-          <span className="text-sm font-medium">Policy modules</span>
-        </div>
-        <DocsLink path={DOC_PATHS.policies} label="Policy docs" />
-      </header>
+    // Recessed page ground with a floating, softly-rounded editor card. Panes
+    // are separated by background shade (side panels recessed vs the editor),
+    // not hard border lines — the VSCode "shades, not rules" feel.
+    <div className="-mx-8 -my-6 h-screen overflow-hidden bg-muted/20 p-3">
+      <div className="flex h-full flex-col overflow-hidden rounded-xl border border-border/60 bg-card shadow-sm">
+        {!loading && (
+          <ModularBanner
+            modular={modular}
+            trailing={
+              <DocsLink path={DOC_PATHS.policies} label="Policy docs" />
+            }
+          />
+        )}
 
-      {!loading && <ModularBanner modular={modular} />}
-
-      {loading || !projectId ? (
-        <div className="flex-1 grid place-items-center text-sm text-muted-foreground">
-          {scope.status === "loading" || loading
-            ? "Loading policy…"
-            : "No project selected."}
-        </div>
-      ) : (
-        <div className="flex-1 grid grid-cols-[240px_minmax(0,1fr)_minmax(320px,380px)] overflow-hidden">
-          <div className="border-r border-border overflow-hidden">
-            <ModuleTree
-              modules={modules.data ?? []}
-              selection={selection}
-              onSelect={setSelection}
-              projectId={projectId}
-              canManage={canManage}
-            />
+        {loading || !projectId ? (
+          <div className="flex-1 grid place-items-center text-sm text-muted-foreground">
+            {scope.status === "loading" || loading
+              ? "Loading policy…"
+              : "No project selected."}
           </div>
-          <div className="overflow-hidden border-r border-border">
-            <EditorPane
-              projectId={projectId}
-              selection={selection}
-              modules={modules.data ?? []}
-              roles={roleBindings}
-              lints={lints}
-              canManage={canManage}
-              onDraftChange={onDraftChange}
-            />
+        ) : (
+          <div className="flex-1 grid grid-cols-[240px_minmax(0,1fr)_minmax(320px,380px)] overflow-hidden">
+            <div className="overflow-hidden bg-background/40">
+              <ModuleTree
+                modules={modules.data ?? []}
+                selection={selection}
+                onSelect={setSelection}
+                projectId={projectId}
+                canManage={canManage}
+              />
+            </div>
+            <div className="overflow-hidden">
+              <EditorPane
+                projectId={projectId}
+                selection={selection}
+                modules={modules.data ?? []}
+                roles={roleBindings}
+                lints={lints}
+                canManage={canManage}
+                onDraftChange={onDraftChange}
+              />
+            </div>
+            <div className="overflow-hidden bg-background/40">
+              <InspectorTabs
+                projectId={projectId}
+                resolved={resolved}
+                lints={lints}
+                roles={roleBindings}
+                draft={draftActive ? draft : null}
+                resolves={resolves}
+                modular={modular}
+                previewing={draftActive && preview.isFetching}
+              />
+            </div>
           </div>
-          <div className="overflow-hidden">
-            <InspectorTabs
-              projectId={projectId}
-              resolved={resolved}
-              lints={lints}
-              roles={roleBindings}
-              draft={draftActive ? draft : null}
-              resolves={resolves}
-              modular={modular}
-              previewing={draftActive && preview.isFetching}
-            />
-          </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 }

--- a/platform/dashboard/src/routes/PolicyModules.tsx
+++ b/platform/dashboard/src/routes/PolicyModules.tsx
@@ -128,6 +128,7 @@ export function PolicyModulesPage() {
               roles={roleBindings}
               draft={draftActive ? draft : null}
               resolves={resolves}
+              modular={modular}
               previewing={draftActive && preview.isFetching}
             />
           </div>

--- a/platform/dashboard/src/routes/PolicyModules.tsx
+++ b/platform/dashboard/src/routes/PolicyModules.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useMemo, useState } from "react";
+import { Boxes } from "lucide-react";
+
+import type { PolicyDraft } from "@/lib/api";
+import { useProjectScoped } from "@/lib/active";
+import {
+  useCanManagePolicy,
+  useDebouncedValue,
+  usePolicyCheck,
+  usePolicyModules,
+  usePolicyPreview,
+  usePolicyRoles,
+  useResolvedPolicy,
+} from "@/lib/policy_modules";
+import type { Selection } from "@/lib/module_tree";
+import { NoProjectEmptyState } from "@/components/NoProjectEmptyState";
+import { DocsLink } from "@/components/DocsLink";
+import { DOC_PATHS } from "@/lib/docs";
+import { ModularBanner } from "@/components/policy_modules/ModularBanner";
+import { ModuleTree } from "@/components/policy_modules/ModuleTree";
+import { EditorPane } from "@/components/policy_modules/EditorPane";
+import { InspectorTabs } from "@/components/policy_modules/InspectorTabs";
+
+/**
+ * Multi-module policy editor. Three panes: the module tree (a rendering of the
+ * `policy_module` rows as the SDK's on-disk layout), a CodeMirror editor for
+ * the open module or `roles.yaml`, and an inspector showing the composed policy
+ * per role, lints, and a decision tester. The resolved + lints panes reflect
+ * the unsaved edit live (debounced `POST /policy/preview`); Save is explicit.
+ */
+export function PolicyModulesPage() {
+  const scope = useProjectScoped();
+  const projectId = scope.projectId;
+  const canManage = useCanManagePolicy();
+
+  const modules = usePolicyModules(projectId);
+  const roles = usePolicyRoles(projectId);
+
+  const [selection, setSelection] = useState<Selection>({ kind: "roles" });
+  // The editor's unsaved overlay (null = clean or unparseable) + whether the
+  // current buffer parses client-side (gates the server preview round-trip).
+  const [draft, setDraft] = useState<PolicyDraft | null>(null);
+  const [draftParses, setDraftParses] = useState(true);
+
+  const onDraftChange = useCallback(
+    (next: PolicyDraft | null, parses: boolean) => {
+      setDraft(next);
+      setDraftParses(parses);
+    },
+    [],
+  );
+
+  // Debounce the overlay so the preview fires on pause, not per keystroke, and
+  // skip it entirely while the draft doesn't parse (no point sending broken
+  // YAML). Latest-wins is handled by the query key on the debounced draft.
+  const debouncedDraft = useDebouncedValue(draft, 600);
+  const draftActive = draft !== null;
+  const previewEnabled = draftParses && debouncedDraft !== null;
+  const preview = usePolicyPreview(projectId, debouncedDraft, previewEnabled);
+
+  const storedResolve = useResolvedPolicy(projectId);
+  const check = usePolicyCheck(projectId);
+
+  const usePreviewData = draftActive && !!preview.data;
+  const resolved = usePreviewData ? preview.data?.resolved : storedResolve.data;
+  const lints = useMemo(
+    () =>
+      usePreviewData ? (preview.data?.lints ?? []) : (check.data?.lints ?? []),
+    [usePreviewData, preview.data, check.data],
+  );
+  // Clean resolution iff nothing is an error lint (a 422 on stored resolve
+  // surfaces as an error lint on check, so this covers both sources).
+  const resolves = lints.every((l) => l.severity !== "error");
+  const roleBindings = roles.data ?? {};
+  const modular = Object.keys(roleBindings).length > 0;
+
+  if (scope.status === "no-project") {
+    return <NoProjectEmptyState resource="policies" />;
+  }
+
+  const loading = modules.isLoading || roles.isLoading;
+
+  return (
+    <div className="-mx-8 -my-6 h-[calc(100vh-56px)] flex flex-col overflow-hidden">
+      <header className="flex items-center justify-between gap-4 px-6 py-3 border-b border-border bg-card">
+        <div className="flex items-center gap-2">
+          <Boxes className="size-4 text-muted-foreground" />
+          <span className="text-sm font-medium">Policy modules</span>
+        </div>
+        <DocsLink path={DOC_PATHS.policies} label="Policy docs" />
+      </header>
+
+      {!loading && <ModularBanner modular={modular} />}
+
+      {loading || !projectId ? (
+        <div className="flex-1 grid place-items-center text-sm text-muted-foreground">
+          {scope.status === "loading" || loading
+            ? "Loading policy…"
+            : "No project selected."}
+        </div>
+      ) : (
+        <div className="flex-1 grid grid-cols-[240px_minmax(0,1fr)_minmax(320px,380px)] overflow-hidden">
+          <div className="border-r border-border overflow-hidden">
+            <ModuleTree
+              modules={modules.data ?? []}
+              selection={selection}
+              onSelect={setSelection}
+              projectId={projectId}
+              canManage={canManage}
+            />
+          </div>
+          <div className="overflow-hidden border-r border-border">
+            <EditorPane
+              projectId={projectId}
+              selection={selection}
+              modules={modules.data ?? []}
+              roles={roleBindings}
+              lints={lints}
+              canManage={canManage}
+              onDraftChange={onDraftChange}
+            />
+          </div>
+          <div className="overflow-hidden">
+            <InspectorTabs
+              projectId={projectId}
+              resolved={resolved}
+              lints={lints}
+              roles={roleBindings}
+              draft={draftActive ? draft : null}
+              resolves={resolves}
+              previewing={draftActive && preview.isFetching}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
The in-dashboard **policy-module editor**: browse and edit boundary + capability modules as a file tree, edit `roles.yaml`, watch the composed policy per role resolve live, and test a tool call against it. One combined PR (backend endpoints + frontend), stacked on #121 (retargets to `main` when #121 merges).

## What it does

A three-pane editor at `/policy-modules` ("Modules" in the sidebar). The tree is a rendering of the store: the platform has no files, so the `policy_module` rows are shown as the SDK's on-disk layout: `boundaries/`, `capabilities/` (nestable subfolders), and a synthetic `roles.yaml` at the root.

- **Tree (left):** new / rename / delete modules; **drag-to-move** between folders (same-tier only, since the move endpoint is same-tier); every destructive action gets a sonner Undo toast. A capability rename cascades to the role bindings that imported it, server-side in one transaction.
- **Editor (center):** the existing CodeMirror `PolicyEditor`, reused. Explicit Save (+ Discard). Client YAML parse errors and semantic `/check` lints render in the gutter, anchored to the offending tool's line.
- **Inspector (right):** **Resolved** (per-role tool→mode table, or the composed policy as one **YAML document** — the "compiled" `hexgate policy resolve` output), **Lints**, and a **decision tester** (role + JSON call → tri-state ALLOW / DENY / APPROVAL_REQUIRED verdict with the failing constraint).
- **Live preview (debounced):** typing fires `POST /policy/preview` only after a ~600ms pause, and only when the draft parses client-side, so the Resolved + Lints panes reflect the unsaved edit without a Save. Latest-wins; Save stays explicit.

Three backend endpoints do the work, all composing over the existing SDK (`resolve_for_project` / `analyze_project` / `PolicySet.evaluate`), no policy logic reimplemented:

| Endpoint | What it does |
| --- | --- |
| `POST /policy/preview` | resolve + lint with an optional unsaved-edit overlay, no write. Always 200 (diagnostics-as-data). |
| `POST /policy/test` | evaluate one call against the whole resolved policy for a role (pydantic engine, no opa). 422 if it won't compose, 404 for an unknown role. |
| `PATCH /policy-modules/{tier}/{path}` | rename/move a module; a capability rename cascades to its role bindings. 409 on clash, 404 if absent. |

## Try it

Create a boundary + two capabilities (put one in a subfolder), bind roles in `roles.yaml`, then: drag a capability between folders and watch the bindings follow; edit a module and watch Resolved + Lints update on pause; flip Resolved to YAML to read the compiled document; run the tester and cross the boundary's constraint to see ALLOW flip to DENY.

## Important files

| File | What to look at |
| --- | --- |
| `platform/api/hexgate_api/features/policy_modules/service.py` | `preview`, `test_policy`, `move_module` (+ the `_validate_module` capability-deny guard and the move's binding cascade) |
| `platform/api/hexgate_api/features/policy_modules/router.py` | the three routes + verdict/outcome mapping |
| `platform/dashboard/src/routes/PolicyModules.tsx` | the page: shared queries + the debounced preview wiring |
| `platform/dashboard/src/components/policy_modules/` | `ModuleTree` (tree + DnD), `EditorPane`, `InspectorTabs` (table/YAML + tester), `TestPanel`, `ModularBanner` |
| `platform/dashboard/src/lib/policy_modules.ts` / `module_tree.ts` | hooks + the pure tree/lint/reparent helpers |

## Notes

- No SDK changes; the endpoints compose over the existing linker/analyzer/evaluator.
- Fail-safe held: a modular resolve failure leaves live bundles untouched; a stored module that no longer parses surfaces as an `invalid-module` lint (check) / 422 (resolve), never a 500.
- Tests: platform-api suite green (479 passed, 4 skipped); dashboard suite green (223 passed) covering API request shapes, the tree/lint/reparent units, and the page (tree render, banner flip, YAML view, lint surfacing).
- Deferred (cheap fast-follows): per-role resolved graph (react-flow, `buildPolicyGraph` exists); cross-tier move; line-level lint anchoring via loader positions.
