### PR TITLE
feat(platform-api): add the span-enricher job (redpanda to clickhouse)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,10 @@ collector-generate: ## Regenerate + compile the collector from builder-config.ya
 # The authenticator makes boot fatal without Postgres, the devtoken schema,
 # and the root public key, so this target now provides the first two and
 # checks for the third — the pre-auth collector booted on Redpanda alone.
+.PHONY: enricher-run
+enricher-run: redpanda-topics clickhouse-up ## Run the span-enricher job (Kafka → ClickHouse)
+	cd platform/api && uv run python -m hexgate_api.jobs.enricher
+
 collector-run: postgres-up redpanda-topics ## Run the collector binary against config.yaml
 	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run python -c \
 		"import asyncio; from hexgate_api.core.db import init_db; asyncio.run(init_db())"

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,14 @@ POSTGRES_DSN ?= postgresql+asyncpg://hexgate:hexgate-dev-password@localhost:5433
 postgres-up: ## Start local Postgres and wait until healthy
 	$(COMPOSE) up -d --wait postgres
 
+# The schema belongs to platform-api; anything else that reads the relational
+# store (collector, enricher, integration tests) creates it through here so a
+# fresh volume never surfaces as "no such table" on the first request.
+.PHONY: postgres-init
+postgres-init: postgres-up ## Create the platform-api tables on local Postgres (idempotent)
+	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run python -c \
+		"import asyncio; from hexgate_api.core.db import init_db; asyncio.run(init_db())"
+
 .PHONY: postgres-stop
 postgres-stop: ## Stop Postgres (keeps the data volume)
 	$(COMPOSE) stop postgres
@@ -253,16 +261,17 @@ collector-generate: ## Regenerate + compile the collector from builder-config.ya
 # The authenticator makes boot fatal without Postgres, the devtoken schema,
 # and the root public key, so this target now provides the first two and
 # checks for the third — the pre-auth collector booted on Redpanda alone.
-.PHONY: enricher-run
-enricher-run: redpanda-topics clickhouse-up ## Run the span-enricher job (Redpanda → ClickHouse)
-	cd platform/api && uv run python -m hexgate_api.jobs.enricher
-
-collector-run: postgres-up redpanda-topics ## Run the collector binary against config.yaml
-	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run python -c \
-		"import asyncio; from hexgate_api.core.db import init_db; asyncio.run(init_db())"
+collector-run: postgres-init redpanda-topics ## Run the collector binary against config.yaml
 	@test -f platform/api/data/hexgate.pub \
 		|| { echo "platform/api/data/hexgate.pub is missing — run 'make platform-api' once to generate the root keypair, or set HEXGATE_COLLECTOR_PUBLIC_KEY_FILE"; exit 1; }
 	cd platform/collector && ./hexgate-collector --config=config.yaml
+
+# Same Postgres as platform-api-pg: the resolver reads agent/agent_version
+# there, and pointing the job at the SQLite fallback instead would resolve
+# every agent_version_id to "" without an error.
+.PHONY: enricher-run
+enricher-run: postgres-init redpanda-topics clickhouse-up ## Run the span-enricher job (Redpanda → ClickHouse)
+	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run python -m hexgate_api.jobs.enricher
 
 .PHONY: collector-test
 collector-test: ## Unit tests for the collector's own Go modules
@@ -270,13 +279,11 @@ collector-test: ## Unit tests for the collector's own Go modules
 
 # Opt-in, like the Python side's `pytest -m integration`: these drive the real
 # binary against a real Postgres and Redpanda, so they are kept out of
-# collector-check. The schema belongs to platform-api, so it is created here
-# rather than by the Go tests.
+# collector-check. The schema belongs to platform-api, so postgres-init creates
+# it rather than the Go tests.
 .PHONY: collector-test-integration
-collector-test-integration: postgres-up redpanda-topics ## Collector integration tests (real Postgres + Redpanda)
+collector-test-integration: postgres-init redpanda-topics ## Collector integration tests (real Postgres + Redpanda)
 	cd platform/collector && go build -o hexgate-collector ./...
-	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run python -c \
-		"import asyncio; from hexgate_api.core.db import init_db; asyncio.run(init_db())"
 	cd $(COLLECTOR_EXT_INTEGRATION) && go test -tags integration -count=1 ./...
 
 .PHONY: collector-check

--- a/Makefile
+++ b/Makefile
@@ -254,7 +254,7 @@ collector-generate: ## Regenerate + compile the collector from builder-config.ya
 # and the root public key, so this target now provides the first two and
 # checks for the third — the pre-auth collector booted on Redpanda alone.
 .PHONY: enricher-run
-enricher-run: redpanda-topics clickhouse-up ## Run the span-enricher job (Kafka → ClickHouse)
+enricher-run: redpanda-topics clickhouse-up ## Run the span-enricher job (Redpanda → ClickHouse)
 	cd platform/api && uv run python -m hexgate_api.jobs.enricher
 
 collector-run: postgres-up redpanda-topics ## Run the collector binary against config.yaml

--- a/platform/api/.env.sample
+++ b/platform/api/.env.sample
@@ -35,6 +35,12 @@ HEXGATE_CLICKHOUSE_PASSWORD=
 HEXGATE_CLICKHOUSE_DATABASE=hexgate_audit
 HEXGATE_CLICKHOUSE_SECURE=
 
+# --- Span enricher (jobs/enricher) -------------------------------------
+# Kafka-protocol endpoint (Redpanda). Dev defaults work with `make
+# enricher-run`; in-compose consumers use redpanda:29092. Same var the
+# collector and create-topics.sh read.
+HEXGATE_REDPANDA_BOOTSTRAP_SERVER=
+
 # --- Google OAuth (optional) -------------------------------------------
 HEXGATE_GOOGLE_CLIENT_ID=
 HEXGATE_GOOGLE_CLIENT_SECRET=

--- a/platform/api/CLAUDE.md
+++ b/platform/api/CLAUDE.md
@@ -9,6 +9,7 @@ After you make changes, run: `make fmt-check && make platform-api-check`  # fmt-
 - `deps/` — FastAPI dependency gates: `identity`, `tokens`, `org`, `project`, `ws`, `clickhouse`.
 - `seeds/defaults.py` — first-boot triple-default seeding (agent seed data lives in `features/agents/seed_data.py`).
 - `features/<x>/` — one vertical slice per context (`tokens`, `projects`, `members`, `orgs`, `invitations`, `agents`, `audit`, `chat`, `auth`), each a `router.py` + `service.py` (agents also `compiler.py`). Domain exceptions live in their `service.py`; exceptions shared across features live with the shared machinery that raises them (e.g. `SchemaOutOfDate` in `core/clickhouse.py`, `EventOutOfWindow` in `query_scope.py`).
+- `jobs/<x>/` — standalone long-running processes (`enricher`: Kafka → ClickHouse span-enricher, run via `python -m hexgate_api.jobs.enricher`). Share core/ + features/ services, never the FastAPI app.
 - `schemas.py` / `models.py` — shared Pydantic DTOs / SQLModel tables.
 - `tests/` mirrors this: `tests/features/<x>/`, `tests/core/`.
 

--- a/platform/api/CLAUDE.md
+++ b/platform/api/CLAUDE.md
@@ -9,7 +9,7 @@ After you make changes, run: `make fmt-check && make platform-api-check`  # fmt-
 - `deps/` — FastAPI dependency gates: `identity`, `tokens`, `org`, `project`, `ws`, `clickhouse`.
 - `seeds/defaults.py` — first-boot triple-default seeding (agent seed data lives in `features/agents/seed_data.py`).
 - `features/<x>/` — one vertical slice per context (`tokens`, `projects`, `members`, `orgs`, `invitations`, `agents`, `audit`, `chat`, `auth`), each a `router.py` + `service.py` (agents also `compiler.py`). Domain exceptions live in their `service.py`; exceptions shared across features live with the shared machinery that raises them (e.g. `SchemaOutOfDate` in `core/clickhouse.py`, `EventOutOfWindow` in `query_scope.py`).
-- `jobs/<x>/` — standalone long-running processes (`enricher`: Kafka → ClickHouse span-enricher, run via `python -m hexgate_api.jobs.enricher`). Share core/ + features/ services, never the FastAPI app.
+- `jobs/<x>/` — standalone long-running processes (`enricher`: Redpanda → ClickHouse span-enricher, run via `python -m hexgate_api.jobs.enricher`). Share core/ + features/ services, never the FastAPI app.
 - `schemas.py` / `models.py` — shared Pydantic DTOs / SQLModel tables.
 - `tests/` mirrors this: `tests/features/<x>/`, `tests/core/`.
 

--- a/platform/api/hexgate_api/jobs/enricher/__init__.py
+++ b/platform/api/hexgate_api/jobs/enricher/__init__.py
@@ -1,0 +1,6 @@
+"""Span-enricher job: Kafka → OTLP decode → enrich → ClickHouse batch inserts.
+
+A standalone long-running process (``python -m hexgate_api.jobs.enricher``),
+not part of the FastAPI app — it shares the app's settings, ClickHouse client,
+and DB session factory, and consumes the OTLP records the Collector produces.
+"""

--- a/platform/api/hexgate_api/jobs/enricher/__main__.py
+++ b/platform/api/hexgate_api/jobs/enricher/__main__.py
@@ -13,7 +13,7 @@ import sys
 
 from dotenv import load_dotenv
 
-from hexgate_api.core.clickhouse import AuditSchemaOutOfDate
+from hexgate_api.core.clickhouse import SchemaOutOfDate
 from hexgate_api.jobs.enricher.consumer import EnricherJob, TopicsMissing
 from hexgate_api.settings import get_settings
 
@@ -28,7 +28,7 @@ def main() -> int:
     )
     try:
         asyncio.run(EnricherJob(get_settings()).run())
-    except (AuditSchemaOutOfDate, TopicsMissing) as exc:
+    except (SchemaOutOfDate, TopicsMissing) as exc:
         _log.error("startup check failed: %s", exc)
         return 1
     return 0

--- a/platform/api/hexgate_api/jobs/enricher/__main__.py
+++ b/platform/api/hexgate_api/jobs/enricher/__main__.py
@@ -1,0 +1,38 @@
+"""Entrypoint: ``python -m hexgate_api.jobs.enricher`` (or ``make enricher-run``).
+
+Exit codes: 0 on a clean stop (SIGTERM/SIGINT), 1 when a startup check
+fails — stale ClickHouse schema or missing topics — so a supervisor sees
+the difference between "done" and "misconfigured".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+
+from dotenv import load_dotenv
+
+from hexgate_api.core.clickhouse import AuditSchemaOutOfDate
+from hexgate_api.jobs.enricher.consumer import EnricherJob, TopicsMissing
+from hexgate_api.settings import get_settings
+
+_log = logging.getLogger(__name__)
+
+
+def main() -> int:
+    load_dotenv()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+    try:
+        asyncio.run(EnricherJob(get_settings()).run())
+    except (AuditSchemaOutOfDate, TopicsMissing) as exc:
+        _log.error("startup check failed: %s", exc)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/platform/api/hexgate_api/jobs/enricher/coerce.py
+++ b/platform/api/hexgate_api/jobs/enricher/coerce.py
@@ -1,0 +1,117 @@
+"""Attribute-value coercion for decoded OTLP spans.
+
+Generic plumbing shared by the per-scope builders in mapping.py: attempt
+type conversion when a span attribute's proto type doesn't match what the
+event field expects (string→int, JSON-string→list/dict, …), log every lossy
+coercion, and reject — via :class:`SpanRejected` — only when coercion fails
+or a required attribute is missing. Nothing here knows the event types;
+that's mapping.py's job.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+_log = logging.getLogger(__name__)
+
+
+class SpanRejected(Exception):
+    """This span cannot become an event — permanently (DLQ, not retry)."""
+
+    def __init__(self, error: str, *, error_class: str, scope: str) -> None:
+        super().__init__(error)
+        self.error = error
+        self.error_class = error_class
+        self.scope = scope
+
+
+def required(attrs: dict[str, Any], key: str, *, scope: str) -> Any:
+    value = attrs.get(key)
+    if value is None:
+        raise SpanRejected(
+            f"missing required attribute {key}", error_class="validation", scope=scope
+        )
+    return value
+
+
+def as_str(value: Any, default: str = "") -> str:
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value
+    _log.warning("coerced non-string attribute %r to str", value)
+    return str(value)
+
+
+def as_int(value: Any, *, key: str, scope: str) -> int:
+    if isinstance(value, bool):  # bool is an int subclass; never a count
+        raise SpanRejected(
+            f"{key} is a bool, expected int", error_class="validation", scope=scope
+        )
+    if isinstance(value, int):
+        return value
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        raise SpanRejected(
+            f"{key}={value!r} is not coercible to int",
+            error_class="validation",
+            scope=scope,
+        ) from None
+    _log.warning("coerced %s=%r to int", key, value)
+    return coerced
+
+
+def as_str_list(value: Any, *, key: str, scope: str) -> list[str]:
+    """Native string array preferred; a JSON-encoded array or a scalar string
+    from a foreign emitter are accepted with a log line."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [as_str(v) for v in value]
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except ValueError:
+            parsed = None
+        if isinstance(parsed, list):
+            _log.warning("coerced JSON-string %s to a list", key)
+            return [as_str(v) for v in parsed]
+        _log.warning("wrapped scalar %s=%r into a single-item list", key, value)
+        return [value]
+    raise SpanRejected(
+        f"{key}={value!r} is not a string list", error_class="validation", scope=scope
+    )
+
+
+def as_json_dict(value: Any, *, key: str, scope: str) -> dict[str, Any] | None:
+    """Dict payloads travel as JSON-string attributes (see semconv docstring);
+    a kvlist already decoded to a dict is accepted with a log line."""
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        _log.warning("accepted kvlist-shaped %s (expected a JSON string)", key)
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except ValueError as exc:
+            raise SpanRejected(
+                f"{key} is not valid JSON: {exc}",
+                error_class="validation",
+                scope=scope,
+            ) from None
+        if not isinstance(parsed, dict):
+            raise SpanRejected(
+                f"{key} JSON is {type(parsed).__name__}, expected object",
+                error_class="validation",
+                scope=scope,
+            )
+        return parsed
+    raise SpanRejected(
+        f"{key}={value!r} is not a JSON-string dict",
+        error_class="validation",
+        scope=scope,
+    )

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -187,8 +187,11 @@ class EnricherJob:
         # topic twice, often adjacent and so inside one poll. ClickHouse only
         # collapses such a pair at insert time when both fall in the same
         # block, so the batch functions ask the caller to dedup by event_id
-        # first (see insert_decisions_batch). First copy wins.
-        seen_event_ids: set[str] = set()
+        # first (see insert_decisions_batch). First copy wins. Scoped by
+        # project: event_id is client-set, project_id is auth-derived, and the
+        # tables' own identity is (project_id, ..., event_id) — one tenant
+        # reusing another's id must never suppress the other's event.
+        seen_event_ids: set[tuple[str, str]] = set()
         dlq_messages: list[tuple[bytes | None, bytes]] = []  # (key, envelope)
         for record in records:
             project_id = record.key.decode("utf-8") if record.key is not None else None
@@ -254,9 +257,9 @@ class EnricherJob:
                         )
                     )
                     continue
-                if event.event_id in seen_event_ids:
+                if (project_id, event.event_id) in seen_event_ids:
                     continue
-                seen_event_ids.add(event.event_id)
+                seen_event_ids.add((project_id, event.event_id))
                 events.append((event, project_id))
 
         versions = await resolve_versions(

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import signal
+from collections.abc import Awaitable, Callable
+from functools import partial
 from typing import Any
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
@@ -139,6 +141,30 @@ class EnricherJob:
             await self._producer.stop()
             await engine.dispose()
 
+    async def _retry_until_acked(
+        self, attempt: Callable[[], Awaitable[None]], what: str
+    ) -> bool:
+        """Run ``attempt`` until it succeeds; False if a stop arrived first.
+
+        A False return means the caller must not commit: the poll replays
+        after restart. A healthy in-flight attempt is never abandoned — the
+        stop check lives in the failure branch, not at the loop top. Initial
+        backoff never exceeds the cap, so tests (and operators) can shrink
+        the whole retry cadence with one setting.
+        """
+        cap = self._settings.enricher_insert_max_backoff_s
+        backoff = min(1.0, cap)
+        while True:
+            try:
+                await attempt()
+                return True
+            except Exception:
+                if self._stop.is_set():
+                    return False
+                _log.exception("%s failed; retrying in %.0fs", what, backoff)
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, cap)
+
     async def _process_poll(self, records: list[Any]) -> None:
         """One full cycle over one poll's records. See the module docstring
         for the ordering contract."""
@@ -246,37 +272,30 @@ class EnricherJob:
         # halting this partition is correct: committing would drop data, and
         # redelivery after a restart dedups. Re-running all three inserts on a
         # partial failure is safe per the batch functions' contract.
-        # Initial backoff never exceeds the cap, so tests (and operators) can
-        # shrink the whole retry cadence with one setting.
-        backoff = min(1.0, self._settings.enricher_insert_max_backoff_s)
-        while True:
-            try:
-                await asyncio.to_thread(
-                    insert_decisions_batch, self._clickhouse, decisions
-                )
-                await asyncio.to_thread(
-                    insert_llm_invocations_batch, self._clickhouse, llms
-                )
-                await asyncio.to_thread(
-                    insert_ban_enforcements_batch, self._clickhouse, bans
-                )
-                break
-            except Exception:
-                if self._stop.is_set():
-                    # Stopping mid-outage: don't wait, don't commit — the poll
-                    # replays after restart. A healthy in-flight poll is never
-                    # abandoned; the check lives here, not at the loop top.
-                    return
-                _log.exception(
-                    "ClickHouse insert failed; retrying whole batch in %.0fs", backoff
-                )
-                await asyncio.sleep(backoff)
-                backoff = min(backoff * 2, self._settings.enricher_insert_max_backoff_s)
-
-        for key, envelope in dlq_messages:
-            await self._producer.send_and_wait(
-                self._settings.redpanda_dlq_topic, envelope, key=key
+        async def _insert_all() -> None:
+            await asyncio.to_thread(insert_decisions_batch, self._clickhouse, decisions)
+            await asyncio.to_thread(
+                insert_llm_invocations_batch, self._clickhouse, llms
             )
+            await asyncio.to_thread(
+                insert_ban_enforcements_batch, self._clickhouse, bans
+            )
+
+        if not await self._retry_until_acked(_insert_all, "ClickHouse insert"):
+            return
+
+        # Same posture for the DLQ: an envelope that never lands would be lost
+        # for good once the offset commits, so a send failure halts here too.
+        # Per message, so a mid-list failure re-sends only what is left.
+        for key, envelope in dlq_messages:
+            send = partial(
+                self._producer.send_and_wait,
+                self._settings.redpanda_dlq_topic,
+                envelope,
+                key=key,
+            )
+            if not await self._retry_until_acked(send, "DLQ send"):
+                return
 
         try:
             await self._consumer.commit()

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -16,11 +16,10 @@ import asyncio
 import logging
 import signal
 from collections.abc import Awaitable, Callable
-from functools import partial
 from typing import Any
 
 from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
-from aiokafka.errors import CommitFailedError
+from aiokafka.errors import CommitFailedError, MessageSizeTooLargeError
 from clickhouse_connect.driver.client import Client
 
 from hexgate_api.core.clickhouse import BatchItem, get_clickhouse, verify_all
@@ -314,13 +313,26 @@ class EnricherJob:
         # for good once the offset commits, so a send failure halts here too.
         # Per message, so a mid-list failure re-sends only what is left.
         for key, envelope in dlq_messages:
-            send = partial(
-                self._producer.send_and_wait,
-                self._settings.redpanda_dlq_topic,
-                envelope,
-                key=key,
-            )
-            if not await self._retry_until_acked(send, "DLQ send"):
+
+            async def _send(
+                key: bytes | None = key, envelope: bytes = envelope
+            ) -> None:
+                try:
+                    await self._producer.send_and_wait(
+                        self._settings.redpanda_dlq_topic, envelope, key=key
+                    )
+                except MessageSizeTooLargeError:
+                    # Client-side and permanent — no retry can ever land it,
+                    # and blocking the partition over a diagnostic envelope
+                    # inverts the DLQ's purpose. Backstop only: dlq.py caps
+                    # envelopes well under the producer limit.
+                    _log.error(
+                        "DLQ envelope over the producer size limit (%d bytes); "
+                        "dropped — the source record still holds the original",
+                        len(envelope),
+                    )
+
+            if not await self._retry_until_acked(_send, "DLQ send"):
                 return
 
         try:

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -173,6 +173,12 @@ class EnricherJob:
         """One full cycle over one poll's records. See the module docstring
         for the ordering contract."""
         events: list[tuple[Event, str]] = []  # (event, project_id)
+        # A produce retry whose first attempt landed puts the same span on the
+        # topic twice, often adjacent and so inside one poll. ClickHouse only
+        # collapses such a pair at insert time when both fall in the same
+        # block, so the batch functions ask the caller to dedup by event_id
+        # first (see insert_decisions_batch). First copy wins.
+        seen_event_ids: set[str] = set()
         dlq_messages: list[tuple[bytes | None, bytes]] = []  # (key, envelope)
         for record in records:
             project_id = record.key.decode("utf-8") if record.key is not None else None
@@ -219,9 +225,7 @@ class EnricherJob:
                 continue
             for scope_name, span, resource_attrs in decoded:
                 try:
-                    events.append(
-                        (map_span(scope_name, span, resource_attrs), project_id)
-                    )
+                    event = map_span(scope_name, span, resource_attrs)
                 except SpanRejected as rejected:
                     # One bad span never rejects its siblings.
                     dlq_messages.append(
@@ -239,6 +243,11 @@ class EnricherJob:
                             ),
                         )
                     )
+                    continue
+                if event.event_id in seen_event_ids:
+                    continue
+                seen_event_ids.add(event.event_id)
+                events.append((event, project_id))
 
         versions = await resolve_versions(
             {(project_id, event.agent_name) for event, project_id in events}

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -145,24 +145,10 @@ class EnricherJob:
         events: list[tuple[Event, str]] = []  # (event, project_id)
         dlq_messages: list[tuple[bytes | None, bytes]] = []  # (key, envelope)
         for record in records:
-            if record.key is None:
-                # No auth-derived project attribution → unattributable, park it.
-                dlq_messages.append(
-                    (
-                        None,
-                        dlq.record_envelope(
-                            error="record has no project_id key",
-                            error_class="missing_key",
-                            project_id=None,
-                            topic=record.topic,
-                            partition=record.partition,
-                            offset=record.offset,
-                            raw_value=record.value,
-                        ),
-                    )
-                )
-                continue
-            project_id = record.key.decode("utf-8")
+            project_id = record.key.decode("utf-8") if record.key is not None else None
+            # Decode before looking at the key: a keyless record is usually a
+            # valid request that lost its auth attribution upstream, and only
+            # a decoded span can be redacted before it is parked.
             try:
                 decoded = decode_record(record.value)
             except RecordDecodeError as exc:
@@ -180,6 +166,26 @@ class EnricherJob:
                         ),
                     )
                 )
+                continue
+            if project_id is None:
+                # No auth-derived project attribution → unattributable, park
+                # every span (redacted) rather than the raw record.
+                for scope_name, span, _resource_attrs in decoded:
+                    dlq_messages.append(
+                        (
+                            None,
+                            dlq.span_envelope(
+                                error="record has no project_id key",
+                                error_class="missing_key",
+                                scope=scope_name,
+                                project_id="",
+                                topic=record.topic,
+                                partition=record.partition,
+                                offset=record.offset,
+                                span=span,
+                            ),
+                        )
+                    )
                 continue
             for scope_name, span, resource_attrs in decoded:
                 try:

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -279,9 +279,18 @@ class EnricherJob:
                 seen_event_ids.add((project_id, event.event_id))
                 events.append((event, project_id))
 
-        versions = await resolve_versions(
-            {(project_id, event.agent_name) for event, project_id in events}
-        )
+        # Postgres is infra exactly like ClickHouse and the DLQ below: a
+        # connection failure or exhausted pool halts this partition with
+        # backoff instead of escaping run() into a restart loop.
+        pairs = {(project_id, event.agent_name) for event, project_id in events}
+        versions: dict[tuple[str, str], str] = {}
+
+        async def _resolve() -> None:
+            nonlocal versions
+            versions = await resolve_versions(pairs)
+
+        if not await self._retry_until_acked(_resolve, "agent version resolve"):
+            return
         decisions = [
             BatchItem(
                 event,

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -23,7 +23,7 @@ from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 from aiokafka.errors import CommitFailedError
 from clickhouse_connect.driver.client import Client
 
-from hexgate_api.core.clickhouse import BatchItem, get_clickhouse
+from hexgate_api.core.clickhouse import BatchItem, get_clickhouse, verify_all
 from hexgate_api.core.db import engine
 from hexgate_api.features.audit.service import (
     insert_ban_enforcements_batch,
@@ -95,10 +95,13 @@ class EnricherJob:
             loop.add_signal_handler(sig, self._stop.set)
 
         # Fail fast on a stale ClickHouse volume — same guard the API runs at
-        # startup, per feature, covering every table this job writes.
+        # startup, aggregated so a volume behind on two tables reports both in
+        # one boot. Sync clickhouse-connect call, so off the loop like the
+        # inserts below.
         self._clickhouse = self._clickhouse or get_clickhouse()
-        verify_audit_schema(self._clickhouse)
-        verify_llm_schema(self._clickhouse)
+        await asyncio.to_thread(
+            verify_all, self._clickhouse, (verify_audit_schema, verify_llm_schema)
+        )
 
         if self._consumer is None:
             self._consumer = AIOKafkaConsumer(

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -20,7 +20,7 @@ from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
 from aiokafka.errors import CommitFailedError
 from clickhouse_connect.driver.client import Client
 
-from hexgate_api.core.clickhouse import get_clickhouse
+from hexgate_api.core.clickhouse import BatchItem, get_clickhouse
 from hexgate_api.core.db import engine
 from hexgate_api.features.audit.service import (
     insert_ban_enforcements_batch,
@@ -208,17 +208,29 @@ class EnricherJob:
             {(project_id, event.agent_name) for event, project_id in events}
         )
         decisions = [
-            (event, pid, versions[(pid, event.agent_name)])
+            BatchItem(
+                event,
+                project_id=pid,
+                agent_version_id=versions[(pid, event.agent_name)],
+            )
             for event, pid in events
             if isinstance(event, DecisionEvent)
         ]
         llms = [
-            (event, pid, versions[(pid, event.agent_name)])
+            BatchItem(
+                event,
+                project_id=pid,
+                agent_version_id=versions[(pid, event.agent_name)],
+            )
             for event, pid in events
             if isinstance(event, LlmInvocationEvent)
         ]
         bans = [
-            (event, pid, versions[(pid, event.agent_name)])
+            BatchItem(
+                event,
+                project_id=pid,
+                agent_version_id=versions[(pid, event.agent_name)],
+            )
             for event, pid in events
             if isinstance(event, BanEnforcementEvent)
         ]

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -1,0 +1,266 @@
+"""The enricher's Kafka lifecycle and poll loop.
+
+Correctness contract, in processing order per poll:
+decode → per-span map/validate (rejects → DLQ envelopes, siblings survive)
+→ resolve agent versions → three batch inserts (retried as a whole until
+ClickHouse acks) → DLQ sends → offset commit. Committing only after the
+ClickHouse ack means a crash anywhere in the cycle replays the poll on
+restart, which is safe: event_id is the idempotency key and
+ReplacingMergeTree collapses the duplicates.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from typing import Any
+
+from aiokafka import AIOKafkaConsumer, AIOKafkaProducer
+from aiokafka.errors import CommitFailedError
+from clickhouse_connect.driver.client import Client
+
+from hexgate_api.core.clickhouse import get_clickhouse
+from hexgate_api.core.db import engine
+from hexgate_api.features.audit.service import (
+    insert_ban_enforcements_batch,
+    insert_decisions_batch,
+)
+from hexgate_api.features.audit.service import verify_schema as verify_audit_schema
+from hexgate_api.features.llm_invocations.service import (
+    insert_llm_invocations_batch,
+)
+from hexgate_api.features.llm_invocations.service import (
+    verify_schema as verify_llm_schema,
+)
+from hexgate_api.jobs.enricher import dlq
+from hexgate_api.jobs.enricher.coerce import SpanRejected
+from hexgate_api.jobs.enricher.decode import RecordDecodeError, decode_record
+from hexgate_api.jobs.enricher.mapping import Event, map_span
+from hexgate_api.jobs.enricher.resolver import resolve_versions
+from hexgate_api.schemas import BanEnforcementEvent, DecisionEvent, LlmInvocationEvent
+from hexgate_api.settings import Settings
+
+_log = logging.getLogger(__name__)
+
+# A CH-outage retry longer than this evicts us from the consumer group and
+# hands the partition to a replica that will hit the same outage. Generous
+# beats the 5-minute default; an eviction would only add rebalance churn.
+_MAX_POLL_INTERVAL_MS = 30 * 60 * 1000
+
+
+class TopicsMissing(Exception):
+    """A required topic does not exist (auto-create is disabled)."""
+
+    def __init__(self, missing: list[str]) -> None:
+        super().__init__(
+            f"missing Kafka topic(s) {', '.join(missing)} — run `make redpanda-topics`"
+        )
+
+
+class EnricherJob:
+    """One consumer-group member. Instantiate once per process."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        clickhouse_client: Client | None = None,
+        consumer: Any | None = None,
+        producer: Any | None = None,
+    ) -> None:
+        # Kafka clients are injectable so unit tests drive _process_poll with
+        # fakes; production leaves them None and run() builds real ones.
+        self._settings = settings
+        self._clickhouse = clickhouse_client
+        self._consumer = consumer
+        self._producer = producer
+        self._stop = asyncio.Event()
+
+    def request_stop(self) -> None:
+        self._stop.set()
+
+    async def run(self) -> None:
+        settings = self._settings
+        # Fail fast on a stale ClickHouse volume — same guard the API runs at
+        # startup, per feature, covering every table this job writes.
+        self._clickhouse = self._clickhouse or get_clickhouse()
+        verify_audit_schema(self._clickhouse)
+        verify_llm_schema(self._clickhouse)
+
+        if self._consumer is None:
+            self._consumer = AIOKafkaConsumer(
+                settings.redpanda_raw_topic,
+                bootstrap_servers=settings.redpanda_bootstrap_server,
+                group_id=settings.enricher_consumer_group,
+                # Offsets are the job's progress marker; committing them is
+                # the last step of a cycle, never automatic.
+                enable_auto_commit=False,
+                auto_offset_reset="earliest",
+                max_poll_interval_ms=_MAX_POLL_INTERVAL_MS,
+            )
+        if self._producer is None:
+            self._producer = AIOKafkaProducer(
+                bootstrap_servers=settings.redpanda_bootstrap_server, acks="all"
+            )
+        await self._consumer.start()
+        await self._producer.start()
+        try:
+            # Auto-create is disabled cluster-wide, so a missing topic is an
+            # operator error worth an actionable exit, not a silent hang.
+            existing = await self._consumer.topics()
+            missing = [
+                topic
+                for topic in (settings.redpanda_raw_topic, settings.redpanda_dlq_topic)
+                if topic not in existing
+            ]
+            if missing:
+                raise TopicsMissing(missing)
+
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(sig, self._stop.set)
+
+            _log.info(
+                "enricher consuming %s (group %s) → ClickHouse",
+                settings.redpanda_raw_topic,
+                settings.enricher_consumer_group,
+            )
+            while not self._stop.is_set():
+                batches = await self._consumer.getmany(
+                    timeout_ms=settings.enricher_poll_timeout_ms,
+                    max_records=settings.enricher_max_poll_records,
+                )
+                records = [record for part in batches.values() for record in part]
+                if records:
+                    await self._process_poll(records)
+        finally:
+            await self._consumer.stop()
+            await self._producer.stop()
+            await engine.dispose()
+
+    async def _process_poll(self, records: list[Any]) -> None:
+        """One full cycle over one poll's records. See the module docstring
+        for the ordering contract."""
+        events: list[tuple[Event, str]] = []  # (event, project_id)
+        dlq_messages: list[tuple[bytes | None, bytes]] = []  # (key, envelope)
+        for record in records:
+            if record.key is None:
+                # No auth-derived project attribution → unattributable, park it.
+                dlq_messages.append(
+                    (
+                        None,
+                        dlq.record_envelope(
+                            error="record has no project_id key",
+                            error_class="missing_key",
+                            project_id=None,
+                            topic=record.topic,
+                            partition=record.partition,
+                            offset=record.offset,
+                            raw_value=record.value,
+                        ),
+                    )
+                )
+                continue
+            project_id = record.key.decode("utf-8")
+            try:
+                decoded = decode_record(record.value)
+            except RecordDecodeError as exc:
+                dlq_messages.append(
+                    (
+                        record.key,
+                        dlq.record_envelope(
+                            error=f"undecodable OTLP payload: {exc}",
+                            error_class="decode",
+                            project_id=project_id,
+                            topic=record.topic,
+                            partition=record.partition,
+                            offset=record.offset,
+                            raw_value=record.value,
+                        ),
+                    )
+                )
+                continue
+            for scope_name, span, resource_attrs in decoded:
+                try:
+                    events.append(
+                        (map_span(scope_name, span, resource_attrs), project_id)
+                    )
+                except SpanRejected as rejected:
+                    # One bad span never rejects its siblings.
+                    dlq_messages.append(
+                        (
+                            record.key,
+                            dlq.span_envelope(
+                                error=rejected.error,
+                                error_class=rejected.error_class,
+                                scope=rejected.scope,
+                                project_id=project_id,
+                                topic=record.topic,
+                                partition=record.partition,
+                                offset=record.offset,
+                                span=span,
+                            ),
+                        )
+                    )
+
+        versions = await resolve_versions(
+            {(project_id, event.agent_name) for event, project_id in events}
+        )
+        decisions = [
+            (event, pid, versions[(pid, event.agent_name)])
+            for event, pid in events
+            if isinstance(event, DecisionEvent)
+        ]
+        llms = [
+            (event, pid, versions[(pid, event.agent_name)])
+            for event, pid in events
+            if isinstance(event, LlmInvocationEvent)
+        ]
+        bans = [
+            (event, pid, versions[(pid, event.agent_name)])
+            for event, pid in events
+            if isinstance(event, BanEnforcementEvent)
+        ]
+
+        # Retry the whole batch until ClickHouse acks. Only infra failures can
+        # land here (bad input was already diverted to the DLQ above), so
+        # halting this partition is correct: committing would drop data, and
+        # redelivery after a restart dedups. Re-running all three inserts on a
+        # partial failure is safe per the batch functions' contract.
+        # Initial backoff never exceeds the cap, so tests (and operators) can
+        # shrink the whole retry cadence with one setting.
+        backoff = min(1.0, self._settings.enricher_insert_max_backoff_s)
+        while True:
+            if self._stop.is_set():
+                return  # stopping mid-outage: no commit, the poll replays later
+            try:
+                await asyncio.to_thread(
+                    insert_decisions_batch, self._clickhouse, decisions
+                )
+                await asyncio.to_thread(
+                    insert_llm_invocations_batch, self._clickhouse, llms
+                )
+                await asyncio.to_thread(
+                    insert_ban_enforcements_batch, self._clickhouse, bans
+                )
+                break
+            except Exception:
+                _log.exception(
+                    "ClickHouse insert failed; retrying whole batch in %.0fs", backoff
+                )
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, self._settings.enricher_insert_max_backoff_s)
+
+        for key, envelope in dlq_messages:
+            await self._producer.send_and_wait(
+                self._settings.redpanda_dlq_topic, envelope, key=key
+            )
+
+        try:
+            await self._consumer.commit()
+        except CommitFailedError:
+            # A rebalance took our partitions mid-cycle. Drop this poll — the
+            # new owner replays it and ClickHouse dedup absorbs the rows (DLQ
+            # consumers must tolerate the duplicate envelopes).
+            _log.warning("offset commit failed after a rebalance; poll will replay")

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -105,9 +105,13 @@ class EnricherJob:
             self._producer = AIOKafkaProducer(
                 bootstrap_servers=settings.redpanda_bootstrap_server, acks="all"
             )
-        await self._consumer.start()
-        await self._producer.start()
+        # Both starts live inside the try: the consumer joins the group on
+        # start(), so a producer that then fails to connect must still leave
+        # the group cleanly instead of holding its partitions until the
+        # session times out. stop() on a never-started client is a no-op.
         try:
+            await self._consumer.start()
+            await self._producer.start()
             # Auto-create is disabled cluster-wide, so a missing topic is an
             # operator error worth an actionable exit, not a silent hang.
             existing = await self._consumer.topics()

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -5,8 +5,9 @@ decode → per-span map/validate (rejects → DLQ envelopes, siblings survive)
 → resolve agent versions → three batch inserts (retried as a whole until
 ClickHouse acks) → DLQ sends → offset commit. Committing only after the
 ClickHouse ack means a crash anywhere in the cycle replays the poll on
-restart, which is safe: event_id is the idempotency key and
-ReplacingMergeTree collapses the duplicates.
+restart, which is safe for the tables: event_id is the idempotency key and
+ReplacingMergeTree collapses the duplicates. DLQ envelopes have no such key
+and are simply re-sent on replay (see dlq.py).
 """
 
 from __future__ import annotations

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -232,8 +232,6 @@ class EnricherJob:
         # shrink the whole retry cadence with one setting.
         backoff = min(1.0, self._settings.enricher_insert_max_backoff_s)
         while True:
-            if self._stop.is_set():
-                return  # stopping mid-outage: no commit, the poll replays later
             try:
                 await asyncio.to_thread(
                     insert_decisions_batch, self._clickhouse, decisions
@@ -246,6 +244,11 @@ class EnricherJob:
                 )
                 break
             except Exception:
+                if self._stop.is_set():
+                    # Stopping mid-outage: don't wait, don't commit — the poll
+                    # replays after restart. A healthy in-flight poll is never
+                    # abandoned; the check lives here, not at the loop top.
+                    return
                 _log.exception(
                     "ClickHouse insert failed; retrying whole batch in %.0fs", backoff
                 )

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -84,6 +84,15 @@ class EnricherJob:
 
     async def run(self) -> None:
         settings = self._settings
+        # Installed first: until this runs SIGTERM has the default disposition
+        # and kills the process outright, skipping the finally below — so a
+        # signal during the broker connects would leave a dead group member
+        # until the session times out. The handler only flags an Event, so
+        # nothing it needs is created later.
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, self._stop.set)
+
         # Fail fast on a stale ClickHouse volume — same guard the API runs at
         # startup, per feature, covering every table this job writes.
         self._clickhouse = self._clickhouse or get_clickhouse()
@@ -122,10 +131,6 @@ class EnricherJob:
             ]
             if missing:
                 raise TopicsMissing(missing)
-
-            loop = asyncio.get_running_loop()
-            for sig in (signal.SIGTERM, signal.SIGINT):
-                loop.add_signal_handler(sig, self._stop.set)
 
             _log.info(
                 "enricher consuming %s (group %s) → ClickHouse",

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -85,15 +85,6 @@ class EnricherJob:
 
     async def run(self) -> None:
         settings = self._settings
-        # Installed first: until this runs SIGTERM has the default disposition
-        # and kills the process outright, skipping the finally below — so a
-        # signal during the broker connects would leave a dead group member
-        # until the session times out. The handler only flags an Event, so
-        # nothing it needs is created later.
-        loop = asyncio.get_running_loop()
-        for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, self._stop.set)
-
         # Fail fast on a stale ClickHouse volume — same guard the API runs at
         # startup, aggregated so a volume behind on two tables reports both in
         # one boot. Sync clickhouse-connect call, so off the loop like the
@@ -135,6 +126,16 @@ class EnricherJob:
             ]
             if missing:
                 raise TopicsMissing(missing)
+
+            # Deliberately registered only now: the handler just flags an
+            # Event that the poll loop and retry loop check, and nothing in
+            # the connects above does. Installed earlier, a SIGTERM during a
+            # start() stuck on a coordinator-less broker would be swallowed
+            # and the process would wait for SIGKILL; with the default
+            # disposition it dies at once (unclean, but it dies).
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(sig, self._stop.set)
 
             _log.info(
                 "enricher consuming %s (group %s) → ClickHouse",

--- a/platform/api/hexgate_api/jobs/enricher/consumer.py
+++ b/platform/api/hexgate_api/jobs/enricher/consumer.py
@@ -51,6 +51,22 @@ _log = logging.getLogger(__name__)
 _MAX_POLL_INTERVAL_MS = 30 * 60 * 1000
 
 
+def _project_id(key: bytes | None) -> str | None:
+    """The auth-derived project attribution, or None when it is unusable.
+
+    A non-UTF-8 key can only come from a foreign producer (the Collector
+    always keys with the project_id string) and is as unattributable as no
+    key at all — both fall through to the missing_key parking path rather
+    than crash the poll.
+    """
+    if key is None:
+        return None
+    try:
+        return key.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+
+
 class TopicsMissing(Exception):
     """A required topic does not exist (auto-create is disabled)."""
 
@@ -193,7 +209,7 @@ class EnricherJob:
         seen_event_ids: set[tuple[str, str]] = set()
         dlq_messages: list[tuple[bytes | None, bytes]] = []  # (key, envelope)
         for record in records:
-            project_id = record.key.decode("utf-8") if record.key is not None else None
+            project_id = _project_id(record.key)
             # Decode before looking at the key: a keyless record is usually a
             # valid request that lost its auth attribution upstream, and only
             # a decoded span can be redacted before it is parked.
@@ -210,7 +226,9 @@ class EnricherJob:
                             topic=record.topic,
                             partition=record.partition,
                             offset=record.offset,
-                            raw_value=record.value,
+                            # None decodes to nothing worth carrying; b"" keeps
+                            # the envelope shape (and b64encode) total.
+                            raw_value=record.value or b"",
                         ),
                     )
                 )

--- a/platform/api/hexgate_api/jobs/enricher/decode.py
+++ b/platform/api/hexgate_api/jobs/enricher/decode.py
@@ -1,0 +1,74 @@
+"""Kafka record bytes → decoded OTLP spans.
+
+One record value is one serialized ``ExportTraceServiceRequest`` (the
+Collector's kafkaexporter, ``encoding: otlp_proto``), carrying up to a whole
+Collector batch of spans across several resource/scope groups.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+from google.protobuf.message import DecodeError
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+from opentelemetry.proto.trace.v1.trace_pb2 import Span
+
+
+class RecordDecodeError(Exception):
+    """The record value is not a parseable ExportTraceServiceRequest."""
+
+
+class DecodedSpan(NamedTuple):
+    scope_name: str
+    span: Span
+    resource_attrs: dict[str, Any]
+
+
+def attr_value(value: AnyValue) -> Any:
+    """Recursively convert an OTLP AnyValue to its Python equivalent.
+
+    kvlists become dicts and arrays lists so the mapping layer can coerce
+    uniformly; an unset AnyValue becomes None.
+    """
+    kind = value.WhichOneof("value")
+    if kind is None:
+        return None
+    if kind == "array_value":
+        return [attr_value(v) for v in value.array_value.values]
+    if kind == "kvlist_value":
+        return attrs_dict(value.kvlist_value.values)
+    return getattr(value, kind)
+
+
+def attrs_dict(attributes: Any) -> dict[str, Any]:
+    """OTLP KeyValue list → plain dict (last occurrence of a key wins)."""
+    out: dict[str, Any] = {}
+    for kv in attributes:
+        assert isinstance(kv, KeyValue)
+        out[kv.key] = attr_value(kv.value)
+    return out
+
+
+def decode_record(value: bytes) -> list[DecodedSpan]:
+    """Parse one record into per-span units, each tagged with its
+    instrumentation scope name and the enclosing resource attributes.
+
+    Raises :class:`RecordDecodeError` when the bytes are not a valid
+    protobuf message; a valid request with zero spans returns [].
+    """
+    request = ExportTraceServiceRequest()
+    try:
+        request.ParseFromString(value)
+    except DecodeError as exc:
+        raise RecordDecodeError(str(exc)) from exc
+    decoded: list[DecodedSpan] = []
+    for resource_spans in request.resource_spans:
+        resource_attrs = attrs_dict(resource_spans.resource.attributes)
+        for scope_spans in resource_spans.scope_spans:
+            scope_name = scope_spans.scope.name
+            for span in scope_spans.spans:
+                decoded.append(DecodedSpan(scope_name, span, resource_attrs))
+    return decoded

--- a/platform/api/hexgate_api/jobs/enricher/decode.py
+++ b/platform/api/hexgate_api/jobs/enricher/decode.py
@@ -52,13 +52,18 @@ def attrs_dict(attributes: Any) -> dict[str, Any]:
     return out
 
 
-def decode_record(value: bytes) -> list[DecodedSpan]:
+def decode_record(value: bytes | None) -> list[DecodedSpan]:
     """Parse one record into per-span units, each tagged with its
     instrumentation scope name and the enclosing resource attributes.
 
     Raises :class:`RecordDecodeError` when the bytes are not a valid
     protobuf message; a valid request with zero spans returns [].
     """
+    if value is None:
+        # A tombstone or a foreign producer's null. ParseFromString(None)
+        # raises TypeError, not DecodeError — unmapped here, it would escape
+        # the caller's decode handling and crash-loop the process.
+        raise RecordDecodeError("record value is None")
     request = ExportTraceServiceRequest()
     try:
         request.ParseFromString(value)

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -3,8 +3,9 @@
 JSON, not protobuf: the DLQ's consumers are humans (``rpk topic consume``)
 and a future replay script, volume is low, and a single span can't be
 re-serialized standalone anyway. One message per rejected unit — a span
-normally, the whole record only when its bytes are undecodable or it
-arrived keyless. Keyed by project_id so DLQ partitioning mirrors the source.
+normally (including every span of a keyless record), the whole record only
+when its bytes are undecodable. Keyed by project_id so DLQ partitioning
+mirrors the source.
 
 DLQ messages can duplicate when a poll is replayed after a rebalance
 (offsets commit only after processing) — consumers must tolerate that.

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -1,0 +1,84 @@
+"""Dead-letter envelopes for permanently-rejected records and spans.
+
+JSON, not protobuf: the DLQ's consumers are humans (``rpk topic consume``)
+and a future replay script, volume is low, and a single span can't be
+re-serialized standalone anyway. One message per rejected unit — a span
+normally, the whole record only when its bytes are undecodable or it
+arrived keyless. Keyed by project_id so DLQ partitioning mirrors the source.
+
+DLQ messages can duplicate when a poll is replayed after a rebalance
+(offsets commit only after processing) — consumers must tolerate that.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+from opentelemetry.proto.trace.v1.trace_pb2 import Span
+
+from hexgate.audit import SENSITIVE_ARG_KEY_RE, redact
+from hexgate_api.jobs.enricher.decode import attrs_dict
+
+
+def _source(topic: str, partition: int, offset: int) -> dict[str, Any]:
+    """Pointer back to the raw record, valid while the source retention lasts."""
+    return {"topic": topic, "partition": partition, "offset": offset}
+
+
+def span_envelope(
+    *,
+    error: str,
+    error_class: str,
+    scope: str,
+    project_id: str,
+    topic: str,
+    partition: int,
+    offset: int,
+    span: Span,
+) -> bytes:
+    """Envelope for one rejected span; its siblings are unaffected.
+
+    Attributes are redacted (substring key match, the stricter of the two
+    SDK patterns) before they land here: this topic has 30-day retention and
+    no ACLs, so unredacted arguments must never reach it.
+    """
+    attributes = redact(attrs_dict(span.attributes), pattern=SENSITIVE_ARG_KEY_RE)
+    payload = {
+        "error": error,
+        "error_class": error_class,
+        "scope": scope,
+        "project_id": project_id,
+        "source": _source(topic, partition, offset),
+        "span": {
+            "name": span.name,
+            "trace_id_hex": span.trace_id.hex(),
+            "span_id_hex": span.span_id.hex(),
+            "start_time_unix_nano": span.start_time_unix_nano,
+            "attributes": attributes,
+        },
+    }
+    return json.dumps(payload, default=str).encode("utf-8")
+
+
+def record_envelope(
+    *,
+    error: str,
+    error_class: str,
+    project_id: str | None,
+    topic: str,
+    partition: int,
+    offset: int,
+    raw_value: bytes,
+) -> bytes:
+    """Envelope for a whole record that never decoded into spans."""
+    payload = {
+        "error": error,
+        "error_class": error_class,
+        "scope": None,
+        "project_id": project_id,
+        "source": _source(topic, partition, offset),
+        "record_value_base64": base64.b64encode(raw_value).decode("ascii"),
+    }
+    return json.dumps(payload).encode("utf-8")

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -7,8 +7,10 @@ normally (including every span of a keyless record), the whole record only
 when its bytes are undecodable. Keyed by project_id so DLQ partitioning
 mirrors the source.
 
-DLQ messages can duplicate when a poll is replayed after a rebalance
-(offsets commit only after processing) — consumers must tolerate that.
+DLQ messages can duplicate whenever a poll replays — a rebalance, a crash, or
+a stop during the DLQ retry loop — because offsets commit only after every
+send has landed. Envelopes carry no dedup key, so nothing collapses them the
+way ReplacingMergeTree does for the tables; consumers must tolerate that.
 """
 
 from __future__ import annotations

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -40,18 +40,21 @@ def _source(topic: str, partition: int, offset: int) -> dict[str, Any]:
 def _redacted_attributes(span: Span) -> dict[str, Any]:
     """Span attributes safe for the DLQ: JSON-string dicts parsed, then redacted.
 
-    A dict field that doesn't parse can't be redacted, so it is dropped rather
-    than forwarded raw — the DLQ is for diagnosing the rejection, and the
-    source record (see ``_source``) still holds the original bytes.
+    A dict field that doesn't parse *to a dict* can't be redacted (``redact``
+    matches keys, so a bare string or list has nothing to match), so it is
+    dropped rather than forwarded raw — the DLQ is for diagnosing the
+    rejection, and the source record (see ``_source``) still holds the
+    original bytes.
     """
     attributes = attrs_dict(span.attributes)
     for key in _JSON_DICT_KEYS:
         raw = attributes.get(key)
         if isinstance(raw, str):
             try:
-                attributes[key] = json.loads(raw)
+                parsed = json.loads(raw)
             except ValueError:
-                attributes[key] = _UNPARSEABLE
+                parsed = None
+            attributes[key] = parsed if isinstance(parsed, dict) else _UNPARSEABLE
     return redact(attributes, pattern=SENSITIVE_ARG_KEY_RE)
 
 

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -21,7 +21,7 @@ from typing import Any
 
 from opentelemetry.proto.trace.v1.trace_pb2 import Span
 
-from hexgate.audit import SENSITIVE_ARG_KEY_RE, redact
+from hexgate.audit import SENSITIVE_ARG_KEY_RE, redact, truncate_json
 from hexgate.tracing import semconv
 from hexgate_api.jobs.enricher.decode import attrs_dict
 
@@ -30,6 +30,15 @@ from hexgate_api.jobs.enricher.decode import attrs_dict
 # with its secret-bearing keys unread.
 _JSON_DICT_KEYS = (semconv.ARGUMENTS, semconv.HINT, semconv.ATTRIBUTES)
 _UNPARSEABLE = "[UNPARSEABLE]"
+
+# Both variable-size fields are capped well below the producer's 1 MiB
+# default max_request_size: an envelope the producer itself cannot send
+# fails client-side on every attempt and would wedge the very partition
+# the DLQ exists to protect. The caps are diagnostic previews, not the
+# record of truth — ``_source`` locates the original bytes while the raw
+# topic's retention lasts.
+_ATTRIBUTES_CAP_BYTES = 32 * 1024
+_RAW_VALUE_CAP_BYTES = 64 * 1024
 
 
 def _source(topic: str, partition: int, offset: int) -> dict[str, Any]:
@@ -55,7 +64,9 @@ def _redacted_attributes(span: Span) -> dict[str, Any]:
             except ValueError:
                 parsed = None
             attributes[key] = parsed if isinstance(parsed, dict) else _UNPARSEABLE
-    return redact(attributes, pattern=SENSITIVE_ARG_KEY_RE)
+    return truncate_json(
+        redact(attributes, pattern=SENSITIVE_ARG_KEY_RE), cap=_ATTRIBUTES_CAP_BYTES
+    )
 
 
 def span_envelope(
@@ -112,6 +123,9 @@ def record_envelope(
         "scope": None,
         "project_id": project_id,
         "source": _source(topic, partition, offset),
-        "record_value_base64": base64.b64encode(raw_value).decode("ascii"),
+        "record_value_base64": base64.b64encode(
+            raw_value[:_RAW_VALUE_CAP_BYTES]
+        ).decode("ascii"),
+        "record_value_truncated": len(raw_value) > _RAW_VALUE_CAP_BYTES,
     }
     return json.dumps(payload).encode("utf-8")

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -19,12 +19,37 @@ from typing import Any
 from opentelemetry.proto.trace.v1.trace_pb2 import Span
 
 from hexgate.audit import SENSITIVE_ARG_KEY_RE, redact
+from hexgate.tracing import semconv
 from hexgate_api.jobs.enricher.decode import attrs_dict
+
+# The dict fields travel as JSON strings (semconv wire contract). ``redact``
+# matches dict keys, so a still-serialized payload would pass through whole
+# with its secret-bearing keys unread.
+_JSON_DICT_KEYS = (semconv.ARGUMENTS, semconv.HINT, semconv.ATTRIBUTES)
+_UNPARSEABLE = "[UNPARSEABLE]"
 
 
 def _source(topic: str, partition: int, offset: int) -> dict[str, Any]:
     """Pointer back to the raw record, valid while the source retention lasts."""
     return {"topic": topic, "partition": partition, "offset": offset}
+
+
+def _redacted_attributes(span: Span) -> dict[str, Any]:
+    """Span attributes safe for the DLQ: JSON-string dicts parsed, then redacted.
+
+    A dict field that doesn't parse can't be redacted, so it is dropped rather
+    than forwarded raw — the DLQ is for diagnosing the rejection, and the
+    source record (see ``_source``) still holds the original bytes.
+    """
+    attributes = attrs_dict(span.attributes)
+    for key in _JSON_DICT_KEYS:
+        raw = attributes.get(key)
+        if isinstance(raw, str):
+            try:
+                attributes[key] = json.loads(raw)
+            except ValueError:
+                attributes[key] = _UNPARSEABLE
+    return redact(attributes, pattern=SENSITIVE_ARG_KEY_RE)
 
 
 def span_envelope(
@@ -42,9 +67,11 @@ def span_envelope(
 
     Attributes are redacted (substring key match, the stricter of the two
     SDK patterns) before they land here: this topic has 30-day retention and
-    no ACLs, so unredacted arguments must never reach it.
+    no ACLs, so unredacted arguments must never reach it. The JSON-string
+    dict fields are parsed first so the key match reaches inside them, and
+    they stay dicts in the envelope.
     """
-    attributes = redact(attrs_dict(span.attributes), pattern=SENSITIVE_ARG_KEY_RE)
+    attributes = _redacted_attributes(span)
     payload = {
         "error": error,
         "error_class": error_class,

--- a/platform/api/hexgate_api/jobs/enricher/enforcement.py
+++ b/platform/api/hexgate_api/jobs/enricher/enforcement.py
@@ -1,0 +1,53 @@
+"""Authoritative server-side redaction + byte caps for decision payloads.
+
+Same pipeline the SDK applies client-side (imported from hexgate.audit, not
+copied — two implementations would drift), but here it is enforcement: the
+batch inserts trust their input and never re-check, so this is the single
+point where oversized or secret-bearing payloads get trimmed. Order and
+gating mirror ``AuditEvent.as_payload``: arguments are redacted (substring
+key match) then capped at 8 KiB; hint is capped at 4 KiB but never redacted
+(policy config, not caller data); attributes are redacted (anchored key
+match) then capped at 4 KiB, with a falsy bag normalised to None.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from hexgate.audit import (
+    MAX_ARGS_BYTES,
+    MAX_ATTRIBUTES_BYTES,
+    MAX_HINT_BYTES,
+    SENSITIVE_ARG_KEY_RE,
+    SENSITIVE_ATTR_KEY_RE,
+    bounded_violations,
+    redact,
+    truncate_json,
+)
+
+
+def capped_arguments(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return truncate_json(
+        redact(value, pattern=SENSITIVE_ARG_KEY_RE), cap=MAX_ARGS_BYTES
+    )
+
+
+def capped_hint(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    return truncate_json(value, cap=MAX_HINT_BYTES)
+
+
+def capped_attributes(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    # Falsy, not ``is not None`` — {} and None both store as absent downstream.
+    if not value:
+        return None
+    return truncate_json(
+        redact(value, pattern=SENSITIVE_ATTR_KEY_RE), cap=MAX_ATTRIBUTES_BYTES
+    )
+
+
+def capped_violations(values: list[str]) -> list[str]:
+    return bounded_violations(values)

--- a/platform/api/hexgate_api/jobs/enricher/mapping.py
+++ b/platform/api/hexgate_api/jobs/enricher/mapping.py
@@ -1,0 +1,183 @@
+"""Decoded OTLP span → validated platform event.
+
+The wire contract lives in hexgate.tracing.semconv (shared with the future
+SDK emitter). Dispatch is by instrumentation scope name; the platform's
+Pydantic models (schemas.py) are the validation layer, so the enricher
+accepts exactly what the HTTP ingest accepts. Type coercion lives in
+coerce.py; redaction/byte caps in enforcement.py — this module is only the
+attribute→field contract for each scope.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from opentelemetry.proto.trace.v1.trace_pb2 import Span
+from pydantic import ValidationError
+
+from hexgate.tracing import semconv
+from hexgate_api.jobs.enricher.coerce import (
+    SpanRejected,
+    as_int,
+    as_json_dict,
+    as_str,
+    as_str_list,
+    required,
+)
+from hexgate_api.jobs.enricher.decode import attrs_dict
+from hexgate_api.jobs.enricher.enforcement import (
+    capped_arguments,
+    capped_attributes,
+    capped_hint,
+    capped_violations,
+)
+from hexgate_api.query_scope import EventOutOfWindow, validate_event_window
+from hexgate_api.schemas import BanEnforcementEvent, DecisionEvent, LlmInvocationEvent
+
+_log = logging.getLogger(__name__)
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+KNOWN_SCOPES = (semconv.SCOPE_AUDIT, semconv.SCOPE_USAGE, semconv.SCOPE_BANS)
+
+Event = DecisionEvent | LlmInvocationEvent | BanEnforcementEvent
+
+
+def _envelope(
+    span: Span, attrs: dict[str, Any], resource_attrs: dict[str, Any], scope: str
+) -> dict[str, Any]:
+    """The AuditEnvelope fields shared by all three event types."""
+    if span.start_time_unix_nano <= 0:
+        raise SpanRejected(
+            "span start_time_unix_nano is unset", error_class="validation", scope=scope
+        )
+    # Integer arithmetic, not fromtimestamp(ns / 1e9): the float loses
+    # precision past ~µs and the storage column is DateTime64(3).
+    occurred_at = _EPOCH + timedelta(microseconds=span.start_time_unix_nano // 1_000)
+    agent_name = as_str(
+        attrs.get(semconv.AGENT_NAME)
+        or resource_attrs.get(semconv.AGENT_NAME)
+        or resource_attrs.get("service.name")
+    )
+    if not agent_name:
+        raise SpanRejected(
+            f"missing required attribute {semconv.AGENT_NAME}",
+            error_class="validation",
+            scope=scope,
+        )
+    return {
+        "event_id": as_str(required(attrs, semconv.EVENT_ID, scope=scope)),
+        "occurred_at": occurred_at,
+        "agent_name": agent_name,
+        "session_id": as_str(attrs.get(semconv.SESSION_ID)),
+        "user_id": as_str(attrs.get(semconv.USER_ID)),
+    }
+
+
+def _decision_fields(attrs: dict[str, Any], scope: str) -> dict[str, Any]:
+    return {
+        "tool_name": as_str(required(attrs, semconv.TOOL_NAME, scope=scope)),
+        "outcome": as_str(required(attrs, semconv.OUTCOME, scope=scope)),
+        "user_roles": as_str_list(
+            attrs.get(semconv.USER_ROLES), key=semconv.USER_ROLES, scope=scope
+        ),
+        "deciding_role": as_str(attrs.get(semconv.DECIDING_ROLE)),
+        "error_type": as_str(attrs.get(semconv.ERROR_TYPE)),
+        "reason": as_str(attrs.get(semconv.REASON)),
+        # Redaction/caps happen here, before validation, so an over-long
+        # violations list is bounded rather than rejected, and the batch
+        # inserts downstream can trust every event as final.
+        "violations": capped_violations(
+            as_str_list(
+                attrs.get(semconv.VIOLATIONS), key=semconv.VIOLATIONS, scope=scope
+            )
+        ),
+        "hint": capped_hint(
+            as_json_dict(attrs.get(semconv.HINT), key=semconv.HINT, scope=scope)
+        ),
+        "arguments": capped_arguments(
+            as_json_dict(
+                attrs.get(semconv.ARGUMENTS), key=semconv.ARGUMENTS, scope=scope
+            )
+        ),
+        "attributes": capped_attributes(
+            as_json_dict(
+                attrs.get(semconv.ATTRIBUTES), key=semconv.ATTRIBUTES, scope=scope
+            )
+        ),
+    }
+
+
+def _usage_fields(attrs: dict[str, Any], span: Span, scope: str) -> dict[str, Any]:
+    latency = attrs.get(semconv.LATENCY_MS)
+    if latency is None:
+        # Point-in-time emitters set start == end; a real duration is a usable
+        # fallback for foreign emitters that only timed the span.
+        elapsed_ns = span.end_time_unix_nano - span.start_time_unix_nano
+        latency = elapsed_ns // 1_000_000 if elapsed_ns > 0 else 0
+    fields = {
+        "model": as_str(required(attrs, semconv.GEN_AI_REQUEST_MODEL, scope=scope)),
+        "input_tokens": as_int(
+            required(attrs, semconv.GEN_AI_USAGE_INPUT_TOKENS, scope=scope),
+            key=semconv.GEN_AI_USAGE_INPUT_TOKENS,
+            scope=scope,
+        ),
+        "output_tokens": as_int(
+            required(attrs, semconv.GEN_AI_USAGE_OUTPUT_TOKENS, scope=scope),
+            key=semconv.GEN_AI_USAGE_OUTPUT_TOKENS,
+            scope=scope,
+        ),
+        "latency_ms": as_int(latency, key=semconv.LATENCY_MS, scope=scope),
+        "error_code": as_str(attrs.get(semconv.ERROR_CODE)),
+    }
+    status = attrs.get(semconv.STATUS)
+    if status is not None:  # absent → the model's "success" default
+        fields["status"] = as_str(status)
+    return fields
+
+
+def _ban_fields(attrs: dict[str, Any], scope: str) -> dict[str, Any]:
+    return {
+        "ban_type": as_str(required(attrs, semconv.BAN_TYPE, scope=scope)),
+        "ban_id": as_str(required(attrs, semconv.BAN_ID, scope=scope)),
+        "reason": as_str(attrs.get(semconv.REASON)),
+    }
+
+
+def map_span(scope_name: str, span: Span, resource_attrs: dict[str, Any]) -> Event:
+    """Build the validated event for one span, or raise :class:`SpanRejected`."""
+    if scope_name not in KNOWN_SCOPES:
+        raise SpanRejected(
+            f"unknown instrumentation scope {scope_name!r}",
+            error_class="unknown_scope",
+            scope=scope_name,
+        )
+    attrs = attrs_dict(span.attributes)
+    payload = _envelope(span, attrs, resource_attrs, scope_name)
+    if scope_name == semconv.SCOPE_AUDIT:
+        model: type[Event] = DecisionEvent
+        payload |= _decision_fields(attrs, scope_name)
+    elif scope_name == semconv.SCOPE_USAGE:
+        model = LlmInvocationEvent
+        payload |= _usage_fields(attrs, span, scope_name)
+    else:
+        model = BanEnforcementEvent
+        payload |= _ban_fields(attrs, scope_name)
+    try:
+        event = model(**payload)
+    except ValidationError as exc:
+        first = exc.errors()[0]
+        raise SpanRejected(
+            f"validation failed on {first.get('loc')}: {first.get('msg')}",
+            error_class="validation",
+            scope=scope_name,
+        ) from None
+    try:
+        validate_event_window(event.occurred_at)
+    except EventOutOfWindow as exc:
+        raise SpanRejected(
+            str(exc), error_class="out_of_window", scope=scope_name
+        ) from None
+    return event

--- a/platform/api/hexgate_api/jobs/enricher/resolver.py
+++ b/platform/api/hexgate_api/jobs/enricher/resolver.py
@@ -1,27 +1,47 @@
 """Batch agent_version_id resolution against the relational store.
 
 The only Postgres-backed step in the job — auth is fully handled at the
-Collector. One session per poll, one lookup per unique (project, agent)
-pair; unresolved pairs map to "" and are inserted as-is, matching the HTTP
+Collector. Two queries per poll regardless of batch size: the agents for
+every unique (project, agent) pair, then their latest versions in one go.
+Unresolved pairs map to "" and are inserted as-is, matching the HTTP
 ingest's tolerance (an unregistered agent name must not lose the record).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import Any
+
+from sqlalchemy import and_, or_
+from sqlmodel import select
+
 from hexgate_api.core.db import async_session_factory
-from hexgate_api.features.agents.service import get_latest_agent_version_id
+from hexgate_api.features.agents.service import get_latest_agent_versions_map
+from hexgate_api.models import Agent
 
 
 async def resolve_versions(
     pairs: set[tuple[str, str]],
+    session_factory: Callable[[], Any] = async_session_factory,
 ) -> dict[tuple[str, str], str]:
     """Map each ``(project_id, agent_name)`` to its latest AgentVersion.id."""
     if not pairs:
         return {}
-    resolved: dict[tuple[str, str], str] = {}
-    async with async_session_factory() as session:
-        for project_id, agent_name in sorted(pairs):
-            resolved[(project_id, agent_name)] = await get_latest_agent_version_id(
-                session, project_id, agent_name
+    resolved = {pair: "" for pair in pairs}
+    async with session_factory() as session:
+        agents_stmt = select(Agent).where(
+            or_(
+                *(
+                    and_(Agent.project_id == project_id, Agent.name == agent_name)
+                    for project_id, agent_name in sorted(pairs)
+                )
             )
+        )
+        agents = (await session.exec(agents_stmt)).all()
+        pair_by_agent_id = {
+            agent.id: (agent.project_id, agent.name) for agent in agents
+        }
+        latest = await get_latest_agent_versions_map(session, list(pair_by_agent_id))
+        for agent_id, version in latest.items():
+            resolved[pair_by_agent_id[agent_id]] = version.id
     return resolved

--- a/platform/api/hexgate_api/jobs/enricher/resolver.py
+++ b/platform/api/hexgate_api/jobs/enricher/resolver.py
@@ -1,0 +1,27 @@
+"""Batch agent_version_id resolution against the relational store.
+
+The only Postgres-backed step in the job — auth is fully handled at the
+Collector. One session per poll, one lookup per unique (project, agent)
+pair; unresolved pairs map to "" and are inserted as-is, matching the HTTP
+ingest's tolerance (an unregistered agent name must not lose the record).
+"""
+
+from __future__ import annotations
+
+from hexgate_api.core.db import async_session_factory
+from hexgate_api.features.agents.service import get_latest_agent_version_id
+
+
+async def resolve_versions(
+    pairs: set[tuple[str, str]],
+) -> dict[tuple[str, str], str]:
+    """Map each ``(project_id, agent_name)`` to its latest AgentVersion.id."""
+    if not pairs:
+        return {}
+    resolved: dict[tuple[str, str], str] = {}
+    async with async_session_factory() as session:
+        for project_id, agent_name in sorted(pairs):
+            resolved[(project_id, agent_name)] = await get_latest_agent_version_id(
+                session, project_id, agent_name
+            )
+    return resolved

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -12,6 +12,9 @@ from pydantic import (
     model_validator,
 )
 
+# Ceiling for counters stored in ClickHouse UInt32 columns (schema.sql).
+UINT32_MAX = 2**32 - 1
+
 
 # ---------------------------------------------------------------------------
 # M3 Phase 4 — Organization wire shapes
@@ -538,9 +541,13 @@ class LlmInvocationEvent(AuditEnvelope):
     """One LLM invocation; mirrors the llm_invocation table."""
 
     model: str = Field(min_length=1, max_length=256)
-    input_tokens: int = Field(ge=0)
-    output_tokens: int = Field(ge=0)
-    latency_ms: int = Field(ge=0)
+    # The upper bound mirrors the UInt32 columns in schema.sql. Without it an
+    # over-range value (e.g. latency sent in ns) passes validation and only
+    # fails at insert time — a permanent ClickHouse error the enricher would
+    # retry forever instead of rejecting the span to the DLQ.
+    input_tokens: int = Field(ge=0, le=UINT32_MAX)
+    output_tokens: int = Field(ge=0, le=UINT32_MAX)
+    latency_ms: int = Field(ge=0, le=UINT32_MAX)
     status: str = Field(default="success", max_length=64)
     error_code: str = Field(default="", max_length=64)
 

--- a/platform/api/hexgate_api/settings.py
+++ b/platform/api/hexgate_api/settings.py
@@ -22,6 +22,18 @@ class Settings(BaseSettings):
     clickhouse_database: str = "hexgate_audit"
     clickhouse_secure: bool = False
 
+    # Span-enricher job (jobs/enricher). Redpanda is Kafka-protocol-compatible,
+    # so these feed a stock Kafka client (aiokafka). localhost:9092 is the host
+    # listener (platform/docker-compose.yml); in-compose consumers use
+    # redpanda:29092. Same env var the collector and create-topics.sh read.
+    redpanda_bootstrap_server: str = "localhost:9092"
+    redpanda_raw_topic: str = "hexgate.otlp.raw"
+    redpanda_dlq_topic: str = "hexgate.otlp.dlq"
+    enricher_consumer_group: str = "hexgate-enricher"
+    enricher_poll_timeout_ms: int = 1000
+    enricher_max_poll_records: int = 500
+    enricher_insert_max_backoff_s: float = 30.0
+
     @model_validator(mode="after")
     def _refuse_dev_password_on_remote_host(self) -> "Settings":
         # The dev default keeps `make clickhouse-up` zero-setup, but pointing

--- a/platform/api/pyproject.toml
+++ b/platform/api/pyproject.toml
@@ -45,6 +45,13 @@ dependencies = [
     # in production. Dev mode stays on StderrEmailSender (no key needed).
     # Sync SDK; wrapped via asyncio.to_thread in mailer.py.
     "resend>=2.4",
+    # Span-enricher job (jobs/enricher): asyncio Kafka client — getmany
+    # batching, manual offset commit, DLQ producer.
+    "aiokafka>=0.12",
+    # The enricher decodes ExportTraceServiceRequest protobufs from Kafka.
+    # Transitive via the hexgate SDK's langfuse chain, but pinned since we
+    # import it directly (same rule as python-dotenv above).
+    "opentelemetry-proto>=1.41",
 ]
 
 [dependency-groups]

--- a/platform/api/tests/jobs/enricher/conftest.py
+++ b/platform/api/tests/jobs/enricher/conftest.py
@@ -167,9 +167,12 @@ class FakeConsumer:
 class FakeProducer:
     calls: list[str]
     sent: list[tuple[str, bytes | None, bytes]] = field(default_factory=list)
+    failures: list[Exception] = field(default_factory=list)  # consumed one per send
 
     async def send_and_wait(self, topic: str, value: bytes, key: bytes | None) -> None:
         self.calls.append("dlq")
+        if self.failures:
+            raise self.failures.pop(0)
         self.sent.append((topic, key, value))
 
 
@@ -179,7 +182,12 @@ def make_job(monkeypatch: pytest.MonkeyPatch):
     append to the shared call log; resolve_versions is stubbed to return
     per-pair fake ids ("" via the `unresolved` flag)."""
 
-    def _make(*, unresolved: bool = False, insert_side_effect: Any = None):
+    def _make(
+        *,
+        unresolved: bool = False,
+        insert_side_effect: Any = None,
+        send_side_effect: Any = None,
+    ):
         calls: list[str] = []
         clickhouse = MagicMock()
 
@@ -199,7 +207,7 @@ def make_job(monkeypatch: pytest.MonkeyPatch):
         )
         settings = Settings(enricher_insert_max_backoff_s=0.01)
         consumer = FakeConsumer(calls)
-        producer = FakeProducer(calls)
+        producer = FakeProducer(calls, failures=list(send_side_effect or []))
         job = EnricherJob(
             settings,
             clickhouse_client=clickhouse,

--- a/platform/api/tests/jobs/enricher/conftest.py
+++ b/platform/api/tests/jobs/enricher/conftest.py
@@ -1,0 +1,211 @@
+"""Shared builders for the enricher tests: hand-built OTLP payloads (the SDK
+emitter doesn't exist yet — the wire contract in hexgate.tracing.semconv is
+authoritative), fake Kafka clients that append to a shared call log so tests
+can assert ordering, and a job factory wired with those fakes."""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+from opentelemetry.proto.common.v1.common_pb2 import (
+    AnyValue,
+    InstrumentationScope,
+    KeyValue,
+)
+from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
+
+from hexgate.tracing import semconv
+from hexgate_api.jobs.enricher.consumer import EnricherJob
+from hexgate_api.settings import Settings
+
+# ---------------------------------------------------------------------------
+# OTLP payload builders
+# ---------------------------------------------------------------------------
+
+
+def any_value(value: Any) -> AnyValue:
+    """Python value → AnyValue, mirroring decode.attr_value in reverse."""
+    if isinstance(value, bool):  # before int: bool is an int subclass
+        return AnyValue(bool_value=value)
+    if isinstance(value, int):
+        return AnyValue(int_value=value)
+    if isinstance(value, float):
+        return AnyValue(double_value=value)
+    if isinstance(value, str):
+        return AnyValue(string_value=value)
+    if isinstance(value, list):
+        wrapped = AnyValue()
+        wrapped.array_value.values.extend(any_value(v) for v in value)
+        return wrapped
+    if isinstance(value, dict):
+        wrapped = AnyValue()
+        wrapped.kvlist_value.values.extend(
+            KeyValue(key=k, value=any_value(v)) for k, v in value.items()
+        )
+        return wrapped
+    raise TypeError(f"unsupported attribute value {value!r}")
+
+
+def make_span(
+    attrs: dict[str, Any],
+    *,
+    start_ns: int | None = None,
+    end_ns: int = 0,
+    name: str = "event",
+) -> Span:
+    if start_ns is None:
+        start_ns = time.time_ns()
+    span = Span(
+        name=name,
+        trace_id=uuid.uuid4().bytes,
+        span_id=uuid.uuid4().bytes[:8],
+        start_time_unix_nano=start_ns,
+        end_time_unix_nano=end_ns,
+    )
+    span.attributes.extend(
+        KeyValue(key=k, value=any_value(v)) for k, v in attrs.items()
+    )
+    return span
+
+
+def make_request_bytes(
+    groups: list[tuple[str, list[Span]]],
+    resource_attrs: dict[str, Any] | None = None,
+) -> bytes:
+    """Serialize (scope_name, spans) groups the way the Collector's
+    kafkaexporter does: one ExportTraceServiceRequest per record."""
+    resource = Resource()
+    if resource_attrs:
+        resource.attributes.extend(
+            KeyValue(key=k, value=any_value(v)) for k, v in resource_attrs.items()
+        )
+    request = ExportTraceServiceRequest(
+        resource_spans=[
+            ResourceSpans(
+                resource=resource,
+                scope_spans=[
+                    ScopeSpans(scope=InstrumentationScope(name=scope), spans=spans)
+                    for scope, spans in groups
+                ],
+            )
+        ]
+    )
+    return request.SerializeToString()
+
+
+# ---------------------------------------------------------------------------
+# Wire-contract attribute dicts (minimal-required, override per test)
+# ---------------------------------------------------------------------------
+
+
+def decision_attrs(**overrides: Any) -> dict[str, Any]:
+    base = {
+        semconv.EVENT_ID: str(uuid.uuid4()),
+        semconv.AGENT_NAME: "researcher",
+        semconv.TOOL_NAME: "web_search",
+        semconv.OUTCOME: "allow",
+    }
+    return {**base, **overrides}
+
+
+def usage_attrs(**overrides: Any) -> dict[str, Any]:
+    base = {
+        semconv.EVENT_ID: str(uuid.uuid4()),
+        semconv.AGENT_NAME: "researcher",
+        semconv.GEN_AI_REQUEST_MODEL: "gpt-4o",
+        semconv.GEN_AI_USAGE_INPUT_TOKENS: 100,
+        semconv.GEN_AI_USAGE_OUTPUT_TOKENS: 50,
+        semconv.LATENCY_MS: 250,
+    }
+    return {**base, **overrides}
+
+
+def ban_attrs(**overrides: Any) -> dict[str, Any]:
+    base = {
+        semconv.EVENT_ID: str(uuid.uuid4()),
+        semconv.AGENT_NAME: "researcher",
+        semconv.BAN_TYPE: "agent",
+        semconv.BAN_ID: "ban_123",
+    }
+    return {**base, **overrides}
+
+
+# ---------------------------------------------------------------------------
+# Fake Kafka clients + job factory
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeRecord:
+    key: bytes | None
+    value: bytes
+    topic: str = "hexgate.otlp.raw"
+    partition: int = 0
+    offset: int = 0
+
+
+@dataclass
+class FakeConsumer:
+    calls: list[str]
+    commits: int = 0
+
+    async def commit(self) -> None:
+        self.calls.append("commit")
+        self.commits += 1
+
+
+@dataclass
+class FakeProducer:
+    calls: list[str]
+    sent: list[tuple[str, bytes | None, bytes]] = field(default_factory=list)
+
+    async def send_and_wait(self, topic: str, value: bytes, key: bytes | None) -> None:
+        self.calls.append("dlq")
+        self.sent.append((topic, key, value))
+
+
+@pytest.fixture
+def make_job(monkeypatch: pytest.MonkeyPatch):
+    """EnricherJob wired with fakes + a MagicMock ClickHouse whose inserts
+    append to the shared call log; resolve_versions is stubbed to return
+    per-pair fake ids ("" via the `unresolved` flag)."""
+
+    def _make(*, unresolved: bool = False, insert_side_effect: Any = None):
+        calls: list[str] = []
+        clickhouse = MagicMock()
+
+        def _log_insert(*args: Any, **kwargs: Any) -> None:
+            calls.append("insert")
+            if _make.insert_failures:  # consume one scheduled failure
+                raise _make.insert_failures.pop(0)
+
+        clickhouse.insert.side_effect = _log_insert
+        _make.insert_failures = list(insert_side_effect or [])
+
+        async def _stub_resolve(pairs: set[tuple[str, str]]):
+            return {pair: "" if unresolved else f"ver_{pair[1]}" for pair in pairs}
+
+        monkeypatch.setattr(
+            "hexgate_api.jobs.enricher.consumer.resolve_versions", _stub_resolve
+        )
+        settings = Settings(enricher_insert_max_backoff_s=0.01)
+        consumer = FakeConsumer(calls)
+        producer = FakeProducer(calls)
+        job = EnricherJob(
+            settings,
+            clickhouse_client=clickhouse,
+            consumer=consumer,
+            producer=producer,
+        )
+        return job, clickhouse, consumer, producer, calls
+
+    return _make

--- a/platform/api/tests/jobs/enricher/test_coerce.py
+++ b/platform/api/tests/jobs/enricher/test_coerce.py
@@ -1,0 +1,79 @@
+"""coerce.py — proto-typed attribute values → event field types."""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate_api.jobs.enricher.coerce import (
+    SpanRejected,
+    as_int,
+    as_json_dict,
+    as_str,
+    as_str_list,
+    required,
+)
+
+
+def test_as_int_happy_path() -> None:
+    assert as_int(42, key="k", scope="s") == 42
+
+
+def test_when_int_arrives_as_string_then_coerced() -> None:
+    assert as_int("42", key="k", scope="s") == 42
+
+
+def test_when_int_is_not_coercible_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected) as exc:
+        as_int("not-a-number", key="k", scope="s")
+    assert exc.value.error_class == "validation"
+
+
+def test_when_int_is_a_bool_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected):
+        as_int(True, key="k", scope="s")
+
+
+def test_as_str_list_happy_path() -> None:
+    assert as_str_list(["a", "b"], key="k", scope="s") == ["a", "b"]
+
+
+def test_when_list_arrives_as_json_string_then_coerced() -> None:
+    assert as_str_list('["a", "b"]', key="k", scope="s") == ["a", "b"]
+
+
+def test_when_list_arrives_as_scalar_then_wrapped() -> None:
+    assert as_str_list("admin", key="k", scope="s") == ["admin"]
+
+
+def test_when_list_is_missing_then_empty() -> None:
+    assert as_str_list(None, key="k", scope="s") == []
+
+
+def test_as_json_dict_happy_path() -> None:
+    assert as_json_dict('{"a": 1}', key="k", scope="s") == {"a": 1}
+
+
+def test_when_json_is_invalid_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected):
+        as_json_dict("{not json", key="k", scope="s")
+
+
+def test_when_json_is_not_an_object_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected):
+        as_json_dict("[1, 2]", key="k", scope="s")
+
+
+def test_when_dict_arrives_as_kvlist_then_accepted() -> None:
+    assert as_json_dict({"a": 1}, key="k", scope="s") == {"a": 1}
+
+
+def test_when_required_attribute_is_missing_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected) as exc:
+        required({}, "sec_ai.event_id", scope="s")
+    assert "sec_ai.event_id" in exc.value.error
+
+
+def test_as_str_stringifies_with_default() -> None:
+    assert as_str(None) == ""
+    assert as_str(None, default="x") == "x"
+    assert as_str(7) == "7"

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -6,11 +6,15 @@ The ordering contract under test: inserts → DLQ sends → offset commit.
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
+
+import pytest
 
 from clickhouse_connect.driver.exceptions import OperationalError
 
 from hexgate.tracing import semconv
 from tests.jobs.enricher.conftest import (
+    FakeConsumer,
     FakeRecord,
     ban_attrs,
     decision_attrs,
@@ -125,3 +129,130 @@ async def test_when_the_agent_version_is_unresolved_then_inserted_with_empty_str
     decision_rows = clickhouse.insert.call_args_list[0].args[1]
     assert decision_rows[0][4] == ""
     assert consumer.commits == 1
+
+
+# ---------------------------------------------------------------------------
+# run() lifecycle + the two availability-critical failure branches
+# ---------------------------------------------------------------------------
+
+
+async def _noop(*_args, **_kwargs):
+    return None
+
+
+class _LifecycleConsumer(FakeConsumer):
+    """FakeConsumer plus the lifecycle surface run() touches. Serves one
+    poll of `records`, then requests a stop so run() returns."""
+
+    def __init__(self, calls, records, topics, job_ref):
+        super().__init__(calls)
+        self._records = records
+        self._topics = topics
+        self._job_ref = job_ref
+        self.started = self.stopped = False
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+    async def topics(self):
+        return self._topics
+
+    async def getmany(self, timeout_ms, max_records):
+        self._job_ref[0].request_stop()  # one poll, then exit the loop
+        return {"tp0": self._records} if self._records else {}
+
+
+def _lifecycle_job(monkeypatch, make_job, *, records, topics):
+    job, clickhouse, _consumer, producer, calls = make_job()
+    consumer = _LifecycleConsumer(calls, records, topics, [job])
+    producer.start = producer.stop = _noop  # type: ignore[attr-defined]
+    job._consumer = consumer
+    monkeypatch.setattr(
+        "hexgate_api.jobs.enricher.consumer.verify_audit_schema", lambda c: None
+    )
+    monkeypatch.setattr(
+        "hexgate_api.jobs.enricher.consumer.verify_llm_schema", lambda c: None
+    )
+    monkeypatch.setattr(
+        "hexgate_api.jobs.enricher.consumer.engine", SimpleNamespace(dispose=_noop)
+    )
+    return job, clickhouse, consumer, calls
+
+
+async def test_run_happy_path_processes_a_poll_then_stops_cleanly(
+    monkeypatch, make_job
+) -> None:
+    records = [_record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])])]
+    job, clickhouse, consumer, calls = _lifecycle_job(
+        monkeypatch,
+        make_job,
+        records=records,
+        topics={"hexgate.otlp.raw", "hexgate.otlp.dlq"},
+    )
+
+    await job.run()
+
+    assert consumer.started and consumer.stopped
+    assert calls == ["insert", "commit"]
+
+
+async def test_when_a_topic_is_missing_then_run_fails_fast(
+    monkeypatch, make_job
+) -> None:
+    from hexgate_api.jobs.enricher.consumer import TopicsMissing
+
+    job, clickhouse, consumer, calls = _lifecycle_job(
+        monkeypatch, make_job, records=[], topics={"hexgate.otlp.raw"}
+    )
+
+    with pytest.raises(TopicsMissing) as exc:
+        await job.run()
+
+    assert "hexgate.otlp.dlq" in str(exc.value)
+    assert "make redpanda-topics" in str(exc.value)
+    assert consumer.stopped  # finally-block cleanup still ran
+
+
+async def test_when_stop_is_requested_mid_outage_then_no_commit(
+    monkeypatch, make_job
+) -> None:
+    """The data-loss guard: a SIGTERM while ClickHouse is down must exit the
+    retry loop WITHOUT committing, so the poll replays after restart."""
+    import hexgate_api.jobs.enricher.consumer as consumer_mod
+
+    job, clickhouse, consumer, producer, calls = make_job(
+        insert_side_effect=[OperationalError("down"), OperationalError("still down")]
+    )
+    records = [_record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])])]
+
+    async def _stop_instead_of_sleeping(_delay):
+        job.request_stop()
+
+    # The first failure sleeps; hijack that sleep to request the stop.
+    monkeypatch.setattr(consumer_mod.asyncio, "sleep", _stop_instead_of_sleeping)
+
+    await job._process_poll(records)
+
+    assert consumer.commits == 0
+    assert producer.sent == []
+
+
+async def test_when_commit_fails_on_rebalance_then_poll_is_dropped_not_fatal(
+    make_job,
+) -> None:
+    from aiokafka.errors import CommitFailedError
+
+    job, clickhouse, consumer, producer, calls = make_job()
+
+    async def _failing_commit():
+        raise CommitFailedError("rebalance")
+
+    consumer.commit = _failing_commit  # type: ignore[method-assign]
+    records = [_record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])])]
+
+    await job._process_poll(records)  # no raise: the new owner replays it
+
+    assert calls == ["insert"]

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -109,6 +109,35 @@ async def test_when_an_insert_fails_then_whole_batch_retried_and_committed_once(
     assert consumer.commits == 1
 
 
+async def test_when_version_resolve_fails_then_retried_and_committed(
+    monkeypatch, make_job
+) -> None:
+    """Postgres gets the same halt-with-backoff posture as ClickHouse and the
+    DLQ: a transient failure retries inside the cycle instead of escaping
+    run() into a backoff-free restart loop."""
+    import hexgate_api.jobs.enricher.consumer as consumer_mod
+
+    job, clickhouse, consumer, producer, calls = make_job()
+    attempts = 0
+
+    async def _flaky_resolve(pairs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise ConnectionError("pool exhausted")
+        return {pair: "" for pair in pairs}
+
+    monkeypatch.setattr(consumer_mod, "resolve_versions", _flaky_resolve)
+
+    await job._process_poll(
+        [_record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])])]
+    )
+
+    assert attempts == 2
+    assert calls == ["insert", "commit"]  # resolve retried, then a normal cycle
+    assert consumer.commits == 1
+
+
 async def test_when_one_span_is_invalid_then_siblings_insert_and_dlq_receives_it(
     make_job,
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -90,19 +90,47 @@ async def test_when_one_span_is_invalid_then_siblings_insert_and_dlq_receives_it
     assert json.loads(envelope)["error_class"] == "validation"
 
 
-async def test_when_the_record_key_is_missing_then_whole_record_to_dlq(
+async def test_when_the_record_key_is_missing_then_each_span_to_dlq_redacted(
     make_job,
 ) -> None:
+    # A keyless record is still a decodable request; it must be parked span by
+    # span through the redacting envelope, never as raw bytes.
     job, clickhouse, consumer, producer, calls = make_job()
-    records = [
-        _record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])], key=None)
+    secret_args = json.dumps({"password": "hunter2", "query": "q"})
+    spans = [
+        make_span(decision_attrs(**{semconv.ARGUMENTS: secret_args})),
+        make_span(decision_attrs()),
     ]
+    records = [_record([(semconv.SCOPE_AUDIT, spans)], key=None)]
 
     await job._process_poll(records)
 
     clickhouse.insert.assert_not_called()
-    assert json.loads(producer.sent[0][2])["error_class"] == "missing_key"
+    assert len(producer.sent) == 2
+    envelopes = [json.loads(sent[2]) for sent in producer.sent]
+    assert {env["error_class"] for env in envelopes} == {"missing_key"}
+    assert all(env["project_id"] == "" for env in envelopes)
+    assert all("record_value_base64" not in env for env in envelopes)
+    assert envelopes[0]["span"]["attributes"][semconv.ARGUMENTS] == {
+        "password": "[REDACTED]",
+        "query": "q",
+    }
     assert consumer.commits == 1  # parked, not stuck: the poll still completes
+
+
+async def test_when_a_keyless_record_is_undecodable_then_whole_record_to_dlq(
+    make_job,
+) -> None:
+    job, clickhouse, consumer, producer, calls = make_job()
+    records = [FakeRecord(key=None, value=b"\xff\xff garbage")]
+
+    await job._process_poll(records)
+
+    clickhouse.insert.assert_not_called()
+    envelope = json.loads(producer.sent[0][2])
+    assert envelope["error_class"] == "decode"
+    assert envelope["project_id"] is None
+    assert consumer.commits == 1
 
 
 async def test_when_the_payload_is_undecodable_then_whole_record_to_dlq(

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -54,6 +54,27 @@ async def test_process_poll_happy_path_inserts_then_commits(make_job) -> None:
     assert decision_rows[0][4] == "ver_researcher"
 
 
+async def test_when_the_same_event_id_arrives_twice_in_one_poll_then_inserted_once(
+    make_job,
+) -> None:
+    # A Collector produce retry whose first attempt landed: two records, same
+    # span. ClickHouse only collapses these at insert time if they share a
+    # block, so the consumer dedups before building the batch.
+    job, clickhouse, consumer, producer, calls = make_job()
+    attrs = decision_attrs()
+    records = [
+        _record([(semconv.SCOPE_AUDIT, [make_span(attrs)])], offset=0),
+        _record([(semconv.SCOPE_AUDIT, [make_span(attrs)])], offset=1),
+    ]
+
+    await job._process_poll(records)
+
+    decision_rows = clickhouse.insert.call_args_list[0].args[1]
+    assert len(decision_rows) == 1
+    assert producer.sent == []  # a duplicate is not an error
+    assert consumer.commits == 1
+
+
 async def test_when_an_insert_fails_then_whole_batch_retried_and_committed_once(
     make_job,
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -244,6 +244,30 @@ async def test_when_a_topic_is_missing_then_run_fails_fast(
     assert consumer.stopped  # finally-block cleanup still ran
 
 
+async def test_when_the_producer_fails_to_start_then_the_consumer_still_stops(
+    monkeypatch, make_job
+) -> None:
+    from aiokafka.errors import KafkaConnectionError
+
+    job, clickhouse, consumer, calls = _lifecycle_job(
+        monkeypatch,
+        make_job,
+        records=[],
+        topics={"hexgate.otlp.raw", "hexgate.otlp.dlq"},
+    )
+
+    async def _refuse_to_start():
+        raise KafkaConnectionError("producer bootstrap unreachable")
+
+    job._producer.start = _refuse_to_start  # type: ignore[method-assign]
+
+    with pytest.raises(KafkaConnectionError):
+        await job.run()
+
+    # The consumer had already joined the group; it must leave it.
+    assert consumer.started and consumer.stopped
+
+
 async def test_when_stop_is_requested_mid_outage_then_no_commit(
     monkeypatch, make_job
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -265,6 +265,44 @@ async def test_when_a_topic_is_missing_then_run_fails_fast(
     assert consumer.stopped  # finally-block cleanup still ran
 
 
+async def test_when_two_tables_are_stale_then_run_reports_both_gaps_at_once(
+    monkeypatch, make_job
+) -> None:
+    # The two per-feature checks are aggregated: a volume behind on both
+    # policy_decision and llm_invocation must name both in one boot, not one
+    # per restart.
+    from hexgate_api.core.clickhouse import SchemaOutOfDate
+
+    job, clickhouse, consumer, calls = _lifecycle_job(
+        monkeypatch,
+        make_job,
+        records=[],
+        topics={"hexgate.otlp.raw", "hexgate.otlp.dlq"},
+    )
+
+    def _audit_stale(_client):
+        raise SchemaOutOfDate({"policy_decision": ["deciding_role"]})
+
+    def _llm_stale(_client):
+        raise SchemaOutOfDate({"llm_invocation": ["latency_ms"]})
+
+    monkeypatch.setattr(
+        "hexgate_api.jobs.enricher.consumer.verify_audit_schema", _audit_stale
+    )
+    monkeypatch.setattr(
+        "hexgate_api.jobs.enricher.consumer.verify_llm_schema", _llm_stale
+    )
+
+    with pytest.raises(SchemaOutOfDate) as exc:
+        await job.run()
+
+    assert exc.value.missing == {
+        "policy_decision": ["deciding_role"],
+        "llm_invocation": ["latency_ms"],
+    }
+    assert not consumer.started  # the check runs before any broker connect
+
+
 async def test_when_the_producer_fails_to_start_then_the_consumer_still_stops(
     monkeypatch, make_job
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -392,6 +392,25 @@ async def test_when_a_dlq_send_fails_then_it_is_retried_and_committed_once(
     assert consumer.commits == 1
 
 
+async def test_when_a_dlq_envelope_is_too_large_then_dropped_and_committed(
+    make_job,
+) -> None:
+    """MessageSizeTooLargeError is client-side and permanent: no retry can
+    ever land the envelope, so it is dropped (the source record still holds
+    the original bytes) and the poll completes instead of wedging."""
+    from aiokafka.errors import MessageSizeTooLargeError
+
+    job, clickhouse, consumer, producer, calls = make_job(
+        send_side_effect=[MessageSizeTooLargeError()]
+    )
+
+    await job._process_poll([_one_bad_span_record()])
+
+    assert calls == ["dlq", "commit"]  # one attempt, no retry loop
+    assert producer.sent == []  # dropped, not delivered
+    assert consumer.commits == 1
+
+
 async def test_when_stop_is_requested_mid_dlq_outage_then_no_commit(
     monkeypatch, make_job
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -1,0 +1,127 @@
+"""consumer.py — one _process_poll cycle driven with fakes.
+
+The ordering contract under test: inserts → DLQ sends → offset commit.
+"""
+
+from __future__ import annotations
+
+import json
+
+from clickhouse_connect.driver.exceptions import OperationalError
+
+from hexgate.tracing import semconv
+from tests.jobs.enricher.conftest import (
+    FakeRecord,
+    ban_attrs,
+    decision_attrs,
+    make_request_bytes,
+    make_span,
+    usage_attrs,
+)
+
+
+def _record(groups, key: bytes | None = b"proj_1", offset: int = 0) -> FakeRecord:
+    return FakeRecord(key=key, value=make_request_bytes(groups), offset=offset)
+
+
+async def test_process_poll_happy_path_inserts_then_commits(make_job) -> None:
+    """All three event types in one poll → three batch inserts, no DLQ,
+    one commit, strictly after the inserts."""
+    job, clickhouse, consumer, producer, calls = make_job()
+    records = [
+        _record(
+            [
+                (semconv.SCOPE_AUDIT, [make_span(decision_attrs())]),
+                (semconv.SCOPE_USAGE, [make_span(usage_attrs())]),
+                (semconv.SCOPE_BANS, [make_span(ban_attrs())]),
+            ]
+        )
+    ]
+
+    await job._process_poll(records)
+
+    assert calls == ["insert", "insert", "insert", "commit"]
+    tables = [c.args[0] for c in clickhouse.insert.call_args_list]
+    assert tables == ["policy_decision", "llm_invocation", "ban_enforcement"]
+    assert producer.sent == []
+    # project_id from the record key, agent_version_id from the resolver.
+    decision_rows = clickhouse.insert.call_args_list[0].args[1]
+    assert decision_rows[0][2] == "proj_1"
+    assert decision_rows[0][4] == "ver_researcher"
+
+
+async def test_when_an_insert_fails_then_whole_batch_retried_and_committed_once(
+    make_job,
+) -> None:
+    job, clickhouse, consumer, producer, calls = make_job(
+        insert_side_effect=[OperationalError("clickhouse briefly down")]
+    )
+    records = [_record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])])]
+
+    await job._process_poll(records)
+
+    # First attempt fails, second succeeds; the empty llm/ban batches
+    # early-return without touching the client.
+    assert calls == ["insert", "insert", "commit"]
+    assert consumer.commits == 1
+
+
+async def test_when_one_span_is_invalid_then_siblings_insert_and_dlq_receives_it(
+    make_job,
+) -> None:
+    bad = decision_attrs()
+    del bad[semconv.TOOL_NAME]
+    job, clickhouse, consumer, producer, calls = make_job()
+    records = [
+        _record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs()), make_span(bad)])])
+    ]
+
+    await job._process_poll(records)
+
+    assert calls == ["insert", "dlq", "commit"]  # inserts before DLQ before commit
+    assert len(clickhouse.insert.call_args_list[0].args[1]) == 1  # sibling survived
+    topic, key, envelope = producer.sent[0]
+    assert topic == "hexgate.otlp.dlq"
+    assert key == b"proj_1"
+    assert json.loads(envelope)["error_class"] == "validation"
+
+
+async def test_when_the_record_key_is_missing_then_whole_record_to_dlq(
+    make_job,
+) -> None:
+    job, clickhouse, consumer, producer, calls = make_job()
+    records = [
+        _record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])], key=None)
+    ]
+
+    await job._process_poll(records)
+
+    clickhouse.insert.assert_not_called()
+    assert json.loads(producer.sent[0][2])["error_class"] == "missing_key"
+    assert consumer.commits == 1  # parked, not stuck: the poll still completes
+
+
+async def test_when_the_payload_is_undecodable_then_whole_record_to_dlq(
+    make_job,
+) -> None:
+    job, clickhouse, consumer, producer, calls = make_job()
+    records = [FakeRecord(key=b"proj_1", value=b"\xff\xff garbage")]
+
+    await job._process_poll(records)
+
+    clickhouse.insert.assert_not_called()
+    assert json.loads(producer.sent[0][2])["error_class"] == "decode"
+    assert consumer.commits == 1
+
+
+async def test_when_the_agent_version_is_unresolved_then_inserted_with_empty_string(
+    make_job,
+) -> None:
+    job, clickhouse, consumer, producer, calls = make_job(unresolved=True)
+    records = [_record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])])]
+
+    await job._process_poll(records)
+
+    decision_rows = clickhouse.insert.call_args_list[0].args[1]
+    assert decision_rows[0][4] == ""
+    assert consumer.commits == 1

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -268,6 +268,52 @@ async def test_when_stop_is_requested_mid_outage_then_no_commit(
     assert producer.sent == []
 
 
+def _one_bad_span_record():
+    bad = decision_attrs()
+    del bad[semconv.TOOL_NAME]
+    return _record([(semconv.SCOPE_AUDIT, [make_span(bad)])])
+
+
+async def test_when_a_dlq_send_fails_then_it_is_retried_and_committed_once(
+    make_job,
+) -> None:
+    from aiokafka.errors import KafkaTimeoutError
+
+    job, clickhouse, consumer, producer, calls = make_job(
+        send_side_effect=[KafkaTimeoutError("dlq leader unavailable")]
+    )
+
+    await job._process_poll([_one_bad_span_record()])
+
+    # First send fails, second lands; the envelope is written exactly once.
+    assert calls == ["dlq", "dlq", "commit"]
+    assert len(producer.sent) == 1
+    assert consumer.commits == 1
+
+
+async def test_when_stop_is_requested_mid_dlq_outage_then_no_commit(
+    monkeypatch, make_job
+) -> None:
+    """Same guard as the ClickHouse path: a SIGTERM while the DLQ topic is
+    unreachable must leave the offset uncommitted so the poll replays."""
+    import hexgate_api.jobs.enricher.consumer as consumer_mod
+    from aiokafka.errors import KafkaTimeoutError
+
+    job, clickhouse, consumer, producer, calls = make_job(
+        send_side_effect=[KafkaTimeoutError("down"), KafkaTimeoutError("still down")]
+    )
+
+    async def _stop_instead_of_sleeping(_delay):
+        job.request_stop()
+
+    monkeypatch.setattr(consumer_mod.asyncio, "sleep", _stop_instead_of_sleeping)
+
+    await job._process_poll([_one_bad_span_record()])
+
+    assert consumer.commits == 0
+    assert producer.sent == []
+
+
 async def test_when_commit_fails_on_rebalance_then_poll_is_dropped_not_fatal(
     make_job,
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -75,6 +75,24 @@ async def test_when_the_same_event_id_arrives_twice_in_one_poll_then_inserted_on
     assert consumer.commits == 1
 
 
+async def test_when_two_projects_share_an_event_id_then_both_are_inserted(
+    make_job,
+) -> None:
+    # event_id is client-set; only the record key is auth-derived. A tenant
+    # reusing another tenant's id is a different event, not a duplicate.
+    job, clickhouse, consumer, producer, calls = make_job()
+    attrs = decision_attrs()
+    records = [
+        _record([(semconv.SCOPE_AUDIT, [make_span(attrs)])], key=b"proj_1"),
+        _record([(semconv.SCOPE_AUDIT, [make_span(attrs)])], key=b"proj_2"),
+    ]
+
+    await job._process_poll(records)
+
+    decision_rows = clickhouse.insert.call_args_list[0].args[1]
+    assert sorted(row[2] for row in decision_rows) == ["proj_1", "proj_2"]
+
+
 async def test_when_an_insert_fails_then_whole_batch_retried_and_committed_once(
     make_job,
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_consumer.py
+++ b/platform/api/tests/jobs/enricher/test_consumer.py
@@ -185,6 +185,41 @@ async def test_when_the_payload_is_undecodable_then_whole_record_to_dlq(
     assert consumer.commits == 1
 
 
+async def test_when_the_record_value_is_none_then_whole_record_to_dlq(
+    make_job,
+) -> None:
+    # A tombstone/null value from a foreign producer must park like any other
+    # undecodable record, not escape as a TypeError and crash-loop the job.
+    job, clickhouse, consumer, producer, calls = make_job()
+    records = [FakeRecord(key=b"proj_1", value=None)]
+
+    await job._process_poll(records)
+
+    clickhouse.insert.assert_not_called()
+    envelope = json.loads(producer.sent[0][2])
+    assert envelope["error_class"] == "decode"
+    assert envelope["record_value_base64"] == ""  # no bytes to carry
+    assert consumer.commits == 1
+
+
+async def test_when_the_record_key_is_not_utf8_then_spans_parked_as_missing_key(
+    make_job,
+) -> None:
+    # A garbled key is as unattributable as no key: the spans park through the
+    # redacting missing_key path instead of UnicodeDecodeError killing run().
+    job, clickhouse, consumer, producer, calls = make_job()
+    records = [
+        _record([(semconv.SCOPE_AUDIT, [make_span(decision_attrs())])], key=b"\xff\xfe")
+    ]
+
+    await job._process_poll(records)
+
+    clickhouse.insert.assert_not_called()
+    envelope = json.loads(producer.sent[0][2])
+    assert envelope["error_class"] == "missing_key"
+    assert consumer.commits == 1
+
+
 async def test_when_the_agent_version_is_unresolved_then_inserted_with_empty_string(
     make_job,
 ) -> None:

--- a/platform/api/tests/jobs/enricher/test_decode.py
+++ b/platform/api/tests/jobs/enricher/test_decode.py
@@ -39,6 +39,13 @@ def test_when_value_is_not_protobuf_then_record_decode_error() -> None:
         decode_record(b"\xff\xff\xff\xff not a protobuf")
 
 
+def test_when_value_is_none_then_record_decode_error() -> None:
+    # ParseFromString(None) raises TypeError, which nothing upstream catches;
+    # it must surface as the decode error the consumer parks to the DLQ.
+    with pytest.raises(RecordDecodeError):
+        decode_record(None)
+
+
 def test_when_request_has_multiple_scopes_then_spans_tagged_per_scope() -> None:
     decoded = decode_record(
         make_request_bytes(

--- a/platform/api/tests/jobs/enricher/test_decode.py
+++ b/platform/api/tests/jobs/enricher/test_decode.py
@@ -1,0 +1,70 @@
+"""decode.py — record bytes → per-span units."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+
+from hexgate.tracing import semconv
+from hexgate_api.jobs.enricher.decode import (
+    RecordDecodeError,
+    attr_value,
+    decode_record,
+)
+from tests.jobs.enricher.conftest import (
+    any_value,
+    ban_attrs,
+    decision_attrs,
+    make_request_bytes,
+    make_span,
+)
+
+
+def test_decode_record_happy_path() -> None:
+    span = make_span(decision_attrs())
+    decoded = decode_record(
+        make_request_bytes(
+            [(semconv.SCOPE_AUDIT, [span])], resource_attrs={"service.name": "svc"}
+        )
+    )
+    assert len(decoded) == 1
+    scope_name, decoded_span, resource_attrs = decoded[0]
+    assert scope_name == semconv.SCOPE_AUDIT
+    assert decoded_span.start_time_unix_nano == span.start_time_unix_nano
+    assert resource_attrs == {"service.name": "svc"}
+
+
+def test_when_value_is_not_protobuf_then_record_decode_error() -> None:
+    with pytest.raises(RecordDecodeError):
+        decode_record(b"\xff\xff\xff\xff not a protobuf")
+
+
+def test_when_request_has_multiple_scopes_then_spans_tagged_per_scope() -> None:
+    decoded = decode_record(
+        make_request_bytes(
+            [
+                (semconv.SCOPE_AUDIT, [make_span(decision_attrs())]),
+                (semconv.SCOPE_BANS, [make_span(ban_attrs()), make_span(ban_attrs())]),
+            ]
+        )
+    )
+    assert [scope for scope, _, _ in decoded] == [
+        semconv.SCOPE_AUDIT,
+        semconv.SCOPE_BANS,
+        semconv.SCOPE_BANS,
+    ]
+
+
+def test_when_request_is_empty_then_no_spans() -> None:
+    assert decode_record(make_request_bytes([])) == []
+
+
+def test_attr_value_converts_array_and_kvlist() -> None:
+    assert attr_value(any_value(["a", "b"])) == ["a", "b"]
+    assert attr_value(any_value({"k": 1, "nested": {"x": True}})) == {
+        "k": 1,
+        "nested": {"x": True},
+    }
+    assert attr_value(AnyValue()) is None
+    # KeyValue with a plain scalar survives the round trip untouched.
+    assert attr_value(KeyValue(key="s", value=any_value("v")).value) == "v"

--- a/platform/api/tests/jobs/enricher/test_dlq.py
+++ b/platform/api/tests/jobs/enricher/test_dlq.py
@@ -53,6 +53,36 @@ def test_when_a_decision_span_is_rejected_then_dlq_attributes_are_redacted() -> 
     assert payload["span"]["attributes"]["sec_ai.api_token"] == "[REDACTED]"
 
 
+def _envelope_attributes(attrs: dict) -> dict:
+    raw = span_envelope(
+        error="whatever",
+        error_class="validation",
+        scope=semconv.SCOPE_AUDIT,
+        project_id="proj_1",
+        topic="t",
+        partition=0,
+        offset=0,
+        span=make_span(attrs),
+    )
+    return json.loads(raw)["span"]["attributes"]
+
+
+def test_when_arguments_hold_a_secret_key_then_dlq_redacts_inside_the_json() -> None:
+    # Arguments arrive as a JSON string; the secret key is inside it, not a
+    # span attribute key, so redaction has to parse before matching.
+    attrs = decision_attrs(
+        **{semconv.ARGUMENTS: json.dumps({"password": "hunter2", "query": "q"})}
+    )
+    attributes = _envelope_attributes(attrs)
+    assert attributes[semconv.ARGUMENTS] == {"password": "[REDACTED]", "query": "q"}
+
+
+def test_when_a_dict_field_is_not_json_then_dlq_drops_it() -> None:
+    attrs = decision_attrs(**{semconv.HINT: "{not json"})
+    attributes = _envelope_attributes(attrs)
+    assert attributes[semconv.HINT] == "[UNPARSEABLE]"
+
+
 def test_when_a_record_is_undecodable_then_envelope_carries_base64() -> None:
     raw_value = b"\xff\xff garbage"
     raw = record_envelope(

--- a/platform/api/tests/jobs/enricher/test_dlq.py
+++ b/platform/api/tests/jobs/enricher/test_dlq.py
@@ -83,6 +83,17 @@ def test_when_a_dict_field_is_not_json_then_dlq_drops_it() -> None:
     assert attributes[semconv.HINT] == "[UNPARSEABLE]"
 
 
+def test_when_a_dict_field_is_valid_json_but_not_a_dict_then_dlq_drops_it() -> None:
+    # A bare JSON string or list parses fine but has no keys to redact, so
+    # a secret in it would pass straight through.
+    attrs = decision_attrs(
+        **{semconv.ARGUMENTS: json.dumps("hunter2"), semconv.HINT: json.dumps([1, 2])}
+    )
+    attributes = _envelope_attributes(attrs)
+    assert attributes[semconv.ARGUMENTS] == "[UNPARSEABLE]"
+    assert attributes[semconv.HINT] == "[UNPARSEABLE]"
+
+
 def test_when_a_record_is_undecodable_then_envelope_carries_base64() -> None:
     raw_value = b"\xff\xff garbage"
     raw = record_envelope(

--- a/platform/api/tests/jobs/enricher/test_dlq.py
+++ b/platform/api/tests/jobs/enricher/test_dlq.py
@@ -1,0 +1,69 @@
+"""dlq.py — dead-letter envelope shapes."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from hexgate.tracing import semconv
+from hexgate_api.jobs.enricher.dlq import record_envelope, span_envelope
+from tests.jobs.enricher.conftest import decision_attrs, make_span
+
+
+def test_span_envelope_happy_path() -> None:
+    span = make_span(decision_attrs(), name="decision")
+    raw = span_envelope(
+        error="missing required attribute sec_ai.tool_name",
+        error_class="validation",
+        scope=semconv.SCOPE_AUDIT,
+        project_id="proj_1",
+        topic="hexgate.otlp.raw",
+        partition=1,
+        offset=4711,
+        span=span,
+    )
+    payload = json.loads(raw)
+    assert payload["error_class"] == "validation"
+    assert payload["scope"] == semconv.SCOPE_AUDIT
+    assert payload["project_id"] == "proj_1"
+    assert payload["source"] == {
+        "topic": "hexgate.otlp.raw",
+        "partition": 1,
+        "offset": 4711,
+    }
+    assert payload["span"]["name"] == "decision"
+    assert payload["span"]["span_id_hex"] == span.span_id.hex()
+
+
+def test_when_a_decision_span_is_rejected_then_dlq_attributes_are_redacted() -> None:
+    # The DLQ has 30-day retention and no ACLs — a secret-bearing argument
+    # key must be blanked even in the rejection record.
+    attrs = decision_attrs(**{"sec_ai.api_token": "s3cr3t"})
+    raw = span_envelope(
+        error="whatever",
+        error_class="validation",
+        scope=semconv.SCOPE_AUDIT,
+        project_id="proj_1",
+        topic="t",
+        partition=0,
+        offset=0,
+        span=make_span(attrs),
+    )
+    payload = json.loads(raw)
+    assert payload["span"]["attributes"]["sec_ai.api_token"] == "[REDACTED]"
+
+
+def test_when_a_record_is_undecodable_then_envelope_carries_base64() -> None:
+    raw_value = b"\xff\xff garbage"
+    raw = record_envelope(
+        error="undecodable OTLP payload",
+        error_class="decode",
+        project_id="proj_1",
+        topic="hexgate.otlp.raw",
+        partition=2,
+        offset=99,
+        raw_value=raw_value,
+    )
+    payload = json.loads(raw)
+    assert payload["scope"] is None
+    assert base64.b64decode(payload["record_value_base64"]) == raw_value

--- a/platform/api/tests/jobs/enricher/test_dlq.py
+++ b/platform/api/tests/jobs/enricher/test_dlq.py
@@ -6,7 +6,12 @@ import base64
 import json
 
 from hexgate.tracing import semconv
-from hexgate_api.jobs.enricher.dlq import record_envelope, span_envelope
+from hexgate_api.jobs.enricher.dlq import (
+    _ATTRIBUTES_CAP_BYTES,
+    _RAW_VALUE_CAP_BYTES,
+    record_envelope,
+    span_envelope,
+)
 from tests.jobs.enricher.conftest import decision_attrs, make_span
 
 
@@ -108,3 +113,35 @@ def test_when_a_record_is_undecodable_then_envelope_carries_base64() -> None:
     payload = json.loads(raw)
     assert payload["scope"] is None
     assert base64.b64decode(payload["record_value_base64"]) == raw_value
+    assert payload["record_value_truncated"] is False
+
+
+def test_when_the_raw_value_exceeds_the_cap_then_dlq_stores_a_prefix() -> None:
+    # base64 inflates by ~33%, so an uncapped near-1MB record would build an
+    # envelope the producer can never send — a permanent failure on the very
+    # path meant to absorb bad input.
+    raw_value = b"\xfe" * (_RAW_VALUE_CAP_BYTES + 1)
+    raw = record_envelope(
+        error="undecodable OTLP payload",
+        error_class="decode",
+        project_id="proj_1",
+        topic="hexgate.otlp.raw",
+        partition=2,
+        offset=99,
+        raw_value=raw_value,
+    )
+    payload = json.loads(raw)
+    stored = base64.b64decode(payload["record_value_base64"])
+    assert stored == raw_value[:_RAW_VALUE_CAP_BYTES]
+    assert payload["record_value_truncated"] is True
+
+
+def test_when_span_attributes_exceed_the_cap_then_dlq_stores_a_preview() -> None:
+    # Rejected spans skip the accepted path's 8 KiB argument cap
+    # (enforcement.py), so the envelope applies its own.
+    attrs = decision_attrs(
+        **{semconv.ARGUMENTS: json.dumps({"blob": "x" * (2 * _ATTRIBUTES_CAP_BYTES)})}
+    )
+    attributes = _envelope_attributes(attrs)
+    assert attributes["_truncated"] is True
+    assert len(json.dumps(attributes).encode("utf-8")) <= _ATTRIBUTES_CAP_BYTES

--- a/platform/api/tests/jobs/enricher/test_enforcement.py
+++ b/platform/api/tests/jobs/enricher/test_enforcement.py
@@ -1,0 +1,57 @@
+"""enforcement.py — parity with the SDK's as_payload redaction/cap semantics."""
+
+from __future__ import annotations
+
+import json
+
+from hexgate.audit import MAX_VIOLATIONS
+from hexgate_api.jobs.enricher.enforcement import (
+    capped_arguments,
+    capped_attributes,
+    capped_hint,
+    capped_violations,
+)
+
+
+def test_capped_arguments_happy_path() -> None:
+    assert capped_arguments({"query": "hello"}) == {"query": "hello"}
+    assert capped_arguments(None) is None
+
+
+def test_when_argument_key_contains_token_then_redacted() -> None:
+    # Substring match: "api_key_id" merely contains a secret-ish word.
+    result = capped_arguments({"api_key_id": "abc", "safe": "x"})
+    assert result == {"api_key_id": "[REDACTED]", "safe": "x"}
+
+
+def test_when_attribute_key_is_authorization_tier_then_not_redacted() -> None:
+    # Anchored match: policy facts like authorization_tier stay readable;
+    # a key named exactly "token" is still blanked.
+    result = capped_attributes({"authorization_tier": "gold", "token": "s3cr3t"})
+    assert result == {"authorization_tier": "gold", "token": "[REDACTED]"}
+
+
+def test_when_arguments_exceed_cap_then_truncated_to_marker() -> None:
+    result = capped_arguments({"blob": "x" * 20_000})
+    assert result["_truncated"] is True
+    assert result["original_bytes"] > 8 * 1024
+    assert len(json.dumps(result).encode()) <= 8 * 1024
+
+
+def test_when_hint_over_cap_then_truncated_but_never_redacted() -> None:
+    # A hint key containing "token" survives; only the size is enforced.
+    small = capped_hint({"token_paths": ["/a"]})
+    assert small == {"token_paths": ["/a"]}
+    big = capped_hint({"paths": ["x" * 100] * 100})
+    assert big["_truncated"] is True
+
+
+def test_when_attributes_are_an_empty_dict_then_none() -> None:
+    assert capped_attributes({}) is None
+    assert capped_attributes(None) is None
+
+
+def test_when_violations_exceed_cap_then_bounded() -> None:
+    bounded = capped_violations([f"v{i}" for i in range(MAX_VIOLATIONS + 10)])
+    assert len(bounded) == MAX_VIOLATIONS
+    assert bounded[-1] == "(+11 more)"

--- a/platform/api/tests/jobs/enricher/test_integration.py
+++ b/platform/api/tests/jobs/enricher/test_integration.py
@@ -1,0 +1,86 @@
+"""End-to-end _process_poll against a real local ClickHouse.
+
+Real protobuf decode, real batch inserts, fake Kafka clients — the broker
+round-trip belongs to the staging wire-up. Opt-in via `pytest -m integration`
+(`make platform-api-test-integration`).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from hexgate.tracing import semconv
+from hexgate_api.jobs.enricher.consumer import EnricherJob
+from hexgate_api.settings import Settings
+from tests.jobs.enricher.conftest import (
+    FakeConsumer,
+    FakeProducer,
+    FakeRecord,
+    ban_attrs,
+    decision_attrs,
+    make_request_bytes,
+    make_span,
+    usage_attrs,
+)
+
+_TABLES = ("policy_decision", "llm_invocation", "ban_enforcement")
+
+
+def _count(client, table: str, project_id: str) -> int:
+    return client.query(
+        f"SELECT count() FROM {table} FINAL WHERE project_id = {{pid:String}}",
+        parameters={"pid": project_id},
+    ).result_rows[0][0]
+
+
+@pytest.mark.integration
+async def test_process_poll_round_trip_and_reprocess_dedup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from hexgate_api.core.clickhouse import get_clickhouse
+
+    client = get_clickhouse()
+    project_id = f"test_proj_{uuid.uuid4().hex[:8]}"
+
+    async def _stub_resolve(pairs):
+        return {pair: "ver_int" for pair in pairs}
+
+    monkeypatch.setattr(
+        "hexgate_api.jobs.enricher.consumer.resolve_versions", _stub_resolve
+    )
+    calls: list[str] = []
+    job = EnricherJob(
+        Settings(enricher_insert_max_backoff_s=0.01),
+        clickhouse_client=client,
+        consumer=FakeConsumer(calls),
+        producer=FakeProducer(calls),
+    )
+    records = [
+        FakeRecord(
+            key=project_id.encode(),
+            value=make_request_bytes(
+                [
+                    (semconv.SCOPE_AUDIT, [make_span(decision_attrs())]),
+                    (semconv.SCOPE_USAGE, [make_span(usage_attrs())]),
+                    (semconv.SCOPE_BANS, [make_span(ban_attrs())]),
+                ]
+            ),
+        )
+    ]
+    try:
+        await job._process_poll(records)
+        assert [_count(client, t, project_id) for t in _TABLES] == [1, 1, 1]
+
+        # Reprocessing the same records (crash-before-commit replay) must not
+        # double-count: event_id dedup via ReplacingMergeTree, FINAL applies
+        # merge semantics at read time.
+        await job._process_poll(records)
+        assert [_count(client, t, project_id) for t in _TABLES] == [1, 1, 1]
+    finally:
+        for table in _TABLES:
+            client.command(
+                f"ALTER TABLE {table} DELETE WHERE project_id = {{pid:String}}",
+                parameters={"pid": project_id},
+            )

--- a/platform/api/tests/jobs/enricher/test_main.py
+++ b/platform/api/tests/jobs/enricher/test_main.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import pytest
 
-from hexgate_api.core.clickhouse import AuditSchemaOutOfDate
+from hexgate_api.core.clickhouse import SchemaOutOfDate
 from hexgate_api.jobs.enricher import __main__ as entry
 from hexgate_api.jobs.enricher.consumer import TopicsMissing
 
 
 @pytest.mark.parametrize(
     "failure",
-    [AuditSchemaOutOfDate({"policy_decision": ["x"]}), TopicsMissing(["t"])],
+    [SchemaOutOfDate({"policy_decision": ["x"]}), TopicsMissing(["t"])],
 )
 def test_when_a_startup_check_fails_then_exit_code_is_1(monkeypatch, failure) -> None:
     async def _run(self):

--- a/platform/api/tests/jobs/enricher/test_main.py
+++ b/platform/api/tests/jobs/enricher/test_main.py
@@ -1,0 +1,29 @@
+"""__main__.py — exit codes a supervisor can act on."""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate_api.core.clickhouse import AuditSchemaOutOfDate
+from hexgate_api.jobs.enricher import __main__ as entry
+from hexgate_api.jobs.enricher.consumer import TopicsMissing
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [AuditSchemaOutOfDate({"policy_decision": ["x"]}), TopicsMissing(["t"])],
+)
+def test_when_a_startup_check_fails_then_exit_code_is_1(monkeypatch, failure) -> None:
+    async def _run(self):
+        raise failure
+
+    monkeypatch.setattr(entry.EnricherJob, "run", _run)
+    assert entry.main() == 1
+
+
+def test_main_happy_path_exits_0(monkeypatch) -> None:
+    async def _run(self):
+        return None
+
+    monkeypatch.setattr(entry.EnricherJob, "run", _run)
+    assert entry.main() == 0

--- a/platform/api/tests/jobs/enricher/test_mapping.py
+++ b/platform/api/tests/jobs/enricher/test_mapping.py
@@ -1,0 +1,134 @@
+"""mapping.py — span → validated event, per the semconv wire contract."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+
+import pytest
+
+from hexgate.tracing import semconv
+from hexgate_api.jobs.enricher.coerce import SpanRejected
+from hexgate_api.jobs.enricher.mapping import map_span
+from hexgate_api.schemas import BanEnforcementEvent, DecisionEvent, LlmInvocationEvent
+from tests.jobs.enricher.conftest import (
+    ban_attrs,
+    decision_attrs,
+    make_span,
+    usage_attrs,
+)
+
+
+def test_map_span_decision_happy_path() -> None:
+    # 1.5ms past the second — must survive into DateTime64(3) precision.
+    start_ns = (int(time.time()) - 60) * 10**9 + 1_500_000
+    attrs = decision_attrs(
+        **{
+            semconv.USER_ROLES: ["admin", "dev"],
+            semconv.DECIDING_ROLE: "admin",
+            semconv.REASON: "matched allow rule",
+            semconv.VIOLATIONS: ["v1"],
+            semconv.ARGUMENTS: json.dumps({"query": "hello"}),
+            semconv.SESSION_ID: "sess_1",
+            semconv.USER_ID: "user_1",
+        }
+    )
+    event = map_span(semconv.SCOPE_AUDIT, make_span(attrs, start_ns=start_ns), {})
+
+    assert isinstance(event, DecisionEvent)
+    assert str(event.event_id) == attrs[semconv.EVENT_ID]
+    assert event.occurred_at == datetime.fromtimestamp(start_ns / 1e9, tz=timezone.utc)
+    assert event.occurred_at.microsecond == 1_500  # ms precision preserved
+    assert event.tool_name == "web_search"
+    assert event.outcome == "allow"
+    assert event.user_roles == ["admin", "dev"]
+    assert event.arguments == {"query": "hello"}
+    assert event.hint is None
+
+
+def test_map_span_llm_happy_path() -> None:
+    event = map_span(semconv.SCOPE_USAGE, make_span(usage_attrs()), {})
+    assert isinstance(event, LlmInvocationEvent)
+    assert event.model == "gpt-4o"
+    assert event.input_tokens == 100
+    assert event.output_tokens == 50
+    assert event.latency_ms == 250
+    assert event.status == "success"  # absent on the wire → model default
+
+
+def test_map_span_ban_happy_path() -> None:
+    event = map_span(semconv.SCOPE_BANS, make_span(ban_attrs()), {})
+    assert isinstance(event, BanEnforcementEvent)
+    assert event.ban_type == "agent"
+    assert event.ban_id == "ban_123"
+
+
+def test_when_scope_is_unknown_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected) as exc:
+        map_span("some.other.scope", make_span(decision_attrs()), {})
+    assert exc.value.error_class == "unknown_scope"
+
+
+def test_when_event_id_is_not_a_uuid_then_span_rejected() -> None:
+    attrs = decision_attrs(**{semconv.EVENT_ID: "not-a-uuid"})
+    with pytest.raises(SpanRejected) as exc:
+        map_span(semconv.SCOPE_AUDIT, make_span(attrs), {})
+    assert exc.value.error_class == "validation"
+
+
+def test_when_outcome_is_invalid_then_span_rejected() -> None:
+    attrs = decision_attrs(**{semconv.OUTCOME: "maybe"})
+    with pytest.raises(SpanRejected):
+        map_span(semconv.SCOPE_AUDIT, make_span(attrs), {})
+
+
+def test_when_arguments_json_is_invalid_then_span_rejected() -> None:
+    attrs = decision_attrs(**{semconv.ARGUMENTS: "{broken"})
+    with pytest.raises(SpanRejected):
+        map_span(semconv.SCOPE_AUDIT, make_span(attrs), {})
+
+
+def test_when_start_time_is_zero_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected) as exc:
+        map_span(semconv.SCOPE_AUDIT, make_span(decision_attrs(), start_ns=0), {})
+    assert "start_time" in exc.value.error
+
+
+def test_when_occurred_at_is_in_the_future_then_span_rejected() -> None:
+    future_ns = time.time_ns() + 10 * 60 * 10**9
+    with pytest.raises(SpanRejected) as exc:
+        map_span(
+            semconv.SCOPE_AUDIT, make_span(decision_attrs(), start_ns=future_ns), {}
+        )
+    assert exc.value.error_class == "out_of_window"
+
+
+def test_when_tokens_arrive_as_strings_then_coerced_to_int() -> None:
+    attrs = usage_attrs(**{semconv.GEN_AI_USAGE_INPUT_TOKENS: "100"})
+    event = map_span(semconv.SCOPE_USAGE, make_span(attrs), {})
+    assert event.input_tokens == 100
+
+
+def test_when_user_roles_arrive_as_json_string_then_coerced_to_list() -> None:
+    attrs = decision_attrs(**{semconv.USER_ROLES: '["admin"]'})
+    event = map_span(semconv.SCOPE_AUDIT, make_span(attrs), {})
+    assert event.user_roles == ["admin"]
+
+
+def test_when_latency_is_absent_then_derived_from_span_duration() -> None:
+    attrs = usage_attrs()
+    del attrs[semconv.LATENCY_MS]
+    start_ns = time.time_ns() - 10**9
+    span = make_span(attrs, start_ns=start_ns, end_ns=start_ns + 42_000_000)
+    event = map_span(semconv.SCOPE_USAGE, span, {})
+    assert event.latency_ms == 42
+
+
+def test_when_agent_name_is_absent_then_resource_service_name_is_used() -> None:
+    attrs = decision_attrs()
+    del attrs[semconv.AGENT_NAME]
+    event = map_span(
+        semconv.SCOPE_AUDIT, make_span(attrs), {"service.name": "svc-agent"}
+    )
+    assert event.agent_name == "svc-agent"

--- a/platform/api/tests/jobs/enricher/test_mapping.py
+++ b/platform/api/tests/jobs/enricher/test_mapping.py
@@ -11,7 +11,12 @@ import pytest
 from hexgate.tracing import semconv
 from hexgate_api.jobs.enricher.coerce import SpanRejected
 from hexgate_api.jobs.enricher.mapping import map_span
-from hexgate_api.schemas import BanEnforcementEvent, DecisionEvent, LlmInvocationEvent
+from hexgate_api.schemas import (
+    UINT32_MAX,
+    BanEnforcementEvent,
+    DecisionEvent,
+    LlmInvocationEvent,
+)
 from tests.jobs.enricher.conftest import (
     ban_attrs,
     decision_attrs,
@@ -102,6 +107,15 @@ def test_when_occurred_at_is_in_the_future_then_span_rejected() -> None:
             semconv.SCOPE_AUDIT, make_span(decision_attrs(), start_ns=future_ns), {}
         )
     assert exc.value.error_class == "out_of_window"
+
+
+def test_when_latency_exceeds_uint32_then_span_rejected() -> None:
+    # A UInt32-overflowing value (e.g. latency emitted in ns) must be rejected
+    # to the DLQ here, not fail permanently at ClickHouse insert time.
+    attrs = usage_attrs(**{semconv.LATENCY_MS: UINT32_MAX + 1})
+    with pytest.raises(SpanRejected) as exc:
+        map_span(semconv.SCOPE_USAGE, make_span(attrs), {})
+    assert exc.value.error_class == "validation"
 
 
 def test_when_tokens_arrive_as_strings_then_coerced_to_int() -> None:

--- a/platform/api/tests/jobs/enricher/test_resolver.py
+++ b/platform/api/tests/jobs/enricher/test_resolver.py
@@ -1,0 +1,51 @@
+"""resolver.py — per-poll agent_version_id resolution."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+
+from hexgate_api.jobs.enricher import resolver
+
+
+@pytest.fixture
+def stub_lookups(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
+    """Replace the session factory and the lookup; record every call."""
+    calls: list[tuple[str, str]] = []
+
+    @asynccontextmanager
+    async def _fake_session_factory():
+        yield object()
+
+    async def _fake_lookup(_session, project_id: str, agent_name: str) -> str:
+        calls.append((project_id, agent_name))
+        return "" if agent_name == "ghost" else f"ver_{agent_name}"
+
+    monkeypatch.setattr(resolver, "async_session_factory", _fake_session_factory)
+    monkeypatch.setattr(resolver, "get_latest_agent_version_id", _fake_lookup)
+    return calls
+
+
+async def test_resolve_versions_happy_path(stub_lookups) -> None:
+    versions = await resolver.resolve_versions({("p1", "researcher"), ("p2", "coder")})
+    assert versions == {
+        ("p1", "researcher"): "ver_researcher",
+        ("p2", "coder"): "ver_coder",
+    }
+
+
+async def test_when_agent_is_unknown_then_empty_string(stub_lookups) -> None:
+    versions = await resolver.resolve_versions({("p1", "ghost")})
+    assert versions == {("p1", "ghost"): ""}
+
+
+async def test_resolve_versions_queries_each_pair_once(stub_lookups) -> None:
+    await resolver.resolve_versions({("p1", "a"), ("p1", "b"), ("p2", "a")})
+    assert len(stub_lookups) == 3
+    assert len(set(stub_lookups)) == 3
+
+
+async def test_when_there_are_no_pairs_then_no_session_is_opened(stub_lookups) -> None:
+    assert await resolver.resolve_versions(set()) == {}
+    assert stub_lookups == []

--- a/platform/api/tests/jobs/enricher/test_resolver.py
+++ b/platform/api/tests/jobs/enricher/test_resolver.py
@@ -3,49 +3,93 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 
 import pytest
 
 from hexgate_api.jobs.enricher import resolver
 
 
+class _FakeSession:
+    """Answers the agents query with a pre-registered list; counts execs."""
+
+    def __init__(self, agents: list[SimpleNamespace]) -> None:
+        self.agents = agents
+        self.execs = 0
+
+    async def exec(self, _stmt):
+        self.execs += 1
+        return SimpleNamespace(all=lambda: self.agents)
+
+
 @pytest.fixture
-def stub_lookups(monkeypatch: pytest.MonkeyPatch) -> list[tuple[str, str]]:
-    """Replace the session factory and the lookup; record every call."""
-    calls: list[tuple[str, str]] = []
+def stub_store(monkeypatch: pytest.MonkeyPatch):
+    """A fake session factory over registered agents, plus a stubbed
+    versions-map lookup; returns (factory, session, map_calls)."""
+    map_calls: list[list[str]] = []
 
-    @asynccontextmanager
-    async def _fake_session_factory():
-        yield object()
+    def _make(agents: list[SimpleNamespace]):
+        session = _FakeSession(agents)
 
-    async def _fake_lookup(_session, project_id: str, agent_name: str) -> str:
-        calls.append((project_id, agent_name))
-        return "" if agent_name == "ghost" else f"ver_{agent_name}"
+        @asynccontextmanager
+        async def _factory():
+            yield session
 
-    monkeypatch.setattr(resolver, "async_session_factory", _fake_session_factory)
-    monkeypatch.setattr(resolver, "get_latest_agent_version_id", _fake_lookup)
-    return calls
+        async def _fake_versions_map(_session, agent_ids: list[str]):
+            map_calls.append(agent_ids)
+            # Every registered agent has one version, ver_<agent_id>.
+            return {
+                agent_id: SimpleNamespace(id=f"ver_{agent_id}")
+                for agent_id in agent_ids
+            }
+
+        monkeypatch.setattr(
+            resolver, "get_latest_agent_versions_map", _fake_versions_map
+        )
+        return _factory, session, map_calls
+
+    return _make
 
 
-async def test_resolve_versions_happy_path(stub_lookups) -> None:
-    versions = await resolver.resolve_versions({("p1", "researcher"), ("p2", "coder")})
+def _agent(agent_id: str, project_id: str, name: str) -> SimpleNamespace:
+    return SimpleNamespace(id=agent_id, project_id=project_id, name=name)
+
+
+async def test_resolve_versions_happy_path(stub_store) -> None:
+    factory, _session, _map_calls = stub_store(
+        [_agent("a1", "p1", "researcher"), _agent("a2", "p2", "coder")]
+    )
+    versions = await resolver.resolve_versions(
+        {("p1", "researcher"), ("p2", "coder")}, session_factory=factory
+    )
     assert versions == {
-        ("p1", "researcher"): "ver_researcher",
-        ("p2", "coder"): "ver_coder",
+        ("p1", "researcher"): "ver_a1",
+        ("p2", "coder"): "ver_a2",
     }
 
 
-async def test_when_agent_is_unknown_then_empty_string(stub_lookups) -> None:
-    versions = await resolver.resolve_versions({("p1", "ghost")})
+async def test_when_agent_is_unknown_then_empty_string(stub_store) -> None:
+    factory, _session, _map_calls = stub_store([])
+    versions = await resolver.resolve_versions(
+        {("p1", "ghost")}, session_factory=factory
+    )
     assert versions == {("p1", "ghost"): ""}
 
 
-async def test_resolve_versions_queries_each_pair_once(stub_lookups) -> None:
-    await resolver.resolve_versions({("p1", "a"), ("p1", "b"), ("p2", "a")})
-    assert len(stub_lookups) == 3
-    assert len(set(stub_lookups)) == 3
+async def test_resolve_versions_issues_two_queries_regardless_of_pairs(
+    stub_store,
+) -> None:
+    factory, session, map_calls = stub_store(
+        [_agent("a1", "p1", "a"), _agent("a2", "p1", "b"), _agent("a3", "p2", "a")]
+    )
+    await resolver.resolve_versions(
+        {("p1", "a"), ("p1", "b"), ("p2", "a")}, session_factory=factory
+    )
+    assert session.execs == 1  # one agents lookup
+    assert map_calls == [["a1", "a2", "a3"]]  # one batched versions lookup
 
 
-async def test_when_there_are_no_pairs_then_no_session_is_opened(stub_lookups) -> None:
-    assert await resolver.resolve_versions(set()) == {}
-    assert stub_lookups == []
+async def test_when_there_are_no_pairs_then_no_session_is_opened(stub_store) -> None:
+    factory, session, _map_calls = stub_store([])
+    assert await resolver.resolve_versions(set(), session_factory=factory) == {}
+    assert session.execs == 0

--- a/platform/api/uv.lock
+++ b/platform/api/uv.lock
@@ -84,6 +84,31 @@ wheels = [
 ]
 
 [[package]]
+name = "aiokafka"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/5f/dfc1180fd22d1acdc91949ec36e97199c43742dacb057cb8efed3679ed04/aiokafka-0.14.0.tar.gz", hash = "sha256:8ffdc945798ba4d3d132b705d4244d0a1f493925efb57c637a2ca88ee82794e1", size = 601374, upload-time = "2026-04-29T10:43:03.574Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/b0/c9384541b2e4cc52a16402fc53fb9d44af0d78d37954cf8c7271c376ad47/aiokafka-0.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:db16e43fac4c1c5006131046c1bf370c580d6ac4495a10ac7778245710943179", size = 345859, upload-time = "2026-04-29T10:42:45.449Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d1/fc266d9f4ffba4f197356c6ffdfbb0fe32e7cb874e240f299935d058ac06/aiokafka-0.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:32a8e91d88cf3ccf0778927715610d6579888c5f4748db4c2022cda25d628a48", size = 348284, upload-time = "2026-04-29T10:42:47.104Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8e/0c4c270786dac79f3fca74c6166c3a25b61b0d26132be0d69f0d7f206f0a/aiokafka-0.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aad4a575a506e7784e25e430f27026fe2f4378560b21b7f4e8c9a54f0d06eaee", size = 1117867, upload-time = "2026-04-29T10:42:48.394Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7f/3b89fbd0a3be9edfd5b51e20bb5cd695c851219b63c501c051cf84367fa9/aiokafka-0.14.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:75e4a003502c9c3b5c705fa7c00d634ba146bf38fa5d525b80bb6ff6e3e779fe", size = 1108860, upload-time = "2026-04-29T10:42:50.249Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/59/849aba75cff93277bf6bf8b630de79e902949ff7ec48e4b12a64e6e32cae/aiokafka-0.14.0-cp313-cp313-win32.whl", hash = "sha256:a128e213cbc2bce0ea3db65a68920e52cebeeb8209bf001ac7aa022a8bd54d7d", size = 310889, upload-time = "2026-04-29T10:42:52.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/e5/52eab8f8515d23da7b5d90e2c5ba10eab9494a0314f749e3f73e003f4a50/aiokafka-0.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:d6fa16bef3544be87bd1a7a8317b9d85e3da59f3202326d9ff22735ed052746e", size = 329470, upload-time = "2026-04-29T10:42:53.536Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9d/984803315fe2b883ea6e08b1d9c8a752bd5c16e966d8714bacc67c72c417/aiokafka-0.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:5d70615d1530ad19d0c4da8d87abaec0a12b9fdaabffdcd4e400efa0c50ef80c", size = 346672, upload-time = "2026-04-29T10:42:55.267Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/da314966b7f3c3117bd78b082563cb03dbe3007848cb8f4b0932faf390a0/aiokafka-0.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7e2392360c370b1ba6564c57d2889e154ecdb43157a8f7b7d7afe5e3c02fcc1a", size = 349594, upload-time = "2026-04-29T10:42:56.565Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7a/160516944ea0e0f68ea78e38f944c52f5248c7c7df26cba22a40b9f25709/aiokafka-0.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:201e38ecc595f9f65a945f1ef9085157ddf28f25cd2e482fd9efa1fcf4638213", size = 1114112, upload-time = "2026-04-29T10:42:57.869Z" },
+    { url = "https://files.pythonhosted.org/packages/68/c4/9841118a2157e913e8ebfbc0a2b58f7b60f1f7202040c3e1df8925ed1184/aiokafka-0.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1cd651e1f56571baae306fdd0b5509047ab9625797a24cd75902e139c5a20318", size = 1098571, upload-time = "2026-04-29T10:42:59.356Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a1/0af8a37849a4108ae227f46c4c62f6beab31863cf66ba318fb73b0be5b26/aiokafka-0.14.0-cp314-cp314-win32.whl", hash = "sha256:128127eb96dab98150b636bb5f480c80e15f02f82a118eec206a521c8cf7cf7c", size = 314107, upload-time = "2026-04-29T10:43:01.111Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/fb46c65f758900c71d0f1c73b7802720f99cabcb1f4a11676573f9bc1b8f/aiokafka-0.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:aa385039aa9b235359319bbdcf48c9c86a75d81c9c547d645056d00361238903", size = 333320, upload-time = "2026-04-29T10:43:02.424Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -175,6 +200,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
     { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
     { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
 ]
 
 [[package]]
@@ -1063,6 +1097,7 @@ name = "hexgate-api"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "aiokafka" },
     { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "biscuit-python" },
@@ -1073,6 +1108,7 @@ dependencies = [
     { name = "greenlet" },
     { name = "hexgate" },
     { name = "httpx-oauth" },
+    { name = "opentelemetry-proto" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -1092,6 +1128,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiokafka", specifier = ">=0.12" },
     { name = "aiosqlite", specifier = ">=0.20" },
     { name = "asyncpg", specifier = ">=0.29" },
     { name = "biscuit-python", specifier = ">=0.4" },
@@ -1102,6 +1139,7 @@ requires-dist = [
     { name = "greenlet", specifier = ">=3.0" },
     { name = "hexgate", editable = "../../" },
     { name = "httpx-oauth", specifier = ">=0.16" },
+    { name = "opentelemetry-proto", specifier = ">=1.41" },
     { name = "pydantic", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.5" },
     { name = "python-dotenv", specifier = ">=1.1.1" },

--- a/platform/redpanda/init/create-topics.sh
+++ b/platform/redpanda/init/create-topics.sh
@@ -51,9 +51,9 @@ create_topic() {
 # survive a brief consumer outage/redeploy.
 create_topic hexgate.otlp.raw 259200000 # 3 days
 
-# Intended for permanently-rejected events (unfixable validation,
-# unresolvable agent_version_id) reaching the enrichment job — once that
-# job and the ingestion Collector exist. Neither does yet, and this
+# Permanently-rejected events from the enrichment job: undecodable
+# payloads, keyless records, spans failing validation. NOT unresolvable
+# agent_version_id — those insert with "" like the HTTP ingest does. This
 # broker has no auth in front of it at all (PLAINTEXT, no ACLs): today,
 # anything that can reach it can write here directly. Nothing currently
 # enforces "auth rejections never reach this topic" as an actual


### PR DESCRIPTION
## What is Changing

New standalone job `hexgate_api/jobs/enricher/` (`python -m hexgate_api.jobs.enricher`, `make enricher-run`): an aiokafka consumer that reads the Collector's OTLP records from `hexgate.otlp.raw`, decodes and validates spans back into the platform's event models, and batch-inserts into ClickHouse.

- `decode.py` — record bytes → per-span units (`ExportTraceServiceRequest` protobuf, AnyValue → Python).
- `coerce.py` — generic attribute-type coercion (string→int, JSON-string→list/dict), lossy coercions logged, failures reject the span.
- `mapping.py` — the semconv wire contract (`hexgate.tracing.semconv`, PR #130) → `DecisionEvent` / `LlmInvocationEvent` / `BanEnforcementEvent`; `occurred_at` from span start time; Pydantic + the ingest window are the validation layer.
- `enforcement.py` — authoritative server-side redaction/byte caps, importing the SDK pipeline (same rules as `AuditEvent.as_payload`).
- `resolver.py` — one DB session per poll, `agent_version_id` per unique (project, agent); unresolved → `""` like the HTTP ingest.
- `dlq.py` + `consumer.py` — per-span dead-lettering to `hexgate.otlp.dlq` (JSON envelopes; attributes redacted with the substring `SENSITIVE_ARG_KEY_RE`, the JSON-string dict fields `arguments`/`hint`/`attributes` parsed first so the key match reaches inside them; anything that doesn't parse to a dict is replaced by `[UNPARSEABLE]` — the `source` pointer still locates the raw record). Keyless records are decoded and parked span by span through the same envelope; only undecodable bytes go out raw. Events are deduped by `(project_id, event_id)` within a poll (first copy wins; a tenant reusing another's id is a different event) before the batch inserts, per the batch functions' contract. ClickHouse inserts and DLQ sends share one retry loop (`_retry_until_acked`: capped backoff, stop-aware, never commits on the way out), offset commit only after both, SIGTERM-clean shutdown with the client `start()` calls inside the `try/finally`.
- Wiring: `redpanda_*`/`enricher_*` settings, `aiokafka` + explicit `opentelemetry-proto` deps, `.env.sample`, stale DLQ comment fixed in `create-topics.sh`, `jobs/` layout line in `platform/api/CLAUDE.md`.
- Makefile: new `postgres-init` target (`postgres-up` + `init_db()`), used by `collector-run`, `collector-test-integration` and the new `enricher-run`, which runs the job with `DATABASE_URL=$(POSTGRES_DSN)` — the same Postgres as `platform-api-pg`, so `agent_version_id` resolves instead of silently falling back to the SQLite file.

Built on #128 (batch inserts), #130 (semconv), #131 (schema guard) and #136 (`verify_all`) — all merged; rebased onto #136 so the startup check is a single `verify_all(...)` call run via `asyncio.to_thread`, reporting every stale table in one boot.

## Why is this change necessary?

This is the consumer the OTLP pipeline has been building toward: Collector (#111, #127) authenticates and buffers spans into Redpanda; the batch inserts (#128) gave ClickHouse a bulk write path; this job connects the two. Offsets commit only after ClickHouse acks, so a crash replays the poll and `event_id` dedup absorbs it — at-least-once end to end with no ack-then-drop. Poisoned input (undecodable records, keyless records, invalid spans) is parked per-span on the DLQ so one bad span never wedges a partition, while infra failures — ClickHouse or the DLQ topic — halt consumption with backoff instead of dropping data or crashing the job.

The DLQ topic has 30-day retention and no ACLs, and there is no SDK span emitter yet, so this job is the authoritative redaction point: a rejected span's tool arguments must never reach the DLQ unredacted, whether the span was rejected for validation, clock skew, or a missing record key.

## Tests

- 69 unit tests (`tests/jobs/enricher/`): decode round-trips, coercion rules, per-scope mapping incl. ms-precision timestamps and rejection paths, SDK-parity redaction/caps, DLQ envelope shapes incl. redaction inside JSON-string dict fields and the unparseable case, keyless records parked span by span (redacted, no raw bytes), resolver caching, and `_process_poll` ordering (inserts → DLQ → commit), insert retry-then-single-commit, DLQ-send retry-then-single-commit, stop mid-outage (ClickHouse and DLQ) → no commit, intra-poll `event_id` dedup, sibling survival, producer-start failure still stops the consumer, two stale tables reported in one `SchemaOutOfDate`.
- 1 integration test (real ClickHouse): full poll round-trip into all three tables; reprocessing the same records leaves `FINAL` counts unchanged.
- Manual smoke (2026-08-27, after the review fixes) against live Redpanda + ClickHouse + Postgres via `make enricher-run`'s command line: valid record → correct `policy_decision` row; one record carrying the same span twice → 1 row without `FINAL` (intra-poll dedup); garbage record → `decode` envelope with raw bytes; span missing `tool_name` with `{"password": …}` in `sec_ai.arguments` → `validation` envelope with `"password": "[REDACTED]"` inside the parsed dict; keyless valid record → `missing_key` span envelope, redacted, no `record_value_base64`; SIGTERM → `LeaveGroup request succeeded`, exit within 1 s, no tracebacks. `make postgres-init` verified live.
- `make fmt-check && make platform-api-check` (586 passed) and `make platform-api-test-integration` (7 passed) green after the rebase onto #136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
