### PR TITLE
feat(sdk): agent-level admission enforcement (AgentGate, closed-world agent keys)

### DIFF
--- a/deploy/agent_gate_demo.py
+++ b/deploy/agent_gate_demo.py
@@ -1,0 +1,287 @@
+"""Hexgate agent-gate demo (marimo) — gate whole agents by policy, in code.
+
+A code-only tour of agent-level enforcement, the sibling to the egress gate. No
+platform, no API key, no model call. Hexgate normally gates the *tool call* the
+model proposes; this gate sits one level up and asks two questions from the same
+policy engine:
+
+  * admission — may this caller, in this role, *run this agent at all*?
+  * reach     — which *other* agents may it call as a tool or hand off to?
+
+Both lower to synthetic tool keys (`agent.run`, `agent.tool:<name>`,
+`agent.handoff:<name>`), so the same engine decides them through the same path as
+any tool. Admission is enforced at run entry today; the handoff interception in
+the framework adapters is the next slice, but the policy already decides it.
+
+Run with `uv run --with marimo marimo edit deploy/agent_gate_demo.py`.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import yaml
+
+    import marimo as mo
+
+    from hexgate import HexgateContext
+    from hexgate.security import (
+        AGENT_RUN_TOOL,
+        AgentNotAdmittedError,
+        agent_target_key,
+        resolve_agent_gate,
+    )
+    from hexgate.security.enforcer import build_enforcer
+    from hexgate.security.policy_set import load_policy_set_from_dict
+
+    return (
+        AGENT_RUN_TOOL,
+        AgentNotAdmittedError,
+        HexgateContext,
+        agent_target_key,
+        build_enforcer,
+        load_policy_set_from_dict,
+        mo,
+        resolve_agent_gate,
+        yaml,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # 🚪 Hexgate — gating whole agents
+
+        The tool gate answers "may the model run *this tool* with *these args*?".
+        The **agent gate** sits one level up and answers two more, from the same
+        policy engine:
+
+        - **admission** — may this caller, in this role, *start this agent at all*?
+          Checked at run entry, before the model sees anything.
+        - **reach** — which *other* agents may it call as a tool, or hand the whole
+          conversation off to?
+
+        Both lower to synthetic tool keys (`agent.run`, `agent.tool:<name>`,
+        `agent.handoff:<name>`), so there is no second decision path: the same
+        engine, constraints, and audit apply. This demo is **code-only** — no
+        platform, no API key, no model call.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 1 · The policy""")
+    return
+
+
+@app.cell
+def _(load_policy_set_from_dict, yaml):
+    # A refund agent that can consult a billing-bot. support may run it and call
+    # billing-bot as a tool, but must never hand the customer conversation off.
+    # billing may hand off, with a human's approval and only one hop deep.
+    # contractor cannot start the agent at all. Any undefined role falls to
+    # `default`, which denies admission — closed-world for free.
+    POLICY_YAML = """
+version: 1
+roles:
+  default:
+    default_policy: { mode: deny }
+    admission: { mode: deny }
+
+  support:
+    default_policy: { mode: deny }
+    admission: { mode: allow }
+    agents:
+      billing-bot:
+        via: [tool]                  # consult as a tool; never hand off
+        mode: allow
+
+  billing:
+    default_policy: { mode: deny }
+    admission: { mode: allow }
+    agents:
+      billing-bot:
+        via: [tool, handoff]         # may also hand off...
+        mode: approval_required      # ...with a human's approval
+        constraints: ["args.depth <= 1"]   # ...and only one hop deep
+
+  contractor:
+    default_policy: { mode: deny }
+    admission: { mode: deny }        # cannot start the agent at all
+"""
+    ps = load_policy_set_from_dict(yaml.safe_load(POLICY_YAML))
+    return POLICY_YAML, ps
+
+
+@app.cell
+def _(POLICY_YAML, mo):
+    mo.md(
+        f"""
+        Written once, in ordinary policy YAML. `admission` is ingress (may I run
+        this agent), `agents` is egress (which agents may I reach, and how).
+
+        ```yaml{POLICY_YAML}```
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 2 · Admission — decided at run entry
+
+        This is the exact check `HexgateAgent` runs at the top of every run, before
+        the model. A refused caller never starts the agent; the run raises
+        `AgentNotAdmittedError` instead. No model call is involved, so we drive the
+        gate directly here.
+        """
+    )
+    return
+
+
+@app.cell
+def _(
+    AgentNotAdmittedError,
+    HexgateContext,
+    build_enforcer,
+    mo,
+    ps,
+    resolve_agent_gate,
+):
+    def _admit(role):
+        # A fresh enforcer + gate, exactly as enforce_policy builds them.
+        gate = resolve_agent_gate(build_enforcer(ps, agent_name="refund_agent"))
+        roles = [role] if role is not None else []
+        with HexgateContext(user_id="demo", user_roles=roles).sync_scope():
+            try:
+                gate.check_admission()
+                return "allow", ""
+            except AgentNotAdmittedError as exc:
+                return exc.decision.outcome.value, exc.decision.reason
+
+    _label = {
+        "allow": "✅ admitted",
+        "deny": "❌ refused",
+        "needs_approval": "🔶 approval",
+    }
+    _cases = [
+        "support",  # admitted
+        "billing",  # admitted
+        "contractor",  # refused (admission: deny)
+        "intern",  # undefined role -> falls to default -> refused
+        None,  # no role at all -> default -> refused
+    ]
+    _rows = ["| caller role | may run `refund_agent`? |", "|---|---|"]
+    for _role in _cases:
+        _outcome, _ = _admit(_role)
+        _shown = _role if _role is not None else "_(none)_"
+        _rows.append(f"| `{_shown}` | {_label.get(_outcome, _outcome)} |")
+    mo.md("\n".join(_rows))
+    return (_admit,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 3 · Reach — which agents may this agent call or hand off to
+
+        The same engine decides agent-to-agent reach. `agent.tool:<name>` is
+        calling a sub-agent as a tool (the orchestrator keeps control);
+        `agent.handoff:<name>` is transferring the whole conversation. A policy can
+        allow one and gate the other.
+
+        > Admission (section 2) is enforced at run entry today. The handoff
+        > *interception* inside the framework adapters is the next slice; the policy
+        > below already decides it through the same path.
+        """
+    )
+    return
+
+
+@app.cell
+def _(agent_target_key, mo, ps):
+    def _reach(role, via, target, **args):
+        return ps.evaluate(
+            role=role, tool=agent_target_key(via, target), args=args
+        ).outcome.value
+
+    _label = {"allow": "✅ allow", "deny": "❌ deny", "needs_approval": "🔶 approval"}
+    # (role, via, args, note)
+    _cases = [
+        ("support", "tool", {}, "consult billing-bot as a tool"),
+        ("support", "handoff", {}, "hand the customer to billing-bot"),
+        ("billing", "tool", {"depth": 0}, "consult billing-bot as a tool"),
+        ("billing", "handoff", {"depth": 0}, "hand off (1 hop)"),
+        ("billing", "handoff", {"depth": 2}, "hand off (2 hops — over the cap)"),
+    ]
+    _rows = ["| role | reach `billing-bot` via | decision | |", "|---|---|---|---|"]
+    for _role, _via, _args, _note in _cases:
+        _outcome = _reach(_role, _via, "billing-bot", **_args)
+        _rows.append(
+            f"| `{_role}` | `{_via}` | {_label.get(_outcome, _outcome)} | {_note} |"
+        )
+    mo.md("\n".join(_rows))
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 4 · Your turn""")
+    return
+
+
+@app.cell
+def _(mo):
+    role_form = (
+        mo.md("**Caller role** {role}")
+        .batch(
+            role=mo.ui.dropdown(
+                options=["support", "billing", "contractor", "intern"],
+                value="support",
+            )
+        )
+        .form(submit_button_label="▶ Check admission")
+    )
+    role_form
+    return (role_form,)
+
+
+@app.cell
+def _(_admit, mo, role_form):
+    if role_form.value is None:
+        _out = mo.callout(
+            mo.md("Pick a role and click **▶ Check admission**."), kind="info"
+        )
+    else:
+        _role = role_form.value["role"]
+        _outcome, _reason = _admit(_role)
+        if _outcome == "allow":
+            _out = mo.callout(
+                mo.md(f"`{_role}` is **admitted** — the agent run starts."),
+                kind="success",
+            )
+        else:
+            _detail = f"\n\nreason: {_reason}" if _reason else ""
+            _out = mo.callout(
+                mo.md(
+                    f"`{_role}` is **refused** (`{_outcome}`) — the run never "
+                    f"starts, `AgentNotAdmittedError` is raised.{_detail}"
+                ),
+                kind="danger",
+            )
+    _out
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/docs/adr/R-AGENT-002-agent-keys-compose-through-the-linker.md
+++ b/docs/adr/R-AGENT-002-agent-keys-compose-through-the-linker.md
@@ -1,0 +1,43 @@
+# R-AGENT-002: Agent-level rules compose through the boundary/capability linker; agent keys are closed-world
+
+**Status:** Accepted · 2026-08-26 · supersedes the opt-in/closed-world portion of R-AGENT-001
+**Applies to:** `hexgate/security/policy.py`, `hexgate/security/rego.py`, `hexgate/security/linker.py`, `hexgate/security/policy_set.py`, `hexgate/security/bundle.py`, `hexgate/security/agent_gate.py`
+
+## Decision
+
+Agent-level rules (`admission` / `agents`, lowered to `agent.run` / `agent.tool:<t>` / `agent.handoff:<t>` keys) MUST compose through the same model as tools (R-POL-001), not a separate runtime fold.
+
+- **Agent keys fold through the linker.** `_fold_tool` and `_tool_names` MUST operate over `effective_tools`, so an `agent.*` key composes exactly like a tool key: a boundary deny wins absolutely and is role-independent; a ceiling boundary makes an unlisted key ineligible; capabilities grant and union; a capability that denies an agent key is a `LinkError`, same as any tool. `admission` / `agents` become allowed module fields.
+- **Agent keys are closed-world.** An unlisted `agent.*` key (admission *and* reach) MUST deny, regardless of `default_policy`. This replaces R-AGENT-001's `agent.run` opt-in-allow: a role that is not granted admission is denied, so a silent co-role can neither admit an unknown caller nor defeat an explicit deny.
+- **Engagement is opt-in and derived, separate from composition.** The agent gate MUST fire only when the policy configures the block — `PolicyEngine.declares_admission()` (and the reach equivalent), derived from whether any resolved role carries the key, and carried in the signed bundle manifest for WASM. An agent whose policy declares no admission is never gated and runs exactly as before. This is what keeps closed-world from locking out agents that don't use admission.
+- **Authoritative, role-independent deny is a boundary.** A per-role rule (single-file or a capability) is per-role and composes by union like a tool rule; to bar a caller regardless of their other roles, the deny MUST be a boundary. Single-file agent rules are not special-cased: a single-file per-role `deny` behaves exactly like a single-file per-role tool `deny`.
+
+## Why
+
+Agent-level enforcement had grown a second composition model — per-role blocks folded by the runtime permissive union — and it leaked two fail-opens: unknown callers were admitted unless `default` denied, and an `admission: deny` was defeated by any admission-silent co-role. Both were artifacts of `agent.run` opt-in-allow (a silent role *granted* admission). The policy system already has the model that fixes them: boundaries are role-independent and deny-wins, so a boundary deny cannot be co-role-defeated, and a ceiling denies the unlisted. Making agent keys closed-world and folding them through the linker removes the fail-opens structurally instead of papering over them with a lint.
+
+Closed-world reintroduces the lockout R-AGENT-001's opt-in avoided (a role not granted admission is denied), but that is the correct fail-closed posture for a gate — and the engagement flag confines it to agents that actually configure admission. An agent that never mentions admission is untouched; one that does must grant it where it wants callers admitted (e.g. `admission: allow` on `default` for broad access). Fail-closed-with-explicit-grants beats fail-open-by-default for a security layer.
+
+Composition and engagement are deliberately separate: engagement answers "is this gate configured at all" (opt-in, backward-compatible), composition answers "how do the rules combine" (the linker fold). Tangling them was the original mistake.
+
+## Consequences
+
+- The two review fail-opens are fixed by construction: unknown/unrecognized callers deny (closed-world), and a silent co-role denies rather than admitting, so it cannot override a deny.
+- The engine simplifies: `agent.run` joins the reach keys as plain closed-world, so the opt-in-allow branch in `get_tool_policy`, the per-role `agent.run` rule in the Rego compiler, and its golden-fixture churn all go away.
+- Agent-level rules gain ceilings and authoritative role-independent denies once authored in the modular layout; single-file policies keep per-role semantics identical to tools.
+- Enforcement is still the WASM for bundles; `declares_admission()` (manifest flag) only tells the gate whether to fire.
+- Supersedes R-AGENT-001's opt-in-allow and the `agents:`-presence reach-engagement wording; R-AGENT-001's engagement-flag and manifest mechanism survive, now uniform for admission and reach.
+
+## Rejected alternatives
+
+- **Keep the single-file opt-in model, add a `permissive-admission` lint.** Ships the fail-opens behind lint-only mitigation and keeps a second composition model contradicting R-POL-001.
+- **A bespoke deny-wins multi-role fold for admission only.** Re-invents what role-independent boundaries already provide, and only for one gate.
+- **Reject single-file per-role agent `deny`.** Inconsistent — a single-file tool `deny` is allowed and per-role; agent keys should match. Authoritative denies are boundaries, by the same rule as tools.
+
+## Verify
+
+```
+pytest tests/security/test_agent_policy.py tests/security/test_linker.py tests/security/test_agent_gate.py -q
+# unlisted agent.run denies; a boundary agent deny is role-independent; a capability
+# that denies an agent key is a LinkError; declares_admission drives engagement.
+```

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     # eventually import from this module).
     from hexgate.cloud.client import HexgateClient
     from hexgate.guards.types import Guard, GuardObserver
+    from hexgate.security.agent_gate import AgentGate
     from hexgate.security.bans import BanGate
     from hexgate.security.binding import PolicyBinding
     from hexgate.security.enforcer import DecisionObserver, PolicyEnforcer
@@ -334,6 +335,7 @@ class HexgateAgent:
         binding: PolicyBinding | None = None,
         hexgate_client: HexgateClient | None = None,
         ban_gate: BanGate | None = None,
+        agent_gate: AgentGate | None = None,
     ) -> None:
         # Private: run only via ainvoke/astream_events, which apply policy
         # refresh + the ban gate. Reaching self._graph directly skips both.
@@ -368,6 +370,10 @@ class HexgateAgent:
         # Kill-switch gate; attached by load_hexgate_agent (platform path only —
         # no gate without a control plane). Threaded through with_tools rebuilds.
         self._ban_gate: BanGate | None = ban_gate
+        # Admission gate; attached by enforce_policy alongside the binding (local,
+        # no control plane needed). Threaded through with_tools rebuilds. Whether it
+        # actually refuses is decided per run from the current policy.
+        self._agent_gate: AgentGate | None = agent_gate
         # api_key intentionally omitted — create_agent has no explicit api_key param
         # (only hexgate_client, attached post-init by _bind_policy). If one is added,
         # thread it through here too, or usage events will keep silently resolving
@@ -396,6 +402,7 @@ class HexgateAgent:
         """
         await _refresh_policy_safely(self)
         await self._check_ban()
+        await self._check_admission()
         return await self._graph.ainvoke(
             payload, config=self._with_usage_callback(config)
         )
@@ -415,6 +422,7 @@ class HexgateAgent:
         """
         await _refresh_policy_safely(self)
         await self._check_ban()
+        await self._check_admission()
         async for event in self._graph.astream_events(
             payload, config=self._with_usage_callback(config), version=version
         ):
@@ -430,6 +438,15 @@ class HexgateAgent:
         from hexgate.runtime.context import get_current_context
 
         await self._ban_gate.check_async(get_current_context())
+
+    async def _check_admission(self) -> None:
+        """Refuse a caller not admitted by policy before the graph runs, if an
+        admission gate is attached. The gate reads the active
+        :class:`HexgateContext` scope for the caller's role; a policy with no
+        admission block makes this a no-op."""
+        if self._agent_gate is None:
+            return
+        await self._agent_gate.check_admission_async()
 
     def with_tools(self, tools: Sequence[ToolSpec]) -> Self:
         """Rebuild the runtime with a new tool list."""
@@ -471,6 +488,7 @@ class HexgateAgent:
             binding=self._binding,
             hexgate_client=self.hexgate_client,
             ban_gate=self._ban_gate,
+            agent_gate=self._agent_gate,
         )
 
     def enforce_policy(
@@ -575,9 +593,16 @@ class HexgateAgent:
                 wrapped.append(tool_spec)
         rebuilt = self.with_tools(wrapped)
         if enforcer is not None:
+            from hexgate.security.agent_gate import resolve_agent_gate
+
             # The binding pairs the enforcer the tools just closed over with the
             # refresh source, so refresh_policy() can swap the policy in place.
             rebuilt._binding = PolicyBinding(enforcer, source)
+            # The admission gate shares that same enforcer, so a refresh that
+            # swaps the policy is reflected on the next run entry too.
+            rebuilt._agent_gate = resolve_agent_gate(
+                enforcer, approval_handler=approval_handler
+            )
         return rebuilt
 
     def refresh_policy(self) -> None:

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -560,8 +560,13 @@ class HexgateAgent:
                 )
             if pipeline is None or pipeline.is_empty:
                 # Nothing to enforce and no guards to run (an observer-only
-                # pipeline can't fire without guards): return unguarded.
-                return self.with_tools(list(self.tools))
+                # pipeline can't fire without guards): return unguarded. Clear any
+                # admission gate a prior enforce_policy attached, or with_tools
+                # would carry it forward and the "unguarded" agent would still
+                # refuse admission.
+                unguarded = self.with_tools(list(self.tools))
+                unguarded._agent_gate = None
+                return unguarded
             enforcer = None  # guards-only gating, no policy engine
         else:
             if isinstance(policy, (PolicyBundle, PolicySet)):
@@ -603,6 +608,10 @@ class HexgateAgent:
             rebuilt._agent_gate = resolve_agent_gate(
                 enforcer, approval_handler=approval_handler
             )
+        else:
+            # Guards-only path: no enforcer, so no admission. Clear any gate a
+            # prior enforce_policy left, which with_tools would otherwise carry.
+            rebuilt._agent_gate = None
         return rebuilt
 
     def refresh_policy(self) -> None:

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -22,7 +22,6 @@ from hexgate.security.bans import (
 from hexgate.security.agent_gate import (
     AgentGate,
     AgentNotAdmittedError,
-    policy_declares_admission,
     resolve_agent_gate,
 )
 from hexgate.security.models import (
@@ -151,7 +150,6 @@ __all__ = [
     "AgentTargetPolicy",
     "AgentVia",
     "agent_target_key",
-    "policy_declares_admission",
     "resolve_agent_gate",
     "LayerKind",
     "LinkError",

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -19,6 +19,12 @@ from hexgate.security.bans import (
     get_ban_source,
     resolve_ban_gate,
 )
+from hexgate.security.agent_gate import (
+    AgentGate,
+    AgentNotAdmittedError,
+    policy_declares_admission,
+    resolve_agent_gate,
+)
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
     AgentPolicy,
@@ -139,10 +145,14 @@ from hexgate.security.testing import (
 __all__ = [
     "AGENT_RUN_TOOL",
     "AgentBannedError",
+    "AgentGate",
+    "AgentNotAdmittedError",
     "AgentPolicy",
     "AgentTargetPolicy",
     "AgentVia",
     "agent_target_key",
+    "policy_declares_admission",
+    "resolve_agent_gate",
     "LayerKind",
     "LinkError",
     "LinkResult",

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -6,12 +6,15 @@ a non-tool subject. It gates *admission* — may this caller, in this role, run 
 agent — by deciding the synthetic ``agent.run`` key at run entry, before the model
 sees anything.
 
-Admission is opt-in. The gate enforces only when the current policy declares an
-``admission`` block, checked per run inside :meth:`AgentGate.check_admission` (not
-at build time), so an agent whose policy never mentions admission runs exactly as
-before, and a hot-reloaded policy that adds or drops admission is honored on the
-next run. A denial is caller-facing: admission fires before the model runs, so
-there is no tool result to render into, the run simply does not start.
+Engagement is opt-in. The gate enforces only when the current policy declares an
+``admission`` block anywhere, read per run via ``PolicyEngine.declares_admission()``
+(not at build time), so an agent whose policy never mentions admission runs exactly
+as before, and a hot-reloaded policy that adds or drops admission is honored on the
+next run. Once admission is declared, agent keys are closed-world (R-AGENT-002): a
+caller whose role is not granted admission is refused, so a silent co-role can
+neither admit an unknown caller nor defeat an explicit deny. A denial is
+caller-facing: admission fires before the model runs, so there is no tool result to
+render into, the run simply does not start.
 """
 
 from __future__ import annotations
@@ -20,7 +23,7 @@ import logging
 from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
-from hexgate.security.decision import Decision, DecisionOutcome, PolicyEngine
+from hexgate.security.decision import Decision, DecisionOutcome
 from hexgate.security.models import AGENT_RUN_TOOL
 
 if TYPE_CHECKING:
@@ -42,30 +45,13 @@ class AgentNotAdmittedError(Exception):
         super().__init__(decision.as_error_message())
 
 
-def policy_declares_admission(engine: PolicyEngine) -> bool:
-    """True if any role in a pydantic :class:`PolicySet` declares an ``admission`` block.
-
-    The opt-in signal. ``decide()`` cannot tell an explicit ``agent.run`` rule from
-    a fall-through to ``default_policy``, so the gate must know whether admission was
-    authored at all. Only the pydantic ``PolicySet`` exposes the ``AgentPolicy`` at
-    runtime; a compiled WASM bundle does not, so it reports ``False`` here and
-    bundle-served admission rides a manifest flag added in a later PR.
-    """
-    from hexgate.security.policy_set import PolicySet
-
-    if isinstance(engine, PolicySet):
-        return any(
-            engine.policy_for(role).admission is not None for role in engine.roles
-        )
-    return False
-
-
 class AgentGate:
     """Reduce an agent run to an admit/refuse verdict via the enforcer.
 
-    Built only for policies that declare admission, so its mere presence means
-    "enforce"; there is no enabled flag. Mirrors the egress ``Gate``: hold the
-    enforcer and the approval handler, decide, fold approval, fail closed.
+    Always built; whether it enforces is decided per run from
+    ``PolicyEngine.declares_admission()``, so its presence does not mean "enforce".
+    Mirrors the egress ``Gate``: hold the enforcer and the approval handler, decide,
+    fold approval, fail closed.
     """
 
     def __init__(
@@ -86,7 +72,7 @@ class AgentGate:
         build time, so a hot-reloaded policy that adds or drops admission is
         honored on the next run rather than frozen at bind.
         """
-        if not policy_declares_admission(self._enforcer.policy):
+        if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
         if decision.allowed:
@@ -101,7 +87,7 @@ class AgentGate:
 
     async def check_admission_async(self) -> None:
         """Async mirror of :meth:`check_admission` — awaits an async handler."""
-        if not policy_declares_admission(self._enforcer.policy):
+        if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
         if decision.allowed:

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -1,0 +1,173 @@
+"""Agent-level admission enforcement.
+
+:class:`AgentGate` is to a whole agent run what the egress :class:`~hexgate.egress.gate.Gate`
+is to a network request: one place that reuses :meth:`PolicyEnforcer.decide` for
+a non-tool subject. It gates *admission* — may this caller, in this role, run this
+agent — by deciding the synthetic ``agent.run`` key at run entry, before the model
+sees anything.
+
+Admission is opt-in. The gate enforces only when the current policy declares an
+``admission`` block, checked per run inside :meth:`AgentGate.check_admission` (not
+at build time), so an agent whose policy never mentions admission runs exactly as
+before, and a hot-reloaded policy that adds or drops admission is honored on the
+next run. A denial is caller-facing: admission fires before the model runs, so
+there is no tool result to render into, the run simply does not start.
+"""
+
+from __future__ import annotations
+
+import logging
+from inspect import isawaitable
+from typing import TYPE_CHECKING, Any
+
+from hexgate.security.decision import Decision, DecisionOutcome, PolicyEngine
+from hexgate.security.models import AGENT_RUN_TOOL
+
+if TYPE_CHECKING:
+    from hexgate.approvals import ApprovalHandler
+    from hexgate.security.enforcer import PolicyEnforcer
+
+_log = logging.getLogger(__name__)
+
+
+class AgentNotAdmittedError(Exception):
+    """Raised at run entry when admission policy refuses this caller.
+
+    Carries the :class:`Decision` so the caller can inspect the reason; the
+    message is the model-safe rendering (arguments and attributes withheld).
+    """
+
+    def __init__(self, decision: Decision) -> None:
+        self.decision = decision
+        super().__init__(decision.as_error_message())
+
+
+def policy_declares_admission(engine: PolicyEngine) -> bool:
+    """True if any role in a pydantic :class:`PolicySet` declares an ``admission`` block.
+
+    The opt-in signal. ``decide()`` cannot tell an explicit ``agent.run`` rule from
+    a fall-through to ``default_policy``, so the gate must know whether admission was
+    authored at all. Only the pydantic ``PolicySet`` exposes the ``AgentPolicy`` at
+    runtime; a compiled WASM bundle does not, so it reports ``False`` here and
+    bundle-served admission rides a manifest flag added in a later PR.
+    """
+    from hexgate.security.policy_set import PolicySet
+
+    if isinstance(engine, PolicySet):
+        return any(
+            engine.policy_for(role).admission is not None for role in engine.roles
+        )
+    return False
+
+
+class AgentGate:
+    """Reduce an agent run to an admit/refuse verdict via the enforcer.
+
+    Built only for policies that declare admission, so its mere presence means
+    "enforce"; there is no enabled flag. Mirrors the egress ``Gate``: hold the
+    enforcer and the approval handler, decide, fold approval, fail closed.
+    """
+
+    def __init__(
+        self,
+        enforcer: PolicyEnforcer,
+        *,
+        approval_handler: ApprovalHandler | None = None,
+    ) -> None:
+        self._enforcer = enforcer
+        self._approval_handler = approval_handler
+
+    def check_admission(self) -> None:
+        """Raise :class:`AgentNotAdmittedError` if admission policy refuses (sync).
+
+        Reads the caller's role from the active context the enforcer sees, so the
+        caller's ``HexgateContext`` scope must already be open at this call site.
+        No-op when the current policy declares no admission — checked here, not at
+        build time, so a hot-reloaded policy that adds or drops admission is
+        honored on the next run rather than frozen at bind.
+        """
+        if not policy_declares_admission(self._enforcer.policy):
+            return
+        decision = self._decide()
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and self._resolve_approval_sync(decision)
+        ):
+            return
+        raise AgentNotAdmittedError(decision)
+
+    async def check_admission_async(self) -> None:
+        """Async mirror of :meth:`check_admission` — awaits an async handler."""
+        if not policy_declares_admission(self._enforcer.policy):
+            return
+        decision = self._decide()
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and await self._resolve_approval_async(decision)
+        ):
+            return
+        raise AgentNotAdmittedError(decision)
+
+    def _decide(self) -> Decision:
+        # agent name rides in args so a constraint can read args.agent; the
+        # enforcer folds the caller's roles and emits the audit event.
+        return self._enforcer.decide(
+            AGENT_RUN_TOOL, {"agent": self._enforcer.agent_name}
+        )
+
+    def _resolve_approval_sync(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                # A sync run entrypoint has no loop to await on; deny rather than
+                # silently skip the human check. Close the coroutine so it does
+                # not leak as a never-awaited warning.
+                if hasattr(result, "close"):
+                    result.close()
+                _log.error(
+                    "admission approval_handler is async on a sync run; "
+                    "denying (fail-closed)"
+                )
+                return False
+            return bool(result)
+        except Exception:
+            _log.exception("admission approval_handler raised; denying (fail-closed)")
+            return False
+
+    async def _resolve_approval_async(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception:
+            _log.exception("admission approval_handler raised; denying (fail-closed)")
+            return False
+
+
+def resolve_agent_gate(
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> AgentGate:
+    """Build the admission gate for ``enforcer``.
+
+    Always returns a gate (unlike :func:`~hexgate.security.bans.resolve_ban_gate`,
+    which needs a platform): admission is a local policy decision. Whether the gate
+    actually enforces is decided per run inside :meth:`AgentGate.check_admission`,
+    so a hot-reloaded policy that adds or drops admission is honored without
+    rebuilding the gate. A policy with no admission block makes every check a no-op.
+    """
+    return AgentGate(enforcer, approval_handler=approval_handler)

--- a/hexgate/security/bundle.py
+++ b/hexgate/security/bundle.py
@@ -305,6 +305,18 @@ class PolicyBundle:
             self, role or DEFAULT_ROLE_NAME, tool, dict(args), attributes=attributes
         )
 
+    def declares_admission(self) -> bool:
+        """Read the admission-configured flag from the signed manifest.
+
+        The compiled WASM is opaque, so the derived signal is recorded at build
+        time (:func:`build_signed_bundle`) under ``agent_gating``. Absent (an older
+        bundle) reads False — safe, those predate agent-level policy (R-AGENT-002)."""
+        return bool(self.manifest.get("agent_gating", {}).get("admission", False))
+
+    def declares_reach(self) -> bool:
+        """Read the reach-configured flag from the signed manifest (reach counterpart)."""
+        return bool(self.manifest.get("agent_gating", {}).get("reach", False))
+
     # ---- Metadata ------------------------------------------------------
 
     @property
@@ -370,12 +382,22 @@ def build_signed_bundle(
     """
     # Lazy import keeps bundle.py importable (and the platform booting) even
     # when the opa-backed compiler isn't needed — only producers hit this.
+    from hexgate.security.policy_set import load_policy_set_from_dict
     from hexgate.security.rego import compile_to_rego
     from hexgate.security.rego_wasm import compile_to_wasm
 
     payload = yaml.safe_load(policy_yaml) or {}
     source_hash = hashlib.sha256(policy_yaml.encode("utf-8")).hexdigest()
     rego_text = compile_to_rego(payload, source_hash=source_hash)
+
+    # Record the agent-gate engagement flags derived from the resolved policy: the
+    # compiled WASM is opaque, so the bundle-backed gate reads these from the
+    # (signed) manifest to decide whether to fire (R-AGENT-002).
+    resolved = load_policy_set_from_dict(payload)
+    agent_gating = {
+        "admission": resolved.declares_admission(),
+        "reach": resolved.declares_reach(),
+    }
 
     wasm_bytes: bytes | None = None
     wasm_hash: str | None = None
@@ -389,6 +411,7 @@ def build_signed_bundle(
         "source_hash": source_hash,
         "rego_hash": hashlib.sha256(rego_text.encode("utf-8")).hexdigest(),
         "wasm_hash": wasm_hash,
+        "agent_gating": agent_gating,
     }
     # The one canonical serialization. Sign these exact bytes.
     manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -69,6 +69,22 @@ class PolicyEngine(Protocol):
         attributes: Mapping[str, Any] | None = None,
     ) -> Verdict: ...
 
+    def declares_admission(self) -> bool:
+        """Whether this policy configures admission anywhere.
+
+        The agent gate's opt-in signal: it fires only when this is true, so an
+        agent that never mentions admission is never gated (agent keys are
+        otherwise closed-world). A pydantic engine derives it from the resolved
+        policy; a WASM bundle reads it from its signed manifest (R-AGENT-002)."""
+        ...
+
+    def declares_reach(self) -> bool:
+        """Whether this policy configures agent-to-agent reach anywhere.
+
+        The delegation seam's opt-in signal, the reach counterpart to
+        :meth:`declares_admission` (consumed once handoff interception lands)."""
+        ...
+
 
 # Over the platform's ``DecisionEvent.reason`` max_length the audit event is
 # rejected outright, losing the record for the calls most worth keeping.

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -158,7 +158,9 @@ def _reject_capability_denies(capabilities: Sequence[ModuleContent]) -> None:
     hoisted here and run over every capability, bound or not.
     """
     for cap in capabilities:
-        for tool, tp in cap.policy.tools.items():
+        # effective_tools, so a capability that denies an agent key (a lowered
+        # agents:/admission deny) is caught too — capabilities grant only.
+        for tool, tp in cap.policy.effective_tools.items():
             if tp.mode == "deny":
                 raise LinkError(
                     f"capability {cap.name!r} denies {tool!r}; capabilities may "
@@ -182,8 +184,10 @@ def link(
         if rule is not None:
             tools[name] = rule
 
-    # Effective default is fail-closed: a tool no layer grants is denied.
-    effective = AgentPolicy(
+    # Effective default is fail-closed: a tool no layer grants is denied. The
+    # folded map may include lowered agent.* keys (composed agent-level blocks),
+    # so build through the resolved path, which carries them in tools directly.
+    effective = AgentPolicy.resolved(
         default_policy=BaseToolPolicy(mode="deny"), tools=tools, consts=consts
     )
     return effective, trace
@@ -276,7 +280,18 @@ def _reject_file_scope(
 # rejected by _reject_unsupported_module_fields, so a field added to AgentPolicy
 # later fails closed here instead of being silently dropped by _fold_tool.
 _MODULE_COMPOSABLE_FIELDS = frozenset(
-    {"version", "inherits", "is_mixin", "default_policy", "tools", "consts"}
+    {
+        "version",
+        "inherits",
+        "is_mixin",
+        "default_policy",
+        "tools",
+        "consts",
+        # Agent-level blocks lower to agent.* keys the fold composes like tools
+        # (a boundary agent-deny is authoritative, a capability agent-grant unions).
+        "admission",
+        "agents",
+    }
 )
 
 
@@ -284,13 +299,14 @@ def _reject_unsupported_module_fields(
     boundaries: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> None:
     """Reject any top-level AgentPolicy field a module sets that the fold does not
-    compose (today: ``admission`` / ``agents``; tomorrow: whatever is added next).
+    compose (whatever is added next).
 
-    ``_fold_tool`` reads only ``.tools``, so an un-composed field would be silently
-    dropped, erasing a rule an operator authored — the same fail-open
-    :func:`_reject_file_scope` guards against, generalized. Allowlisting the fields
-    the fold understands means a new AgentPolicy field is rejected automatically
-    until composition learns it, rather than shipping fail-open by omission."""
+    The fold composes ``tools`` and the lowered ``agent.*`` keys from
+    ``effective_tools``, so an un-composed field would be silently dropped, erasing
+    a rule an operator authored — the same fail-open :func:`_reject_file_scope`
+    guards against, generalized. Allowlisting the fields the fold understands means
+    a new AgentPolicy field is rejected automatically until composition learns it,
+    rather than shipping fail-open by omission."""
     for module in (*boundaries, *capabilities):
         extra = module.policy.model_fields_set - _MODULE_COMPOSABLE_FIELDS
         if extra:
@@ -310,7 +326,7 @@ def _fold_tool(
     """Resolve one tool across all layers. ``None`` means implicit-deny (omit)."""
     # Capabilities may only grant. A capability deny is a config error.
     for cap in capabilities:
-        tp = cap.policy.tools.get(tool)
+        tp = cap.policy.effective_tools.get(tool)
         if tp is not None and tp.mode == "deny":
             raise LinkError(
                 f"capability {cap.name!r} denies {tool!r}; capabilities may only "
@@ -321,7 +337,7 @@ def _fold_tool(
     #    (has constraints) instead subtracts its region from the grant (step 5).
     conditional_denies: list[tuple[ModuleContent, list[str]]] = []
     for g in boundaries:
-        tp = g.policy.tools.get(tool)
+        tp = g.policy.effective_tools.get(tool)
         if tp is not None and tp.mode == "deny":
             if tp.constraints:
                 conditional_denies.append((g, list(tp.constraints)))
@@ -334,7 +350,7 @@ def _fold_tool(
     contributors: list[Provenance] = []
     ceiling_constraints: list[str] = []
     for g in boundaries:
-        tp = g.policy.tools.get(tool)
+        tp = g.policy.effective_tools.get(tool)
         is_ceiling = g.policy.default_policy.mode == "deny"
         if tp is not None and tp.mode in GRANT_MODES:
             ceiling_constraints.extend(tp.constraints)  # fences intersect (AND)
@@ -349,7 +365,7 @@ def _fold_tool(
     # 3+4. Capability grants. No grant → eligible but ungranted → implicit deny.
     grants: list[tuple[ModuleContent, ToolPolicy]] = []
     for cap in capabilities:
-        tp = cap.policy.tools.get(tool)
+        tp = cap.policy.effective_tools.get(tool)
         if tp is not None and tp.mode in GRANT_MODES:
             grants.append((cap, tp))
     if not grants:
@@ -407,7 +423,8 @@ def _any_approval(
     if any(tp.mode == "approval_required" for tp in grants):
         return True
     return any(
-        (tp := g.policy.tools.get(tool)) is not None and tp.mode == "approval_required"
+        (tp := g.policy.effective_tools.get(tool)) is not None
+        and tp.mode == "approval_required"
         for g in boundaries
     )
 
@@ -416,7 +433,8 @@ def _tool_names(*groups: list[ModuleContent]) -> list[str]:
     names: set[str] = set()
     for group in groups:
         for module in group:
-            names.update(module.policy.tools)
+            # effective_tools, so lowered agent.* keys are folded like tool keys.
+            names.update(module.policy.effective_tools)
     return sorted(names)
 
 

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -173,6 +173,29 @@ class AgentPolicy(BaseModel):
                 )
         return value
 
+    @classmethod
+    def resolved(
+        cls,
+        *,
+        default_policy: BaseToolPolicy,
+        tools: dict[str, ToolPolicy],
+        consts: dict[str, Any],
+    ) -> "AgentPolicy":
+        """Build a linker-resolved policy directly from folded tool keys.
+
+        The fold composes agent-level blocks into lowered ``agent.*`` keys and
+        stores them alongside ordinary tools, so a resolved policy carries them
+        in ``tools`` rather than in ``admission``/``agents``: per-via divergence
+        across capabilities (a target allowed via one mode, denied via another,
+        or granted different constraints per mode) can't always be reverse-lowered
+        into a single :class:`AgentTargetPolicy`. The reserved-key guard on
+        ``tools`` is an authoring ergonomic that does not apply to this machine
+        path, so this bypasses validation via ``model_construct`` — every value is
+        an already-validated model instance produced by the fold."""
+        return cls.model_construct(
+            default_policy=default_policy, tools=dict(tools), consts=dict(consts)
+        )
+
     def lowered_agent_tools(self) -> dict[str, BaseToolPolicy]:
         """Expand ``admission``/``agents`` into synthetic tool entries.
 

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -13,20 +13,19 @@ from hexgate.security.decision import DecisionOutcome, Verdict
 from hexgate.security.errors import ApprovalRequiredError, PolicyDeniedError
 from hexgate.security.file_scope import build_file_scope_hint, is_path_allowed
 from hexgate.security.models import (
-    AGENT_RUN_TOOL,
     AgentPolicy,
     BaseToolPolicy,
     FileToolPolicy,
     ToolPolicy,
-    is_agent_reach_key,
+    is_agent_key,
 )
 
-# Reach keys are closed-world: an unlisted agent.tool:/agent.handoff: denies
-# regardless of default_policy, so a permissive tool default never silently grants
-# agent reach. Admission (agent.run) is the opposite: opt-in, so an unlisted
-# agent.run admits (a role that declares no admission does not restrict it).
-_AGENT_REACH_CLOSED_WORLD_DENY = BaseToolPolicy(mode="deny")
-_ADMISSION_OPT_IN_ALLOW = BaseToolPolicy(mode="allow")
+# Agent keys (admission agent.run AND reach agent.tool:/agent.handoff:) are
+# closed-world: an unlisted agent key denies regardless of default_policy. A role
+# that is not granted admission is denied, so a permissive tool default cannot
+# silently grant a run or a handoff. Whether admission is enforced at all is the
+# gate's opt-in engagement decision (declares_admission), not this fallback (R-AGENT-002).
+_AGENT_CLOSED_WORLD_DENY = BaseToolPolicy(mode="deny")
 
 if TYPE_CHECKING:
     from hexgate.security.bundle import PolicyBundle
@@ -53,27 +52,18 @@ def get_tool_policy(policy: AgentPolicy, tool_name: str) -> ToolPolicy:
     """Resolve the effective policy for a tool name.
 
     Reads ``effective_tools`` (authored tools plus lowered ``agent.*`` keys) so a
-    synthetic agent-level key resolves through the same path as any tool. Fallbacks
-    for an unlisted key differ by kind:
-
-    * an unlisted **reach** key (``agent.tool:`` / ``agent.handoff:``) denies,
-      closed-world, so a permissive ``default_policy`` cannot silently grant a
-      handoff or sub-agent call;
-    * an unlisted ``agent.run`` **admits** (admission is opt-in — a role that
-      declares no admission does not restrict who may start the agent);
-    * any other unlisted tool falls to ``default_policy``.
-
-    The Rego compiler mirrors both (it excludes reach keys from its permissive
-    catch-all and emits an opt-in allow rule for ``agent.run``), keeping the engines
-    in agreement.
+    synthetic agent-level key resolves through the same path as any tool. An
+    unlisted **agent** key (admission or reach) denies, closed-world, so a
+    permissive ``default_policy`` never silently grants a run or a handoff; any
+    other unlisted tool falls to ``default_policy``. The Rego compiler mirrors this
+    (its permissive catch-all excludes every agent key), keeping the engines in
+    agreement (R-AGENT-002).
     """
     tool_policy = policy.effective_tools.get(tool_name)
     if tool_policy is not None:
         return tool_policy
-    if tool_name == AGENT_RUN_TOOL:
-        return _ADMISSION_OPT_IN_ALLOW
-    if is_agent_reach_key(tool_name):
-        return _AGENT_REACH_CLOSED_WORLD_DENY
+    if is_agent_key(tool_name):
+        return _AGENT_CLOSED_WORLD_DENY
     return policy.default_policy
 
 

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -39,10 +39,12 @@ import yaml
 from hexgate.security.constraints import iter_const_refs, parse_constraint
 from hexgate.security.decision import Verdict
 from hexgate.security.models import (
+    AGENT_RUN_TOOL,
     AgentPolicy,
     AgentTargetPolicy,
     BaseToolPolicy,
     ToolPolicy,
+    is_agent_reach_key,
 )
 
 
@@ -121,6 +123,24 @@ class PolicySet:
     def roles(self) -> list[str]:
         """List of role names, including ``default``, excluding mixins."""
         return sorted(self._policies)
+
+    def declares_admission(self) -> bool:
+        """True if any resolved role carries the ``agent.run`` key.
+
+        Derived from ``effective_tools`` rather than a source field so it holds
+        after inheritance and module folding, where the ``admission`` block has
+        become an ``agent.run`` key (R-AGENT-002)."""
+        return any(
+            AGENT_RUN_TOOL in policy.effective_tools
+            for policy in self._policies.values()
+        )
+
+    def declares_reach(self) -> bool:
+        """True if any resolved role carries an ``agent.tool:`` / ``agent.handoff:`` key."""
+        return any(
+            any(is_agent_reach_key(key) for key in policy.effective_tools)
+            for policy in self._policies.values()
+        )
 
     def __contains__(self, role: str) -> bool:
         return role in self._policies

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -299,24 +299,6 @@ def _rules_for_role(
                 helpers,
             )
         )
-    if AGENT_RUN_TOOL not in effective:
-        # Admission is opt-in: a role that declares no admission rule admits, so an
-        # unlisted agent.run allows regardless of default_policy. Emitted for every
-        # role (not gated on agent blocks) so it matches the unconditional
-        # _ADMISSION_OPT_IN_ALLOW fallback in the pydantic engine — otherwise a role
-        # without an admission rule would deny agent.run on the WASM path while
-        # allowing it on the pydantic path (the same non-monotonic lockout, one
-        # engine over).
-        out.extend(
-            _gated_rules(
-                role,
-                role_guard,
-                [f'    input.tool == "{_escape_string(AGENT_RUN_TOOL)}"'],
-                BaseToolPolicy(mode="allow"),
-                AGENT_RUN_TOOL,
-                helpers,
-            )
-        )
     out.extend(_default_rules(role, role_guard, policy.default_policy, listed, helpers))
     return out
 
@@ -336,12 +318,13 @@ def _default_rules(
     """
     if default_policy.mode == "deny":
         return []
-    # Reach keys are closed-world: a permissive default must not grant an unlisted
-    # agent.tool:/agent.handoff:, so exclude them from the catch-all (an unlisted
-    # reach key then matches no rule and denies). agent.run is deliberately NOT
-    # excluded — admission is opt-in and its own rule handles it. Mirrors
-    # get_tool_policy / is_agent_reach_key in the pydantic engine.
-    tool_guard = [
+    # Agent keys are closed-world: a permissive default must not grant an unlisted
+    # agent key, so exclude them from the catch-all (an unlisted agent key then
+    # matches no rule and denies). Excludes exactly the reserved shapes — agent.run
+    # and the reach prefixes — so an authored tool merely named "agent.foo" still
+    # follows the default, matching is_agent_key in the pydantic engine (R-AGENT-002).
+    tool_guard = [f"    input.tool != {json.dumps(AGENT_RUN_TOOL)}"]
+    tool_guard += [
         f"    not startswith(input.tool, {json.dumps(prefix)})"
         for prefix in AGENT_REACH_PREFIXES
     ]

--- a/tests/agents/test_create_agent_binding.py
+++ b/tests/agents/test_create_agent_binding.py
@@ -19,7 +19,7 @@ from langchain_core.tools import tool
 from hexgate.agents import factory
 from hexgate.adapters.langchain.tools import GuardedTool
 from hexgate.cloud.client import HexgateError
-from hexgate.security import AgentPolicy, PolicySet
+from hexgate.security import AgentPolicy, BaseToolPolicy, PolicySet
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 from hexgate.security.source import PlatformPolicySource
 
@@ -355,3 +355,13 @@ def test_enforce_policy_none_without_source_is_noop() -> None:
 
     assert rebuilt.tools == [echo]  # unwrapped
     assert rebuilt._binding is None
+
+
+def test_enforce_policy_none_clears_a_prior_admission_gate() -> None:
+    # enforce_policy(None) returns an unguarded rebuild; a prior admission gate
+    # must not survive via with_tools, or the "unguarded" agent still refuses.
+    agent, _ = factory.create_agent(model="openai:gpt-5.4", tools=[echo], name="a")
+    guarded = agent.enforce_policy(AgentPolicy(admission=BaseToolPolicy(mode="allow")))
+    assert guarded._agent_gate is not None
+    unguarded = guarded.enforce_policy(None)
+    assert unguarded._agent_gate is None

--- a/tests/agents/test_factory.py
+++ b/tests/agents/test_factory.py
@@ -384,6 +384,73 @@ async def test_hexgate_agent_astream_raises_before_first_event_when_banned() -> 
             async for _ in agent.astream_events({}, {}, version="v2"):
                 pass
 
+
+def _admission_gate(mode: str):
+    """An admission gate whose policy admits/denies with the given mode."""
+    from hexgate.security import AgentPolicy, BaseToolPolicy
+    from hexgate.security.agent_gate import resolve_agent_gate
+    from hexgate.security.enforcer import PolicyEnforcer
+    from hexgate.security.policy_set import load_policy_set
+
+    policy = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"),
+        admission=BaseToolPolicy(mode=mode),
+    )
+    return resolve_agent_gate(PolicyEnforcer(load_policy_set(policy), agent_name="bot"))
+
+
+def _agent_with_admission(graph: FakeAgent, gate) -> factory.HexgateAgent:
+    return factory.HexgateAgent(
+        graph=graph,
+        model="m",
+        tools=[],
+        system_prompt=None,
+        name="bot",
+        agent_gate=gate,
+    )
+
+
+@pytest.mark.asyncio
+async def test_hexgate_agent_ainvoke_refused_before_graph_when_not_admitted() -> None:
+    from hexgate.runtime import HexgateContext
+    from hexgate.security.agent_gate import AgentNotAdmittedError
+
+    graph = FakeAgent()
+    agent = _agent_with_admission(graph, _admission_gate("deny"))
+
+    async with HexgateContext(user_id="u1", user_roles=["support"]):
+        with pytest.raises(AgentNotAdmittedError):
+            await agent.ainvoke({}, {})
+
+    assert graph.ainvoke_calls == []  # graph never ran
+
+
+@pytest.mark.asyncio
+async def test_hexgate_agent_ainvoke_runs_when_admitted() -> None:
+    from hexgate.runtime import HexgateContext
+
+    graph = FakeAgent()
+    agent = _agent_with_admission(graph, _admission_gate("allow"))
+
+    async with HexgateContext(user_id="u1", user_roles=["support"]):
+        await agent.ainvoke({}, {})
+
+    assert len(graph.ainvoke_calls) == 1  # admission allowed → graph ran
+
+
+@pytest.mark.asyncio
+async def test_hexgate_agent_astream_refused_when_not_admitted() -> None:
+    from hexgate.runtime import HexgateContext
+    from hexgate.security.agent_gate import AgentNotAdmittedError
+
+    graph = FakeAgent()
+    agent = _agent_with_admission(graph, _admission_gate("deny"))
+
+    async with HexgateContext(user_id="u1", user_roles=["support"]):
+        with pytest.raises(AgentNotAdmittedError):
+            async for _ in agent.astream_events({}, {}, version="v2"):
+                pass
+
     assert graph.astream_event_calls == []
 
 

--- a/tests/security/golden/policy_fixture.rego
+++ b/tests/security/golden/policy_fixture.rego
@@ -111,20 +111,10 @@ violations contains `ctx.region in ["EU", "UK"]` if {
     not _p_b7b1e13455
 }
 
-allow if {
-    input.role == "billing"
-    input.tool == "agent.run"
-}
-
 # ---- role: default -----------------------------------------------------
 allow if {
     not input.role in {"billing", "support"}
     input.tool == "web_search"
-}
-
-allow if {
-    not input.role in {"billing", "support"}
-    input.tool == "agent.run"
 }
 
 # ---- role: support -----------------------------------------------------
@@ -149,11 +139,6 @@ violations contains `args.amount <= 500` if {
 allow if {
     input.role == "support"
     input.tool == "read_file"
-}
-
-allow if {
-    input.role == "support"
-    input.tool == "agent.run"
 }
 
 _p_066518c099 if {

--- a/tests/security/test_agent_gate.py
+++ b/tests/security/test_agent_gate.py
@@ -1,0 +1,145 @@
+"""Tests for the admission gate (``security/agent_gate.py``).
+
+The gate reuses ``PolicyEnforcer.decide`` on the synthetic ``agent.run`` key, so
+these drive it through a real ``PolicySet`` enforcer under an open context scope,
+the same path a run entry takes. Admission is opt-in: no admission block means no
+gate (``resolve_agent_gate`` returns ``None``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate.runtime.context import HexgateContext
+from hexgate.security import (
+    AgentNotAdmittedError,
+    AgentPolicy,
+    BaseToolPolicy,
+    resolve_agent_gate,
+)
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import load_policy_set
+
+_ROLE = HexgateContext(user_id="u", user_roles=["support"])
+
+
+def _enforcer(admission_mode: str | None) -> PolicyEnforcer:
+    admission = BaseToolPolicy(mode=admission_mode) if admission_mode else None
+    policy = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"),
+        admission=admission,
+    )
+    return PolicyEnforcer(load_policy_set(policy), agent_name="my-agent")
+
+
+# --- opt-in ----------------------------------------------------------------
+
+
+def test_no_admission_block_is_a_noop() -> None:
+    # A gate is always built, but a policy with no admission block never refuses:
+    # the opt-in is checked per run, so this stays a no-op (and hot-reload safe).
+    gate = resolve_agent_gate(_enforcer(None))
+    with _ROLE.sync_scope():
+        gate.check_admission()  # does not raise
+
+
+def test_gate_builds_with_admission() -> None:
+    assert resolve_agent_gate(_enforcer("allow")) is not None
+
+
+# --- verdicts --------------------------------------------------------------
+
+
+def test_admission_allow_passes() -> None:
+    gate = resolve_agent_gate(_enforcer("allow"))
+    with _ROLE.sync_scope():
+        gate.check_admission()  # does not raise
+
+
+def test_admission_deny_raises() -> None:
+    gate = resolve_agent_gate(_enforcer("deny"))
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_deny_error_carries_decision() -> None:
+    gate = resolve_agent_gate(_enforcer("deny"))
+    with _ROLE.sync_scope():
+        try:
+            gate.check_admission()
+        except AgentNotAdmittedError as exc:
+            assert exc.decision.tool_name == "agent.run"
+            assert not exc.decision.allowed
+        else:  # pragma: no cover
+            pytest.fail("expected AgentNotAdmittedError")
+
+
+# --- approval --------------------------------------------------------------
+
+
+def test_approval_bool_true_passes() -> None:
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=True)
+    with _ROLE.sync_scope():
+        gate.check_admission()
+
+
+def test_approval_bool_false_raises() -> None:
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=False)
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_approval_no_handler_raises() -> None:
+    gate = resolve_agent_gate(_enforcer("approval_required"))
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_approval_sync_callable_approves_and_denies() -> None:
+    approve = resolve_agent_gate(
+        _enforcer("approval_required"), approval_handler=lambda d: True
+    )
+    deny = resolve_agent_gate(
+        _enforcer("approval_required"), approval_handler=lambda d: False
+    )
+    with _ROLE.sync_scope():
+        approve.check_admission()
+        with pytest.raises(AgentNotAdmittedError):
+            deny.check_admission()
+
+
+def test_approval_handler_raises_fails_closed() -> None:
+    def boom(_decision: object) -> bool:
+        raise RuntimeError("handler blew up")
+
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=boom)
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_async_handler_on_sync_run_denies() -> None:
+    async def slow(_decision: object) -> bool:
+        return True
+
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=slow)
+    # A coroutine handler cannot be awaited on the sync entrypoint → fail closed.
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+# --- async path ------------------------------------------------------------
+
+
+async def test_async_admission_allow_passes() -> None:
+    gate = resolve_agent_gate(_enforcer("allow"))
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_admission_async()
+
+
+async def test_async_admission_approval_async_handler() -> None:
+    async def approve(_decision: object) -> bool:
+        return True
+
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=approve)
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_admission_async()

--- a/tests/security/test_agent_gate.py
+++ b/tests/security/test_agent_gate.py
@@ -2,8 +2,8 @@
 
 The gate reuses ``PolicyEnforcer.decide`` on the synthetic ``agent.run`` key, so
 these drive it through a real ``PolicySet`` enforcer under an open context scope,
-the same path a run entry takes. Admission is opt-in: no admission block means no
-gate (``resolve_agent_gate`` returns ``None``).
+the same path a run entry takes. Admission is opt-in: ``resolve_agent_gate`` always
+returns a gate, but a policy that declares no admission makes every check a no-op.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from hexgate.security import (
     resolve_agent_gate,
 )
 from hexgate.security.enforcer import PolicyEnforcer
-from hexgate.security.policy_set import load_policy_set
+from hexgate.security.policy_set import load_policy_set, load_policy_set_from_dict
 
 _ROLE = HexgateContext(user_id="u", user_roles=["support"])
 
@@ -143,3 +143,42 @@ async def test_async_admission_approval_async_handler() -> None:
     gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=approve)
     async with HexgateContext(user_id="u", user_roles=["support"]):
         await gate.check_admission_async()
+
+
+# --- multi-role opt-in (no lockout) ----------------------------------------
+
+
+def test_role_without_admission_is_admitted_despite_another_role_declaring_it() -> None:
+    # Regression: admission is opt-in, so adding it to one role must not lock out
+    # roles that declare none. viewer (no admission) stays admitted even though
+    # admin/contractor declare admission; the union is monotonic.
+    ps = load_policy_set_from_dict(
+        {
+            "roles": {
+                "default": {"default_policy": {"mode": "deny"}},
+                "admin": {
+                    "default_policy": {"mode": "deny"},
+                    "admission": {"mode": "allow"},
+                },
+                "contractor": {
+                    "default_policy": {"mode": "deny"},
+                    "admission": {"mode": "deny"},
+                },
+                "viewer": {"default_policy": {"mode": "deny"}},  # no admission
+            }
+        }
+    )
+    gate = resolve_agent_gate(PolicyEnforcer(ps, agent_name="agent"))
+
+    # viewer declares no admission → opt-in admit (not locked out).
+    with HexgateContext(user_id="u", user_roles=["viewer"]).sync_scope():
+        gate.check_admission()
+
+    # contractor explicitly denies admission.
+    with HexgateContext(user_id="u", user_roles=["contractor"]).sync_scope():
+        with pytest.raises(AgentNotAdmittedError):
+            gate.check_admission()
+
+    # carrying both: viewer's opt-in admits via the permissive union.
+    with HexgateContext(user_id="u", user_roles=["viewer", "contractor"]).sync_scope():
+        gate.check_admission()

--- a/tests/security/test_agent_gate.py
+++ b/tests/security/test_agent_gate.py
@@ -2,8 +2,9 @@
 
 The gate reuses ``PolicyEnforcer.decide`` on the synthetic ``agent.run`` key, so
 these drive it through a real ``PolicySet`` enforcer under an open context scope,
-the same path a run entry takes. Admission is opt-in: ``resolve_agent_gate`` always
-returns a gate, but a policy that declares no admission makes every check a no-op.
+the same path a run entry takes. Engagement is opt-in: ``resolve_agent_gate`` always
+returns a gate, but a policy that declares no admission anywhere makes every check
+a no-op. Once admission is declared, agent keys are closed-world (R-AGENT-002).
 """
 
 from __future__ import annotations
@@ -145,13 +146,14 @@ async def test_async_admission_approval_async_handler() -> None:
         await gate.check_admission_async()
 
 
-# --- multi-role opt-in (no lockout) ----------------------------------------
+# --- multi-role (closed-world + permissive union) --------------------------
 
 
-def test_role_without_admission_is_admitted_despite_another_role_declaring_it() -> None:
-    # Regression: admission is opt-in, so adding it to one role must not lock out
-    # roles that declare none. viewer (no admission) stays admitted even though
-    # admin/contractor declare admission; the union is monotonic.
+def test_admission_is_closed_world_across_roles_with_permissive_union() -> None:
+    # Under Option B (R-AGENT-002) admission is closed-world once any role declares
+    # it: engagement is PolicySet-wide (admin declares admission → the gate fires
+    # for everyone), so a role not granted admission is refused. The multi-role
+    # fold stays permissive: any role that grants admission admits the caller.
     ps = load_policy_set_from_dict(
         {
             "roles": {
@@ -164,21 +166,32 @@ def test_role_without_admission_is_admitted_despite_another_role_declaring_it() 
                     "default_policy": {"mode": "deny"},
                     "admission": {"mode": "deny"},
                 },
-                "viewer": {"default_policy": {"mode": "deny"}},  # no admission
+                "viewer": {"default_policy": {"mode": "deny"}},  # no admission grant
             }
         }
     )
     gate = resolve_agent_gate(PolicyEnforcer(ps, agent_name="agent"))
 
-    # viewer declares no admission → opt-in admit (not locked out).
-    with HexgateContext(user_id="u", user_roles=["viewer"]).sync_scope():
+    # admin is granted admission → admitted.
+    with HexgateContext(user_id="u", user_roles=["admin"]).sync_scope():
         gate.check_admission()
 
-    # contractor explicitly denies admission.
+    # viewer grants no admission → closed-world refuse (the gate is engaged because
+    # admin declares admission somewhere in the set).
+    with HexgateContext(user_id="u", user_roles=["viewer"]).sync_scope():
+        with pytest.raises(AgentNotAdmittedError):
+            gate.check_admission()
+
+    # contractor explicitly denies admission → refused.
     with HexgateContext(user_id="u", user_roles=["contractor"]).sync_scope():
         with pytest.raises(AgentNotAdmittedError):
             gate.check_admission()
 
-    # carrying both: viewer's opt-in admits via the permissive union.
-    with HexgateContext(user_id="u", user_roles=["viewer", "contractor"]).sync_scope():
+    # admin + contractor: the permissive union admits (admin grants; ALLOW wins).
+    with HexgateContext(user_id="u", user_roles=["contractor", "admin"]).sync_scope():
         gate.check_admission()
+
+    # viewer + contractor: neither grants admission → refused.
+    with HexgateContext(user_id="u", user_roles=["viewer", "contractor"]).sync_scope():
+        with pytest.raises(AgentNotAdmittedError):
+            gate.check_admission()

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -176,26 +176,25 @@ def test_unlisted_target_is_closed_world_under_deny_default() -> None:
     assert_denies(_policy(), agent_target_key("handoff", "evil-bot"))
 
 
-def test_admission_is_opt_in_when_unlisted_but_enforced_when_declared() -> None:
-    # agent.run is opt-in: a policy that declares no admission admits (even under a
-    # deny-default), so adding admission to one role never locks out roles without
-    # it. A declared admission still enforces.
-    no_admission = AgentPolicy(default_policy=BaseToolPolicy(mode="deny"))
-    assert_allows(no_admission, AGENT_RUN_TOOL)  # absent → admit, not deny-default
-    declared_deny = AgentPolicy(
-        default_policy=BaseToolPolicy(mode="deny"),
-        admission=BaseToolPolicy(mode="deny"),
-    )
-    assert_denies(declared_deny, AGENT_RUN_TOOL)
+def test_agent_run_is_closed_world_at_the_engine() -> None:
+    # agent.run is closed-world like reach: an unlisted agent.run denies regardless
+    # of default_policy. Opt-in lives at the gate (declares_admission), not here, so
+    # the engine never opt-in-admits (R-AGENT-002).
+    allow_default = AgentPolicy(default_policy=BaseToolPolicy(mode="allow"))
+    assert_denies(allow_default, AGENT_RUN_TOOL)  # closed-world, not default-allow
+    admits = AgentPolicy(admission=BaseToolPolicy(mode="allow"))
+    assert_allows(admits, AGENT_RUN_TOOL)  # declared allow → admit
+    denies = AgentPolicy(admission=BaseToolPolicy(mode="deny"))
+    assert_denies(denies, AGENT_RUN_TOOL)
 
 
 def test_authored_agent_prefixed_tool_follows_default_not_closed_world() -> None:
     # An authored tool whose name merely starts with "agent." (not a reserved key)
-    # follows default_policy, it is not swept into the closed-world reach handling.
+    # follows default_policy, it is not swept into the closed-world agent handling.
     policy = AgentPolicy(default_policy=BaseToolPolicy(mode="allow"))
     assert_allows(policy, "agent.foo")  # not a key → default allow
     assert_allows(policy, "agent.tool")  # no colon → not a reach key → default allow
-    assert_allows(policy, AGENT_RUN_TOOL)  # admission opt-in → allow
+    assert_denies(policy, AGENT_RUN_TOOL)  # real agent key → closed-world deny
     assert_denies(policy, agent_target_key("tool", "x"))  # real reach key → deny
 
 
@@ -210,32 +209,30 @@ def test_rego_compiler_emits_lowered_agent_keys() -> None:
     assert 'input.tool == "agent.handoff:billing-bot"' in rego
 
 
-def test_rego_permissive_default_excludes_reach_keys_and_opts_in_admission() -> None:
-    # Reach keys are excluded from the permissive catch-all (so they deny), while
-    # admission opts in via its own rule. The old broad ``agent.`` exclusion is gone
-    # (it wrongly caught authored agent.* tool names).
-    rego = compile_to_rego(
-        {
-            "default_policy": {"mode": "allow"},
-            "agents": {"b": {"mode": "allow", "via": ["tool"]}},
-        }
-    )
+def test_rego_permissive_default_excludes_all_agent_keys() -> None:
+    # Every agent key (agent.run + reach prefixes) is excluded from the permissive
+    # catch-all, so an unlisted agent key denies. The exclusion is the exact
+    # reserved set (not a broad ``agent.`` prefix that would catch authored
+    # agent.*-named tools), matching is_agent_key (R-AGENT-002).
+    rego = compile_to_rego({"default_policy": {"mode": "allow"}})
+    assert 'input.tool != "agent.run"' in rego
     assert 'not startswith(input.tool, "agent.tool:")' in rego
     assert 'not startswith(input.tool, "agent.handoff:")' in rego
-    assert 'input.tool == "agent.run"' in rego  # opt-in admit rule
-    assert 'not startswith(input.tool, "agent.")' not in rego
+    assert 'not startswith(input.tool, "agent.")' not in rego  # not the broad prefix
 
 
 @needs_opa
 def test_closed_world_agent_parity_pydantic_vs_wasm() -> None:
     # The fallbacks must agree across engines under an allow-default: ordinary tools
-    # and authored agent.*-named tools follow the default (allow), admission opts in
-    # (allow), and unlisted reach keys deny — on both the pydantic and WASM paths.
+    # and authored agent.*-named tools follow the default (allow), while every agent
+    # key is closed-world — a declared admission allows, an unlisted agent.run and
+    # unlisted reach keys deny — on both the pydantic and WASM paths.
     from hexgate.security import compile_to_wasm, verdict_from_rego
     from hexgate.security.wasm_engine import WasmPolicy
 
     payload = {
         "default_policy": {"mode": "allow"},
+        "admission": {"mode": "allow"},
         "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
     }
     ps = load_policy_set_from_dict(payload)
@@ -244,7 +241,7 @@ def test_closed_world_agent_parity_pydantic_vs_wasm() -> None:
     cases = [
         "some_unlisted_tool",  # ordinary tool → default allow
         "agent.foo",  # authored agent.*-named tool (not a key) → default allow
-        AGENT_RUN_TOOL,  # admission opt-in → allow
+        AGENT_RUN_TOOL,  # admission declared allow → allow
         agent_target_key("tool", "billing-bot"),  # listed → allow
         agent_target_key("handoff", "billing-bot"),  # via not listed → deny
         agent_target_key("tool", "other-bot"),  # target not listed → deny

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -291,31 +291,48 @@ def test_file_scope_in_module_raises():
         link([guard], [])
 
 
-def test_link_rejects_agents_block_in_module() -> None:
-    # An ``agents`` egress rule authored in a module would be silently dropped by
-    # the fold (which composes ``.tools`` only) — the same fail-open file_scope
-    # guards against. Fail loud instead.
-    mod = ModuleContent(
+def test_boundary_agents_deny_composes_as_authoritative_deny() -> None:
+    # An ``agents`` block lowers to agent.* keys the fold composes like tools
+    # (R-AGENT-002). A boundary agent-deny is authoritative — it folds to a hard
+    # deny on the lowered reach key, exactly as a boundary tool deny would.
+    boundary = ModuleContent(
         name="b",
         kind="boundary",
         policy=AgentPolicy(agents={"evil-bot": {"mode": "deny"}}),
         source="b.yaml",
         content_hash="hash-b",
     )
-    with pytest.raises(LinkError, match=r"\['agents'\]"):
-        link([mod], [])
+    effective, _ = link([boundary], [])
+    denied = effective.effective_tools["agent.handoff:evil-bot"]
+    assert denied.mode == "deny"
 
 
-def test_link_rejects_admission_block_in_module() -> None:
-    mod = ModuleContent(
+def test_capability_admission_grant_composes() -> None:
+    # A capability may grant admission: an ``admission`` block lowers to agent.run,
+    # which the fold unions like any other capability grant.
+    cap = ModuleContent(
         name="c",
         kind="capability",
         policy=AgentPolicy(admission={"mode": "allow"}),
         source="c.yaml",
         content_hash="hash-c",
     )
-    with pytest.raises(LinkError, match=r"\['admission'\]"):
-        link([], [mod])
+    effective, _ = link([], [cap])
+    assert effective.effective_tools["agent.run"].mode == "allow"
+
+
+def test_capability_agents_deny_is_a_link_error() -> None:
+    # Capabilities grant only, agent keys included: a capability that denies a
+    # lowered agent key is a config error, same as a capability tool deny.
+    cap = ModuleContent(
+        name="c",
+        kind="capability",
+        policy=AgentPolicy(agents={"evil-bot": {"mode": "deny"}}),
+        source="c.yaml",
+        content_hash="hash-c",
+    )
+    with pytest.raises(LinkError, match=r"agent\.handoff:evil-bot"):
+        link([], [cap])
 
 
 # --- provenance + policy-set wiring ---

--- a/tests/security/test_rego_compile.py
+++ b/tests/security/test_rego_compile.py
@@ -154,13 +154,12 @@ def test_emits_allow_rule_per_role_and_tool() -> None:
     rules = _allow_rules(rego)
     # support_bot: 3 roles (read_only is mixin, dropped) × 3 tools (web_search,
     # read_file each get an allow per role; refund_order is allow for support
-    # + billing, deny for default). Plus one agent.run opt-in allow per role,
-    # since no role lists admission (admission is opt-in, so an absent agent.run
-    # admits — emitted on every role to match the pydantic engine).
-    #   default  → web_search, read_file, agent.run (refund_order is deny, no rule)
-    #   support  → web_search, read_file, refund_order (2 constraints), agent.run
-    #   billing  → web_search, read_file, refund_order (2 constraints), agent.run
-    assert len(rules) == (2 + 1) + (3 + 1) + (3 + 1)
+    # + billing, deny for default). No role lists admission, and agent.run is
+    # closed-world (no opt-in rule) — so no agent.* rules are emitted (R-AGENT-002).
+    #   default  → web_search, read_file (refund_order is deny, no rule)
+    #   support  → web_search, read_file, refund_order (2 constraints)
+    #   billing  → web_search, read_file, refund_order (2 constraints)
+    assert len(rules) == 2 + 3 + 3
 
 
 def test_mixin_role_omitted_from_output() -> None:


### PR DESCRIPTION
Add agent-level admission enforcement: gate whether a caller, in their role, may run an agent at all, decided at run entry before the model sees anything. This folds in the former #124 (AgentGate runtime) and the model reconcile it depends on, so it lands as one coherent feature instead of a stacked pair. Pure SDK, no platform or dashboard change, no migration. It is the A2 step of the agent-level enforcement series (A1, the `admission`/`agents` lowering, is already merged); A3 (handoff/delegation interception) and A4 (depth cap) follow.

This supersedes #124, which was built on an opt-in admission model that review showed had two fail-opens. Rather than patch them in the runtime, the fix is to reconcile agent-level rules with the boundary/capability module model from #115 (R-POL-001) and make agent keys closed-world.

## Design

Agent-level rules (`admission` / `agents`) lower to synthetic `agent.run` / `agent.tool:<t>` / `agent.handoff:<t>` keys that both engines already read through `effective_tools`. This PR makes those keys first-class in the linker fold, closed-world at the engines, and cleanly separates two things #124 had tangled: how rules compose vs. whether the gate is engaged at all.

- Agent keys fold through the linker, exactly like tool keys. A boundary agent-deny is authoritative and role-independent, a ceiling boundary makes an unlisted agent key ineligible, capabilities grant and union, a capability that denies an agent key is a `LinkError`. `admission` / `agents` become allowed module fields.
- Agent keys are closed-world. An unlisted agent key (admission and reach) denies regardless of `default_policy`, so a silent co-role can neither admit an unknown caller nor defeat an explicit deny. This drops `agent.run`'s old opt-in-allow (the `get_tool_policy` fallback and the per-role Rego rule), removing both fail-opens by construction.
- Engagement is opt-in and derived, separate from composition. `PolicyEngine.declares_admission()` / `declares_reach()` decide whether the gate fires: the pydantic engine derives it from whether any resolved role carries the key; the WASM bundle reads an `agent_gating` block recorded in the signed manifest at build time. An agent whose policy never mentions admission is never gated and runs exactly as before, which is what keeps closed-world from locking out agents that do not use the feature.
- `AgentGate` is the runtime, mirroring the egress `Gate`: it reuses `PolicyEnforcer.decide` on the `agent.run` key at run entry, folds approval, and fails closed with `AgentNotAdmittedError`. It is wired in `HexgateAgent` by `enforce_policy` alongside the binding (local, no control plane), threaded through `with_tools` rebuilds, and cleared on the unguarded path. Whether it refuses is decided per run from the current policy, so a hot-reload that adds or drops admission is honored on the next run.

Full rationale and rejected alternatives in `docs/adr/R-AGENT-002`.

## Important files

| File | What to look at |
| --- | --- |
| `hexgate/security/agent_gate.py` | the runtime gate: `check_admission[_async]` reads `declares_admission()` per run, decides `agent.run`, folds approval, fails closed |
| `hexgate/agents/factory.py` | how the gate is wired: attached in `enforce_policy`, threaded through `with_tools`, cleared on the unguarded/guards-only paths, checked at `ainvoke`/`astream_events` entry |
| `hexgate/security/linker.py` | agent keys fold through `effective_tools` in `_fold_tool` / `_tool_names` / `_reject_capability_denies`; `admission`/`agents` in `_MODULE_COMPOSABLE_FIELDS`; resolved policy via `AgentPolicy.resolved()` |
| `hexgate/security/policy.py` | `get_tool_policy` fallback collapsed: every unlisted agent key denies closed-world |
| `hexgate/security/rego.py` | removed the per-role `agent.run` opt-in rule; catch-all excludes exactly the reserved agent keys, not a broad `agent.` prefix |
| `hexgate/security/decision.py`, `policy_set.py`, `bundle.py`, `models.py` | `declares_admission()`/`declares_reach()` on the protocol (pydantic from `effective_tools`, WASM from the manifest); `AgentPolicy.resolved()` builder |
| `docs/adr/R-AGENT-002-...md` | the decision, why, rejected alternatives |
| `tests/security/test_agent_gate.py` | admission verdicts + the multi-role closed-world/permissive-union case |
| `tests/security/test_linker.py`, `test_agent_policy.py`, `test_rego_compile.py` | the behaviour flips: boundary agent-deny composes, capability agent-deny is a LinkError, unlisted `agent.run` denies, no per-role admit rule |

## Test plan

Ran the SDK suite against the hexanlp-demo env: `pytest tests/ -q` gives 2091 passed, 6 skipped (opt-in integration), 20 deselected. `ruff check` clean over `hexgate/`, `tests/`, and the demo; `ruff format --check` clean.

By hand I checked the semantics that changed: (1) a boundary `agents: {x: deny}` folds to a hard deny on `agent.handoff:x` in `effective_tools`, and a capability `agents: {x: deny}` raises `LinkError`; (2) an unlisted `agent.run` under `default_policy: allow` denies on both the pydantic and compiled-WASM paths (parity case in `test_closed_world_agent_parity_pydantic_vs_wasm`); (3) the golden Rego fixture lost exactly the three per-role `agent.run` allow rules and nothing else; (4) the multi-role gate: `admin` (granted) admits, `viewer` (no grant, gate engaged because `admin` declares admission) is refused, `contractor` (`admission: deny`) is refused, `[contractor, admin]` admits via the permissive union, `[viewer, contractor]` is refused. A reviewer catches a regression through the pydantic-vs-WASM parity tests, the golden snapshot, and the multi-role gate test.

## Try it

```
# marimo admission demo against an inline policy (support/billing admitted,
# contractor + unroled refused, closed-world):
uv run marimo edit deploy/agent_gate_demo.py

# the model + linker changes:
uv run pytest tests/security -q
```

## Notes

- No platform or dashboard change; the only manifest touched is the signed WASM bundle manifest (`build_signed_bundle`), which gains an `agent_gating` block. Older bundles without it read `declares_admission()` as False, which is safe (they predate agent-level policy).
- Closes/supersedes #124. Supersedes the opt-in/closed-world half of R-AGENT-001; its engagement-flag and manifest mechanism survive, now uniform for admission and reach.
- Behaviour change to be aware of when authoring: once a policy declares `admission` on any role, admission is enforced for every caller (closed-world), so grant it on each role that should be admitted (e.g. `admission: allow` on `default` for broad access). An agent that declares no admission is unaffected.
- Follow-ups: A3 (handoff/delegation interception, which consumes `declares_reach()`) and A4 (depth cap). Design doc: `docs/adr/R-AGENT-002-agent-keys-compose-through-the-linker.md`.
