### PR TITLE
fix(sdk): reject exponentially-backtracking regexes at policy load

### DIFF
--- a/docs/adr/R-CONSTRAINT-001-reject-exponential-regex.md
+++ b/docs/adr/R-CONSTRAINT-001-reject-exponential-regex.md
@@ -1,0 +1,137 @@
+# R-CONSTRAINT-001: `matches` regexes must be linear-time, not just RE2-shaped
+
+**Status:** Accepted · 2026-08-24
+**Applies to:** `hexgate/security/constraints.py`, `hexgate/security/regex_safety.py`
+
+## Decision
+
+A constraint's `matches` pattern is refused at **policy load** when it is
+**exponentially ambiguous** — when some state of its automaton can be reached
+from itself, over one word, by two distinct paths. Detection is exact (a search
+over the product automaton), not a syntactic "nested quantifier" rule, and the
+error carries a concrete example string plus the rewrite to apply.
+
+Three verdicts, and each has a defined outcome:
+
+| verdict | meaning | outcome |
+|---|---|---|
+| witness | two distinct paths found | refuse, showing the example |
+| `False` | provably linear | accept |
+| `None` | search budget exhausted | refuse as unverifiable |
+
+## Why
+
+`_validate_re2` already refuses regex *syntax* RE2 cannot run, so a policy
+cannot mean one thing on the pydantic engine and another in a WASM bundle. That
+covers what the engines can **express**; it says nothing about what they
+**cost**.
+
+Python's `re` backtracks. RE2 does not. `^(a+)+$` is accepted by both, is linear
+under RE2, and is exponential under `re`. Measured on the evaluator's own entry
+point (`check_constraints`), with the pattern as an email allowlist
+`^([a-zA-Z0-9_-]+)*@corp[.]com$`:
+
+| argument length | 20 | 24 | 26 | 28 | 30 | 32 | 34 |
+|---|---|---|---|---|---|---|---|
+| decision time | 0.04 s | 0.54 s | 2.21 s | 8.74 s | 37.8 s | 149 s | 596 s |
+
+Lengths 20-28 were timed through `check_constraints`; 30 and beyond with the
+same `re.search` call `_eval_call` makes, since with this change in place the
+pattern no longer loads. The rate holds across the whole range at roughly four
+times longer per two characters added (x4.1, x3.9, x4.0), so a 34-character
+argument already costs ten minutes. Continuing that slope puts the low forties
+in the hours — that last step is an extrapolation, not a measurement.
+
+The arguments a constraint tests are written by a model and influenced by the
+caller, and `hexgate/security/` carries no timeout or argument-size cap — so
+the component deciding whether a tool call is allowed can be stalled by the
+input it exists to filter. The local and pydantic-fallback modes are supported
+deployment shapes (`source.py`), not just dev conveniences, so this is reachable
+in production.
+
+Exponential ambiguity is the right property to test because it is *exactly* what
+RE2's construction rules out — which is why RE2 can promise linear time. Testing
+for it tests the divergence itself rather than a syntax that correlates with it.
+
+## Not covered
+
+Cost that grows *polynomially* rather than by doubling is **out of scope here**,
+and deliberately so rather than by oversight.
+
+Measured, on the same engine entry point:
+
+| pattern | 1 000 chars | 2 000 chars | 4 000 chars |
+|---|---|---|---|
+| `^a*a*a*$` | 1.06s | 8.55s | 67.6s |
+
+Two different repetitions can absorb the same text, so the engine tries every
+way to divide the input between them. It needs no crafted string, only a long
+argument, and RE2 stays linear on it, so it is the same parity gap one tier
+down.
+
+A detector for it was written and then dropped from this change, because it
+could not be shown to be precise: it reports the *structure*, and the structure
+is not always reachable as a slow input. `^.*foo.*$` has it and runs in linear
+time (measured flat to 8 000 characters) because the pattern matches as soon as
+`foo` appears, so no input both exercises the ambiguity and fails. Reporting it
+would mean warning about patterns that are fine.
+
+Closing that gap needs the automaton to model *acceptance*, so the analysis can
+require a failing continuation after the pumped section. That is a larger change
+and belongs in its own review, not bundled here.
+
+## Consequences
+
+- A pattern that is safe under RE2 but exponential under `re` no longer loads,
+  even for a deployment that only ever runs the WASM engine. Deliberate: one
+  policy language, one behaviour, whichever engine is underneath. The rewrite is
+  usually trivial (`(a+)+` → `a+`).
+- The check runs inside the already-cached `parse_constraint`, so it costs
+  nothing per decision.
+- `None` (budget exhausted) fails closed. No policy pattern in this repo comes
+  near the budget — every shipped pattern resolves under 20 000 steps against a
+  200 000 default.
+- An epsilon cycle alone does not make a pattern exponential and is not treated
+  as ambiguity. `(a?)+` has one (an empty iteration) but every iteration matches
+  exactly one character, so there is a single way to split the input and it runs
+  linearly; `(a*)*` has the same cycle *and* iterations that can absorb any
+  number of characters, so it is exponential. Routes are therefore counted
+  without reusing an edge, which is what separates the two.
+- A repetition bound wider than 4 is read as unbounded. Unrolling a bound
+  exactly leaves an automaton with no cycle, and the analysis looks for a state
+  reachable from itself — so exact modelling would certify every bounded pattern
+  as linear however slow it is (`^(a{1,10}){1,10}$` spans 100 characters and
+  takes 14.7s on a 40-character argument). Narrow bounds stay exact, so
+  `^(a{1,4}){1,4}$`, `^(\d{1,3}\.){3}\d{1,3}$` and `^(\w{1,63}\.){1,10}[a-z]{2,6}$`
+  are not swept up.
+- The analysis models the RE2 subset the grammar allows. A construct it cannot
+  model raises `UnsupportedRegex` rather than answering "linear".
+
+## Rejected alternatives
+
+- **A syntactic "nested quantifier" rule.** Wrong in both directions. It rejects
+  `^([a-z0-9-]+[.])+corp[.]com$`, which is nested *and* linear because the
+  mandatory `[.]` forces one split per iteration; and it misses `^(a|aa)+$`,
+  which has no nesting at all and is exponential. Both are in the test corpus.
+- **A runtime timeout.** Python's `re` cannot be interrupted from another
+  thread, `signal.alarm` is Unix-only, and a subprocess per constraint would
+  dominate decision latency. It would also convert a policy bug into a runtime
+  failure on the enforcement path, which is the worst place to discover it.
+- **Capping argument length before matching.** Changes semantics for legitimate
+  long arguments, and the cap would have to be brutal to help: 30 characters
+  already costs 38 seconds.
+- **Swapping `re` for a linear-time engine** (`google-re2`, or a Thompson
+  simulation of the supported subset). The soundest fix and the largest: a new
+  dependency or a second regex engine to keep in parity with RE2 forever. Worth
+  revisiting if `matches` ever needs to accept patterns this ADR refuses; until
+  then, refusing them is the smaller and more reviewable change.
+
+## Verify
+
+```
+pytest tests/security/test_regex_safety.py
+```
+
+passes: every blow-up shape is refused, every `matches` pattern this repo ships
+still loads, and each reported example is a string the engine genuinely fails to
+match (which is what forces it to try every split).

--- a/docs/policy/writing-conditions.mdx
+++ b/docs/policy/writing-conditions.mdx
@@ -95,6 +95,25 @@ pattern anywhere in the string. Add `^` and `$` when you mean the *whole* value,
 like the ticket-ID example above.
 </Tip>
 
+<Warning>
+A pattern must be one a regex engine can match in **linear time**. Policies are
+refused at load when a repetition can match the same text more than one way —
+`^(a+)+$`, `^([a-z]+)*$`, `^(a|aa)+$` — because the engine then has to try every
+split. A 34-character argument already takes ten minutes to decide, and the cost
+keeps quadrupling every two characters. The error names the pattern and an
+example string.
+
+The fix is to leave only one way to match each repetition: `^(a+)+$` is just
+`^a+$`, and a repeated group needs a separator that cannot be absorbed by the
+group itself — `^([a-z0-9-]+[.])+corp[.]com$` is fine, because the `[.]` ends
+every iteration.
+
+A milder version of the same problem is not refused today: two repetitions that
+can both absorb the same text, like `^a*a*a*$`, still load, and matching cost
+then grows with the square or cube of the argument length rather than doubling.
+Worth avoiding, but it will not stop a policy from loading.
+</Warning>
+
 ## Rules over a list
 
 When an argument is a **list**, `every` and `any` let you constrain its

--- a/hexgate/security/constraints.py
+++ b/hexgate/security/constraints.py
@@ -84,6 +84,10 @@ from functools import lru_cache
 from typing import Any
 
 from hexgate.security.errors import PolicyDeniedError
+from hexgate.security.regex_safety import (
+    UnsupportedRegex,
+    find_exponential_ambiguity,
+)
 
 
 class ConstraintParseError(ValueError):
@@ -659,6 +663,53 @@ def _validate_re2(pattern: str, source: str) -> None:
             "(backreferences, lookaround, \\Z anchor, inline comments, or "
             "conditionals) — the WASM engine would diverge"
         )
+    _validate_linear_time(pattern, source)
+
+
+def _validate_linear_time(pattern: str, source: str) -> None:
+    """Reject a regex RE2 runs in linear time but Python's ``re`` does not.
+
+    The pydantic engine evaluates ``matches`` with ``re.search``, which
+    backtracks; a WASM bundle runs the same pattern under RE2, which cannot.
+    So an exponentially ambiguous pattern is a second way for the two engines
+    to diverge — not on the verdict, but on whether one of them returns at
+    all — and the arguments a constraint is fed are attacker-influenced.
+    Refused at load, like the syntax above, so it cannot reach a deployment.
+
+    See :mod:`hexgate.security.regex_safety` and
+    ``docs/adr/R-CONSTRAINT-001``.
+    """
+    try:
+        witness = find_exponential_ambiguity(pattern)
+    except UnsupportedRegex as exc:
+        if exc.re2_incompatible:
+            raise ConstraintParseError(
+                f"regex {pattern!r} in {source!r} uses an atomic group or a "
+                "possessive quantifier, which RE2 does not have — the WASM "
+                "engine would diverge"
+            ) from exc
+        raise ConstraintParseError(
+            f"regex {pattern!r} in {source!r} uses {exc.construct}, which this "
+            "check cannot verify as linear-time — rewrite it with the "
+            "constructs the policy grammar documents"
+        ) from exc
+    if witness is False:
+        return
+    if witness is None:
+        raise ConstraintParseError(
+            f"regex {pattern!r} in {source!r} is too complex to verify as "
+            "linear-time on the backtracking engine — simplify it so the "
+            "policy behaves the same on both engines"
+        )
+    raise ConstraintParseError(
+        f"regex {pattern!r} in {source!r} can backtrack exponentially: the "
+        f"segment {witness.pump!r} can be matched more than one way, so on an "
+        f"input like {witness.example!r} the number of combinations Python's "
+        "engine must try doubles as the input grows, while the WASM engine "
+        "stays linear. Rewrite the repetition so each iteration has only one "
+        "way to match (a required separator between iterations, or a single "
+        "quantifier instead of a nested one)"
+    )
 
 
 def _find_operator(text: str) -> tuple[str | None, int]:

--- a/hexgate/security/regex_safety.py
+++ b/hexgate/security/regex_safety.py
@@ -1,0 +1,527 @@
+"""Reject regexes that a backtracking engine runs in exponential time.
+
+:mod:`hexgate.security.constraints` already refuses regex *syntax* RE2 cannot
+run (backreferences, lookaround, ...) so a policy tested on the pydantic engine
+compiles to an equivalent WASM bundle. That covers what the two engines can
+*express*; it says nothing about what they *cost*.
+
+The gap this module closes: Python's ``re`` backtracks, RE2 does not. A pattern
+like ``^(a+)+$`` is accepted by both, runs in linear time under RE2, and takes
+exponential time under ``re`` — about four times longer per two characters
+added. Since the tool arguments a constraint tests are attacker-influenced (a
+model writes them, and the caller influences the model), a policy carrying such
+a pattern lets a 34-character argument hold a CPU for ten minutes *in the engine
+whose job is to decide whether that call is allowed* — measured, and still
+quadrupling every two characters. So this is the same divergence
+``_validate_re2`` exists to prevent, one level down: not "the WASM engine would
+disagree" but "the WASM engine would finish".
+
+Detection is exact rather than a syntactic heuristic, because both error
+directions are expensive: a missed pattern leaves the hang in place, and a
+wrongly rejected pattern refuses a policy that was fine. "Nested quantifier"
+would be the easy rule and it is wrong — ``^([a-z0-9-]+[.])+corp[.]com$`` is
+nested and linear, because the mandatory ``[.]`` forces one split per
+iteration. What actually matters is **exponential ambiguity (EDA)**: whether
+some state of the automaton can be reached from itself, over one word, by two
+*distinct* paths. If it can, a failing match must try every combination of
+those paths and the cost doubles per repetition; if it cannot, the match is
+linear. That property is exactly what RE2's construction rules out, which is
+why RE2 can promise linear time — so testing for it is testing for the
+divergence itself, not for a syntax that correlates with it.
+
+The check runs at policy load (inside the cached
+:func:`~hexgate.security.constraints.parse_constraint`), never per tool call,
+so it costs nothing at decision time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# The parse tree has no public API. ``re._parser`` is the module the stdlib
+# itself parses with; the old public alias ``sre_parse`` is deprecated. Only the
+# parse tree is used here, never the compiler.
+import re._parser as sre_parse
+
+MAX_CODEPOINT = 0x10FFFF
+
+# Product-automaton steps before the search gives up. A policy regex explores a
+# few hundred; the cap exists so a pathological pattern cannot turn the *check*
+# into the hang it is meant to prevent. Exhausting it returns "undecided", and
+# the caller refuses the pattern rather than guessing.
+DEFAULT_BUDGET = 200_000
+
+# Edge-disjoint epsilon routes explored per state pair before the count is
+# abandoned. Reached only by pathological nesting; realistic patterns finish
+# in a handful of steps.
+_ROUTE_BUDGET = 4_000
+
+# How many times the ambiguous segment is repeated in the example string.
+# Enough to show the shape and to be visibly slow, small enough that the
+# example stays readable in an error message and cheap to run.
+_EXAMPLE_REPEATS = 4
+
+# Characters preferred when rendering a charset in the example string.
+_WITNESS_PREFERENCE = "abxyz01_-./@ "
+
+
+# Constructs Python's `re` accepts that RE2 (Go regexp, what Rego runs) has no
+# equivalent for. Verified with `opa eval`: `regex.match("(?>a+)+", "aaa")` and
+# `regex.match("a*+", "aaa")` are both undefined, while Python matches. They are
+# named here rather than pattern-matched on the source text because `\++` (a
+# repeated literal plus) is not a possessive quantifier and must stay legal.
+RE2_MISSING_CONSTRUCTS = frozenset({"ATOMIC_GROUP", "POSSESSIVE_REPEAT"})
+
+
+class UnsupportedRegex(Exception):
+    """A construct this analysis does not model, so the verdict is unknown.
+
+    ``re2_incompatible`` marks the ones RE2 cannot run either, which the caller
+    reports as an engine-divergence problem rather than an analysis limit.
+    """
+
+    def __init__(self, construct: str) -> None:
+        super().__init__(construct)
+        self.construct = construct
+        self.re2_incompatible = construct in RE2_MISSING_CONSTRUCTS
+
+
+# --------------------------------------------------------------------------
+# character sets, as sorted disjoint codepoint intervals
+# --------------------------------------------------------------------------
+
+
+def _normalise(intervals: list[tuple[int, int]]) -> tuple[tuple[int, int], ...]:
+    out: list[tuple[int, int]] = []
+    for lo, hi in sorted(intervals):
+        if out and lo <= out[-1][1] + 1:
+            out[-1] = (out[-1][0], max(out[-1][1], hi))
+        else:
+            out.append((lo, hi))
+    return tuple(out)
+
+
+def _intersect(
+    a: tuple[tuple[int, int], ...], b: tuple[tuple[int, int], ...]
+) -> tuple[tuple[int, int], ...]:
+    out: list[tuple[int, int]] = []
+    i = j = 0
+    while i < len(a) and j < len(b):
+        lo = max(a[i][0], b[j][0])
+        hi = min(a[i][1], b[j][1])
+        if lo <= hi:
+            out.append((lo, hi))
+        if a[i][1] < b[j][1]:
+            i += 1
+        else:
+            j += 1
+    return tuple(out)
+
+
+def _invert(a: tuple[tuple[int, int], ...]) -> tuple[tuple[int, int], ...]:
+    out: list[tuple[int, int]] = []
+    prev = 0
+    for lo, hi in a:
+        if lo > prev:
+            out.append((prev, lo - 1))
+        prev = hi + 1
+    if prev <= MAX_CODEPOINT:
+        out.append((prev, MAX_CODEPOINT))
+    return tuple(out)
+
+
+_DIGIT = ((48, 57),)
+_WORD = _normalise([(48, 57), (65, 90), (95, 95), (97, 122)])
+_SPACE = _normalise([(9, 13), (32, 32)])
+
+# `re.ASCII` is how the evaluator runs `matches` (to mirror RE2's Go engine),
+# so the classes are pinned to their ASCII meaning here too.
+_CATEGORIES = {
+    sre_parse.CATEGORY_DIGIT: _DIGIT,
+    sre_parse.CATEGORY_NOT_DIGIT: _invert(_DIGIT),
+    sre_parse.CATEGORY_WORD: _WORD,
+    sre_parse.CATEGORY_NOT_WORD: _invert(_WORD),
+    sre_parse.CATEGORY_SPACE: _SPACE,
+    sre_parse.CATEGORY_NOT_SPACE: _invert(_SPACE),
+}
+
+
+def _construct_name(op: object) -> str:
+    """The parser's name for a construct, e.g. ``ATOMIC_GROUP``."""
+    return str(getattr(op, "name", op))
+
+
+def _charset(op: object, av: object) -> tuple[tuple[int, int], ...]:
+    """The set of codepoints one atom can consume."""
+    if op is sre_parse.LITERAL:
+        return ((av, av),)  # type: ignore[misc]
+    if op is sre_parse.NOT_LITERAL:
+        return _invert(((av, av),))  # type: ignore[misc]
+    if op is sre_parse.ANY:
+        return ((0, MAX_CODEPOINT),)
+    if op is sre_parse.IN:
+        items = list(av)  # type: ignore[call-overload]
+        negated = bool(items) and items[0][0] is sre_parse.NEGATE
+        if negated:
+            items = items[1:]
+        acc: list[tuple[int, int]] = []
+        for item_op, item_av in items:
+            if item_op is sre_parse.LITERAL:
+                acc.append((item_av, item_av))
+            elif item_op is sre_parse.RANGE:
+                acc.append((item_av[0], item_av[1]))
+            elif item_op is sre_parse.CATEGORY:
+                if item_av not in _CATEGORIES:
+                    raise UnsupportedRegex(_construct_name(item_av))
+                acc.extend(_CATEGORIES[item_av])
+            else:
+                raise UnsupportedRegex(_construct_name(item_op))
+        merged = _normalise(acc)
+        return _invert(merged) if negated else merged
+    raise UnsupportedRegex(_construct_name(op))
+
+
+# --------------------------------------------------------------------------
+# Thompson automaton
+# --------------------------------------------------------------------------
+
+
+class _Automaton:
+    """A Thompson NFA: epsilon edges plus one charset per consuming edge.
+
+    Built structurally, so a path through it corresponds to a way the
+    backtracking engine can match — which is what the ambiguity search needs.
+    Kept canonical (no redundant epsilon edge for the zero-iteration case):
+    a duplicated route would read as ambiguity that the engine never has.
+    """
+
+    __slots__ = ("epsilon", "moves", "size")
+
+    def __init__(self) -> None:
+        self.epsilon: dict[int, set[int]] = {}
+        self.moves: dict[int, list[tuple[tuple[tuple[int, int], ...], int]]] = {}
+        self.size = 0
+
+    def state(self) -> int:
+        s = self.size
+        self.size += 1
+        self.epsilon[s] = set()
+        self.moves[s] = []
+        return s
+
+    def link(self, src: int, dst: int) -> None:
+        self.epsilon[src].add(dst)
+
+    def consume(self, src: int, charset: tuple[tuple[int, int], ...], dst: int) -> None:
+        self.moves[src].append((charset, dst))
+
+    def closure(self, start: int) -> set[int]:
+        seen = {start}
+        stack = [start]
+        while stack:
+            for nxt in self.epsilon[stack.pop()]:
+                if nxt not in seen:
+                    seen.add(nxt)
+                    stack.append(nxt)
+        return seen
+
+
+# Bounds this small are modelled exactly; wider ones are read as unbounded.
+#
+# A fully unrolled bound has no cycle, and "a state reachable from itself two
+# ways" is the whole basis of the analysis — so modelling a wide bound exactly
+# would prove every such pattern safe by construction, however slow it really
+# is. `(a{1,10}){1,10}` spans 100 characters and takes 14.7s on a 40-character
+# argument. Reading a wide bound as unbounded restores the cycle and catches it;
+# the price is treating `{1,10}` like `+`, which is what it amounts to for any
+# argument long enough to matter. Small bounds stay exact, so `(a{1,2}){1,2}`
+# (four characters at most, genuinely harmless) is not swept up.
+_UNROLL_CAP = 4
+
+# An exact repeat (`{n}`) adds no ambiguity of its own, so it is unrolled
+# straight up to here — `[a-f0-9]{64}` costs 64 states and stays precise.
+_EXACT_CAP = 128
+
+
+def _build(seq: object, nfa: _Automaton, start: int) -> int:
+    """Compile a parsed subpattern, returning the state it ends in."""
+    cur = start
+    for op, av in seq:  # type: ignore[attr-defined]
+        if op is sre_parse.AT:
+            continue  # anchors consume nothing
+        if op in (
+            sre_parse.LITERAL,
+            sre_parse.NOT_LITERAL,
+            sre_parse.ANY,
+            sre_parse.IN,
+        ):
+            nxt = nfa.state()
+            nfa.consume(cur, _charset(op, av), nxt)
+            cur = nxt
+        elif op is sre_parse.SUBPATTERN:
+            cur = _build(av[3], nfa, cur)  # type: ignore[index]
+        elif op is sre_parse.BRANCH:
+            end = nfa.state()
+            for branch in av[1]:  # type: ignore[index]
+                entry = nfa.state()
+                nfa.link(cur, entry)
+                nfa.link(_build(branch, nfa, entry), end)
+            cur = end
+        elif op in (sre_parse.MAX_REPEAT, sre_parse.MIN_REPEAT):
+            minimum, maximum, body = av  # type: ignore[misc]
+            bounded = maximum is not sre_parse.MAXREPEAT
+            if bounded and maximum <= _UNROLL_CAP:
+                # Narrow bound: exact, so a pattern that can only ever span a
+                # few characters is not reported as a runaway.
+                for _ in range(minimum):
+                    cur = _build(body, nfa, cur)
+                end = nfa.state()
+                nfa.link(cur, end)
+                for _ in range(maximum - minimum):
+                    cur = _build(body, nfa, cur)
+                    nfa.link(cur, end)
+                cur = end
+            elif bounded and minimum == maximum and maximum <= _EXACT_CAP:
+                for _ in range(minimum):
+                    cur = _build(body, nfa, cur)
+            else:
+                # Unbounded, or a bound wide enough to behave like one. Read
+                # as "at least `minimum`": an over-approximation, but the
+                # honest direction here, since the alternative proves wide
+                # bounds safe by construction (see `_UNROLL_CAP`).
+                for _ in range(min(minimum, _UNROLL_CAP)):
+                    cur = _build(body, nfa, cur)
+                split = nfa.state()
+                nfa.link(cur, split)
+                entry = nfa.state()
+                nfa.link(split, entry)
+                nfa.link(_build(body, nfa, entry), split)
+                end = nfa.state()
+                nfa.link(split, end)
+                cur = end
+        else:
+            raise UnsupportedRegex(_construct_name(op))
+    return cur
+
+
+def _route_multiplicity(
+    nfa: _Automaton, src: int, dst: int, budget: int = _ROUTE_BUDGET
+) -> int:
+    """Distinct epsilon routes from ``src`` to ``dst``: 0, 1, or 2 ("several").
+
+    Two epsilon routes between the same pair of consumed characters are already
+    two distinct paths — this is why ``(a+)+`` is exponential while ``a+`` is
+    not: after each ``a`` the engine may stay in the inner loop or close it and
+    open a new outer iteration.
+
+    A route may not reuse an edge. Reusing one means going round a loop without
+    consuming anything — an empty iteration, which engines prune — so it is not
+    a route the engine would actually take. That distinction is the whole
+    difference between ``(a*)*``, where an iteration can absorb one character or
+    several and the routes are genuinely different, and ``(a?)+``, where every
+    iteration matches exactly one character and the only extra "route" is the
+    empty loop. Both have an epsilon cycle; only the first is exponential.
+    """
+    found = 0
+    spent = 0
+
+    def walk(node: int, used: frozenset[tuple[int, int]]) -> None:
+        nonlocal found, spent
+        if found >= 2 or spent > budget:
+            return
+        spent += 1
+        if node == dst:
+            found += 1
+            return
+        for nxt in nfa.epsilon[node]:
+            edge = (node, nxt)
+            if edge not in used:
+                walk(nxt, used | {edge})
+
+    walk(src, frozenset())
+    return min(found, 2)
+
+
+@dataclass(frozen=True, slots=True)
+class _Step:
+    """One consuming step available from a state, after epsilon moves."""
+
+    charset: tuple[tuple[int, int], ...]
+    target: int
+    edge: tuple[int, int]
+    ambiguous_route: bool
+
+
+def _steps(nfa: _Automaton) -> dict[int, list[_Step]]:
+    table: dict[int, list[_Step]] = {}
+    for src in range(nfa.size):
+        out: list[_Step] = []
+        for mid in nfa.closure(src):
+            several = _route_multiplicity(nfa, src, mid) >= 2
+            for index, (charset, target) in enumerate(nfa.moves[mid]):
+                out.append(_Step(charset, target, (mid, index), several))
+        table[src] = out
+    return table
+
+
+def _reachable_states(nfa: _Automaton, steps: dict[int, list[_Step]]) -> set[int]:
+    """States the engine can actually be in, walking from the start state.
+
+    An ambiguous loop sitting in a part of the automaton no input can reach is
+    never explored, so flagging it would refuse a pattern that is fine in
+    practice. Only reachable states are candidates.
+    """
+    seen = set(nfa.closure(0))
+    stack = [0]
+    while stack:
+        for step in steps[stack.pop()]:
+            if step.target not in seen:
+                seen.add(step.target)
+                seen |= nfa.closure(step.target)
+                stack.append(step.target)
+    return seen
+
+
+def _pick_char(charset: tuple[tuple[int, int], ...]) -> str:
+    """A readable representative of a charset, for the example string."""
+    for candidate in _WITNESS_PREFERENCE:
+        point = ord(candidate)
+        for lo, hi in charset:
+            if lo <= point <= hi:
+                return candidate
+    lo = charset[0][0]
+    return chr(lo) if 32 <= lo < 127 else "?"
+
+
+@dataclass(frozen=True, slots=True)
+class AmbiguityWitness:
+    """Where a pattern's repetition can match the same text two ways.
+
+    ``prefix`` reaches the ambiguous state, ``pump`` is the segment matchable by
+    two distinct paths from there, and ``example`` puts them together with a
+    trailing character that cannot continue the match — a failing match being
+    what makes an engine explore combinations instead of stopping at the first
+    success.
+
+    It is a witness, not a worst case: it shows *that* the pattern is ambiguous,
+    and the ambiguity is what makes the pattern exponential, but some other
+    input may drive the cost up faster than this one does. Messages built from
+    it should point at the construct, not promise a timing.
+    """
+
+    prefix: str
+    pump: str
+    example: str
+
+
+def _reconstruct(
+    parents: dict[tuple[int, int, bool], tuple[tuple[int, int, bool], str]],
+    node: tuple[int, int, bool],
+    last: str,
+) -> str:
+    chars = [last]
+    while node in parents:
+        node, char = parents[node]
+        chars.append(char)
+    return "".join(reversed(chars))
+
+
+def _prefix_to(nfa: _Automaton, steps: dict[int, list[_Step]], goal: int) -> str:
+    """Shortest word taking the automaton from its start state to ``goal``."""
+    if goal == 0:
+        return ""
+    seen = {0}
+    queue: list[tuple[int, str]] = [(0, "")]
+    while queue:
+        state, word = queue.pop(0)
+        for step in steps[state]:
+            if step.target == goal:
+                return word + _pick_char(step.charset)
+            if step.target not in seen:
+                seen.add(step.target)
+                queue.append((step.target, word + _pick_char(step.charset)))
+    return ""
+
+
+def _rejecting_char(steps: dict[int, list[_Step]], state: int) -> str:
+    """A character no continuation accepts, so the match must fail and unwind.
+
+    Taken from the complement of what the state can consume rather than a fixed
+    shortlist: a negated class like ``[^,]`` accepts every character a shortlist
+    would offer, and the only one that stops it is the comma it excludes.
+    Returns ``""`` when every character is accepted (a bare ``.``), in which case
+    no example can be made to fail.
+    """
+    accepted: list[tuple[int, int]] = []
+    for step in steps[state]:
+        accepted.extend(step.charset)
+    remaining = _invert(_normalise(accepted)) if accepted else ((0, MAX_CODEPOINT),)
+    for lo, hi in remaining:
+        for point in range(lo, min(hi, 0x7E) + 1):
+            if 0x21 <= point <= 0x7E:  # printable ASCII, so the example reads
+                return chr(point)
+    return ""
+
+
+def find_exponential_ambiguity(
+    pattern: str, budget: int = DEFAULT_BUDGET
+) -> AmbiguityWitness | None | bool:
+    """Look for two distinct paths that leave a state and return to it.
+
+    Returns an :class:`AmbiguityWitness` when the pattern can backtrack
+    exponentially, ``False`` when it provably cannot, and ``None`` when the
+    search ran out of budget and the answer is unknown.
+
+    Two matches are walked in lock-step over the same word from ``(q, q)``.
+    They diverge when they take different edges, or when one of them reaches
+    its edge by an epsilon route that is itself ambiguous. Coming back to
+    ``(q, q)`` after diverging exhibits one word with two distinct paths, which
+    is the exponential-ambiguity condition.
+    """
+    parsed = sre_parse.parse(pattern, re.ASCII)
+    nfa = _Automaton()
+    _build(parsed, nfa, nfa.state())
+    steps = _steps(nfa)
+    reachable = _reachable_states(nfa, steps)
+    spent = 0
+    for start in range(nfa.size):
+        if start not in reachable or not steps[start]:
+            continue
+        origin = (start, start, False)
+        seen = {origin}
+        parents: dict[tuple[int, int, bool], tuple[tuple[int, int, bool], str]] = {}
+        stack = [origin]
+        while stack:
+            node = stack.pop()
+            left, right, diverged = node
+            spent += 1
+            if spent > budget:
+                return None
+            for a in steps[left]:
+                for b in steps[right]:
+                    shared = _intersect(a.charset, b.charset)
+                    if not shared:
+                        continue
+                    now = (
+                        diverged
+                        or a.edge != b.edge
+                        or a.ambiguous_route
+                        or b.ambiguous_route
+                    )
+                    char = _pick_char(shared)
+                    if a.target == start and b.target == start and now:
+                        pump = _reconstruct(parents, node, char)
+                        prefix = _prefix_to(nfa, steps, start)
+                        tail = _rejecting_char(steps, start)
+                        return AmbiguityWitness(
+                            prefix=prefix,
+                            pump=pump,
+                            example=prefix + pump * _EXAMPLE_REPEATS + tail,
+                        )
+                    nxt = (a.target, b.target, now)
+                    if nxt not in seen:
+                        seen.add(nxt)
+                        parents[nxt] = (node, char)
+                        stack.append(nxt)
+    return False

--- a/tests/security/test_regex_safety.py
+++ b/tests/security/test_regex_safety.py
@@ -1,0 +1,268 @@
+"""Exponential-ambiguity detection — the linear-time half of RE2 parity.
+
+``_validate_re2`` keeps a policy's regexes to syntax RE2 can run. This suite
+covers the other half: a pattern both engines accept but only one of them
+finishes. The evaluator matches with ``re.search`` (backtracking) while a WASM
+bundle runs RE2 (linear), so an exponentially ambiguous pattern hangs the engine
+that decides whether a tool call is allowed — on arguments a model writes.
+
+Both error directions are covered, because both are expensive:
+
+  * a **miss** leaves the hang in place, so every blow-up shape is here (nested
+    quantifier, ambiguous alternation, nullable loop body, and the "two epsilon
+    routes to the same edge" case a syntactic rule cannot see);
+  * a **false alarm** refuses a policy that was always fine, so the linear
+    corpus holds every ``matches`` pattern this repo ships plus the shapes a
+    naive "nested quantifier" rule would wrongly reject — above all
+    ``^([a-z0-9-]+[.])+corp[.]com$``, which is nested *and* linear because the
+    mandatory ``[.]`` forces one split per iteration.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from hexgate.security.constraints import ConstraintParseError, parse_constraint
+from hexgate.security.regex_safety import (
+    AmbiguityWitness,
+    UnsupportedRegex,
+    find_exponential_ambiguity,
+)
+
+# Each entry blows up for a different reason, so a detector that special-cases
+# one shape fails the rest.
+EXPONENTIAL = [
+    "^(a+)+$",  # the textbook nested quantifier
+    "^([a-z]+)*$",  # star of plus
+    r"^(\d+)+$",  # the same, over a category
+    "^([a-zA-Z0-9_-]+)*@corp[.]com$",  # a plausible email allowlist
+    "^(a|aa)+$",  # branches that overlap
+    "^(a|a)+$",  # duplicated branches: one word, two edges
+    "^(ab|a|b)+$",  # branches overlapping after one char
+    "(x+x+)+y",  # two inner loops sharing an alphabet
+    "^(a*)*$",  # nullable body, iterations of any length
+    "^(_?/*)*$",  # the same, spelled less obviously
+    "^(a*)+$",
+    "^([a-z]*)*$",
+    r"^(\w+\s?)*$",  # trailing optional frees the seam
+    "^([^,]+)+$",  # a negated class, the shape a CSV-ish rule reaches for
+]
+
+# Must keep working. First block: every ``matches`` pattern the repo ships
+# (docs, tests, examples). Second: shapes a syntactic rule would wrongly reject.
+LINEAR = [
+    "^inv_[0-9]+$",
+    "^INC-[0-9]+$",
+    r"^\d+$",
+    "[0-9]+",
+    "^(web|api)-[a-z0-9]+$",
+    r"^https://drive\.hexamind\.ai/",
+    "(?P<n>[0-9]+)",
+    "^([a-z0-9-]+[.])+corp[.]com$",  # nested, but each iteration is forced
+    "^[a-z]+(_[a-z]+)*$",
+    "^(/[a-z]+)+/data$",
+    "^v[0-9]+([.][0-9]+)*$",
+    "^(foo|bar)+$",
+    "^(?:abc)+$",
+    "^(a?b)*$",
+    "^a{2,4}$",
+    "^[A-Z]{2,4}-[0-9]{1,6}$",
+    "^[a-f0-9]{64}$",
+    "^[a-z]*[0-9]*$",
+    "^[a-z]+@[a-z]+[.]com$",
+    "^/api/v[0-9]+/[a-z]+$",
+    r"^\w+$",
+    # An epsilon cycle is not enough on its own: every iteration of `(a?)+`
+    # matches exactly one character, so there is only one way to split the
+    # input and the empty iterations are pruned. Contrast `^(a*)*$` above,
+    # where an iteration can absorb one character or several.
+    "^(a?)+$",
+    "^(x?)+$",
+    "^(a?b?)+$",
+    # Wildcards and negated classes are ordinary policy material; only the
+    # nested forms above are a problem.
+    "^.+$",
+    "^.*x$",
+    "^[^,]+$",
+    "^([^,]+,)+[^,]+$",  # forced by the mandatory comma, like the domain case
+]
+
+
+def _constraint(pattern: str) -> str:
+    """The constraint line carrying ``pattern``, escaped as the grammar wants."""
+    return f"matches(args.v, {json.dumps(pattern)})"
+
+
+@pytest.mark.parametrize("pattern", EXPONENTIAL)
+def test_exponential_patterns_are_detected(pattern: str) -> None:
+    witness = find_exponential_ambiguity(pattern)
+    assert isinstance(witness, AmbiguityWitness), pattern
+    assert witness.pump, "a witness must name the segment that can be split"
+
+
+@pytest.mark.parametrize("pattern", LINEAR)
+def test_linear_patterns_are_not_flagged(pattern: str) -> None:
+    # A false alarm refuses a policy that was always fine, so this is the more
+    # important half of the suite.
+    assert find_exponential_ambiguity(pattern) is False, pattern
+
+
+@pytest.mark.parametrize("pattern", EXPONENTIAL)
+def test_witness_example_is_a_failing_match(pattern: str) -> None:
+    """The reported string must be one the engine cannot match.
+
+    A witness that matched would return on the first success and demonstrate
+    nothing; a failing match is what obliges the engine to work through the
+    combinations. Wall-clock assertions would be flaky in CI, and the witness is
+    deliberately not claimed to be the worst input for the pattern (see
+    :class:`AmbiguityWitness`), so the assertion is the structural property the
+    example is built to have.
+    """
+    witness = find_exponential_ambiguity(pattern)
+    assert isinstance(witness, AmbiguityWitness)
+    assert witness.pump in witness.example
+    assert re.compile(pattern, re.ASCII).search(witness.example) is None, pattern
+
+
+@pytest.mark.parametrize("pattern", EXPONENTIAL)
+def test_policy_load_refuses_exponential_regex(pattern: str) -> None:
+    # End-to-end contract: such a policy never loads, so it cannot reach a
+    # deployment where one engine hangs and the other does not.
+    with pytest.raises(ConstraintParseError, match="backtrack exponentially"):
+        parse_constraint(_constraint(pattern))
+
+
+@pytest.mark.parametrize("pattern", LINEAR)
+def test_policy_load_still_accepts_linear_regex(pattern: str) -> None:
+    parse_constraint(_constraint(pattern))
+
+
+def test_error_names_the_pattern_and_how_to_fix_it() -> None:
+    with pytest.raises(ConstraintParseError) as excinfo:
+        parse_constraint(_constraint("^(a+)+$"))
+    message = str(excinfo.value)
+    assert "^(a+)+$" in message
+    # An actionable error says what to do, not only what is wrong.
+    assert "Rewrite" in message
+
+
+def test_budget_exhaustion_is_undecided_rather_than_a_guess() -> None:
+    # Running out of budget must report "unknown" so the caller can fail closed,
+    # never False — which would wave a bomb through.
+    assert find_exponential_ambiguity("^(a+)+$", budget=1) is None
+
+
+def test_undecided_pattern_is_refused_at_load(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "hexgate.security.constraints.find_exponential_ambiguity",
+        lambda pattern, *args, **kwargs: None,
+    )
+    parse_constraint.cache_clear()
+    with pytest.raises(ConstraintParseError, match="too complex to verify"):
+        parse_constraint(_constraint("^[a-z]+$"))
+    parse_constraint.cache_clear()
+
+
+def test_realistic_patterns_stay_far_inside_the_budget() -> None:
+    # The check runs at policy load, not per decision, but it still must not
+    # become the new slow path: a tight budget suffices for everything shipped.
+    for pattern in LINEAR:
+        assert find_exponential_ambiguity(pattern, budget=20_000) is not None, pattern
+
+
+def test_unsupported_construct_is_reported_not_swallowed() -> None:
+    # Backreferences are already refused by `_validate_re2`; if one ever reached
+    # this module it must say so rather than silently answering "linear".
+    with pytest.raises(UnsupportedRegex):
+        find_exponential_ambiguity(r"(a)\1")
+
+
+# Constructs Python's `re` accepts that RE2 has no equivalent for. Verified with
+# `opa eval`: both are undefined under RE2 while Python matches, so they are the
+# same engine-divergence class `_validate_re2` already refuses — they simply
+# were not on its list, because a source-text rule cannot tell `a*+` from `\++`.
+RE2_MISSING = ["(?>a+)+", "a*+", "(?>[a-z]+)", "a{2,3}+"]
+
+
+@pytest.mark.parametrize("pattern", RE2_MISSING)
+def test_re2_missing_constructs_are_refused(pattern: str) -> None:
+    with pytest.raises(ConstraintParseError, match="RE2 does not have"):
+        parse_constraint(_constraint(pattern))
+
+
+def test_no_construct_escapes_as_an_unexpected_exception() -> None:
+    """The grammar's no-crash guarantee: only ConstraintParseError comes out.
+
+    A construct the analysis cannot model must be refused as a config error, not
+    surface as an internal exception from the regex checker.
+    """
+    for pattern in RE2_MISSING + EXPONENTIAL + ["(?i)abc", r"\w+", "[[]+"]:
+        try:
+            parse_constraint(_constraint(pattern))
+        except ConstraintParseError:
+            pass
+
+
+def test_case_insensitive_patterns_are_still_analysed() -> None:
+    # `(?i)` is folded into the character sets by the parser, so the analysis
+    # sees the real alphabet rather than silently under-approximating it.
+    assert find_exponential_ambiguity("(?i)(a+)+") is not False
+    assert find_exponential_ambiguity("(?i)abc") is False
+
+
+# Bounded repeats. A wide bound behaves like an unbounded one for any argument
+# long enough to matter — `^(a{1,10}){1,10}$` spans 100 characters and takes 14.7s
+# on a 40-character argument — while a narrow one can only ever span a few
+# characters and is harmless. Both must be judged on that difference, not on the
+# fact that they are bounded.
+BOUNDED_RUNAWAY = ["^(a{1,10}){1,10}$", "^([a-z]{1,8}){1,8}$", "^(a{1,5})+$"]
+BOUNDED_HARMLESS = [
+    "^(a{1,2}){1,2}$",
+    "^(a{1,4}){1,4}$",
+    "^a{2,4}$",
+    "^[a-f0-9]{64}$",
+    "^[A-Z]{2,4}-[0-9]{1,6}$",
+    r"^(\d{1,3}\.){3}\d{1,3}$",  # an IPv4 rule
+    r"^(\w{1,63}\.){1,10}[a-z]{2,6}$",  # a hostname rule
+]
+
+
+@pytest.mark.parametrize("pattern", BOUNDED_RUNAWAY)
+def test_wide_bounds_are_not_proved_safe_by_their_bound(pattern: str) -> None:
+    """A wide bound must not certify a pattern as linear.
+
+    Unrolling a bound exactly leaves an automaton with no cycle, and "a state
+    reachable from itself two ways" is what the analysis looks for — so exact
+    modelling would prove every bounded pattern safe by construction, however
+    slow it really is. Wide bounds are therefore read as unbounded.
+    """
+    assert find_exponential_ambiguity(pattern), pattern
+
+
+@pytest.mark.parametrize("pattern", BOUNDED_HARMLESS)
+def test_narrow_bounds_are_left_alone(pattern: str) -> None:
+    # The other half: reading *every* bound as unbounded would refuse patterns
+    # that can only ever span a handful of characters, including the ordinary
+    # IPv4 and hostname shapes.
+    assert find_exponential_ambiguity(pattern) is False, pattern
+
+
+def test_wildcard_repetition_is_detected() -> None:
+    """``^(.+)+$`` is exponential too, and needs its own case.
+
+    ``.`` accepts every character, so no trailing character can make the match
+    fail and :func:`_rejecting_char` returns nothing. The witness therefore
+    cannot be a failing string the way it is for every other shape, which is why
+    this pattern is not in ``EXPONENTIAL`` (that list also asserts the example
+    fails to match). The ambiguity is real regardless: on an input that does
+    fail — a newline in the middle, which ``.`` cannot cross — matching takes
+    0.002s at 16 characters, 0.034s at 20 and 0.582s at 24.
+    """
+    assert isinstance(find_exponential_ambiguity("^(.+)+$"), AmbiguityWitness)
+    with pytest.raises(ConstraintParseError, match="backtrack exponentially"):
+        parse_constraint(_constraint("^(.+)+$"))


### PR DESCRIPTION
Closes #134.

## The gap

`_validate_re2` keeps a policy's `matches` patterns to syntax RE2 can run, so a
policy tested on the pydantic engine cannot mean something else once it ships as
a WASM bundle. That covers what the two engines can **express**. It says nothing
about what they **cost**.

Python's `re` backtracks; RE2 does not. `^(a+)+$` is accepted by both, linear
under RE2, exponential under `re`. Measured through the evaluator's own entry
point (`check_constraints`), with the pattern written as an email allowlist:

```
matches(args.email, "^([a-zA-Z0-9_-]+)*@corp[.]com$")
```

| argument length | 20 | 24 | 26 | 28 | 30 | 32 | 34 |
|---|---|---|---|---|---|---|---|
| time to decide one call | 0.04s | 0.54s | 2.21s | 8.74s | 37.8s | 149s | 596s |

Lengths 20-28 were timed through `check_constraints`; 30 and beyond with the
same `re.search` call `_eval_call` makes, since with this change in place the
pattern no longer loads. The rate holds across the range at roughly four times
longer per two characters added (x4.1, x3.9, x4.0), so a 34-character argument
already costs ten minutes. Continuing that slope puts the low forties in the
hours — that last step is an extrapolation, not a measurement. `hexgate/security/` has no
timeout and no argument-size cap, so the component deciding whether a tool call
is allowed can be stalled by the argument it exists to filter — and those
arguments are model-written and caller-influenced.

This is reachable wherever the pydantic engine runs, which per `source.py`
includes the documented local mode and the "platform served no compiled bundle"
fallback, not only development.

## The change

Patterns are refused at **policy load**, where the RE2 syntax check already
lives, so nothing changes on the decision path: the check sits inside the
already-cached `parse_constraint`, and its worst case over the patterns this
repo ships measured 3ms, once.

Detection is exponential ambiguity — whether some state of the automaton can be
reached from itself, over one word, by two distinct paths. That is precisely
the property RE2's construction rules out, which is why RE2 can promise linear
time, so the check tests the divergence itself rather than a syntax that
correlates with it.

A syntactic "nested quantifier" rule would be wrong in both directions, and both
cases are in the test corpus:

- it would **reject** `^([a-z0-9-]+[.])+corp[.]com$` — nested, and linear,
  because the mandatory `[.]` forces one split per iteration;
- it would **miss** `^(a|aa)+$` — not nested, and exponential.

Three verdicts, each with a defined outcome: a witness refuses the pattern, a
proof of linearity accepts it, and an exhausted search budget refuses it as
unverifiable rather than guessing. The error names the pattern and an example:

```
regex '^(a+)+$' in 'matches(args.v, "^(a+)+$")' can backtrack exponentially:
the segment 'aa' can be matched more than one way, so on an input like
'aaaaaaaaaa!' the number of combinations Python's engine must try doubles as
the input grows, while the WASM engine stays linear. Rewrite the repetition so
each iteration has only one way to match (a required separator between
iterations, or a single quantifier instead of a nested one)
```

### Wide repetition bounds

A bound wider than 4 is read as unbounded. Unrolling a bound exactly leaves an
automaton with no cycle, and "a state reachable from itself two ways" is the
whole basis of the analysis — so exact modelling would certify every bounded
pattern as linear however slow it really is. `^(a{1,10}){1,10}$` spans 100
characters and takes 14.7s on a 40-character argument.

Narrow bounds stay exact, so patterns that can only ever span a few characters
are not swept up: `^(a{1,4}){1,4}$`, and the ordinary `^(\d{1,3}\.){3}\d{1,3}$`
and `^(\w{1,63}\.){1,10}[a-z]{2,6}$` shapes.

## A second, smaller finding

Two constructs pass `_validate_re2` on `main` and are undefined under RE2:
**atomic groups** `(?>a+)+` and **possessive quantifiers** `a*+`. Verified with
the method the existing comment cites:

```
$ opa eval 'regex.match("(?>a+)+", "aaa")'
{}                     # undefined under RE2
>>> re.search(r"(?>a+)+", "aaa")
<re.Match object; span=(0, 3), match='aaa'>
```

They are the same divergence class the existing list covers; they were missing
because a source-text rule cannot tell `a*+` from `\++`, a repeated literal
plus. Detected from the parse tree instead.

Fixing this is required by the change either way: without it, those two patterns
escaped as an unexpected exception type instead of `ConstraintParseError`, which
the grammar's no-crash guarantee forbids.

## Validation

- **Every flagged pattern was confirmed**: for 50 randomly generated patterns
  the check refused, an input was hunted that measurably explodes. 50/50
  confirmed, no false positive left standing. One needed a hand-built string
  (`'0-' + 'a'*12 + '!'`: 22k steps at 8 characters, 114k at 10, budget
  exhausted at 12) that the generic generator never produced.
- **And the reverse direction**: of 118 generated patterns, 27 were passed as
  linear and each was then attacked with anchored, pumped inputs drawn from its
  own alphabet. None exploded — 0 false negatives.
- Both directions were re-run after every change to the model, since tightening
  one moves the other. Measurement uses a step-bounded backtracking simulator
  rather than wall-clock, so the comparison is deterministic and cannot hang.
- The corpus holds every `matches` pattern this repo ships (docs, tests,
  examples); all still load.
- New module at 97.0% branch coverage; the six uncovered lines are defensive
  guards for constructs the parser does not produce in practice.
- The corpus covers wildcards and negated classes too: `^(.+)+$` and
  `^([^,]+)+$` are refused, while `^.+$`, `^[^,]+$` and
  `^([^,]+,)+[^,]+$` load as before.
- Full SDK suite: identical pass/fail sets before and after. This machine has 24
  pre-existing failures on `main` — bundle-hash tests that mismatch under
  Windows line endings — and the same 24 after, with no additions.
- `test_engine_parity.py` and `test_rego_compile.py` ran against a real `opa`
  binary rather than skipping.

## What this does not cover

Cost that grows **polynomially** rather than by doubling is out of scope, and
that is a decision rather than an oversight.

| pattern | 1 000 chars | 2 000 chars | 4 000 chars |
|---|---|---|---|
| `^a*a*a*$` | 1.06s | 8.55s | 67.6s |

Two different repetitions absorbing the same text; no crafted string needed,
just a long argument, and RE2 stays linear on it. A detector for it was written
and then dropped from this change, because its precision could not be
demonstrated: it reports the *structure*, and the structure is not always
reachable as a slow input. `^.*foo.*$` has it and is linear (measured flat to
8 000 characters), because the pattern matches as soon as `foo` appears, so no
input both exercises the ambiguity and fails.

Closing that needs the automaton to model acceptance, so the analysis can
require a failing continuation after the pumped section. That is a larger change
and belongs in its own review. It is written up in the ADR with the numbers.

Two further limits, stated rather than implied: anchors (`^`, `\b`) are treated
as consuming nothing, which is an over-approximation I did not find a failing
case for but have not proved safe; and the 4-character bound threshold is a
judgement call, not a derived constant.

## One judgement call worth your view

The refusal applies even to a deployment that only ever runs the WASM engine,
where such a pattern would be safe. That is deliberate — one policy language,
one behaviour, whichever engine is underneath — and the rewrite is usually
trivial (`(a+)+` → `a+`). But it is a strictness decision rather than a
technical necessity, and if you would rather have it as an `analyzer.py` lint
than a hard refusal, that is a small change to make.
