### PR TITLE
docs(sdk): support-bot demo with modular tools and agent reach (marimo)

### DIFF
--- a/deploy/agent_gate_demo.py
+++ b/deploy/agent_gate_demo.py
@@ -1,0 +1,287 @@
+"""Hexgate agent-gate demo (marimo) — gate whole agents by policy, in code.
+
+A code-only tour of agent-level enforcement, the sibling to the egress gate. No
+platform, no API key, no model call. Hexgate normally gates the *tool call* the
+model proposes; this gate sits one level up and asks two questions from the same
+policy engine:
+
+  * admission — may this caller, in this role, *run this agent at all*?
+  * reach     — which *other* agents may it call as a tool or hand off to?
+
+Both lower to synthetic tool keys (`agent.run`, `agent.tool:<name>`,
+`agent.handoff:<name>`), so the same engine decides them through the same path as
+any tool. Admission is enforced at run entry today; the handoff interception in
+the framework adapters is the next slice, but the policy already decides it.
+
+Run with `uv run --with marimo marimo edit deploy/agent_gate_demo.py`.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import yaml
+
+    import marimo as mo
+
+    from hexgate import HexgateContext
+    from hexgate.security import (
+        AGENT_RUN_TOOL,
+        AgentNotAdmittedError,
+        agent_target_key,
+        resolve_agent_gate,
+    )
+    from hexgate.security.enforcer import build_enforcer
+    from hexgate.security.policy_set import load_policy_set_from_dict
+
+    return (
+        AGENT_RUN_TOOL,
+        AgentNotAdmittedError,
+        HexgateContext,
+        agent_target_key,
+        build_enforcer,
+        load_policy_set_from_dict,
+        mo,
+        resolve_agent_gate,
+        yaml,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # 🚪 Hexgate — gating whole agents
+
+        The tool gate answers "may the model run *this tool* with *these args*?".
+        The **agent gate** sits one level up and answers two more, from the same
+        policy engine:
+
+        - **admission** — may this caller, in this role, *start this agent at all*?
+          Checked at run entry, before the model sees anything.
+        - **reach** — which *other* agents may it call as a tool, or hand the whole
+          conversation off to?
+
+        Both lower to synthetic tool keys (`agent.run`, `agent.tool:<name>`,
+        `agent.handoff:<name>`), so there is no second decision path: the same
+        engine, constraints, and audit apply. This demo is **code-only** — no
+        platform, no API key, no model call.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 1 · The policy""")
+    return
+
+
+@app.cell
+def _(load_policy_set_from_dict, yaml):
+    # A refund agent that can consult a billing-bot. support may run it and call
+    # billing-bot as a tool, but must never hand the customer conversation off.
+    # billing may hand off, with a human's approval and only one hop deep.
+    # contractor cannot start the agent at all. Any undefined role falls to
+    # `default`, which denies admission — closed-world for free.
+    POLICY_YAML = """
+version: 1
+roles:
+  default:
+    default_policy: { mode: deny }
+    admission: { mode: deny }
+
+  support:
+    default_policy: { mode: deny }
+    admission: { mode: allow }
+    agents:
+      billing-bot:
+        via: [tool]                  # consult as a tool; never hand off
+        mode: allow
+
+  billing:
+    default_policy: { mode: deny }
+    admission: { mode: allow }
+    agents:
+      billing-bot:
+        via: [tool, handoff]         # may also hand off...
+        mode: approval_required      # ...with a human's approval
+        constraints: ["args.depth <= 1"]   # ...and only one hop deep
+
+  contractor:
+    default_policy: { mode: deny }
+    admission: { mode: deny }        # cannot start the agent at all
+"""
+    ps = load_policy_set_from_dict(yaml.safe_load(POLICY_YAML))
+    return POLICY_YAML, ps
+
+
+@app.cell
+def _(POLICY_YAML, mo):
+    mo.md(
+        f"""
+        Written once, in ordinary policy YAML. `admission` is ingress (may I run
+        this agent), `agents` is egress (which agents may I reach, and how).
+
+        ```yaml{POLICY_YAML}```
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 2 · Admission — decided at run entry
+
+        This is the exact check `HexgateAgent` runs at the top of every run, before
+        the model. A refused caller never starts the agent; the run raises
+        `AgentNotAdmittedError` instead. No model call is involved, so we drive the
+        gate directly here.
+        """
+    )
+    return
+
+
+@app.cell
+def _(
+    AgentNotAdmittedError,
+    HexgateContext,
+    build_enforcer,
+    mo,
+    ps,
+    resolve_agent_gate,
+):
+    def _admit(role):
+        # A fresh enforcer + gate, exactly as enforce_policy builds them.
+        gate = resolve_agent_gate(build_enforcer(ps, agent_name="refund_agent"))
+        roles = [role] if role is not None else []
+        with HexgateContext(user_id="demo", user_roles=roles).sync_scope():
+            try:
+                gate.check_admission()
+                return "allow", ""
+            except AgentNotAdmittedError as exc:
+                return exc.decision.outcome.value, exc.decision.reason
+
+    _label = {
+        "allow": "✅ admitted",
+        "deny": "❌ refused",
+        "needs_approval": "🔶 approval",
+    }
+    _cases = [
+        "support",  # admitted
+        "billing",  # admitted
+        "contractor",  # refused (admission: deny)
+        "intern",  # undefined role -> falls to default -> refused
+        None,  # no role at all -> default -> refused
+    ]
+    _rows = ["| caller role | may run `refund_agent`? |", "|---|---|"]
+    for _role in _cases:
+        _outcome, _ = _admit(_role)
+        _shown = _role if _role is not None else "_(none)_"
+        _rows.append(f"| `{_shown}` | {_label.get(_outcome, _outcome)} |")
+    mo.md("\n".join(_rows))
+    return (_admit,)
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 3 · Reach — which agents may this agent call or hand off to
+
+        The same engine decides agent-to-agent reach. `agent.tool:<name>` is
+        calling a sub-agent as a tool (the orchestrator keeps control);
+        `agent.handoff:<name>` is transferring the whole conversation. A policy can
+        allow one and gate the other.
+
+        > Admission (section 2) is enforced at run entry today. The handoff
+        > *interception* inside the framework adapters is the next slice; the policy
+        > below already decides it through the same path.
+        """
+    )
+    return
+
+
+@app.cell
+def _(agent_target_key, mo, ps):
+    def _reach(role, via, target, **args):
+        return ps.evaluate(
+            role=role, tool=agent_target_key(via, target), args=args
+        ).outcome.value
+
+    _label = {"allow": "✅ allow", "deny": "❌ deny", "needs_approval": "🔶 approval"}
+    # (role, via, args, note)
+    _cases = [
+        ("support", "tool", {}, "consult billing-bot as a tool"),
+        ("support", "handoff", {}, "hand the customer to billing-bot"),
+        ("billing", "tool", {"depth": 0}, "consult billing-bot as a tool"),
+        ("billing", "handoff", {"depth": 0}, "hand off (1 hop)"),
+        ("billing", "handoff", {"depth": 2}, "hand off (2 hops — over the cap)"),
+    ]
+    _rows = ["| role | reach `billing-bot` via | decision | |", "|---|---|---|---|"]
+    for _role, _via, _args, _note in _cases:
+        _outcome = _reach(_role, _via, "billing-bot", **_args)
+        _rows.append(
+            f"| `{_role}` | `{_via}` | {_label.get(_outcome, _outcome)} | {_note} |"
+        )
+    mo.md("\n".join(_rows))
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 4 · Your turn""")
+    return
+
+
+@app.cell
+def _(mo):
+    role_form = (
+        mo.md("**Caller role** {role}")
+        .batch(
+            role=mo.ui.dropdown(
+                options=["support", "billing", "contractor", "intern"],
+                value="support",
+            )
+        )
+        .form(submit_button_label="▶ Check admission")
+    )
+    role_form
+    return (role_form,)
+
+
+@app.cell
+def _(_admit, mo, role_form):
+    if role_form.value is None:
+        _out = mo.callout(
+            mo.md("Pick a role and click **▶ Check admission**."), kind="info"
+        )
+    else:
+        _role = role_form.value["role"]
+        _outcome, _reason = _admit(_role)
+        if _outcome == "allow":
+            _out = mo.callout(
+                mo.md(f"`{_role}` is **admitted** — the agent run starts."),
+                kind="success",
+            )
+        else:
+            _detail = f"\n\nreason: {_reason}" if _reason else ""
+            _out = mo.callout(
+                mo.md(
+                    f"`{_role}` is **refused** (`{_outcome}`) — the run never "
+                    f"starts, `AgentNotAdmittedError` is raised.{_detail}"
+                ),
+                kind="danger",
+            )
+    _out
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/deploy/support_bot_demo.py
+++ b/deploy/support_bot_demo.py
@@ -1,0 +1,448 @@
+"""Hexgate support-bot demo (marimo) — one modular policy, tools *and* agents.
+
+A read-top-to-bottom tour of a small customer-support system where the WHOLE
+policy — tool permissions *and* agent-to-agent reach — is composed from the same
+shared modules by the linker, then enforced. Fully local (no platform, no API
+key, no model call):
+
+  many module .yaml files  →  resolve_for_project()  →  one PolicySet per role
+
+The system has two agents: a front-line `support_bot` and a refunds specialist
+`billing_bot`. A role's policy governs both what tools it may call (support caps
+out before refunds; billing refunds up to the boundary's $1000 ceiling) *and*
+whether `support_bot` may hand the conversation off to `billing_bot`. Agent
+reach is closed-world: no role may reach `billing_bot` until a capability grants
+it — the same module pipeline as tools (new in the agent-reach work).
+
+Run with `uv run --with marimo marimo edit deploy/support_bot_demo.py`.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import os
+    import shutil
+    import tempfile
+    from pathlib import Path
+    from textwrap import dedent
+
+    # Force offline: the gate's enforcer wires an audit sender that otherwise
+    # falls back to HEXGATE_API_KEY. This is a policy tour — keep it local.
+    os.environ["HEXGATE_LOCAL_MODE"] = "1"
+
+    import marimo as mo
+
+    from hexgate import HexgateContext
+    from hexgate.security import (
+        ReachNotAllowedError,
+        agent_target_key,
+        load_local_modules,
+        resolve_for_project,
+        resolve_reach_gate,
+    )
+    from hexgate.security.enforcer import build_enforcer
+
+    return (
+        HexgateContext,
+        Path,
+        ReachNotAllowedError,
+        agent_target_key,
+        build_enforcer,
+        dedent,
+        load_local_modules,
+        mo,
+        resolve_for_project,
+        resolve_reach_gate,
+        shutil,
+        tempfile,
+    )
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        # 🎧 Hexgate — one modular policy, tools *and* agents
+
+        A customer-support system with two agents: front-line `support_bot` and
+        refunds specialist `billing_bot`. Everything a role may do is composed
+        from the **same shared modules**:
+
+        - **Tool permissions** — may this role call this tool with these args?
+        - **Agent reach** — may `support_bot` hand the conversation off to
+          `billing_bot`?
+
+        Both are authored as modules (security's **boundary** + teams'
+        **capabilities**), bound to roles, and folded by the linker into one
+        `PolicySet` per role. Agent-level policy is modular too — it rides the
+        exact same pipeline as tools. All local: no platform, no API key, no
+        model call.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 1 · The modules
+
+        One **boundary** (security-owned) sets the org's allowed surface and its
+        caps — including the ceiling on agent reach: `support_bot` may *hand off*
+        to `billing_bot` (never call it as a tool). **Capabilities** (team-owned)
+        grant subsets. A **role** names the capabilities it imports.
+        """
+    )
+    return
+
+
+@app.cell
+def _(dedent):
+    # Edit these and the whole notebook re-resolves. The boundary is a ceiling
+    # (default deny): it enumerates the allowed surface, so a tool — or a reach
+    # target — it doesn't list is ineligible no matter what a capability grants.
+    BOUNDARIES = {
+        "org_core": dedent(
+            """
+            default_policy: { mode: deny }
+            tools:
+              view_orders:     { mode: allow }
+              send_email:      { mode: allow }
+              escalate:        { mode: allow }
+              refund_order:    { mode: allow, constraints: ["args.amount <= 1000"] }  # hard cap
+              delete_database: { mode: deny }                                          # absolute
+            agents:
+              # reach ceiling: hand-off to billing_bot is permitted; agent-as-tool
+              # is not (billing_bot must own the conversation for a refund).
+              billing_bot: { via: [handoff], mode: allow }
+            """
+        ),
+    }
+    CAPABILITIES = {
+        "read_only": dedent(
+            """
+            tools:
+              view_orders: { mode: allow }
+            """
+        ),
+        "support_leaf": dedent(
+            """
+            tools:
+              send_email: { mode: allow }
+              escalate:   { mode: approval_required }
+            """
+        ),
+        "payments": dedent(
+            """
+            tools:
+              refund_order: { mode: allow, constraints: ['args.currency in ["USD", "EUR"]'] }
+            """
+        ),
+        "billing_reach": dedent(
+            """
+            # grants the agent-level reach: this role's support_bot may hand off
+            # to billing_bot. No grant -> closed-world deny.
+            agents:
+              billing_bot: { via: [handoff], mode: allow }
+            """
+        ),
+    }
+    # Role -> the capabilities it imports (the boundary applies to every role).
+    ROLES = {
+        "default": ["read_only"],
+        "support": ["read_only", "support_leaf"],
+        "billing": ["read_only", "payments", "billing_reach"],
+    }
+    return BOUNDARIES, CAPABILITIES, ROLES
+
+
+@app.cell
+def _(BOUNDARIES, CAPABILITIES, Path, load_local_modules, shutil, tempfile):
+    # Write the modules to a policies/ tree and load them through the real
+    # local-files loader — the same path as `hexgate policy resolve --dir`. A
+    # stable dir (recreated each run) so re-running on an edit doesn't leak.
+    def _write_modules(boundaries, capabilities):
+        root = Path(tempfile.gettempdir()) / "hexgate-support-demo"
+        shutil.rmtree(root, ignore_errors=True)
+        for kind, mods in (
+            ("boundaries", boundaries),
+            ("capabilities", capabilities),
+        ):
+            d = root / "policies" / kind
+            d.mkdir(parents=True, exist_ok=True)
+            for name, body in mods.items():
+                (d / f"{name}.yaml").write_text(body, encoding="utf-8")
+        return load_local_modules(root)
+
+    boundaries, library = _write_modules(BOUNDARIES, CAPABILITIES)
+    return boundaries, library
+
+
+@app.cell
+def _(ROLES, boundaries, library, resolve_for_project):
+    # One resolve. The role-keyed PolicySet carries tools AND agent reach — the
+    # fold lowers the `agents` blocks to `agent.handoff:<target>` keys and
+    # composes them exactly like tool keys.
+    policy_set = resolve_for_project(boundaries, library, ROLES).policy_set
+    return (policy_set,)
+
+
+@app.cell
+def _(ROLES, mo, policy_set):
+    _LABEL = {"allow": "✅", "deny": "❌", "needs_approval": "🔶 approval"}
+    _CALLS = [
+        ("view_orders", {}),
+        ("send_email", {}),
+        ("escalate", {}),
+        ("refund_order", {"amount": 800, "currency": "USD"}),
+        ("refund_order", {"amount": 2000, "currency": "USD"}),
+    ]
+
+    def _cell(role, tool, args):
+        o = policy_set.evaluate(role=role, tool=tool, args=args).outcome.value
+        return _LABEL.get(o, o)
+
+    _cols = [f"`{t}`" + (f"<br>`{a}`" if a else "") for t, a in _CALLS]
+    _header = "| role | " + " | ".join(_cols) + " |"
+    _sep = "|" + "---|" * (len(_CALLS) + 1)
+    _rows = [
+        "| `" + r + "` | " + " | ".join(_cell(r, t, a) for t, a in _CALLS) + " |"
+        for r in ROLES
+    ]
+    mo.md(
+        "**Resolved tool policy, per role**\n\n" + "\n".join([_header, _sep, *_rows])
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 2 · Agent reach — composed from the same modules
+
+        Reach is **closed-world**: no role may reach `billing_bot` until a
+        capability grants it. Only `billing` imports `billing_reach`, so only
+        `billing` may hand `support_bot`'s conversation off — `support` and
+        `default` are denied, and nobody may reach it *as a tool* (the boundary
+        ceilinged `handoff` only). This runs the real `ReachGate` — the seam the
+        framework calls at a hand-off — over the modularly-composed policy.
+        """
+    )
+    return
+
+
+@app.cell
+def _(
+    HexgateContext,
+    ReachNotAllowedError,
+    build_enforcer,
+    policy_set,
+    resolve_reach_gate,
+):
+    def reach(role, via="handoff", target="billing_bot"):
+        """Run the real ReachGate for `role`: may support_bot reach `target`?
+
+        Returns (outcome, reason). The source agent's policy governs reach, so
+        the gate is built from support_bot's enforcer and decides the target's
+        lowered key. No-op-safe: closed-world denies an ungranted role."""
+        gate = resolve_reach_gate(build_enforcer(policy_set, agent_name="support_bot"))
+        roles = [role] if role is not None else []
+        with HexgateContext(user_id="demo", user_roles=roles).sync_scope():
+            try:
+                gate.check_reach(target, via=via)
+                return "allow", ""
+            except ReachNotAllowedError as exc:
+                return exc.decision.outcome.value, exc.decision.reason
+
+    return (reach,)
+
+
+@app.cell
+def _(mo, reach):
+    _LABEL = {"allow": "✅ allowed", "deny": "❌ refused", "needs_approval": "🔶 approval"}
+    _rows = [
+        "| caller role | `support_bot` → `billing_bot` (handoff) | (as tool) |",
+        "|---|---|---|",
+    ]
+    for _role in ["default", "support", "billing"]:
+        _h, _ = reach(_role, via="handoff")
+        _t, _ = reach(_role, via="tool")
+        _rows.append(f"| `{_role}` | {_LABEL.get(_h, _h)} | {_LABEL.get(_t, _t)} |")
+    mo.md(
+        "**Reach, live from the gate**\n\n"
+        + "\n".join(_rows)
+        + "\n\n> `billing` was granted `handoff` by the `billing_reach` "
+        "capability; `support`/`default` hit the closed-world deny; and "
+        "*as-tool* reach is refused for everyone (the boundary ceilinged "
+        "`handoff` only)."
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 3 · Capping hand-off depth
+
+        The boundary can also **cap how deep a hand-off chain goes** with a
+        constraint on `args.depth` — the framework's hand-off seam supplies the
+        current depth. Here we author the cap and pass the depth explicitly to
+        show it: one hop is allowed, a second is refused.
+        """
+    )
+    return
+
+
+@app.cell
+def _(
+    Path,
+    agent_target_key,
+    dedent,
+    load_local_modules,
+    mo,
+    resolve_for_project,
+    shutil,
+    tempfile,
+):
+    def _resolve_depth_capped():
+        root = Path(tempfile.gettempdir()) / "hexgate-support-depth"
+        shutil.rmtree(root, ignore_errors=True)
+        (root / "policies" / "boundaries").mkdir(parents=True, exist_ok=True)
+        cap = root / "policies" / "capabilities"
+        cap.mkdir(parents=True, exist_ok=True)
+        (root / "policies" / "boundaries" / "org.yaml").write_text(
+            dedent(
+                """
+                default_policy: { mode: deny }
+                agents:
+                  billing_bot: { via: [handoff], mode: allow, constraints: ["args.depth <= 1"] }
+                """
+            )
+        )
+        (cap / "billing_reach.yaml").write_text(
+            "agents:\n  billing_bot: { via: [handoff], mode: allow }\n"
+        )
+        b, lib = load_local_modules(root)
+        return resolve_for_project(b, lib, {"default": ["billing_reach"]}).policy_set
+
+    _ps = _resolve_depth_capped()
+    _key = agent_target_key("handoff", "billing_bot")
+    _hop1 = _ps.evaluate(role="default", tool=_key, args={"depth": 1}).outcome.value
+    _hop2 = _ps.evaluate(role="default", tool=_key, args={"depth": 2}).outcome.value
+    mo.md(
+        "boundary reach cap `args.depth <= 1`:\n\n"
+        f"- hand-off at depth 1 → **{_hop1}**\n"
+        f"- hand-off at depth 2 → **{_hop2}** (over the cap)"
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ## 4 · One pipeline
+
+        Nothing above is bolted on: the tool table (§1) and the reach table (§2)
+        came from the **same** `resolve_for_project` call over the same modules.
+        Agent-level policy — reach here, and admission the same way — lowers to
+        `agent.*` decision keys the linker folds like any tool, so a boundary
+        can cap it and a capability can grant it, bound to roles.
+        """
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""## 5 · Your turn""")
+    return
+
+
+@app.cell
+def _(mo):
+    play = (
+        mo.md("""**caller role** {role} &nbsp;&nbsp; **reach via** {via}""")
+        .batch(
+            role=mo.ui.dropdown(
+                options=["default", "support", "billing"], value="support"
+            ),
+            via=mo.ui.dropdown(options=["handoff", "tool"], value="handoff"),
+        )
+        .form(submit_button_label="▶ Check reach")
+    )
+    play
+    return (play,)
+
+
+@app.cell
+def _(mo, play, policy_set, reach):
+    if play.value is None:
+        _out = mo.callout(mo.md("Pick a role + via, then **▶ Check reach**."), kind="info")
+    else:
+        _role = play.value["role"]
+        _via = play.value["via"]
+        _outcome, _reason = reach(_role, via=_via)
+        _refund = policy_set.evaluate(
+            role=_role, tool="refund_order", args={"amount": 800, "currency": "USD"}
+        ).outcome.value
+        if _outcome == "allow":
+            _reach_md = mo.callout(
+                mo.md(
+                    f"**Reach ✅** — as `{_role}`, `support_bot` may `{_via}` to "
+                    f"`billing_bot`."
+                ),
+                kind="success",
+            )
+        else:
+            _detail = f"\n\nreason: {_reason}" if _reason else ""
+            _reach_md = mo.callout(
+                mo.md(
+                    f"**Reach ❌** — as `{_role}`, `support_bot` may not `{_via}` "
+                    f"to `billing_bot` (`{_outcome}`).{_detail}"
+                ),
+                kind="danger",
+            )
+        _out = mo.vstack(
+            [
+                _reach_md,
+                mo.md(
+                    f"For reference, `refund_order($800, USD)` as `{_role}` → "
+                    f"**{_refund}** (same modular policy, tool side)."
+                ),
+            ]
+        )
+    _out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md(
+        """
+        ---
+        The same linker + rules power the CLI — point it at a policies/ tree of
+        your own:
+
+        ```
+        hexgate policy resolve --dir <your policies/ dir>
+        ```
+
+        Reach and admission are enforced at run entry / hand-off by the
+        `ReachGate` / `AgentGate` seams a live agent runs, over the policy the
+        linker composed from these modules.
+        """
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/docs/adr/R-AGENT-002-agent-keys-compose-through-the-linker.md
+++ b/docs/adr/R-AGENT-002-agent-keys-compose-through-the-linker.md
@@ -1,0 +1,43 @@
+# R-AGENT-002: Agent-level rules compose through the boundary/capability linker; agent keys are closed-world
+
+**Status:** Accepted · 2026-08-26 · supersedes the opt-in/closed-world portion of R-AGENT-001
+**Applies to:** `hexgate/security/policy.py`, `hexgate/security/rego.py`, `hexgate/security/linker.py`, `hexgate/security/policy_set.py`, `hexgate/security/bundle.py`, `hexgate/security/agent_gate.py`
+
+## Decision
+
+Agent-level rules (`admission` / `agents`, lowered to `agent.run` / `agent.tool:<t>` / `agent.handoff:<t>` keys) MUST compose through the same model as tools (R-POL-001), not a separate runtime fold.
+
+- **Agent keys fold through the linker.** `_fold_tool` and `_tool_names` MUST operate over `effective_tools`, so an `agent.*` key composes exactly like a tool key: a boundary deny wins absolutely and is role-independent; a ceiling boundary makes an unlisted key ineligible; capabilities grant and union; a capability that denies an agent key is a `LinkError`, same as any tool. `admission` / `agents` become allowed module fields.
+- **Agent keys are closed-world.** An unlisted `agent.*` key (admission *and* reach) MUST deny, regardless of `default_policy`. This replaces R-AGENT-001's `agent.run` opt-in-allow: a role that is not granted admission is denied, so a silent co-role can neither admit an unknown caller nor defeat an explicit deny.
+- **Engagement is opt-in and derived, separate from composition.** The agent gate MUST fire only when the policy configures the block — `PolicyEngine.declares_admission()` (and the reach equivalent), derived from whether any resolved role carries the key, and carried in the signed bundle manifest for WASM. An agent whose policy declares no admission is never gated and runs exactly as before. This is what keeps closed-world from locking out agents that don't use admission.
+- **Authoritative, role-independent deny is a boundary.** A per-role rule (single-file or a capability) is per-role and composes by union like a tool rule; to bar a caller regardless of their other roles, the deny MUST be a boundary. Single-file agent rules are not special-cased: a single-file per-role `deny` behaves exactly like a single-file per-role tool `deny`.
+
+## Why
+
+Agent-level enforcement had grown a second composition model — per-role blocks folded by the runtime permissive union — and it leaked two fail-opens: unknown callers were admitted unless `default` denied, and an `admission: deny` was defeated by any admission-silent co-role. Both were artifacts of `agent.run` opt-in-allow (a silent role *granted* admission). The policy system already has the model that fixes them: boundaries are role-independent and deny-wins, so a boundary deny cannot be co-role-defeated, and a ceiling denies the unlisted. Making agent keys closed-world and folding them through the linker removes the fail-opens structurally instead of papering over them with a lint.
+
+Closed-world reintroduces the lockout R-AGENT-001's opt-in avoided (a role not granted admission is denied), but that is the correct fail-closed posture for a gate — and the engagement flag confines it to agents that actually configure admission. An agent that never mentions admission is untouched; one that does must grant it where it wants callers admitted (e.g. `admission: allow` on `default` for broad access). Fail-closed-with-explicit-grants beats fail-open-by-default for a security layer.
+
+Composition and engagement are deliberately separate: engagement answers "is this gate configured at all" (opt-in, backward-compatible), composition answers "how do the rules combine" (the linker fold). Tangling them was the original mistake.
+
+## Consequences
+
+- The two review fail-opens are fixed by construction: unknown/unrecognized callers deny (closed-world), and a silent co-role denies rather than admitting, so it cannot override a deny.
+- The engine simplifies: `agent.run` joins the reach keys as plain closed-world, so the opt-in-allow branch in `get_tool_policy`, the per-role `agent.run` rule in the Rego compiler, and its golden-fixture churn all go away.
+- Agent-level rules gain ceilings and authoritative role-independent denies once authored in the modular layout; single-file policies keep per-role semantics identical to tools.
+- Enforcement is still the WASM for bundles; `declares_admission()` (manifest flag) only tells the gate whether to fire.
+- Supersedes R-AGENT-001's opt-in-allow and the `agents:`-presence reach-engagement wording; R-AGENT-001's engagement-flag and manifest mechanism survive, now uniform for admission and reach.
+
+## Rejected alternatives
+
+- **Keep the single-file opt-in model, add a `permissive-admission` lint.** Ships the fail-opens behind lint-only mitigation and keeps a second composition model contradicting R-POL-001.
+- **A bespoke deny-wins multi-role fold for admission only.** Re-invents what role-independent boundaries already provide, and only for one gate.
+- **Reject single-file per-role agent `deny`.** Inconsistent — a single-file tool `deny` is allowed and per-role; agent keys should match. Authoritative denies are boundaries, by the same rule as tools.
+
+## Verify
+
+```
+pytest tests/security/test_agent_policy.py tests/security/test_linker.py tests/security/test_agent_gate.py -q
+# unlisted agent.run denies; a boundary agent deny is role-independent; a capability
+# that denies an agent key is a LinkError; declares_admission drives engagement.
+```

--- a/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
+++ b/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
@@ -33,7 +33,7 @@ Warn-and-defer keeps closed-world honest across frameworks: enforcement lands on
 ## Deferred (follow-ups, warned in the interim)
 
 - **Per-sub-agent / post-handoff admission** (B re-checking admission at its run entry): needs resolving sub-agent policies and handling unregistered sub-agents, so it is out of this slice. Reach from the governed source is the boundary control today.
-- **Agent-as-tool reach on OpenAI** (`Agent.as_tool`): no metadata links the produced function tool back to a target agent name at the seam.
+- **Agent-as-tool reach on OpenAI** (`Agent.as_tool`): no metadata links the produced function tool back to a target agent name at the seam, so it cannot be *enforced* — but a policy that declares a `via: tool` target now *warns* (`warn_if_tool_reach_unenforced`, gated on `declares_tool_reach()` so handoff-only policies are not spammed), so the gap is no longer silent.
 - **pydantic_ai and native reach**: no runtime target handle.
 - **Manifest drift lint** (reach key vs declared sub-agents/handoffs): needs `AgentManifest` to carry target declarations, a cross-package change.
 

--- a/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
+++ b/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
@@ -1,0 +1,48 @@
+# R-AGENT-003: Reach and admission are enforced at per-framework runtime seams
+
+**Status:** Accepted · 2026-08-26 · builds on R-AGENT-002
+**Applies to:** `hexgate/security/agent_gate.py`, `hexgate/security/naming.py`, `hexgate/adapters/openai/runner.py`, `hexgate/adapters/google/runner.py`, `hexgate/adapters/pydantic_ai/wrapper.py`, `hexgate/adapters/langchain/wrapper.py`, `hexgate/agents/factory.py`
+
+## Decision
+
+Agent-level admission (`agent.run`) and reach (`agent.handoff:<t>` / `agent.tool:<t>`) are enforced at framework-specific runtime seams by two gates that reuse `PolicyEnforcer.decide`, mirroring the egress `Gate`. R-AGENT-002 defined the policy model; this defines where and how it runs.
+
+- **One canonical name.** A target's name at a seam derives identically to an agent's own name via `canonical_agent_name` (trim, blank/None → `"default"`, no case folding). Own-name and target-name must agree or a reach key would not match the name its target registers with. This is the one derivation; the two prior per-adapter spellings are gone.
+- **Reach is governed by the source agent's policy, at the seam, before control transfers.** `ReachGate.check_reach(target, via)` decides the lowered key and raises `ReachNotAllowedError` on a deny.
+  - **OpenAI:** the SDK `on_handoff` hook (awaited before the transfer completes, so raising vetoes it) → `via="handoff"`.
+  - **Google ADK:** a `BasePlugin.before_tool_callback` intercepting the two shapes ADK expresses as tool calls: `transfer_to_agent` (`via="handoff"`) and `AgentTool` (`via="tool"`).
+  - Only reach from a **Hexgate-governed source** (the resolved top-level agent) is gated; a transfer from an un-governed sub-agent is left alone (sub-agent governance is a later slice).
+- **Admission is enforced at run entry for the top-level agent**, inside the context scope so the caller's role is visible, on the OpenAI and Google runners. A non-admitted caller is refused before the run starts.
+- **Handoff depth is a per-run runaway cap, independent of reach policy.** A handoff transfers control forward, so the count of handoffs within one run is the chain depth; past `max_handoff_depth` the seam raises `HandoffDepthExceededError`. OpenAI counts on the per-run hook; Google counts per `invocation_id` on the shared plugin and clears it in `after_run_callback`.
+- **Where the framework hides the target, warn — never silently pass.** pydantic_ai (delegation inside a tool body), the native single-graph agent (no handoff seam), and agent-as-tool on OpenAI expose no target handle, so a declared block is surfaced by `warn_if_admission_unenforced` / `warn_if_reach_unenforced` at wrap time.
+
+## Why
+
+The two gates share `_PolicyGate` (enforcer + approval fold + fail-closed), so admission and reach behave identically and are defined once. Enforcing at the framework seam (not a wrapper around the whole run) is what lets reach fire at the exact moment control would transfer, so a denied handoff never starts the target. Governing reach by the **source** policy matches the model: the `agents` block on A says who A may reach; B's own admission is a separate direction (its run entry).
+
+Counting handoffs as depth is exact for these SDKs because a handoff is a forward transfer with no return, so a run is a chain and the handoff count is its length. The cap is deliberately policy-independent: it stops a runaway even when every hop is allowed.
+
+Warn-and-defer keeps closed-world honest across frameworks: enforcement lands only where a target handle exists, and everywhere else the gap is loud (one log per framework/agent) rather than a silent no-op, so an operator is never misled into thinking a declared block is enforced.
+
+## Consequences
+
+- Reach and admission are enforced end-to-end on OpenAI (handoff) and Google (handoff + agent-as-tool); the interim `warn_if_admission_unenforced` is gone from those adapters.
+- A denied reach or admission fails closed by raising, aborting the run rather than degrading to an ungoverned continuation.
+- `HexgateRunner(max_handoff_depth=N)` is opt-in on both adapters (None = no cap).
+
+## Deferred (follow-ups, warned in the interim)
+
+- **Per-sub-agent / post-handoff admission** (B re-checking admission at its run entry): needs resolving sub-agent policies and handling unregistered sub-agents, so it is out of this slice. Reach from the governed source is the boundary control today.
+- **Agent-as-tool reach on OpenAI** (`Agent.as_tool`): no metadata links the produced function tool back to a target agent name at the seam.
+- **pydantic_ai and native reach**: no runtime target handle.
+- **Manifest drift lint** (reach key vs declared sub-agents/handoffs): needs `AgentManifest` to carry target declarations, a cross-package change.
+
+## Verify
+
+```
+pytest tests/security/test_reach_gate.py tests/security/test_naming.py \
+       tests/adapters/openai/test_runner_reach_admission.py \
+       tests/adapters/google/test_runner.py -q
+# reach denies an unlisted/deny target and vetoes the transfer; admission refuses a
+# non-admitted caller at run entry; the depth cap raises past max_handoff_depth.
+```

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -11,8 +11,10 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator
 import nest_asyncio
 from google.adk.agents import BaseAgent
 from google.adk.apps import App
+from google.adk.plugins.base_plugin import BasePlugin
 from google.adk.runners import Runner
 from google.adk.sessions import BaseSessionService
+from google.adk.tools.agent_tool import AgentTool
 from google.genai import types
 from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
@@ -24,11 +26,49 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext
+from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
 from hexgate.security.bans import resolve_ban_gate
-from hexgate.security.naming import canonical_agent_name
+from hexgate.security.naming import canonical_agent_name, canonical_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
+
+
+class _HexgateReachPlugin(BasePlugin):
+    """Enforce agent-to-agent reach at the ADK tool seam.
+
+    ADK expresses delegation as tool calls: ``transfer_to_agent(agent_name=...)``
+    (handoff, control transfers) and :class:`AgentTool` (agent-as-tool, the caller
+    keeps control). ``before_tool_callback`` fires before either runs, so deciding
+    the target's reach key here and raising :class:`ReachNotAllowedError` on a deny
+    stops the transfer/delegation before it happens. Reach is governed by the
+    source agent's policy; only the governed root's reach is gated (a transfer
+    originating from an un-governed sub-agent is left alone, matching the OpenAI
+    adapter). Ordinary tools fall through — they are already gated by the wrapped
+    enforcer.
+    """
+
+    def __init__(self, runner: "HexgateRunner") -> None:
+        super().__init__(name="hexgate_reach")
+        self._runner = runner
+
+    async def before_tool_callback(self, *, tool, tool_args, tool_context) -> None:
+        if canonical_name(tool_context.agent_name) != self._runner._agent_name:
+            return None  # source is not the governed root; reach from it isn't gated
+        if tool.name == "transfer_to_agent":
+            target, via = tool_args.get("agent_name"), "handoff"
+        elif isinstance(tool, AgentTool):
+            target, via = getattr(tool.agent, "name", None), "tool"
+        else:
+            return None  # ordinary tool; the wrapped enforcer already gates it
+        if not target:
+            return None
+        gate = resolve_reach_gate(
+            self._runner._binding.enforcer,
+            approval_handler=self._runner._approval_handler,
+        )
+        await gate.check_reach_async(canonical_name(target), via=via)
+        return None
 
 
 class HexgateRunner:
@@ -57,6 +97,7 @@ class HexgateRunner:
         # Policy resolves at construction (the loud-failure point); the
         # Runner is built once — refresh swaps the enforcer's policy
         # without touching it. One client is shared with the ban resolver.
+        self._approval_handler = approval_handler
         client = HexgateClient(HexgateConfig.from_env(api_key=self.api_key))
         self._wrapped_agent, self._binding = wrap_google_agent(
             agent,
@@ -68,6 +109,9 @@ class HexgateRunner:
         )
         plugins = list(runner_kwargs.pop("plugins", None) or [])
         plugins.append(HexgateUsagePlugin(api_key=self.api_key))
+        # Reach enforcement at the ADK transfer/AgentTool seam. Appended after the
+        # caller's plugins so it always runs; it never rewrites tool input.
+        plugins.append(_HexgateReachPlugin(self))
         app = App(name=app_name, root_agent=self._wrapped_agent, plugins=plugins)
         self._runner = Runner(
             app=app,
@@ -78,6 +122,22 @@ class HexgateRunner:
         self._ban_gate = resolve_ban_gate(
             self._agent_name, api_key=self.api_key, client=client
         )
+
+    async def _check_admission_async(self) -> None:
+        """Refuse a caller not admitted by the root agent's policy before the run
+        drives. Must run inside the active HexgateContext scope. No-op when the
+        policy declares no admission."""
+        gate = resolve_agent_gate(
+            self._binding.enforcer, approval_handler=self._approval_handler
+        )
+        await gate.check_admission_async()
+
+    def _check_admission_sync(self) -> None:
+        """Sync mirror of :meth:`_check_admission_async`."""
+        gate = resolve_agent_gate(
+            self._binding.enforcer, approval_handler=self._approval_handler
+        )
+        gate.check_admission()
 
     def _setup_observability(self):
         """Install Langfuse + GoogleADKInstrumentor (idempotent)."""
@@ -119,6 +179,7 @@ class HexgateRunner:
         if self._ban_gate is not None:
             self._ban_gate.check(hexgate_context)
         with hexgate_context.sync_scope(), self._propagate(hexgate_context):
+            self._check_admission_sync()  # in-scope: reads the caller's role
             agen = self._runner.run_async(
                 user_id=hexgate_context.user_id,
                 session_id=hexgate_context.session_id,
@@ -156,6 +217,7 @@ class HexgateRunner:
         if self._ban_gate is not None:
             await self._ban_gate.check_async(hexgate_context)
         async with hexgate_context:
+            await self._check_admission_async()  # in-scope: reads the caller's role
             with self._propagate(hexgate_context):
                 async for event in self._runner.run_async(
                     user_id=hexgate_context.user_id,

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -60,6 +60,16 @@ class _HexgateReachPlugin(BasePlugin):
         self._depth: dict[str, int] = {}
 
     async def before_tool_callback(self, *, tool, tool_args, tool_context) -> None:
+        # A raise here aborts the run, so after_run_callback never fires; drop this
+        # invocation's depth entry on the way out to keep the shared map from
+        # leaking one entry per aborted (over-depth or reach-denied) run.
+        try:
+            return await self._gate_tool(tool, tool_args, tool_context)
+        except Exception:
+            self._depth.pop(tool_context.invocation_id, None)
+            raise
+
+    async def _gate_tool(self, tool, tool_args, tool_context) -> None:
         is_transfer = tool.name == "transfer_to_agent"
         # Depth cap first, as a runaway guard independent of reach policy and of
         # which agent transfers: a transfer moves control forward, so the count of

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -25,6 +25,7 @@ from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext
 from hexgate.security.bans import resolve_ban_gate
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -73,7 +74,7 @@ class HexgateRunner:
             session_service=session_service,
             **runner_kwargs,
         )
-        self._agent_name = getattr(agent, "name", "default")
+        self._agent_name = canonical_agent_name(agent)
         self._ban_gate = resolve_ban_gate(
             self._agent_name, api_key=self.api_key, client=client
         )

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -26,7 +26,11 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext
-from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
+from hexgate.security.agent_gate import (
+    HandoffDepthExceededError,
+    resolve_agent_gate,
+    resolve_reach_gate,
+)
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.naming import canonical_agent_name, canonical_name
 
@@ -51,11 +55,24 @@ class _HexgateReachPlugin(BasePlugin):
     def __init__(self, runner: "HexgateRunner") -> None:
         super().__init__(name="hexgate_reach")
         self._runner = runner
+        # Handoff depth per invocation (this plugin is shared across runs, unlike
+        # the OpenAI per-run hook), cleared in after_run_callback.
+        self._depth: dict[str, int] = {}
 
     async def before_tool_callback(self, *, tool, tool_args, tool_context) -> None:
+        is_transfer = tool.name == "transfer_to_agent"
+        # Depth cap first, as a runaway guard independent of reach policy and of
+        # which agent transfers: a transfer moves control forward, so the count of
+        # transfers in one invocation is the chain depth.
+        cap = self._runner._max_handoff_depth
+        if is_transfer and cap is not None:
+            inv = tool_context.invocation_id
+            self._depth[inv] = self._depth.get(inv, 0) + 1
+            if self._depth[inv] > cap:
+                raise HandoffDepthExceededError(self._depth[inv], cap)
         if canonical_name(tool_context.agent_name) != self._runner._agent_name:
             return None  # source is not the governed root; reach from it isn't gated
-        if tool.name == "transfer_to_agent":
+        if is_transfer:
             target, via = tool_args.get("agent_name"), "handoff"
         elif isinstance(tool, AgentTool):
             target, via = getattr(tool.agent, "name", None), "tool"
@@ -68,6 +85,11 @@ class _HexgateReachPlugin(BasePlugin):
             approval_handler=self._runner._approval_handler,
         )
         await gate.check_reach_async(canonical_name(target), via=via)
+        return None
+
+    async def after_run_callback(self, *, invocation_context) -> None:
+        # Drop this invocation's depth counter so the map does not grow unbounded.
+        self._depth.pop(invocation_context.invocation_id, None)
         return None
 
 
@@ -84,6 +106,7 @@ class HexgateRunner:
         approval_handler: ApprovalHandler | None = None,
         guards: "Sequence[Guard] | None" = None,
         guard_observer: "GuardObserver | None" = None,
+        max_handoff_depth: int | None = None,
         **runner_kwargs: Any,
     ):
         # ``guards`` matches the OpenAI runner's constructor. ADK's ``run`` has
@@ -98,6 +121,9 @@ class HexgateRunner:
         # Runner is built once — refresh swaps the enforcer's policy
         # without touching it. One client is shared with the ban resolver.
         self._approval_handler = approval_handler
+        # Handoff-chain depth cap (None = no cap); enforced per invocation by the
+        # reach plugin.
+        self._max_handoff_depth = max_handoff_depth
         client = HexgateClient(HexgateConfig.from_env(api_key=self.api_key))
         self._wrapped_agent, self._binding = wrap_google_agent(
             agent,

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -21,6 +21,7 @@ from hexgate.guards.types import build_pipeline
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.cloud.client import HexgateClient
@@ -48,7 +49,7 @@ def wrap_google_agent(
     unregistered agent (platform 404) raises — register it first with
     ``hexgate register``.
     """
-    agent_name = getattr(agent, "name", "default")
+    agent_name = canonical_agent_name(agent)
     tools = list(getattr(agent, "tools", []) or [])
 
     resolved = resolve_policy(agent_name, api_key=api_key, client=client)

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -19,7 +19,6 @@ from hexgate.adapters.google.tools import wrap_tools
 from hexgate.approvals import ApprovalHandler
 from hexgate.guards.types import build_pipeline
 from hexgate.security.binding import PolicyBinding, resolve_policy
-from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.enforcer import build_enforcer
 from hexgate.security.naming import canonical_agent_name
 
@@ -54,9 +53,8 @@ def wrap_google_agent(
 
     resolved = resolve_policy(agent_name, api_key=api_key, client=client)
     enforcer = build_enforcer(resolved.engine, agent_name=agent_name, api_key=api_key)
-    warn_if_admission_unenforced(
-        resolved.engine, framework="Google ADK", agent_name=agent_name
-    )
+    # No admission/reach warning here: the Google HexgateRunner enforces both
+    # (admission at run entry, reach at the transfer/AgentTool seam).
     pipeline = build_pipeline(guards, observer=guard_observer)
     guarded_tools = wrap_tools(
         tools, enforcer, approval_handler=approval_handler, pipeline=pipeline

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -19,6 +19,7 @@ from hexgate.adapters.google.tools import wrap_tools
 from hexgate.approvals import ApprovalHandler
 from hexgate.guards.types import build_pipeline
 from hexgate.security.binding import PolicyBinding, resolve_policy
+from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.enforcer import build_enforcer
 
 if TYPE_CHECKING:
@@ -52,6 +53,9 @@ def wrap_google_agent(
 
     resolved = resolve_policy(agent_name, api_key=api_key, client=client)
     enforcer = build_enforcer(resolved.engine, agent_name=agent_name, api_key=api_key)
+    warn_if_admission_unenforced(
+        resolved.engine, framework="Google ADK", agent_name=agent_name
+    )
     pipeline = build_pipeline(guards, observer=guard_observer)
     guarded_tools = wrap_tools(
         tools, enforcer, approval_handler=approval_handler, pipeline=pipeline

--- a/hexgate/adapters/langchain/wrapper.py
+++ b/hexgate/adapters/langchain/wrapper.py
@@ -22,6 +22,7 @@ from hexgate.adapters.langchain.tools import install_enforcer_on_tools
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.guards.types import build_pipeline
+from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -64,6 +65,9 @@ def wrap_langchain_agent(
     resolved = resolve_policy(agent_name, api_key=resolved_key, client=client)
     enforcer = build_enforcer(
         resolved.engine, agent_name=agent_name, api_key=resolved_key
+    )
+    warn_if_admission_unenforced(
+        resolved.engine, framework="LangChain", agent_name=agent_name
     )
     pipeline = build_pipeline(guards, observer=guard_observer)
     install_enforcer_on_tools(tools, enforcer=enforcer, pipeline=pipeline)

--- a/hexgate/adapters/langchain/wrapper.py
+++ b/hexgate/adapters/langchain/wrapper.py
@@ -22,7 +22,10 @@ from hexgate.adapters.langchain.tools import install_enforcer_on_tools
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.guards.types import build_pipeline
-from hexgate.security.agent_gate import warn_if_admission_unenforced
+from hexgate.security.agent_gate import (
+    warn_if_admission_unenforced,
+    warn_if_reach_unenforced,
+)
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -68,6 +71,9 @@ def wrap_langchain_agent(
         resolved.engine, agent_name=agent_name, api_key=resolved_key
     )
     warn_if_admission_unenforced(
+        resolved.engine, framework="LangChain", agent_name=agent_name
+    )
+    warn_if_reach_unenforced(
         resolved.engine, framework="LangChain", agent_name=agent_name
     )
     pipeline = build_pipeline(guards, observer=guard_observer)

--- a/hexgate/adapters/langchain/wrapper.py
+++ b/hexgate/adapters/langchain/wrapper.py
@@ -26,6 +26,7 @@ from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -56,7 +57,7 @@ def wrap_langchain_agent(
             "No API key provided. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
         )
 
-    agent_name = getattr(agent, "name", "default")
+    agent_name = canonical_agent_name(agent)
     tool_names = [tool.name for tool in tools]
 
     # One client shared by the policy and ban resolvers — avoids a second

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -40,6 +40,7 @@ from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -126,10 +127,10 @@ class HexgateRunner:
         unregistered agent (platform 404) raises — register it first with
         ``hexgate register``.
         """
-        # `or "default"` collapses a None/empty name to a real string (matches
-        # the pydantic_ai adapter) so a null identity never reaches the cache
-        # key or the platform resolve / enforcer / audit below.
-        name = getattr(agent, "name", None) or "default"
+        # Shared derivation (trim + blank/None → "default") so a null identity
+        # never reaches the cache key or the platform resolve / enforcer / audit
+        # below, and so it matches how a reach target would be named.
+        name = canonical_agent_name(agent)
         binding = self._bindings.get(name)
         if binding is None:
             resolved = resolve_policy(name, api_key=self.api_key, client=self._client)
@@ -146,7 +147,7 @@ class HexgateRunner:
     def _ban_gate_for(self, agent: Agent) -> BanGate | None:
         """Get-or-resolve the cached ban gate for ``agent``'s name (``None`` in
         local mode / no key). ``None`` is cached too, so we resolve once."""
-        name = getattr(agent, "name", None) or "default"
+        name = canonical_agent_name(agent)
         if name not in self._ban_gates:
             self._ban_gates[name] = resolve_ban_gate(
                 name, api_key=self.api_key, client=self._client

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -36,6 +36,7 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext
+from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -134,6 +135,9 @@ class HexgateRunner:
             resolved = resolve_policy(name, api_key=self.api_key, client=self._client)
             enforcer = build_enforcer(
                 resolved.engine, agent_name=name, api_key=self.api_key
+            )
+            warn_if_admission_unenforced(
+                resolved.engine, framework="OpenAI Agents", agent_name=name
             )
             binding = PolicyBinding(enforcer, resolved.source)
             self._bindings[name] = binding

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -36,7 +36,7 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext
-from hexgate.security.agent_gate import warn_if_admission_unenforced
+from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -85,6 +85,32 @@ class _CompositeRunHooks(RunHooks):
     async def on_tool_end(self, context, agent, tool, result) -> None:
         for hook in self._hooks:
             await hook.on_tool_end(context, agent, tool, result)
+
+
+class _HexgateReachHooks(RunHooks):
+    """Enforce agent-to-agent reach at the SDK handoff seam.
+
+    ``on_handoff`` fires (awaited, via ``asyncio.gather``) after the target agent
+    is resolved but before the handoff completes, so raising here vetoes the
+    transfer and the target never runs. Reach is governed by the *source* agent's
+    policy, so this looks up the source's cached binding and decides
+    ``agent.handoff:<target>``. Only handoffs from a Hexgate-governed source (the
+    resolved top-level agent) are gated; a handoff from an un-governed sub-agent is
+    left alone here (sub-agent governance is a later slice). Agent-as-tool reach
+    (``Agent.as_tool``) has no target handle at this seam and is not gated.
+    """
+
+    def __init__(self, runner: "HexgateRunner") -> None:
+        self._runner = runner
+
+    async def on_handoff(self, context, from_agent, to_agent) -> None:
+        binding = self._runner._bindings.get(canonical_agent_name(from_agent))
+        if binding is None:
+            return  # source is not Hexgate-governed; reach from it isn't gated here
+        gate = resolve_reach_gate(
+            binding.enforcer, approval_handler=self._runner._approval_handler
+        )
+        await gate.check_reach_async(canonical_agent_name(to_agent), via="handoff")
 
 
 class HexgateRunner:
@@ -137,9 +163,6 @@ class HexgateRunner:
             enforcer = build_enforcer(
                 resolved.engine, agent_name=name, api_key=self.api_key
             )
-            warn_if_admission_unenforced(
-                resolved.engine, framework="OpenAI Agents", agent_name=name
-            )
             binding = PolicyBinding(enforcer, resolved.source)
             self._bindings[name] = binding
         return binding
@@ -153,6 +176,22 @@ class HexgateRunner:
                 name, api_key=self.api_key, client=self._client
             )
         return self._ban_gates[name]
+
+    async def _check_admission_async(self, binding: PolicyBinding) -> None:
+        """Refuse a caller not admitted by the top-level agent's policy, before the
+        run starts. Must run inside the active HexgateContext scope (admission reads
+        the caller's role from it). No-op when the policy declares no admission."""
+        gate = resolve_agent_gate(
+            binding.enforcer, approval_handler=self._approval_handler
+        )
+        await gate.check_admission_async()
+
+    def _check_admission_sync(self, binding: PolicyBinding) -> None:
+        """Sync mirror of :meth:`_check_admission_async`."""
+        gate = resolve_agent_gate(
+            binding.enforcer, approval_handler=self._approval_handler
+        )
+        gate.check_admission()
 
     def _setup_observability(self):
         """Install Langfuse + OpenAIAgentsInstrumentor (idempotent)."""
@@ -174,21 +213,29 @@ class HexgateRunner:
             yield
 
     def _merge_hooks(self, hooks: RunHooks | None) -> RunHooks:
-        """Compose caller-supplied ``hooks`` with the usage hook — never
-        clobber a hooks object the caller already passed."""
-        usage_hooks = HexgateUsageHooks(api_key=self.api_key)
-        if hooks is None:
-            return usage_hooks
-        if not isinstance(hooks, RunHooksBase):
-            # A Hexgate guard list passed to run(hooks=...) instead of the
-            # constructor would otherwise crash at the first lifecycle callback,
-            # far from the mistake. Name it here.
-            raise TypeError(
-                f"run(hooks=...) takes an agents RunHooks object, got "
-                f"{type(hooks).__name__}. Hexgate guards go on the constructor: "
-                "HexgateRunner(guards=[...])."
-            )
-        return _CompositeRunHooks([hooks, usage_hooks])
+        """Compose the caller's ``hooks`` with Hexgate's own — never clobber a
+        hooks object the caller already passed.
+
+        Always installs the usage hook and the reach hook (which enforces
+        ``agent.handoff:*`` at the SDK handoff seam), so the result is always a
+        composite fanning out to every hook in turn.
+        """
+        installed: list[RunHooksBase] = [
+            HexgateUsageHooks(api_key=self.api_key),
+            _HexgateReachHooks(self),
+        ]
+        if hooks is not None:
+            if not isinstance(hooks, RunHooksBase):
+                # A Hexgate guard list passed to run(hooks=...) instead of the
+                # constructor would otherwise crash at the first lifecycle callback,
+                # far from the mistake. Name it here.
+                raise TypeError(
+                    f"run(hooks=...) takes an agents RunHooks object, got "
+                    f"{type(hooks).__name__}. Hexgate guards go on the constructor: "
+                    "HexgateRunner(guards=[...])."
+                )
+            installed.insert(0, hooks)
+        return _CompositeRunHooks(installed)
 
     async def run(
         self,
@@ -215,6 +262,7 @@ class HexgateRunner:
             guard_observer=self._guard_observer,
         )
         async with hexgate_context:
+            await self._check_admission_async(binding)  # in-scope: reads the role
             with self._propagate(hexgate_context, agent.name):
                 return await Runner.run(
                     wrapped_agent,
@@ -249,6 +297,7 @@ class HexgateRunner:
             guard_observer=self._guard_observer,
         )
         with hexgate_context.sync_scope():
+            self._check_admission_sync(binding)  # in-scope: reads the role
             with self._propagate(hexgate_context, agent.name):
                 try:
                     return Runner.run_sync(
@@ -319,6 +368,8 @@ class HexgateRunner:
         )
 
         with hexgate_context.sync_scope():
+            # Before run_streamed spawns its task, so a non-admitted run yields nothing.
+            self._check_admission_sync(binding)
             with self._propagate(hexgate_context, agent.name):
                 result = Runner.run_streamed(
                     wrapped_agent,

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -36,7 +36,11 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext
-from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
+from hexgate.security.agent_gate import (
+    HandoffDepthExceededError,
+    resolve_agent_gate,
+    resolve_reach_gate,
+)
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -102,8 +106,16 @@ class _HexgateReachHooks(RunHooks):
 
     def __init__(self, runner: "HexgateRunner") -> None:
         self._runner = runner
+        self._depth = 0  # per-run: this hook is rebuilt on every run
 
     async def on_handoff(self, context, from_agent, to_agent) -> None:
+        # Depth cap first, as a runaway guard independent of reach policy: a
+        # handoff transfers control forward, so the count of handoffs in this run
+        # is the chain depth. Counts every handoff, governed source or not.
+        self._depth += 1
+        cap = self._runner._max_handoff_depth
+        if cap is not None and self._depth > cap:
+            raise HandoffDepthExceededError(self._depth, cap)
         binding = self._runner._bindings.get(canonical_agent_name(from_agent))
         if binding is None:
             return  # source is not Hexgate-governed; reach from it isn't gated here
@@ -123,6 +135,7 @@ class HexgateRunner:
         approval_handler: ApprovalHandler | None = None,
         guards: "Sequence[Guard] | None" = None,
         guard_observer: "GuardObserver | None" = None,
+        max_handoff_depth: int | None = None,
     ):
         # ``guards`` (not ``hooks``) on purpose: ``run*`` below already take a
         # ``hooks=`` that means the agents SDK's ``RunHooks`` (we mirror the SDK
@@ -140,6 +153,8 @@ class HexgateRunner:
         # Ban gates cached per agent name too (None cached to avoid re-resolving).
         self._ban_gates: dict[str, BanGate | None] = {}
         self._approval_handler = approval_handler
+        # Handoff-chain depth cap (None = no cap); enforced per run by the reach hook.
+        self._max_handoff_depth = max_handoff_depth
         # Guards are fixed per runner; threaded into each per-call rewrap below,
         # where wrap_openai_agent builds the pipeline (matching the other adapters).
         self._guards = guards

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -40,6 +40,7 @@ from hexgate.security.agent_gate import (
     HandoffDepthExceededError,
     resolve_agent_gate,
     resolve_reach_gate,
+    warn_if_tool_reach_unenforced,
 )
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
@@ -177,6 +178,11 @@ class HexgateRunner:
             resolved = resolve_policy(name, api_key=self.api_key, client=self._client)
             enforcer = build_enforcer(
                 resolved.engine, agent_name=name, api_key=self.api_key
+            )
+            # Handoff reach is enforced (on_handoff); agent-as-tool reach is not,
+            # so warn if the policy declares a via: tool target.
+            warn_if_tool_reach_unenforced(
+                resolved.engine, framework="OpenAI Agents", agent_name=name
             )
             binding = PolicyBinding(enforcer, resolved.source)
             self._bindings[name] = binding
@@ -366,6 +372,11 @@ class HexgateRunner:
         tools fire there, not in ``stream_events``. So the HexgateContext scope must be
         active around the ``run_streamed`` call for the task to inherit it —
         the wrapped iterator re-opens it for exit/audit semantics.
+
+        Admission is checked synchronously before the task spawns (so a refused run
+        yields nothing). Like any sync entrypoint, an *async* ``approval_handler``
+        cannot be awaited here and fails closed on a NEEDS_APPROVAL admission
+        verdict; use the async ``run`` entrypoint if admission approval is async.
         """
         self._setup_observability()
         binding = self._binding_for(agent)

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -23,7 +23,10 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.guards.types import build_pipeline
-from hexgate.security.agent_gate import warn_if_admission_unenforced
+from hexgate.security.agent_gate import (
+    warn_if_admission_unenforced,
+    warn_if_reach_unenforced,
+)
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -92,6 +95,9 @@ def wrap_pydantic_agent(
         resolved.engine, agent_name=agent_name, api_key=resolved_key
     )
     warn_if_admission_unenforced(
+        resolved.engine, framework="pydantic_ai", agent_name=agent_name
+    )
+    warn_if_reach_unenforced(
         resolved.engine, framework="pydantic_ai", agent_name=agent_name
     )
     pipeline = build_pipeline(guards, observer=guard_observer)

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -23,6 +23,7 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.guards.types import build_pipeline
+from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -88,6 +89,9 @@ def wrap_pydantic_agent(
     resolved = resolve_policy(agent_name, api_key=resolved_key, client=client)
     enforcer = build_enforcer(
         resolved.engine, agent_name=agent_name, api_key=resolved_key
+    )
+    warn_if_admission_unenforced(
+        resolved.engine, framework="pydantic_ai", agent_name=agent_name
     )
     pipeline = build_pipeline(guards, observer=guard_observer)
     cloned_agent = _clone_agent_with_tools(

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -27,6 +27,7 @@ from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -80,7 +81,7 @@ def wrap_pydantic_agent(
             "No API key provided. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
         )
 
-    agent_name = getattr(agent, "name", None) or "default"
+    agent_name = canonical_agent_name(agent)
     tools = _extract_tools(agent)
 
     # One client shared by the policy and ban resolvers — avoids a second

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -598,7 +598,10 @@ class HexgateAgent:
                 wrapped.append(tool_spec)
         rebuilt = self.with_tools(wrapped)
         if enforcer is not None:
-            from hexgate.security.agent_gate import resolve_agent_gate
+            from hexgate.security.agent_gate import (
+                resolve_agent_gate,
+                warn_if_reach_unenforced,
+            )
 
             # The binding pairs the enforcer the tools just closed over with the
             # refresh source, so refresh_policy() can swap the policy in place.
@@ -607,6 +610,12 @@ class HexgateAgent:
             # swaps the policy is reflected on the next run entry too.
             rebuilt._agent_gate = resolve_agent_gate(
                 enforcer, approval_handler=approval_handler
+            )
+            # Admission is enforced here, but reach is not: the native agent is a
+            # single graph with no agent-to-agent handoff seam. Warn if the policy
+            # declares reach, so it is not a silent no-op.
+            warn_if_reach_unenforced(
+                enforcer.policy, framework="native", agent_name=self.name or "default"
             )
         else:
             # Guards-only path: no enforcer, so no admission. Clear any gate a

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     # eventually import from this module).
     from hexgate.cloud.client import HexgateClient
     from hexgate.guards.types import Guard, GuardObserver
+    from hexgate.security.agent_gate import AgentGate
     from hexgate.security.bans import BanGate
     from hexgate.security.binding import PolicyBinding
     from hexgate.security.enforcer import DecisionObserver, PolicyEnforcer
@@ -334,6 +335,7 @@ class HexgateAgent:
         binding: PolicyBinding | None = None,
         hexgate_client: HexgateClient | None = None,
         ban_gate: BanGate | None = None,
+        agent_gate: AgentGate | None = None,
     ) -> None:
         # Private: run only via ainvoke/astream_events, which apply policy
         # refresh + the ban gate. Reaching self._graph directly skips both.
@@ -368,6 +370,10 @@ class HexgateAgent:
         # Kill-switch gate; attached by load_hexgate_agent (platform path only —
         # no gate without a control plane). Threaded through with_tools rebuilds.
         self._ban_gate: BanGate | None = ban_gate
+        # Admission gate; attached by enforce_policy alongside the binding (local,
+        # no control plane needed). Threaded through with_tools rebuilds. Whether it
+        # actually refuses is decided per run from the current policy.
+        self._agent_gate: AgentGate | None = agent_gate
         # api_key intentionally omitted — create_agent has no explicit api_key param
         # (only hexgate_client, attached post-init by _bind_policy). If one is added,
         # thread it through here too, or usage events will keep silently resolving
@@ -396,6 +402,7 @@ class HexgateAgent:
         """
         await _refresh_policy_safely(self)
         await self._check_ban()
+        await self._check_admission()
         return await self._graph.ainvoke(
             payload, config=self._with_usage_callback(config)
         )
@@ -415,6 +422,7 @@ class HexgateAgent:
         """
         await _refresh_policy_safely(self)
         await self._check_ban()
+        await self._check_admission()
         async for event in self._graph.astream_events(
             payload, config=self._with_usage_callback(config), version=version
         ):
@@ -430,6 +438,15 @@ class HexgateAgent:
         from hexgate.runtime.context import get_current_context
 
         await self._ban_gate.check_async(get_current_context())
+
+    async def _check_admission(self) -> None:
+        """Refuse a caller not admitted by policy before the graph runs, if an
+        admission gate is attached. The gate reads the active
+        :class:`HexgateContext` scope for the caller's role; a policy with no
+        admission block makes this a no-op."""
+        if self._agent_gate is None:
+            return
+        await self._agent_gate.check_admission_async()
 
     def with_tools(self, tools: Sequence[ToolSpec]) -> Self:
         """Rebuild the runtime with a new tool list."""
@@ -471,6 +488,7 @@ class HexgateAgent:
             binding=self._binding,
             hexgate_client=self.hexgate_client,
             ban_gate=self._ban_gate,
+            agent_gate=self._agent_gate,
         )
 
     def enforce_policy(
@@ -575,9 +593,16 @@ class HexgateAgent:
                 wrapped.append(tool_spec)
         rebuilt = self.with_tools(wrapped)
         if enforcer is not None:
+            from hexgate.security.agent_gate import resolve_agent_gate
+
             # The binding pairs the enforcer the tools just closed over with the
             # refresh source, so refresh_policy() can swap the policy in place.
             rebuilt._binding = PolicyBinding(enforcer, source)
+            # The admission gate shares that same enforcer, so a refresh that
+            # swaps the policy is reflected on the next run entry too.
+            rebuilt._agent_gate = resolve_agent_gate(
+                enforcer, approval_handler=approval_handler
+            )
         return rebuilt
 
     def refresh_policy(self) -> None:

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -560,8 +560,13 @@ class HexgateAgent:
                 )
             if pipeline is None or pipeline.is_empty:
                 # Nothing to enforce and no guards to run (an observer-only
-                # pipeline can't fire without guards): return unguarded.
-                return self.with_tools(list(self.tools))
+                # pipeline can't fire without guards): return unguarded. Clear any
+                # admission gate a prior enforce_policy attached, or with_tools
+                # would carry it forward and the "unguarded" agent would still
+                # refuse admission.
+                unguarded = self.with_tools(list(self.tools))
+                unguarded._agent_gate = None
+                return unguarded
             enforcer = None  # guards-only gating, no policy engine
         else:
             if isinstance(policy, (PolicyBundle, PolicySet)):
@@ -603,6 +608,10 @@ class HexgateAgent:
             rebuilt._agent_gate = resolve_agent_gate(
                 enforcer, approval_handler=approval_handler
             )
+        else:
+            # Guards-only path: no enforcer, so no admission. Clear any gate a
+            # prior enforce_policy left, which with_tools would otherwise carry.
+            rebuilt._agent_gate = None
         return rebuilt
 
     def refresh_policy(self) -> None:

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -22,8 +22,12 @@ from hexgate.security.bans import (
 from hexgate.security.agent_gate import (
     AgentGate,
     AgentNotAdmittedError,
+    ReachGate,
+    ReachNotAllowedError,
     resolve_agent_gate,
+    resolve_reach_gate,
     warn_if_admission_unenforced,
+    warn_if_reach_unenforced,
 )
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
@@ -147,6 +151,8 @@ __all__ = [
     "AgentBannedError",
     "AgentGate",
     "AgentNotAdmittedError",
+    "ReachGate",
+    "ReachNotAllowedError",
     "AgentPolicy",
     "AgentTargetPolicy",
     "AgentVia",
@@ -252,5 +258,7 @@ __all__ = [
     "load_policy_set",
     "load_policy_set_from_dict",
     "parse_constraint",
+    "resolve_reach_gate",
     "warn_if_admission_unenforced",
+    "warn_if_reach_unenforced",
 ]

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -22,6 +22,7 @@ from hexgate.security.bans import (
 from hexgate.security.agent_gate import (
     AgentGate,
     AgentNotAdmittedError,
+    HandoffDepthExceededError,
     ReachGate,
     ReachNotAllowedError,
     resolve_agent_gate,
@@ -151,6 +152,7 @@ __all__ = [
     "AgentBannedError",
     "AgentGate",
     "AgentNotAdmittedError",
+    "HandoffDepthExceededError",
     "ReachGate",
     "ReachNotAllowedError",
     "AgentPolicy",

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -22,7 +22,6 @@ from hexgate.security.bans import (
 from hexgate.security.agent_gate import (
     AgentGate,
     AgentNotAdmittedError,
-    policy_declares_admission,
     resolve_agent_gate,
 )
 from hexgate.security.models import (
@@ -151,7 +150,6 @@ __all__ = [
     "AgentTargetPolicy",
     "AgentVia",
     "agent_target_key",
-    "policy_declares_admission",
     "resolve_agent_gate",
     "LayerKind",
     "LinkError",

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -29,6 +29,7 @@ from hexgate.security.agent_gate import (
     resolve_reach_gate,
     warn_if_admission_unenforced,
     warn_if_reach_unenforced,
+    warn_if_tool_reach_unenforced,
 )
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
@@ -263,4 +264,5 @@ __all__ = [
     "resolve_reach_gate",
     "warn_if_admission_unenforced",
     "warn_if_reach_unenforced",
+    "warn_if_tool_reach_unenforced",
 ]

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -23,6 +23,7 @@ from hexgate.security.agent_gate import (
     AgentGate,
     AgentNotAdmittedError,
     resolve_agent_gate,
+    warn_if_admission_unenforced,
 )
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
@@ -251,4 +252,5 @@ __all__ = [
     "load_policy_set",
     "load_policy_set_from_dict",
     "parse_constraint",
+    "warn_if_admission_unenforced",
 ]

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -19,6 +19,12 @@ from hexgate.security.bans import (
     get_ban_source,
     resolve_ban_gate,
 )
+from hexgate.security.agent_gate import (
+    AgentGate,
+    AgentNotAdmittedError,
+    policy_declares_admission,
+    resolve_agent_gate,
+)
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
     AgentPolicy,
@@ -139,10 +145,14 @@ from hexgate.security.testing import (
 __all__ = [
     "AGENT_RUN_TOOL",
     "AgentBannedError",
+    "AgentGate",
+    "AgentNotAdmittedError",
     "AgentPolicy",
     "AgentTargetPolicy",
     "AgentVia",
     "agent_target_key",
+    "policy_declares_admission",
+    "resolve_agent_gate",
     "LayerKind",
     "LinkError",
     "LinkResult",

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -94,6 +94,29 @@ def warn_if_reach_unenforced(
     )
 
 
+def warn_if_tool_reach_unenforced(
+    engine: PolicyEngine, *, framework: str, agent_name: str
+) -> None:
+    """Warn once when a policy declares agent-as-tool reach on an adapter that
+    enforces handoff reach but not agent-as-tool reach (OpenAI).
+
+    OpenAI gates handoffs at ``on_handoff`` but ``Agent.as_tool`` produces a plain
+    function tool with no link back to the target agent, so ``via: tool`` targets
+    are not enforceable at that seam. Fires only when a tool-via target is actually
+    declared (``declares_tool_reach``), so a handoff-only policy is not warned."""
+    if not engine.declares_tool_reach():
+        return
+    if not _mark_warned(_reach_unenforced_warned, framework, agent_name):
+        return
+    _log.warning(
+        "policy for agent %r declares agent-as-tool reach ('agents' target with "
+        "via: tool), but the %s adapter enforces handoff reach only; as-tool "
+        "delegations will proceed without a reach check.",
+        agent_name,
+        framework,
+    )
+
+
 def _mark_warned(seen: set[tuple[str, str]], framework: str, agent_name: str) -> bool:
     """Record ``(framework, agent_name)`` in ``seen``; return True the first time."""
     key = (framework, agent_name)
@@ -211,6 +234,28 @@ class _PolicyGate:
             )
             return False
 
+    def _cleared_sync(self, decision: Decision) -> bool:
+        """Whether ``decision`` clears the gate (sync): allowed outright, or a
+        NEEDS_APPROVAL that a handler approves. The one place the pass/refuse
+        condition lives, so admission and reach can never drift."""
+        if decision.allowed:
+            return True
+        return (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and self._resolve_approval_sync(decision)
+        )
+
+    async def _cleared_async(self, decision: Decision) -> bool:
+        """Async mirror of :meth:`_cleared_sync` — awaits an async handler."""
+        if decision.allowed:
+            return True
+        return (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and await self._resolve_approval_async(decision)
+        )
+
 
 class AgentGate(_PolicyGate):
     """Reduce an agent run to an admit/refuse verdict via the enforcer.
@@ -233,30 +278,16 @@ class AgentGate(_PolicyGate):
         if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and self._resolve_approval_sync(decision)
-        ):
-            return
-        raise AgentNotAdmittedError(decision)
+        if not self._cleared_sync(decision):
+            raise AgentNotAdmittedError(decision)
 
     async def check_admission_async(self) -> None:
         """Async mirror of :meth:`check_admission` — awaits an async handler."""
         if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and await self._resolve_approval_async(decision)
-        ):
-            return
-        raise AgentNotAdmittedError(decision)
+        if not await self._cleared_async(decision):
+            raise AgentNotAdmittedError(decision)
 
     def _decide(self) -> Decision:
         # agent name rides in args so a constraint can read args.agent; the
@@ -287,30 +318,16 @@ class ReachGate(_PolicyGate):
         if not self._enforcer.policy.declares_reach():
             return
         decision = self._decide(target, via)
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and self._resolve_approval_sync(decision)
-        ):
-            return
-        raise ReachNotAllowedError(decision)
+        if not self._cleared_sync(decision):
+            raise ReachNotAllowedError(decision)
 
     async def check_reach_async(self, target: str, *, via: AgentVia) -> None:
         """Async mirror of :meth:`check_reach` — awaits an async handler."""
         if not self._enforcer.policy.declares_reach():
             return
         decision = self._decide(target, via)
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and await self._resolve_approval_async(decision)
-        ):
-            return
-        raise ReachNotAllowedError(decision)
+        if not await self._cleared_async(decision):
+            raise ReachNotAllowedError(decision)
 
     def _decide(self, target: str, via: AgentVia) -> Decision:
         # target/via ride in args so a constraint can read args.target / args.via;

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -6,12 +6,15 @@ a non-tool subject. It gates *admission* — may this caller, in this role, run 
 agent — by deciding the synthetic ``agent.run`` key at run entry, before the model
 sees anything.
 
-Admission is opt-in. The gate enforces only when the current policy declares an
-``admission`` block, checked per run inside :meth:`AgentGate.check_admission` (not
-at build time), so an agent whose policy never mentions admission runs exactly as
-before, and a hot-reloaded policy that adds or drops admission is honored on the
-next run. A denial is caller-facing: admission fires before the model runs, so
-there is no tool result to render into, the run simply does not start.
+Engagement is opt-in. The gate enforces only when the current policy declares an
+``admission`` block anywhere, read per run via ``PolicyEngine.declares_admission()``
+(not at build time), so an agent whose policy never mentions admission runs exactly
+as before, and a hot-reloaded policy that adds or drops admission is honored on the
+next run. Once admission is declared, agent keys are closed-world (R-AGENT-002): a
+caller whose role is not granted admission is refused, so a silent co-role can
+neither admit an unknown caller nor defeat an explicit deny. A denial is
+caller-facing: admission fires before the model runs, so there is no tool result to
+render into, the run simply does not start.
 """
 
 from __future__ import annotations
@@ -20,7 +23,7 @@ import logging
 from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
-from hexgate.security.decision import Decision, DecisionOutcome, PolicyEngine
+from hexgate.security.decision import Decision, DecisionOutcome
 from hexgate.security.models import AGENT_RUN_TOOL
 
 if TYPE_CHECKING:
@@ -42,30 +45,13 @@ class AgentNotAdmittedError(Exception):
         super().__init__(decision.as_error_message())
 
 
-def policy_declares_admission(engine: PolicyEngine) -> bool:
-    """True if any role in a pydantic :class:`PolicySet` declares an ``admission`` block.
-
-    The opt-in signal. ``decide()`` cannot tell an explicit ``agent.run`` rule from
-    a fall-through to ``default_policy``, so the gate must know whether admission was
-    authored at all. Only the pydantic ``PolicySet`` exposes the ``AgentPolicy`` at
-    runtime; a compiled WASM bundle does not, so it reports ``False`` here and
-    bundle-served admission rides a manifest flag added in a later PR.
-    """
-    from hexgate.security.policy_set import PolicySet
-
-    if isinstance(engine, PolicySet):
-        return any(
-            engine.policy_for(role).admission is not None for role in engine.roles
-        )
-    return False
-
-
 class AgentGate:
     """Reduce an agent run to an admit/refuse verdict via the enforcer.
 
-    Built only for policies that declare admission, so its mere presence means
-    "enforce"; there is no enabled flag. Mirrors the egress ``Gate``: hold the
-    enforcer and the approval handler, decide, fold approval, fail closed.
+    Always built; whether it enforces is decided per run from
+    ``PolicyEngine.declares_admission()``, so its presence does not mean "enforce".
+    Mirrors the egress ``Gate``: hold the enforcer and the approval handler, decide,
+    fold approval, fail closed.
     """
 
     def __init__(
@@ -86,7 +72,7 @@ class AgentGate:
         build time, so a hot-reloaded policy that adds or drops admission is
         honored on the next run rather than frozen at bind.
         """
-        if not policy_declares_admission(self._enforcer.policy):
+        if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
         if decision.allowed:
@@ -101,7 +87,7 @@ class AgentGate:
 
     async def check_admission_async(self) -> None:
         """Async mirror of :meth:`check_admission` — awaits an async handler."""
-        if not policy_declares_admission(self._enforcer.policy):
+        if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
         if decision.allowed:

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -1,20 +1,24 @@
-"""Agent-level admission enforcement.
+"""Agent-level admission and reach enforcement.
 
-:class:`AgentGate` is to a whole agent run what the egress :class:`~hexgate.egress.gate.Gate`
-is to a network request: one place that reuses :meth:`PolicyEnforcer.decide` for
-a non-tool subject. It gates *admission* — may this caller, in this role, run this
-agent — by deciding the synthetic ``agent.run`` key at run entry, before the model
-sees anything.
+Two gates that are to a whole agent run what the egress :class:`~hexgate.egress.gate.Gate`
+is to a network request: one place that reuses :meth:`PolicyEnforcer.decide` for a
+non-tool subject, folds approval, and fails closed.
 
-Engagement is opt-in. The gate enforces only when the current policy declares an
-``admission`` block anywhere, read per run via ``PolicyEngine.declares_admission()``
-(not at build time), so an agent whose policy never mentions admission runs exactly
-as before, and a hot-reloaded policy that adds or drops admission is honored on the
-next run. Once admission is declared, agent keys are closed-world (R-AGENT-002): a
-caller whose role is not granted admission is refused, so a silent co-role can
-neither admit an unknown caller nor defeat an explicit deny. A denial is
-caller-facing: admission fires before the model runs, so there is no tool result to
-render into, the run simply does not start.
+* :class:`AgentGate` gates *admission* — may this caller, in this role, run this
+  agent at all — by deciding the synthetic ``agent.run`` key at run entry, before
+  the model sees anything.
+* :class:`ReachGate` gates *reach* — may this agent hand off to (or delegate
+  as-tool to) another agent — by deciding the synthetic ``agent.handoff:<target>``
+  / ``agent.tool:<target>`` key at the handoff/delegation seam.
+
+Both share one shape (:class:`_PolicyGate`): hold the enforcer + approval handler,
+decide, fold approval, fail closed. Engagement is opt-in and read per run from the
+policy (``declares_admission()`` / ``declares_reach()``), not frozen at build time,
+so a hot-reloaded policy that adds or drops a block is honored on the next run and
+an agent whose policy never mentions admission/reach runs exactly as before. Once a
+block is declared, agent keys are closed-world (R-AGENT-002): a caller/agent not
+granted the key is refused, so a silent co-role can neither grant an unknown subject
+nor defeat an explicit deny.
 """
 
 from __future__ import annotations
@@ -24,19 +28,25 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 from hexgate.security.decision import Decision, DecisionOutcome
-from hexgate.security.models import AGENT_RUN_TOOL
+from hexgate.security.models import AGENT_RUN_TOOL, agent_target_key
+from hexgate.security.naming import canonical_name
 
 if TYPE_CHECKING:
     from hexgate.approvals import ApprovalHandler
     from hexgate.security.decision import PolicyEngine
     from hexgate.security.enforcer import PolicyEnforcer
+    from hexgate.security.models import AgentVia
 
 _log = logging.getLogger(__name__)
 
-# Dedupe key: admission is enforced only on the native HexgateAgent in A2, so the
-# framework adapters warn once per (framework, agent) that a declared admission
-# block is not enforced there yet. Per-adapter run-entry admission lands in A3.
+
+# ---- interim adapter warnings ---------------------------------------------
+#
+# Admission and reach are wired into some adapters incrementally. Where an adapter
+# cannot enforce a declared block yet, warn once per (framework, agent) rather than
+# fail open in silence. Deduped so a long-lived process logs it once, not per run.
 _admission_unenforced_warned: set[tuple[str, str]] = set()
+_reach_unenforced_warned: set[tuple[str, str]] = set()
 
 
 def warn_if_admission_unenforced(
@@ -44,28 +54,56 @@ def warn_if_admission_unenforced(
 ) -> None:
     """Warn once when a policy declares admission on an adapter that can't enforce it.
 
-    Admission (the ``agent.run`` run-entry gate) is wired only into the native
-    :class:`~hexgate.agents.factory.HexgateAgent` in A2; the OpenAI/Google/
-    pydantic_ai/LangChain adapters check the ban gate at run entry but not
-    admission. Until per-adapter admission lands (A3), a declared ``admission``
-    block is a silent no-op on those adapters — so surface it loudly at wrap time
-    rather than fail open without a trace. No-op when the policy declares no
-    admission (the common case), and deduped per ``(framework, agent_name)`` so a
-    long-lived process logs it once, not per run."""
+    Admission (the ``agent.run`` run-entry gate) is not wired into every framework
+    adapter yet. Where it is not, a declared ``admission`` block is a silent no-op,
+    so surface it loudly at wrap time. No-op when the policy declares no admission
+    (the common case)."""
     if not engine.declares_admission():
         return
-    key = (framework, agent_name)
-    if key in _admission_unenforced_warned:
+    if not _mark_warned(_admission_unenforced_warned, framework, agent_name):
         return
-    _admission_unenforced_warned.add(key)
     _log.warning(
         "policy for agent %r declares an 'admission' block, but admission is not "
-        "enforced on the %s adapter yet (only on the native HexgateAgent); this run "
-        "will proceed without an admission check. Per-adapter admission lands in a "
-        "follow-up (A3); use the native agent to enforce admission today.",
+        "enforced on the %s adapter yet; this run will proceed without an admission "
+        "check. Use the native agent (or a supported adapter) to enforce admission.",
         agent_name,
         framework,
     )
+
+
+def warn_if_reach_unenforced(
+    engine: PolicyEngine, *, framework: str, agent_name: str
+) -> None:
+    """Warn once when a policy declares reach on an adapter that can't enforce it.
+
+    Reach (``agent.handoff:`` / ``agent.tool:``) is enforced only where the
+    framework exposes a target-agent handle at the seam (OpenAI handoffs, Google
+    sub-agents/AgentTool). On adapters that hide the target (pydantic_ai delegation
+    inside a tool body, the native single-graph agent), a declared reach block is a
+    silent no-op, so surface it loudly. No-op when no reach is declared."""
+    if not engine.declares_reach():
+        return
+    if not _mark_warned(_reach_unenforced_warned, framework, agent_name):
+        return
+    _log.warning(
+        "policy for agent %r declares agent reach ('agents' block), but reach is not "
+        "enforced on the %s adapter yet (it exposes no target-agent handle at the "
+        "handoff/delegation seam); handoffs will proceed without a reach check.",
+        agent_name,
+        framework,
+    )
+
+
+def _mark_warned(seen: set[tuple[str, str]], framework: str, agent_name: str) -> bool:
+    """Record ``(framework, agent_name)`` in ``seen``; return True the first time."""
+    key = (framework, agent_name)
+    if key in seen:
+        return False
+    seen.add(key)
+    return True
+
+
+# ---- errors ---------------------------------------------------------------
 
 
 class AgentNotAdmittedError(Exception):
@@ -80,14 +118,32 @@ class AgentNotAdmittedError(Exception):
         super().__init__(decision.as_error_message())
 
 
-class AgentGate:
-    """Reduce an agent run to an admit/refuse verdict via the enforcer.
+class ReachNotAllowedError(Exception):
+    """Raised at a handoff/delegation seam when reach policy refuses the target.
 
-    Always built; whether it enforces is decided per run from
-    ``PolicyEngine.declares_admission()``, so its presence does not mean "enforce".
-    Mirrors the egress ``Gate``: hold the enforcer and the approval handler, decide,
-    fold approval, fail closed.
+    The reach counterpart to :class:`AgentNotAdmittedError`: it fires when the
+    source agent may not reach the target agent, before control transfers. Carries
+    the :class:`Decision`; the message is the model-safe rendering.
     """
+
+    def __init__(self, decision: Decision) -> None:
+        self.decision = decision
+        super().__init__(decision.as_error_message())
+
+
+# ---- gates ----------------------------------------------------------------
+
+
+class _PolicyGate:
+    """Shared machinery for the admission and reach gates.
+
+    Holds the enforcer and approval handler and folds a NEEDS_APPROVAL verdict
+    through the handler (fail-closed on any error, or on an async handler reached
+    from a sync entrypoint). Subclasses add their subject-specific ``decide`` and
+    the engagement check; ``_SUBJECT`` labels the fail-closed log lines.
+    """
+
+    _SUBJECT = "policy"
 
     def __init__(
         self,
@@ -97,6 +153,55 @@ class AgentGate:
     ) -> None:
         self._enforcer = enforcer
         self._approval_handler = approval_handler
+
+    def _resolve_approval_sync(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                # A sync run entrypoint has no loop to await on; deny rather than
+                # silently skip the human check. Close the coroutine so it does
+                # not leak as a never-awaited warning.
+                if hasattr(result, "close"):
+                    result.close()
+                _log.error(
+                    "%s approval_handler is async on a sync run; denying (fail-closed)",
+                    self._SUBJECT,
+                )
+                return False
+            return bool(result)
+        except Exception:
+            _log.exception(
+                "%s approval_handler raised; denying (fail-closed)", self._SUBJECT
+            )
+            return False
+
+    async def _resolve_approval_async(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception:
+            _log.exception(
+                "%s approval_handler raised; denying (fail-closed)", self._SUBJECT
+            )
+            return False
+
+
+class AgentGate(_PolicyGate):
+    """Reduce an agent run to an admit/refuse verdict via the enforcer.
+
+    Always built; whether it enforces is decided per run from
+    ``PolicyEngine.declares_admission()``, so its presence does not mean "enforce".
+    """
+
+    _SUBJECT = "admission"
 
     def check_admission(self) -> None:
         """Raise :class:`AgentNotAdmittedError` if admission policy refuses (sync).
@@ -142,40 +247,64 @@ class AgentGate:
             AGENT_RUN_TOOL, {"agent": self._enforcer.agent_name}
         )
 
-    def _resolve_approval_sync(self, decision: Decision) -> bool:
-        handler = self._approval_handler
-        if isinstance(handler, bool):
-            return handler
-        try:
-            result: Any = handler(decision)  # type: ignore[misc]
-            if isawaitable(result):
-                # A sync run entrypoint has no loop to await on; deny rather than
-                # silently skip the human check. Close the coroutine so it does
-                # not leak as a never-awaited warning.
-                if hasattr(result, "close"):
-                    result.close()
-                _log.error(
-                    "admission approval_handler is async on a sync run; "
-                    "denying (fail-closed)"
-                )
-                return False
-            return bool(result)
-        except Exception:
-            _log.exception("admission approval_handler raised; denying (fail-closed)")
-            return False
 
-    async def _resolve_approval_async(self, decision: Decision) -> bool:
-        handler = self._approval_handler
-        if isinstance(handler, bool):
-            return handler
-        try:
-            result: Any = handler(decision)  # type: ignore[misc]
-            if isawaitable(result):
-                result = await result
-            return bool(result)
-        except Exception:
-            _log.exception("admission approval_handler raised; denying (fail-closed)")
-            return False
+class ReachGate(_PolicyGate):
+    """Reduce an agent-to-agent reach to an allow/refuse verdict via the enforcer.
+
+    Always built; whether it enforces is decided per seam from
+    ``PolicyEngine.declares_reach()``. The source agent's policy governs reach, so
+    this gate is built from the source agent's enforcer and decides the target's
+    lowered key (``agent.handoff:<target>`` / ``agent.tool:<target>``).
+    """
+
+    _SUBJECT = "reach"
+
+    def check_reach(self, target: str, *, via: AgentVia) -> None:
+        """Raise :class:`ReachNotAllowedError` if reach to ``target`` is refused (sync).
+
+        ``target`` is the target agent's name (canonicalized here so it matches the
+        policy key derived from the same name). No-op when the current policy
+        declares no reach.
+        """
+        if not self._enforcer.policy.declares_reach():
+            return
+        decision = self._decide(target, via)
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and self._resolve_approval_sync(decision)
+        ):
+            return
+        raise ReachNotAllowedError(decision)
+
+    async def check_reach_async(self, target: str, *, via: AgentVia) -> None:
+        """Async mirror of :meth:`check_reach` — awaits an async handler."""
+        if not self._enforcer.policy.declares_reach():
+            return
+        decision = self._decide(target, via)
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and await self._resolve_approval_async(decision)
+        ):
+            return
+        raise ReachNotAllowedError(decision)
+
+    def _decide(self, target: str, via: AgentVia) -> Decision:
+        # target/via ride in args so a constraint can read args.target / args.via;
+        # the key encodes the same (canonical) target so the policy match is exact.
+        canonical = canonical_name(target)
+        return self._enforcer.decide(
+            agent_target_key(via, canonical),
+            {"agent": self._enforcer.agent_name, "target": canonical, "via": via},
+        )
+
+
+# ---- builders -------------------------------------------------------------
 
 
 def resolve_agent_gate(
@@ -192,3 +321,15 @@ def resolve_agent_gate(
     rebuilding the gate. A policy with no admission block makes every check a no-op.
     """
     return AgentGate(enforcer, approval_handler=approval_handler)
+
+
+def resolve_reach_gate(
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> ReachGate:
+    """Build the reach gate for ``enforcer`` (the reach counterpart to
+    :func:`resolve_agent_gate`). Always returns a gate; enforcement is decided per
+    seam from the current policy, so a policy with no ``agents`` block is a no-op.
+    """
+    return ReachGate(enforcer, approval_handler=approval_handler)

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -131,6 +131,24 @@ class ReachNotAllowedError(Exception):
         super().__init__(decision.as_error_message())
 
 
+class HandoffDepthExceededError(Exception):
+    """Raised when a run's handoff chain grows past its depth cap.
+
+    A handoff transfers control forward (A → B → C …), so the count of handoffs
+    within one run is the depth of the chain. The cap is a runaway guard,
+    independent of reach policy: even an all-allowed chain stops here. Carries the
+    observed ``depth`` and the ``cap`` it exceeded.
+    """
+
+    def __init__(self, depth: int, cap: int) -> None:
+        self.depth = depth
+        self.cap = cap
+        super().__init__(
+            f"handoff depth {depth} exceeds the cap of {cap}; refusing further "
+            "delegation in this run"
+        )
+
+
 # ---- gates ----------------------------------------------------------------
 
 

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -28,9 +28,44 @@ from hexgate.security.models import AGENT_RUN_TOOL
 
 if TYPE_CHECKING:
     from hexgate.approvals import ApprovalHandler
+    from hexgate.security.decision import PolicyEngine
     from hexgate.security.enforcer import PolicyEnforcer
 
 _log = logging.getLogger(__name__)
+
+# Dedupe key: admission is enforced only on the native HexgateAgent in A2, so the
+# framework adapters warn once per (framework, agent) that a declared admission
+# block is not enforced there yet. Per-adapter run-entry admission lands in A3.
+_admission_unenforced_warned: set[tuple[str, str]] = set()
+
+
+def warn_if_admission_unenforced(
+    engine: PolicyEngine, *, framework: str, agent_name: str
+) -> None:
+    """Warn once when a policy declares admission on an adapter that can't enforce it.
+
+    Admission (the ``agent.run`` run-entry gate) is wired only into the native
+    :class:`~hexgate.agents.factory.HexgateAgent` in A2; the OpenAI/Google/
+    pydantic_ai/LangChain adapters check the ban gate at run entry but not
+    admission. Until per-adapter admission lands (A3), a declared ``admission``
+    block is a silent no-op on those adapters — so surface it loudly at wrap time
+    rather than fail open without a trace. No-op when the policy declares no
+    admission (the common case), and deduped per ``(framework, agent_name)`` so a
+    long-lived process logs it once, not per run."""
+    if not engine.declares_admission():
+        return
+    key = (framework, agent_name)
+    if key in _admission_unenforced_warned:
+        return
+    _admission_unenforced_warned.add(key)
+    _log.warning(
+        "policy for agent %r declares an 'admission' block, but admission is not "
+        "enforced on the %s adapter yet (only on the native HexgateAgent); this run "
+        "will proceed without an admission check. Per-adapter admission lands in a "
+        "follow-up (A3); use the native agent to enforce admission today.",
+        agent_name,
+        framework,
+    )
 
 
 class AgentNotAdmittedError(Exception):

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -1,0 +1,173 @@
+"""Agent-level admission enforcement.
+
+:class:`AgentGate` is to a whole agent run what the egress :class:`~hexgate.egress.gate.Gate`
+is to a network request: one place that reuses :meth:`PolicyEnforcer.decide` for
+a non-tool subject. It gates *admission* — may this caller, in this role, run this
+agent — by deciding the synthetic ``agent.run`` key at run entry, before the model
+sees anything.
+
+Admission is opt-in. The gate enforces only when the current policy declares an
+``admission`` block, checked per run inside :meth:`AgentGate.check_admission` (not
+at build time), so an agent whose policy never mentions admission runs exactly as
+before, and a hot-reloaded policy that adds or drops admission is honored on the
+next run. A denial is caller-facing: admission fires before the model runs, so
+there is no tool result to render into, the run simply does not start.
+"""
+
+from __future__ import annotations
+
+import logging
+from inspect import isawaitable
+from typing import TYPE_CHECKING, Any
+
+from hexgate.security.decision import Decision, DecisionOutcome, PolicyEngine
+from hexgate.security.models import AGENT_RUN_TOOL
+
+if TYPE_CHECKING:
+    from hexgate.approvals import ApprovalHandler
+    from hexgate.security.enforcer import PolicyEnforcer
+
+_log = logging.getLogger(__name__)
+
+
+class AgentNotAdmittedError(Exception):
+    """Raised at run entry when admission policy refuses this caller.
+
+    Carries the :class:`Decision` so the caller can inspect the reason; the
+    message is the model-safe rendering (arguments and attributes withheld).
+    """
+
+    def __init__(self, decision: Decision) -> None:
+        self.decision = decision
+        super().__init__(decision.as_error_message())
+
+
+def policy_declares_admission(engine: PolicyEngine) -> bool:
+    """True if any role in a pydantic :class:`PolicySet` declares an ``admission`` block.
+
+    The opt-in signal. ``decide()`` cannot tell an explicit ``agent.run`` rule from
+    a fall-through to ``default_policy``, so the gate must know whether admission was
+    authored at all. Only the pydantic ``PolicySet`` exposes the ``AgentPolicy`` at
+    runtime; a compiled WASM bundle does not, so it reports ``False`` here and
+    bundle-served admission rides a manifest flag added in a later PR.
+    """
+    from hexgate.security.policy_set import PolicySet
+
+    if isinstance(engine, PolicySet):
+        return any(
+            engine.policy_for(role).admission is not None for role in engine.roles
+        )
+    return False
+
+
+class AgentGate:
+    """Reduce an agent run to an admit/refuse verdict via the enforcer.
+
+    Built only for policies that declare admission, so its mere presence means
+    "enforce"; there is no enabled flag. Mirrors the egress ``Gate``: hold the
+    enforcer and the approval handler, decide, fold approval, fail closed.
+    """
+
+    def __init__(
+        self,
+        enforcer: PolicyEnforcer,
+        *,
+        approval_handler: ApprovalHandler | None = None,
+    ) -> None:
+        self._enforcer = enforcer
+        self._approval_handler = approval_handler
+
+    def check_admission(self) -> None:
+        """Raise :class:`AgentNotAdmittedError` if admission policy refuses (sync).
+
+        Reads the caller's role from the active context the enforcer sees, so the
+        caller's ``HexgateContext`` scope must already be open at this call site.
+        No-op when the current policy declares no admission — checked here, not at
+        build time, so a hot-reloaded policy that adds or drops admission is
+        honored on the next run rather than frozen at bind.
+        """
+        if not policy_declares_admission(self._enforcer.policy):
+            return
+        decision = self._decide()
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and self._resolve_approval_sync(decision)
+        ):
+            return
+        raise AgentNotAdmittedError(decision)
+
+    async def check_admission_async(self) -> None:
+        """Async mirror of :meth:`check_admission` — awaits an async handler."""
+        if not policy_declares_admission(self._enforcer.policy):
+            return
+        decision = self._decide()
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and await self._resolve_approval_async(decision)
+        ):
+            return
+        raise AgentNotAdmittedError(decision)
+
+    def _decide(self) -> Decision:
+        # agent name rides in args so a constraint can read args.agent; the
+        # enforcer folds the caller's roles and emits the audit event.
+        return self._enforcer.decide(
+            AGENT_RUN_TOOL, {"agent": self._enforcer.agent_name}
+        )
+
+    def _resolve_approval_sync(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                # A sync run entrypoint has no loop to await on; deny rather than
+                # silently skip the human check. Close the coroutine so it does
+                # not leak as a never-awaited warning.
+                if hasattr(result, "close"):
+                    result.close()
+                _log.error(
+                    "admission approval_handler is async on a sync run; "
+                    "denying (fail-closed)"
+                )
+                return False
+            return bool(result)
+        except Exception:
+            _log.exception("admission approval_handler raised; denying (fail-closed)")
+            return False
+
+    async def _resolve_approval_async(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception:
+            _log.exception("admission approval_handler raised; denying (fail-closed)")
+            return False
+
+
+def resolve_agent_gate(
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> AgentGate:
+    """Build the admission gate for ``enforcer``.
+
+    Always returns a gate (unlike :func:`~hexgate.security.bans.resolve_ban_gate`,
+    which needs a platform): admission is a local policy decision. Whether the gate
+    actually enforces is decided per run inside :meth:`AgentGate.check_admission`,
+    so a hot-reloaded policy that adds or drops admission is honored without
+    rebuilding the gate. A policy with no admission block makes every check a no-op.
+    """
+    return AgentGate(enforcer, approval_handler=approval_handler)

--- a/hexgate/security/bundle.py
+++ b/hexgate/security/bundle.py
@@ -305,6 +305,18 @@ class PolicyBundle:
             self, role or DEFAULT_ROLE_NAME, tool, dict(args), attributes=attributes
         )
 
+    def declares_admission(self) -> bool:
+        """Read the admission-configured flag from the signed manifest.
+
+        The compiled WASM is opaque, so the derived signal is recorded at build
+        time (:func:`build_signed_bundle`) under ``agent_gating``. Absent (an older
+        bundle) reads False — safe, those predate agent-level policy (R-AGENT-002)."""
+        return bool(self.manifest.get("agent_gating", {}).get("admission", False))
+
+    def declares_reach(self) -> bool:
+        """Read the reach-configured flag from the signed manifest (reach counterpart)."""
+        return bool(self.manifest.get("agent_gating", {}).get("reach", False))
+
     # ---- Metadata ------------------------------------------------------
 
     @property
@@ -370,12 +382,22 @@ def build_signed_bundle(
     """
     # Lazy import keeps bundle.py importable (and the platform booting) even
     # when the opa-backed compiler isn't needed — only producers hit this.
+    from hexgate.security.policy_set import load_policy_set_from_dict
     from hexgate.security.rego import compile_to_rego
     from hexgate.security.rego_wasm import compile_to_wasm
 
     payload = yaml.safe_load(policy_yaml) or {}
     source_hash = hashlib.sha256(policy_yaml.encode("utf-8")).hexdigest()
     rego_text = compile_to_rego(payload, source_hash=source_hash)
+
+    # Record the agent-gate engagement flags derived from the resolved policy: the
+    # compiled WASM is opaque, so the bundle-backed gate reads these from the
+    # (signed) manifest to decide whether to fire (R-AGENT-002).
+    resolved = load_policy_set_from_dict(payload)
+    agent_gating = {
+        "admission": resolved.declares_admission(),
+        "reach": resolved.declares_reach(),
+    }
 
     wasm_bytes: bytes | None = None
     wasm_hash: str | None = None
@@ -389,6 +411,7 @@ def build_signed_bundle(
         "source_hash": source_hash,
         "rego_hash": hashlib.sha256(rego_text.encode("utf-8")).hexdigest(),
         "wasm_hash": wasm_hash,
+        "agent_gating": agent_gating,
     }
     # The one canonical serialization. Sign these exact bytes.
     manifest_bytes = (json.dumps(manifest, indent=2, sort_keys=True) + "\n").encode(

--- a/hexgate/security/bundle.py
+++ b/hexgate/security/bundle.py
@@ -317,6 +317,11 @@ class PolicyBundle:
         """Read the reach-configured flag from the signed manifest (reach counterpart)."""
         return bool(self.manifest.get("agent_gating", {}).get("reach", False))
 
+    def declares_tool_reach(self) -> bool:
+        """Read the agent-as-tool reach flag from the signed manifest. Absent (an
+        older bundle) reads False, so no spurious warning fires."""
+        return bool(self.manifest.get("agent_gating", {}).get("reach_tool", False))
+
     # ---- Metadata ------------------------------------------------------
 
     @property
@@ -397,6 +402,7 @@ def build_signed_bundle(
     agent_gating = {
         "admission": resolved.declares_admission(),
         "reach": resolved.declares_reach(),
+        "reach_tool": resolved.declares_tool_reach(),
     }
 
     wasm_bytes: bytes | None = None

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -69,6 +69,22 @@ class PolicyEngine(Protocol):
         attributes: Mapping[str, Any] | None = None,
     ) -> Verdict: ...
 
+    def declares_admission(self) -> bool:
+        """Whether this policy configures admission anywhere.
+
+        The agent gate's opt-in signal: it fires only when this is true, so an
+        agent that never mentions admission is never gated (agent keys are
+        otherwise closed-world). A pydantic engine derives it from the resolved
+        policy; a WASM bundle reads it from its signed manifest (R-AGENT-002)."""
+        ...
+
+    def declares_reach(self) -> bool:
+        """Whether this policy configures agent-to-agent reach anywhere.
+
+        The delegation seam's opt-in signal, the reach counterpart to
+        :meth:`declares_admission` (consumed once handoff interception lands)."""
+        ...
+
 
 # Over the platform's ``DecisionEvent.reason`` max_length the audit event is
 # rejected outright, losing the record for the calls most worth keeping.

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -85,6 +85,14 @@ class PolicyEngine(Protocol):
         :meth:`declares_admission` (consumed once handoff interception lands)."""
         ...
 
+    def declares_tool_reach(self) -> bool:
+        """Whether this policy configures agent-as-tool (``via: tool``) reach.
+
+        A finer signal than :meth:`declares_reach`: an adapter that enforces
+        handoff reach but not agent-as-tool reach (OpenAI) warns only when this is
+        true, so a handoff-only policy is not spammed."""
+        ...
+
 
 # Over the platform's ``DecisionEvent.reason`` max_length the audit event is
 # rejected outright, losing the record for the calls most worth keeping.

--- a/hexgate/security/linker.py
+++ b/hexgate/security/linker.py
@@ -158,7 +158,9 @@ def _reject_capability_denies(capabilities: Sequence[ModuleContent]) -> None:
     hoisted here and run over every capability, bound or not.
     """
     for cap in capabilities:
-        for tool, tp in cap.policy.tools.items():
+        # effective_tools, so a capability that denies an agent key (a lowered
+        # agents:/admission deny) is caught too — capabilities grant only.
+        for tool, tp in cap.policy.effective_tools.items():
             if tp.mode == "deny":
                 raise LinkError(
                     f"capability {cap.name!r} denies {tool!r}; capabilities may "
@@ -182,8 +184,10 @@ def link(
         if rule is not None:
             tools[name] = rule
 
-    # Effective default is fail-closed: a tool no layer grants is denied.
-    effective = AgentPolicy(
+    # Effective default is fail-closed: a tool no layer grants is denied. The
+    # folded map may include lowered agent.* keys (composed agent-level blocks),
+    # so build through the resolved path, which carries them in tools directly.
+    effective = AgentPolicy.resolved(
         default_policy=BaseToolPolicy(mode="deny"), tools=tools, consts=consts
     )
     return effective, trace
@@ -276,7 +280,18 @@ def _reject_file_scope(
 # rejected by _reject_unsupported_module_fields, so a field added to AgentPolicy
 # later fails closed here instead of being silently dropped by _fold_tool.
 _MODULE_COMPOSABLE_FIELDS = frozenset(
-    {"version", "inherits", "is_mixin", "default_policy", "tools", "consts"}
+    {
+        "version",
+        "inherits",
+        "is_mixin",
+        "default_policy",
+        "tools",
+        "consts",
+        # Agent-level blocks lower to agent.* keys the fold composes like tools
+        # (a boundary agent-deny is authoritative, a capability agent-grant unions).
+        "admission",
+        "agents",
+    }
 )
 
 
@@ -284,13 +299,14 @@ def _reject_unsupported_module_fields(
     boundaries: list[ModuleContent], capabilities: list[ModuleContent]
 ) -> None:
     """Reject any top-level AgentPolicy field a module sets that the fold does not
-    compose (today: ``admission`` / ``agents``; tomorrow: whatever is added next).
+    compose (whatever is added next).
 
-    ``_fold_tool`` reads only ``.tools``, so an un-composed field would be silently
-    dropped, erasing a rule an operator authored — the same fail-open
-    :func:`_reject_file_scope` guards against, generalized. Allowlisting the fields
-    the fold understands means a new AgentPolicy field is rejected automatically
-    until composition learns it, rather than shipping fail-open by omission."""
+    The fold composes ``tools`` and the lowered ``agent.*`` keys from
+    ``effective_tools``, so an un-composed field would be silently dropped, erasing
+    a rule an operator authored — the same fail-open :func:`_reject_file_scope`
+    guards against, generalized. Allowlisting the fields the fold understands means
+    a new AgentPolicy field is rejected automatically until composition learns it,
+    rather than shipping fail-open by omission."""
     for module in (*boundaries, *capabilities):
         extra = module.policy.model_fields_set - _MODULE_COMPOSABLE_FIELDS
         if extra:
@@ -310,7 +326,7 @@ def _fold_tool(
     """Resolve one tool across all layers. ``None`` means implicit-deny (omit)."""
     # Capabilities may only grant. A capability deny is a config error.
     for cap in capabilities:
-        tp = cap.policy.tools.get(tool)
+        tp = cap.policy.effective_tools.get(tool)
         if tp is not None and tp.mode == "deny":
             raise LinkError(
                 f"capability {cap.name!r} denies {tool!r}; capabilities may only "
@@ -321,7 +337,7 @@ def _fold_tool(
     #    (has constraints) instead subtracts its region from the grant (step 5).
     conditional_denies: list[tuple[ModuleContent, list[str]]] = []
     for g in boundaries:
-        tp = g.policy.tools.get(tool)
+        tp = g.policy.effective_tools.get(tool)
         if tp is not None and tp.mode == "deny":
             if tp.constraints:
                 conditional_denies.append((g, list(tp.constraints)))
@@ -334,7 +350,7 @@ def _fold_tool(
     contributors: list[Provenance] = []
     ceiling_constraints: list[str] = []
     for g in boundaries:
-        tp = g.policy.tools.get(tool)
+        tp = g.policy.effective_tools.get(tool)
         is_ceiling = g.policy.default_policy.mode == "deny"
         if tp is not None and tp.mode in GRANT_MODES:
             ceiling_constraints.extend(tp.constraints)  # fences intersect (AND)
@@ -349,7 +365,7 @@ def _fold_tool(
     # 3+4. Capability grants. No grant → eligible but ungranted → implicit deny.
     grants: list[tuple[ModuleContent, ToolPolicy]] = []
     for cap in capabilities:
-        tp = cap.policy.tools.get(tool)
+        tp = cap.policy.effective_tools.get(tool)
         if tp is not None and tp.mode in GRANT_MODES:
             grants.append((cap, tp))
     if not grants:
@@ -407,7 +423,8 @@ def _any_approval(
     if any(tp.mode == "approval_required" for tp in grants):
         return True
     return any(
-        (tp := g.policy.tools.get(tool)) is not None and tp.mode == "approval_required"
+        (tp := g.policy.effective_tools.get(tool)) is not None
+        and tp.mode == "approval_required"
         for g in boundaries
     )
 
@@ -416,7 +433,8 @@ def _tool_names(*groups: list[ModuleContent]) -> list[str]:
     names: set[str] = set()
     for group in groups:
         for module in group:
-            names.update(module.policy.tools)
+            # effective_tools, so lowered agent.* keys are folded like tool keys.
+            names.update(module.policy.effective_tools)
     return sorted(names)
 
 

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, get_args
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from hexgate.security.constraints import parse_constraint
+from hexgate.security.naming import canonical_name
 
 PolicyMode = Literal["allow", "deny", "approval_required"]
 
@@ -203,6 +204,11 @@ class AgentPolicy(BaseModel):
         ``via`` mode (``agent.tool:<name>`` / ``agent.handoff:<name>``). Only the
         *listed* rules are lowered; the fallback for an unlisted target is the
         agent gate's concern, not this map's.
+
+        The target name is canonicalized (:func:`~hexgate.security.naming.canonical_name`)
+        so the lowered key matches the one the reach gate derives from the runtime
+        target's name — both sides normalize identically, or a padded authored name
+        would never match and a policy-allowed handoff would fall to closed-world deny.
         """
         lowered: dict[str, BaseToolPolicy] = {}
         if self.admission is not None:
@@ -212,7 +218,7 @@ class AgentPolicy(BaseModel):
             # rebuild would silently drop any field later added to BaseToolPolicy.
             # via is an extra field the engines ignore.
             for via in target_policy.via:
-                lowered[agent_target_key(via, target)] = target_policy
+                lowered[agent_target_key(via, canonical_name(target))] = target_policy
         return lowered
 
     @cached_property

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -75,6 +75,14 @@ def agent_target_key(via: AgentVia, target: str) -> str:
     return f"agent.{via}:{target}"
 
 
+def is_agent_via_key(name: str, via: AgentVia) -> bool:
+    """True for a reach key of a specific ``via`` mode (``agent.<via>:``).
+
+    Lets a caller tell agent-as-tool reach from handoff reach, e.g. to warn only
+    about the mode a given adapter cannot enforce."""
+    return name.startswith(f"agent.{via}:")
+
+
 def is_agent_reach_key(name: str) -> bool:
     """True for an ``agent.tool:`` / ``agent.handoff:`` reach key.
 

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -173,6 +173,29 @@ class AgentPolicy(BaseModel):
                 )
         return value
 
+    @classmethod
+    def resolved(
+        cls,
+        *,
+        default_policy: BaseToolPolicy,
+        tools: dict[str, ToolPolicy],
+        consts: dict[str, Any],
+    ) -> "AgentPolicy":
+        """Build a linker-resolved policy directly from folded tool keys.
+
+        The fold composes agent-level blocks into lowered ``agent.*`` keys and
+        stores them alongside ordinary tools, so a resolved policy carries them
+        in ``tools`` rather than in ``admission``/``agents``: per-via divergence
+        across capabilities (a target allowed via one mode, denied via another,
+        or granted different constraints per mode) can't always be reverse-lowered
+        into a single :class:`AgentTargetPolicy`. The reserved-key guard on
+        ``tools`` is an authoring ergonomic that does not apply to this machine
+        path, so this bypasses validation via ``model_construct`` — every value is
+        an already-validated model instance produced by the fold."""
+        return cls.model_construct(
+            default_policy=default_policy, tools=dict(tools), consts=dict(consts)
+        )
+
     def lowered_agent_tools(self) -> dict[str, BaseToolPolicy]:
         """Expand ``admission``/``agents`` into synthetic tool entries.
 

--- a/hexgate/security/naming.py
+++ b/hexgate/security/naming.py
@@ -1,0 +1,41 @@
+"""Canonical agent-name derivation, shared by every adapter and the reach gate.
+
+An agent's name is the identity a policy references two ways: its *own* name selects
+its policy, and a *reach* key (``agent.handoff:<name>`` / ``agent.tool:<name>``)
+names a *target* agent. Both the own-name lookup and the target-name match must
+derive the name the same way, or a target authored under the name it registers with
+would silently fail to match at the handoff seam. Before this module the derivation
+was duplicated across adapters in two subtly different spellings
+(``getattr(agent, "name", "default")`` vs ``... or "default"``); this is now the
+one place it lives.
+
+Matching is exact on the trimmed name (no case folding): a policy target name must
+equal the name its agent registers with. Case-insensitive matching would have to be
+applied to both the policy key (at lowering) and the runtime name to stay in parity,
+so it is deliberately left as a possible follow-up rather than a silent half-fix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The identity a null/blank-named agent collapses to, so it never reaches a policy
+# lookup, a cache key, or a reach match as ``None``/``""``.
+DEFAULT_AGENT_NAME = "default"
+
+
+def canonical_name(name: str | None) -> str:
+    """Normalize an agent name string: trim whitespace, blank/None → ``"default"``."""
+    if not isinstance(name, str):
+        return DEFAULT_AGENT_NAME
+    return name.strip() or DEFAULT_AGENT_NAME
+
+
+def canonical_agent_name(agent: Any) -> str:
+    """The name a framework ``Agent`` object is known by for policy.
+
+    Reads the framework-agnostic ``name`` attribute (every supported SDK agent has
+    one) through :func:`canonical_name`. Used for both an agent's own-name lookup
+    and, at the handoff/delegation seam, for the target agent's reach match, so the
+    two can never drift."""
+    return canonical_name(getattr(agent, "name", None))

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -13,20 +13,19 @@ from hexgate.security.decision import DecisionOutcome, Verdict
 from hexgate.security.errors import ApprovalRequiredError, PolicyDeniedError
 from hexgate.security.file_scope import build_file_scope_hint, is_path_allowed
 from hexgate.security.models import (
-    AGENT_RUN_TOOL,
     AgentPolicy,
     BaseToolPolicy,
     FileToolPolicy,
     ToolPolicy,
-    is_agent_reach_key,
+    is_agent_key,
 )
 
-# Reach keys are closed-world: an unlisted agent.tool:/agent.handoff: denies
-# regardless of default_policy, so a permissive tool default never silently grants
-# agent reach. Admission (agent.run) is the opposite: opt-in, so an unlisted
-# agent.run admits (a role that declares no admission does not restrict it).
-_AGENT_REACH_CLOSED_WORLD_DENY = BaseToolPolicy(mode="deny")
-_ADMISSION_OPT_IN_ALLOW = BaseToolPolicy(mode="allow")
+# Agent keys (admission agent.run AND reach agent.tool:/agent.handoff:) are
+# closed-world: an unlisted agent key denies regardless of default_policy. A role
+# that is not granted admission is denied, so a permissive tool default cannot
+# silently grant a run or a handoff. Whether admission is enforced at all is the
+# gate's opt-in engagement decision (declares_admission), not this fallback (R-AGENT-002).
+_AGENT_CLOSED_WORLD_DENY = BaseToolPolicy(mode="deny")
 
 if TYPE_CHECKING:
     from hexgate.security.bundle import PolicyBundle
@@ -53,27 +52,18 @@ def get_tool_policy(policy: AgentPolicy, tool_name: str) -> ToolPolicy:
     """Resolve the effective policy for a tool name.
 
     Reads ``effective_tools`` (authored tools plus lowered ``agent.*`` keys) so a
-    synthetic agent-level key resolves through the same path as any tool. Fallbacks
-    for an unlisted key differ by kind:
-
-    * an unlisted **reach** key (``agent.tool:`` / ``agent.handoff:``) denies,
-      closed-world, so a permissive ``default_policy`` cannot silently grant a
-      handoff or sub-agent call;
-    * an unlisted ``agent.run`` **admits** (admission is opt-in — a role that
-      declares no admission does not restrict who may start the agent);
-    * any other unlisted tool falls to ``default_policy``.
-
-    The Rego compiler mirrors both (it excludes reach keys from its permissive
-    catch-all and emits an opt-in allow rule for ``agent.run``), keeping the engines
-    in agreement.
+    synthetic agent-level key resolves through the same path as any tool. An
+    unlisted **agent** key (admission or reach) denies, closed-world, so a
+    permissive ``default_policy`` never silently grants a run or a handoff; any
+    other unlisted tool falls to ``default_policy``. The Rego compiler mirrors this
+    (its permissive catch-all excludes every agent key), keeping the engines in
+    agreement (R-AGENT-002).
     """
     tool_policy = policy.effective_tools.get(tool_name)
     if tool_policy is not None:
         return tool_policy
-    if tool_name == AGENT_RUN_TOOL:
-        return _ADMISSION_OPT_IN_ALLOW
-    if is_agent_reach_key(tool_name):
-        return _AGENT_REACH_CLOSED_WORLD_DENY
+    if is_agent_key(tool_name):
+        return _AGENT_CLOSED_WORLD_DENY
     return policy.default_policy
 
 

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -39,10 +39,12 @@ import yaml
 from hexgate.security.constraints import iter_const_refs, parse_constraint
 from hexgate.security.decision import Verdict
 from hexgate.security.models import (
+    AGENT_RUN_TOOL,
     AgentPolicy,
     AgentTargetPolicy,
     BaseToolPolicy,
     ToolPolicy,
+    is_agent_reach_key,
 )
 
 
@@ -121,6 +123,24 @@ class PolicySet:
     def roles(self) -> list[str]:
         """List of role names, including ``default``, excluding mixins."""
         return sorted(self._policies)
+
+    def declares_admission(self) -> bool:
+        """True if any resolved role carries the ``agent.run`` key.
+
+        Derived from ``effective_tools`` rather than a source field so it holds
+        after inheritance and module folding, where the ``admission`` block has
+        become an ``agent.run`` key (R-AGENT-002)."""
+        return any(
+            AGENT_RUN_TOOL in policy.effective_tools
+            for policy in self._policies.values()
+        )
+
+    def declares_reach(self) -> bool:
+        """True if any resolved role carries an ``agent.tool:`` / ``agent.handoff:`` key."""
+        return any(
+            any(is_agent_reach_key(key) for key in policy.effective_tools)
+            for policy in self._policies.values()
+        )
 
     def __contains__(self, role: str) -> bool:
         return role in self._policies

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -45,6 +45,7 @@ from hexgate.security.models import (
     BaseToolPolicy,
     ToolPolicy,
     is_agent_reach_key,
+    is_agent_via_key,
 )
 
 
@@ -139,6 +140,13 @@ class PolicySet:
         """True if any resolved role carries an ``agent.tool:`` / ``agent.handoff:`` key."""
         return any(
             any(is_agent_reach_key(key) for key in policy.effective_tools)
+            for policy in self._policies.values()
+        )
+
+    def declares_tool_reach(self) -> bool:
+        """True if any resolved role carries an ``agent.tool:`` (agent-as-tool) key."""
+        return any(
+            any(is_agent_via_key(key, "tool") for key in policy.effective_tools)
             for policy in self._policies.values()
         )
 

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -299,24 +299,6 @@ def _rules_for_role(
                 helpers,
             )
         )
-    if AGENT_RUN_TOOL not in effective:
-        # Admission is opt-in: a role that declares no admission rule admits, so an
-        # unlisted agent.run allows regardless of default_policy. Emitted for every
-        # role (not gated on agent blocks) so it matches the unconditional
-        # _ADMISSION_OPT_IN_ALLOW fallback in the pydantic engine — otherwise a role
-        # without an admission rule would deny agent.run on the WASM path while
-        # allowing it on the pydantic path (the same non-monotonic lockout, one
-        # engine over).
-        out.extend(
-            _gated_rules(
-                role,
-                role_guard,
-                [f'    input.tool == "{_escape_string(AGENT_RUN_TOOL)}"'],
-                BaseToolPolicy(mode="allow"),
-                AGENT_RUN_TOOL,
-                helpers,
-            )
-        )
     out.extend(_default_rules(role, role_guard, policy.default_policy, listed, helpers))
     return out
 
@@ -336,12 +318,13 @@ def _default_rules(
     """
     if default_policy.mode == "deny":
         return []
-    # Reach keys are closed-world: a permissive default must not grant an unlisted
-    # agent.tool:/agent.handoff:, so exclude them from the catch-all (an unlisted
-    # reach key then matches no rule and denies). agent.run is deliberately NOT
-    # excluded — admission is opt-in and its own rule handles it. Mirrors
-    # get_tool_policy / is_agent_reach_key in the pydantic engine.
-    tool_guard = [
+    # Agent keys are closed-world: a permissive default must not grant an unlisted
+    # agent key, so exclude them from the catch-all (an unlisted agent key then
+    # matches no rule and denies). Excludes exactly the reserved shapes — agent.run
+    # and the reach prefixes — so an authored tool merely named "agent.foo" still
+    # follows the default, matching is_agent_key in the pydantic engine (R-AGENT-002).
+    tool_guard = [f"    input.tool != {json.dumps(AGENT_RUN_TOOL)}"]
+    tool_guard += [
         f"    not startswith(input.tool, {json.dumps(prefix)})"
         for prefix in AGENT_REACH_PREFIXES
     ]

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -683,7 +683,7 @@ async def test_reach_plugin_gates_transfer_to_agent(
     )
     plugin = _HexgateReachPlugin(runner)
     tool = SimpleNamespace(name="transfer_to_agent")
-    ctx = SimpleNamespace(agent_name="orchestrator")  # the governed root
+    ctx = SimpleNamespace(agent_name="orchestrator", invocation_id="i")  # governed root
     async with _user():
         await plugin.before_tool_callback(
             tool=tool, tool_args={"agent_name": "billing-bot"}, tool_context=ctx
@@ -703,7 +703,7 @@ async def test_reach_plugin_skips_non_root_source(
     )
     plugin = _HexgateReachPlugin(runner)
     tool = SimpleNamespace(name="transfer_to_agent")
-    ctx = SimpleNamespace(agent_name="a-sub-agent")  # not the governed root
+    ctx = SimpleNamespace(agent_name="a-sub-agent", invocation_id="i")  # not root
     async with _user():
         await plugin.before_tool_callback(
             tool=tool, tool_args={"agent_name": "evil-bot"}, tool_context=ctx
@@ -719,7 +719,7 @@ async def test_reach_plugin_ignores_ordinary_tool(
     )
     plugin = _HexgateReachPlugin(runner)
     tool = SimpleNamespace(name="search")  # a normal tool, not a transfer/AgentTool
-    ctx = SimpleNamespace(agent_name="orchestrator")
+    ctx = SimpleNamespace(agent_name="orchestrator", invocation_id="i")
     async with _user():
         await plugin.before_tool_callback(
             tool=tool, tool_args={"q": "x"}, tool_context=ctx
@@ -757,10 +757,8 @@ async def test_reach_plugin_enforces_depth_cap_per_invocation(
             await plugin.before_tool_callback(
                 tool=tool, tool_args={"agent_name": "b"}, tool_context=ctx
             )  # depth 2 > cap
-    # after_run clears this invocation's counter so it does not leak.
-    await plugin.after_run_callback(
-        invocation_context=SimpleNamespace(invocation_id="inv-1")
-    )
+    # The raise aborts the run (after_run_callback never fires), so the callback
+    # must have already dropped this invocation's counter — no leak.
     assert "inv-1" not in plugin._depth
 
 

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -25,6 +25,7 @@ from hexgate.security import (
     AgentNotAdmittedError,
     AgentPolicy,
     BaseToolPolicy,
+    HandoffDepthExceededError,
     PolicySet,
     ReachNotAllowedError,
     ResolvedPolicy,
@@ -737,6 +738,30 @@ def test_admission_sync_noop_without_admission(
     runner = _runner_with_policy(monkeypatch)  # no admission declared
     with _user().sync_scope():
         runner._check_admission_sync()  # no raise
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_enforces_depth_cap_per_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(monkeypatch, agents={"b": {"mode": "allow"}})
+    runner._max_handoff_depth = 1
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="transfer_to_agent")
+    ctx = SimpleNamespace(agent_name="orchestrator", invocation_id="inv-1")
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"agent_name": "b"}, tool_context=ctx
+        )  # depth 1 == cap → ok
+        with pytest.raises(HandoffDepthExceededError):
+            await plugin.before_tool_callback(
+                tool=tool, tool_args={"agent_name": "b"}, tool_context=ctx
+            )  # depth 2 > cap
+    # after_run clears this invocation's counter so it does not leak.
+    await plugin.after_run_callback(
+        invocation_context=SimpleNamespace(invocation_id="inv-1")
+    )
+    assert "inv-1" not in plugin._depth
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -17,12 +17,20 @@ from google.genai import types
 
 from hexgate.adapters.google import runner as runner_mod
 from hexgate.adapters.google import wrapper as wrapper_mod
-from hexgate.adapters.google.runner import HexgateRunner
+from hexgate.adapters.google.runner import HexgateRunner, _HexgateReachPlugin
 from hexgate.adapters.google.usage import HexgateUsagePlugin
 from hexgate.runtime import HexgateContext
 from hexgate.runtime.context import get_current_context
-from hexgate.security import AgentPolicy, BaseToolPolicy, PolicySet, ResolvedPolicy
+from hexgate.security import (
+    AgentNotAdmittedError,
+    AgentPolicy,
+    BaseToolPolicy,
+    PolicySet,
+    ReachNotAllowedError,
+    ResolvedPolicy,
+)
 from hexgate.security.bans import BanEntry, BanGate, BanSet
+from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.errors import AgentBannedError
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 from hexgate.tracing import _senders as senders_mod
@@ -579,6 +587,10 @@ def test_not_banned_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
 class _CountingBinding:
     def __init__(self) -> None:
         self.refreshes = 0
+        # A real enforcer with a plain policy, so the run-entry admission check is
+        # a no-op (declares_admission() is False) rather than an AttributeError.
+        engine = PolicySet({DEFAULT_ROLE_NAME: AgentPolicy()})
+        self.enforcer = PolicyEnforcer(engine, agent_name="my-agent")
 
     def refresh(self) -> None:
         self.refreshes += 1
@@ -631,6 +643,100 @@ def test_construction_does_not_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
     runner, binding = _runner_with_counting_binding(monkeypatch)
 
     assert binding.refreshes == 0
+
+
+# ---------------------------------------------------------------------------
+# Agent-level reach + admission (A3)
+# ---------------------------------------------------------------------------
+
+
+def _runner_with_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    agents: dict | None = None,
+    admission: str | None = None,
+) -> HexgateRunner:
+    """A runner whose binding carries a chosen agent-level policy, for driving the
+    reach plugin and admission helpers directly."""
+    runner, binding = _runner_with_counting_binding(monkeypatch)
+    runner._agent_name = "orchestrator"
+    engine = PolicySet(
+        {
+            DEFAULT_ROLE_NAME: AgentPolicy(
+                default_policy=BaseToolPolicy(mode="allow"),
+                agents=agents or {},
+                admission=BaseToolPolicy(mode=admission) if admission else None,
+            )
+        }
+    )
+    binding.enforcer = PolicyEnforcer(engine, agent_name="orchestrator")
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_gates_transfer_to_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(
+        monkeypatch, agents={"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="transfer_to_agent")
+    ctx = SimpleNamespace(agent_name="orchestrator")  # the governed root
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"agent_name": "billing-bot"}, tool_context=ctx
+        )
+        with pytest.raises(ReachNotAllowedError):
+            await plugin.before_tool_callback(
+                tool=tool, tool_args={"agent_name": "evil-bot"}, tool_context=ctx
+            )
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_skips_non_root_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(
+        monkeypatch, agents={"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="transfer_to_agent")
+    ctx = SimpleNamespace(agent_name="a-sub-agent")  # not the governed root
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"agent_name": "evil-bot"}, tool_context=ctx
+        )  # not gated → no raise
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_ignores_ordinary_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(
+        monkeypatch, agents={"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="search")  # a normal tool, not a transfer/AgentTool
+    ctx = SimpleNamespace(agent_name="orchestrator")
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"q": "x"}, tool_context=ctx
+        )  # falls through → no raise
+
+
+def test_admission_sync_denies_non_admitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = _runner_with_policy(monkeypatch, admission="deny")
+    with _user().sync_scope(), pytest.raises(AgentNotAdmittedError):
+        runner._check_admission_sync()
+
+
+def test_admission_sync_noop_without_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(monkeypatch)  # no admission declared
+    with _user().sync_scope():
+        runner._check_admission_sync()  # no raise
 
 
 # ---------------------------------------------------------------------------
@@ -697,8 +803,10 @@ def test_constructor_passes_a_usage_plugin_when_no_plugins_supplied(
 
     [fake_runner] = fake.instances
     plugins = fake_runner.kwargs["app"].plugins
-    assert len(plugins) == 1
-    assert isinstance(plugins[0], HexgateUsagePlugin)
+    # usage plugin + the reach-enforcement plugin
+    assert len(plugins) == 2
+    assert any(isinstance(p, HexgateUsagePlugin) for p in plugins)
+    assert any(isinstance(p, _HexgateReachPlugin) for p in plugins)
 
 
 def test_constructor_preserves_caller_supplied_plugins(
@@ -721,7 +829,8 @@ def test_constructor_preserves_caller_supplied_plugins(
     plugins = fake_runner.kwargs["app"].plugins
     assert custom_plugin in plugins
     assert any(isinstance(p, HexgateUsagePlugin) for p in plugins)
-    assert len(plugins) == 2
+    assert any(isinstance(p, _HexgateReachPlugin) for p in plugins)
+    assert len(plugins) == 3  # custom + usage + reach
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -13,7 +13,11 @@ from agents.items import ModelResponse
 from agents.usage import Usage
 
 from hexgate.adapters.openai import runner as runner_mod
-from hexgate.adapters.openai.runner import HexgateRunner
+from hexgate.adapters.openai.runner import (
+    HexgateRunner,
+    _CompositeRunHooks,
+    _HexgateReachHooks,
+)
 from hexgate.adapters.openai.usage import HexgateUsageHooks
 from hexgate.runtime import HexgateContext
 from hexgate.runtime.context import get_current_context
@@ -218,7 +222,10 @@ async def test_run_wraps_agent_opens_user_scope_and_calls_runner_run(
     assert captured["agent"].name == agent.name
     assert captured["input"] == "hello"
     assert captured["kwargs"]["run_config"] is None
-    assert isinstance(captured["kwargs"]["hooks"], HexgateUsageHooks)
+    hooks = captured["kwargs"]["hooks"]
+    assert isinstance(hooks, _CompositeRunHooks)
+    assert any(isinstance(h, HexgateUsageHooks) for h in hooks._hooks)
+    assert any(isinstance(h, _HexgateReachHooks) for h in hooks._hooks)
     # HexgateContext scope was live for the duration of Runner.run.
     assert captured["active_user"] is context
     # Scope unwound on exit — no leak.
@@ -704,7 +711,7 @@ def _fake_llm_response(
 
 
 @pytest.mark.asyncio
-async def test_run_passes_a_usage_hooks_instance_when_caller_passes_none(
+async def test_run_installs_usage_and_reach_hooks_when_caller_passes_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _silence_observability(monkeypatch)
@@ -721,7 +728,10 @@ async def test_run_passes_a_usage_hooks_instance_when_caller_passes_none(
     runner = HexgateRunner(api_key="k")
     await runner.run(_make_agent(), "hi", hexgate_context=_user())
 
-    assert isinstance(captured["hooks"], HexgateUsageHooks)
+    hooks = captured["hooks"]
+    assert isinstance(hooks, _CompositeRunHooks)
+    assert any(isinstance(h, HexgateUsageHooks) for h in hooks._hooks)
+    assert any(isinstance(h, _HexgateReachHooks) for h in hooks._hooks)
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/openai/test_runner_reach_admission.py
+++ b/tests/adapters/openai/test_runner_reach_admission.py
@@ -1,0 +1,159 @@
+"""Agent-level reach + admission wiring for the OpenAI runner (A3).
+
+Reach is enforced at the SDK handoff seam via ``_HexgateReachHooks.on_handoff``
+(governed by the *source* agent's policy); admission is enforced at run entry via
+the top-level agent's policy. These drive the seams directly rather than through a
+full SDK handoff, which needs a live model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agents import Agent, FunctionTool
+
+from hexgate.adapters.openai import runner as runner_mod
+from hexgate.adapters.openai.runner import HexgateRunner, _HexgateReachHooks
+from hexgate.runtime import HexgateContext
+from hexgate.security import (
+    AgentNotAdmittedError,
+    AgentPolicy,
+    BaseToolPolicy,
+    PolicySet,
+    ReachNotAllowedError,
+    ResolvedPolicy,
+)
+from hexgate.security.binding import PolicyBinding
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+
+
+def _user() -> HexgateContext:
+    return HexgateContext(user_id="u-1", session_id="s-1", user_roles=["developer"])
+
+
+def _agent(name: str) -> Agent:
+    async def on_invoke(_ctx: Any, raw: str) -> str:
+        return raw
+
+    tool = FunctionTool(
+        name="echo",
+        description="echo",
+        params_json_schema={"type": "object"},
+        on_invoke_tool=on_invoke,
+    )
+    return Agent(name=name, tools=[tool])
+
+
+def _silence_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(HexgateRunner, "_setup_observability", lambda self: None)
+    monkeypatch.setattr(runner_mod, "resolve_ban_gate", lambda *a, **k: None)
+
+
+# --- reach at the handoff seam ---------------------------------------------
+
+
+def _reach_binding(agents: dict) -> PolicyBinding:
+    engine = PolicySet(
+        {
+            DEFAULT_ROLE_NAME: AgentPolicy(
+                default_policy=BaseToolPolicy(mode="allow"), agents=agents
+            )
+        }
+    )
+    return PolicyBinding(PolicyEnforcer(engine, agent_name="orchestrator"), None)
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_gates_handoff_by_source_policy() -> None:
+    runner = HexgateRunner(api_key="k")
+    runner._bindings["orchestrator"] = _reach_binding(
+        {"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    hook = _HexgateReachHooks(runner)
+    source = _agent("orchestrator")
+    async with _user():
+        await hook.on_handoff(None, source, _agent("billing-bot"))  # listed → ok
+        with pytest.raises(ReachNotAllowedError):
+            await hook.on_handoff(None, source, _agent("evil-bot"))  # unlisted → deny
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_skips_ungoverned_source() -> None:
+    # A handoff from an agent with no cached binding (not Hexgate-governed) is not
+    # gated here — no resolve, no raise.
+    runner = HexgateRunner(api_key="k")
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        await hook.on_handoff(None, _agent("stranger"), _agent("evil-bot"))
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_noop_without_reach_policy() -> None:
+    runner = HexgateRunner(api_key="k")
+    runner._bindings["orchestrator"] = _reach_binding({})  # declares no reach
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        await hook.on_handoff(None, _agent("orchestrator"), _agent("anyone"))
+
+
+# --- admission at run entry ------------------------------------------------
+
+
+def _patch_admission_resolve(
+    monkeypatch: pytest.MonkeyPatch, admission_mode: str
+) -> None:
+    def fake_resolve(name: str, *, api_key: str, client: object = None):
+        engine = PolicySet(
+            {
+                DEFAULT_ROLE_NAME: AgentPolicy(
+                    default_policy=BaseToolPolicy(mode="allow"),
+                    admission=BaseToolPolicy(mode=admission_mode),
+                )
+            }
+        )
+        return ResolvedPolicy(engine, None)
+
+    monkeypatch.setattr(runner_mod, "resolve_policy", fake_resolve)
+
+
+@pytest.mark.asyncio
+async def test_run_refuses_non_admitted_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "deny")
+    called = {"run": False}
+
+    async def fake_run(*_a: Any, **_k: Any) -> str:
+        called["run"] = True
+        return "ok"
+
+    monkeypatch.setattr(runner_mod.Runner, "run", staticmethod(fake_run))
+    runner = HexgateRunner(api_key="k")
+    with pytest.raises(AgentNotAdmittedError):
+        await runner.run(_agent("my-agent"), "hi", hexgate_context=_user())
+    assert called["run"] is False  # refused before the underlying run
+
+
+@pytest.mark.asyncio
+async def test_run_admits_when_policy_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "allow")
+
+    async def fake_run(*_a: Any, **_k: Any) -> str:
+        return "ok"
+
+    monkeypatch.setattr(runner_mod.Runner, "run", staticmethod(fake_run))
+    runner = HexgateRunner(api_key="k")
+    assert await runner.run(_agent("my-agent"), "hi", hexgate_context=_user()) == "ok"
+
+
+def test_run_sync_refuses_non_admitted_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "deny")
+    monkeypatch.setattr(
+        runner_mod.Runner, "run_sync", staticmethod(lambda *a, **k: "ok")
+    )
+    runner = HexgateRunner(api_key="k")
+    with pytest.raises(AgentNotAdmittedError):
+        runner.run_sync(_agent("my-agent"), "hi", hexgate_context=_user())

--- a/tests/adapters/openai/test_runner_reach_admission.py
+++ b/tests/adapters/openai/test_runner_reach_admission.py
@@ -20,6 +20,7 @@ from hexgate.security import (
     AgentNotAdmittedError,
     AgentPolicy,
     BaseToolPolicy,
+    HandoffDepthExceededError,
     PolicySet,
     ReachNotAllowedError,
     ResolvedPolicy,
@@ -96,6 +97,30 @@ async def test_reach_hook_noop_without_reach_policy() -> None:
     hook = _HexgateReachHooks(runner)
     async with _user():
         await hook.on_handoff(None, _agent("orchestrator"), _agent("anyone"))
+
+
+# --- handoff depth cap (A4) ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_enforces_depth_cap() -> None:
+    # Depth counts every handoff in the run (the hook is per-run), independent of
+    # reach policy: an un-governed source still counts toward the cap.
+    runner = HexgateRunner(api_key="k", max_handoff_depth=1)
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        await hook.on_handoff(None, _agent("a"), _agent("b"))  # depth 1 == cap → ok
+        with pytest.raises(HandoffDepthExceededError):
+            await hook.on_handoff(None, _agent("a"), _agent("c"))  # depth 2 > cap
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_no_cap_by_default() -> None:
+    runner = HexgateRunner(api_key="k")  # no cap
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        for _ in range(5):
+            await hook.on_handoff(None, _agent("a"), _agent("b"))  # never raises
 
 
 # --- admission at run entry ------------------------------------------------

--- a/tests/agents/test_create_agent_binding.py
+++ b/tests/agents/test_create_agent_binding.py
@@ -19,7 +19,7 @@ from langchain_core.tools import tool
 from hexgate.agents import factory
 from hexgate.adapters.langchain.tools import GuardedTool
 from hexgate.cloud.client import HexgateError
-from hexgate.security import AgentPolicy, PolicySet
+from hexgate.security import AgentPolicy, BaseToolPolicy, PolicySet
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 from hexgate.security.source import PlatformPolicySource
 
@@ -355,3 +355,13 @@ def test_enforce_policy_none_without_source_is_noop() -> None:
 
     assert rebuilt.tools == [echo]  # unwrapped
     assert rebuilt._binding is None
+
+
+def test_enforce_policy_none_clears_a_prior_admission_gate() -> None:
+    # enforce_policy(None) returns an unguarded rebuild; a prior admission gate
+    # must not survive via with_tools, or the "unguarded" agent still refuses.
+    agent, _ = factory.create_agent(model="openai:gpt-5.4", tools=[echo], name="a")
+    guarded = agent.enforce_policy(AgentPolicy(admission=BaseToolPolicy(mode="allow")))
+    assert guarded._agent_gate is not None
+    unguarded = guarded.enforce_policy(None)
+    assert unguarded._agent_gate is None

--- a/tests/agents/test_factory.py
+++ b/tests/agents/test_factory.py
@@ -384,6 +384,73 @@ async def test_hexgate_agent_astream_raises_before_first_event_when_banned() -> 
             async for _ in agent.astream_events({}, {}, version="v2"):
                 pass
 
+
+def _admission_gate(mode: str):
+    """An admission gate whose policy admits/denies with the given mode."""
+    from hexgate.security import AgentPolicy, BaseToolPolicy
+    from hexgate.security.agent_gate import resolve_agent_gate
+    from hexgate.security.enforcer import PolicyEnforcer
+    from hexgate.security.policy_set import load_policy_set
+
+    policy = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"),
+        admission=BaseToolPolicy(mode=mode),
+    )
+    return resolve_agent_gate(PolicyEnforcer(load_policy_set(policy), agent_name="bot"))
+
+
+def _agent_with_admission(graph: FakeAgent, gate) -> factory.HexgateAgent:
+    return factory.HexgateAgent(
+        graph=graph,
+        model="m",
+        tools=[],
+        system_prompt=None,
+        name="bot",
+        agent_gate=gate,
+    )
+
+
+@pytest.mark.asyncio
+async def test_hexgate_agent_ainvoke_refused_before_graph_when_not_admitted() -> None:
+    from hexgate.runtime import HexgateContext
+    from hexgate.security.agent_gate import AgentNotAdmittedError
+
+    graph = FakeAgent()
+    agent = _agent_with_admission(graph, _admission_gate("deny"))
+
+    async with HexgateContext(user_id="u1", user_roles=["support"]):
+        with pytest.raises(AgentNotAdmittedError):
+            await agent.ainvoke({}, {})
+
+    assert graph.ainvoke_calls == []  # graph never ran
+
+
+@pytest.mark.asyncio
+async def test_hexgate_agent_ainvoke_runs_when_admitted() -> None:
+    from hexgate.runtime import HexgateContext
+
+    graph = FakeAgent()
+    agent = _agent_with_admission(graph, _admission_gate("allow"))
+
+    async with HexgateContext(user_id="u1", user_roles=["support"]):
+        await agent.ainvoke({}, {})
+
+    assert len(graph.ainvoke_calls) == 1  # admission allowed → graph ran
+
+
+@pytest.mark.asyncio
+async def test_hexgate_agent_astream_refused_when_not_admitted() -> None:
+    from hexgate.runtime import HexgateContext
+    from hexgate.security.agent_gate import AgentNotAdmittedError
+
+    graph = FakeAgent()
+    agent = _agent_with_admission(graph, _admission_gate("deny"))
+
+    async with HexgateContext(user_id="u1", user_roles=["support"]):
+        with pytest.raises(AgentNotAdmittedError):
+            async for _ in agent.astream_events({}, {}, version="v2"):
+                pass
+
     assert graph.astream_event_calls == []
 
 

--- a/tests/security/golden/policy_fixture.rego
+++ b/tests/security/golden/policy_fixture.rego
@@ -111,20 +111,10 @@ violations contains `ctx.region in ["EU", "UK"]` if {
     not _p_b7b1e13455
 }
 
-allow if {
-    input.role == "billing"
-    input.tool == "agent.run"
-}
-
 # ---- role: default -----------------------------------------------------
 allow if {
     not input.role in {"billing", "support"}
     input.tool == "web_search"
-}
-
-allow if {
-    not input.role in {"billing", "support"}
-    input.tool == "agent.run"
 }
 
 # ---- role: support -----------------------------------------------------
@@ -149,11 +139,6 @@ violations contains `args.amount <= 500` if {
 allow if {
     input.role == "support"
     input.tool == "read_file"
-}
-
-allow if {
-    input.role == "support"
-    input.tool == "agent.run"
 }
 
 _p_066518c099 if {

--- a/tests/security/test_agent_gate.py
+++ b/tests/security/test_agent_gate.py
@@ -9,6 +9,8 @@ a no-op. Once admission is declared, agent keys are closed-world (R-AGENT-002).
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from hexgate.runtime.context import HexgateContext
@@ -17,7 +19,9 @@ from hexgate.security import (
     AgentPolicy,
     BaseToolPolicy,
     resolve_agent_gate,
+    warn_if_admission_unenforced,
 )
+from hexgate.security import agent_gate as agent_gate_mod
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.policy_set import load_policy_set, load_policy_set_from_dict
 
@@ -195,3 +199,44 @@ def test_admission_is_closed_world_across_roles_with_permissive_union() -> None:
     with HexgateContext(user_id="u", user_roles=["viewer", "contractor"]).sync_scope():
         with pytest.raises(AgentNotAdmittedError):
             gate.check_admission()
+
+
+# --- adapter interim warning (admission unenforced off the native agent) ---
+
+
+def _engine(admission_mode: str | None):
+    admission = BaseToolPolicy(mode=admission_mode) if admission_mode else None
+    return load_policy_set(
+        AgentPolicy(default_policy=BaseToolPolicy(mode="deny"), admission=admission)
+    )
+
+
+def test_warn_if_admission_unenforced_fires_once_when_declared(caplog) -> None:
+    agent_gate_mod._admission_unenforced_warned.clear()
+    engine = _engine("allow")
+    with caplog.at_level(logging.WARNING, logger=agent_gate_mod.__name__):
+        warn_if_admission_unenforced(engine, framework="OpenAI Agents", agent_name="a")
+        warn_if_admission_unenforced(engine, framework="OpenAI Agents", agent_name="a")
+    records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(records) == 1  # deduped per (framework, agent)
+    assert "admission" in records[0].getMessage()
+    assert "OpenAI Agents" in records[0].getMessage()
+
+
+def test_warn_if_admission_unenforced_silent_without_admission(caplog) -> None:
+    agent_gate_mod._admission_unenforced_warned.clear()
+    with caplog.at_level(logging.WARNING, logger=agent_gate_mod.__name__):
+        warn_if_admission_unenforced(
+            _engine(None), framework="Google ADK", agent_name="a"
+        )
+    assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+
+
+def test_warn_if_admission_unenforced_distinguishes_framework_and_agent(caplog) -> None:
+    agent_gate_mod._admission_unenforced_warned.clear()
+    engine = _engine("deny")  # declared (deny) still counts as configured
+    with caplog.at_level(logging.WARNING, logger=agent_gate_mod.__name__):
+        warn_if_admission_unenforced(engine, framework="OpenAI Agents", agent_name="a")
+        warn_if_admission_unenforced(engine, framework="Google ADK", agent_name="a")
+        warn_if_admission_unenforced(engine, framework="OpenAI Agents", agent_name="b")
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 3

--- a/tests/security/test_agent_gate.py
+++ b/tests/security/test_agent_gate.py
@@ -1,0 +1,145 @@
+"""Tests for the admission gate (``security/agent_gate.py``).
+
+The gate reuses ``PolicyEnforcer.decide`` on the synthetic ``agent.run`` key, so
+these drive it through a real ``PolicySet`` enforcer under an open context scope,
+the same path a run entry takes. Admission is opt-in: no admission block means no
+gate (``resolve_agent_gate`` returns ``None``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate.runtime.context import HexgateContext
+from hexgate.security import (
+    AgentNotAdmittedError,
+    AgentPolicy,
+    BaseToolPolicy,
+    resolve_agent_gate,
+)
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import load_policy_set
+
+_ROLE = HexgateContext(user_id="u", user_roles=["support"])
+
+
+def _enforcer(admission_mode: str | None) -> PolicyEnforcer:
+    admission = BaseToolPolicy(mode=admission_mode) if admission_mode else None
+    policy = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"),
+        admission=admission,
+    )
+    return PolicyEnforcer(load_policy_set(policy), agent_name="my-agent")
+
+
+# --- opt-in ----------------------------------------------------------------
+
+
+def test_no_admission_block_is_a_noop() -> None:
+    # A gate is always built, but a policy with no admission block never refuses:
+    # the opt-in is checked per run, so this stays a no-op (and hot-reload safe).
+    gate = resolve_agent_gate(_enforcer(None))
+    with _ROLE.sync_scope():
+        gate.check_admission()  # does not raise
+
+
+def test_gate_builds_with_admission() -> None:
+    assert resolve_agent_gate(_enforcer("allow")) is not None
+
+
+# --- verdicts --------------------------------------------------------------
+
+
+def test_admission_allow_passes() -> None:
+    gate = resolve_agent_gate(_enforcer("allow"))
+    with _ROLE.sync_scope():
+        gate.check_admission()  # does not raise
+
+
+def test_admission_deny_raises() -> None:
+    gate = resolve_agent_gate(_enforcer("deny"))
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_deny_error_carries_decision() -> None:
+    gate = resolve_agent_gate(_enforcer("deny"))
+    with _ROLE.sync_scope():
+        try:
+            gate.check_admission()
+        except AgentNotAdmittedError as exc:
+            assert exc.decision.tool_name == "agent.run"
+            assert not exc.decision.allowed
+        else:  # pragma: no cover
+            pytest.fail("expected AgentNotAdmittedError")
+
+
+# --- approval --------------------------------------------------------------
+
+
+def test_approval_bool_true_passes() -> None:
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=True)
+    with _ROLE.sync_scope():
+        gate.check_admission()
+
+
+def test_approval_bool_false_raises() -> None:
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=False)
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_approval_no_handler_raises() -> None:
+    gate = resolve_agent_gate(_enforcer("approval_required"))
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_approval_sync_callable_approves_and_denies() -> None:
+    approve = resolve_agent_gate(
+        _enforcer("approval_required"), approval_handler=lambda d: True
+    )
+    deny = resolve_agent_gate(
+        _enforcer("approval_required"), approval_handler=lambda d: False
+    )
+    with _ROLE.sync_scope():
+        approve.check_admission()
+        with pytest.raises(AgentNotAdmittedError):
+            deny.check_admission()
+
+
+def test_approval_handler_raises_fails_closed() -> None:
+    def boom(_decision: object) -> bool:
+        raise RuntimeError("handler blew up")
+
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=boom)
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+def test_async_handler_on_sync_run_denies() -> None:
+    async def slow(_decision: object) -> bool:
+        return True
+
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=slow)
+    # A coroutine handler cannot be awaited on the sync entrypoint → fail closed.
+    with _ROLE.sync_scope(), pytest.raises(AgentNotAdmittedError):
+        gate.check_admission()
+
+
+# --- async path ------------------------------------------------------------
+
+
+async def test_async_admission_allow_passes() -> None:
+    gate = resolve_agent_gate(_enforcer("allow"))
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_admission_async()
+
+
+async def test_async_admission_approval_async_handler() -> None:
+    async def approve(_decision: object) -> bool:
+        return True
+
+    gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=approve)
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_admission_async()

--- a/tests/security/test_agent_gate.py
+++ b/tests/security/test_agent_gate.py
@@ -2,8 +2,8 @@
 
 The gate reuses ``PolicyEnforcer.decide`` on the synthetic ``agent.run`` key, so
 these drive it through a real ``PolicySet`` enforcer under an open context scope,
-the same path a run entry takes. Admission is opt-in: no admission block means no
-gate (``resolve_agent_gate`` returns ``None``).
+the same path a run entry takes. Admission is opt-in: ``resolve_agent_gate`` always
+returns a gate, but a policy that declares no admission makes every check a no-op.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from hexgate.security import (
     resolve_agent_gate,
 )
 from hexgate.security.enforcer import PolicyEnforcer
-from hexgate.security.policy_set import load_policy_set
+from hexgate.security.policy_set import load_policy_set, load_policy_set_from_dict
 
 _ROLE = HexgateContext(user_id="u", user_roles=["support"])
 
@@ -143,3 +143,42 @@ async def test_async_admission_approval_async_handler() -> None:
     gate = resolve_agent_gate(_enforcer("approval_required"), approval_handler=approve)
     async with HexgateContext(user_id="u", user_roles=["support"]):
         await gate.check_admission_async()
+
+
+# --- multi-role opt-in (no lockout) ----------------------------------------
+
+
+def test_role_without_admission_is_admitted_despite_another_role_declaring_it() -> None:
+    # Regression: admission is opt-in, so adding it to one role must not lock out
+    # roles that declare none. viewer (no admission) stays admitted even though
+    # admin/contractor declare admission; the union is monotonic.
+    ps = load_policy_set_from_dict(
+        {
+            "roles": {
+                "default": {"default_policy": {"mode": "deny"}},
+                "admin": {
+                    "default_policy": {"mode": "deny"},
+                    "admission": {"mode": "allow"},
+                },
+                "contractor": {
+                    "default_policy": {"mode": "deny"},
+                    "admission": {"mode": "deny"},
+                },
+                "viewer": {"default_policy": {"mode": "deny"}},  # no admission
+            }
+        }
+    )
+    gate = resolve_agent_gate(PolicyEnforcer(ps, agent_name="agent"))
+
+    # viewer declares no admission → opt-in admit (not locked out).
+    with HexgateContext(user_id="u", user_roles=["viewer"]).sync_scope():
+        gate.check_admission()
+
+    # contractor explicitly denies admission.
+    with HexgateContext(user_id="u", user_roles=["contractor"]).sync_scope():
+        with pytest.raises(AgentNotAdmittedError):
+            gate.check_admission()
+
+    # carrying both: viewer's opt-in admits via the permissive union.
+    with HexgateContext(user_id="u", user_roles=["viewer", "contractor"]).sync_scope():
+        gate.check_admission()

--- a/tests/security/test_agent_gate.py
+++ b/tests/security/test_agent_gate.py
@@ -2,8 +2,9 @@
 
 The gate reuses ``PolicyEnforcer.decide`` on the synthetic ``agent.run`` key, so
 these drive it through a real ``PolicySet`` enforcer under an open context scope,
-the same path a run entry takes. Admission is opt-in: ``resolve_agent_gate`` always
-returns a gate, but a policy that declares no admission makes every check a no-op.
+the same path a run entry takes. Engagement is opt-in: ``resolve_agent_gate`` always
+returns a gate, but a policy that declares no admission anywhere makes every check
+a no-op. Once admission is declared, agent keys are closed-world (R-AGENT-002).
 """
 
 from __future__ import annotations
@@ -145,13 +146,14 @@ async def test_async_admission_approval_async_handler() -> None:
         await gate.check_admission_async()
 
 
-# --- multi-role opt-in (no lockout) ----------------------------------------
+# --- multi-role (closed-world + permissive union) --------------------------
 
 
-def test_role_without_admission_is_admitted_despite_another_role_declaring_it() -> None:
-    # Regression: admission is opt-in, so adding it to one role must not lock out
-    # roles that declare none. viewer (no admission) stays admitted even though
-    # admin/contractor declare admission; the union is monotonic.
+def test_admission_is_closed_world_across_roles_with_permissive_union() -> None:
+    # Under Option B (R-AGENT-002) admission is closed-world once any role declares
+    # it: engagement is PolicySet-wide (admin declares admission → the gate fires
+    # for everyone), so a role not granted admission is refused. The multi-role
+    # fold stays permissive: any role that grants admission admits the caller.
     ps = load_policy_set_from_dict(
         {
             "roles": {
@@ -164,21 +166,32 @@ def test_role_without_admission_is_admitted_despite_another_role_declaring_it() 
                     "default_policy": {"mode": "deny"},
                     "admission": {"mode": "deny"},
                 },
-                "viewer": {"default_policy": {"mode": "deny"}},  # no admission
+                "viewer": {"default_policy": {"mode": "deny"}},  # no admission grant
             }
         }
     )
     gate = resolve_agent_gate(PolicyEnforcer(ps, agent_name="agent"))
 
-    # viewer declares no admission → opt-in admit (not locked out).
-    with HexgateContext(user_id="u", user_roles=["viewer"]).sync_scope():
+    # admin is granted admission → admitted.
+    with HexgateContext(user_id="u", user_roles=["admin"]).sync_scope():
         gate.check_admission()
 
-    # contractor explicitly denies admission.
+    # viewer grants no admission → closed-world refuse (the gate is engaged because
+    # admin declares admission somewhere in the set).
+    with HexgateContext(user_id="u", user_roles=["viewer"]).sync_scope():
+        with pytest.raises(AgentNotAdmittedError):
+            gate.check_admission()
+
+    # contractor explicitly denies admission → refused.
     with HexgateContext(user_id="u", user_roles=["contractor"]).sync_scope():
         with pytest.raises(AgentNotAdmittedError):
             gate.check_admission()
 
-    # carrying both: viewer's opt-in admits via the permissive union.
-    with HexgateContext(user_id="u", user_roles=["viewer", "contractor"]).sync_scope():
+    # admin + contractor: the permissive union admits (admin grants; ALLOW wins).
+    with HexgateContext(user_id="u", user_roles=["contractor", "admin"]).sync_scope():
         gate.check_admission()
+
+    # viewer + contractor: neither grants admission → refused.
+    with HexgateContext(user_id="u", user_roles=["viewer", "contractor"]).sync_scope():
+        with pytest.raises(AgentNotAdmittedError):
+            gate.check_admission()

--- a/tests/security/test_agent_policy.py
+++ b/tests/security/test_agent_policy.py
@@ -176,26 +176,25 @@ def test_unlisted_target_is_closed_world_under_deny_default() -> None:
     assert_denies(_policy(), agent_target_key("handoff", "evil-bot"))
 
 
-def test_admission_is_opt_in_when_unlisted_but_enforced_when_declared() -> None:
-    # agent.run is opt-in: a policy that declares no admission admits (even under a
-    # deny-default), so adding admission to one role never locks out roles without
-    # it. A declared admission still enforces.
-    no_admission = AgentPolicy(default_policy=BaseToolPolicy(mode="deny"))
-    assert_allows(no_admission, AGENT_RUN_TOOL)  # absent → admit, not deny-default
-    declared_deny = AgentPolicy(
-        default_policy=BaseToolPolicy(mode="deny"),
-        admission=BaseToolPolicy(mode="deny"),
-    )
-    assert_denies(declared_deny, AGENT_RUN_TOOL)
+def test_agent_run_is_closed_world_at_the_engine() -> None:
+    # agent.run is closed-world like reach: an unlisted agent.run denies regardless
+    # of default_policy. Opt-in lives at the gate (declares_admission), not here, so
+    # the engine never opt-in-admits (R-AGENT-002).
+    allow_default = AgentPolicy(default_policy=BaseToolPolicy(mode="allow"))
+    assert_denies(allow_default, AGENT_RUN_TOOL)  # closed-world, not default-allow
+    admits = AgentPolicy(admission=BaseToolPolicy(mode="allow"))
+    assert_allows(admits, AGENT_RUN_TOOL)  # declared allow → admit
+    denies = AgentPolicy(admission=BaseToolPolicy(mode="deny"))
+    assert_denies(denies, AGENT_RUN_TOOL)
 
 
 def test_authored_agent_prefixed_tool_follows_default_not_closed_world() -> None:
     # An authored tool whose name merely starts with "agent." (not a reserved key)
-    # follows default_policy, it is not swept into the closed-world reach handling.
+    # follows default_policy, it is not swept into the closed-world agent handling.
     policy = AgentPolicy(default_policy=BaseToolPolicy(mode="allow"))
     assert_allows(policy, "agent.foo")  # not a key → default allow
     assert_allows(policy, "agent.tool")  # no colon → not a reach key → default allow
-    assert_allows(policy, AGENT_RUN_TOOL)  # admission opt-in → allow
+    assert_denies(policy, AGENT_RUN_TOOL)  # real agent key → closed-world deny
     assert_denies(policy, agent_target_key("tool", "x"))  # real reach key → deny
 
 
@@ -210,32 +209,30 @@ def test_rego_compiler_emits_lowered_agent_keys() -> None:
     assert 'input.tool == "agent.handoff:billing-bot"' in rego
 
 
-def test_rego_permissive_default_excludes_reach_keys_and_opts_in_admission() -> None:
-    # Reach keys are excluded from the permissive catch-all (so they deny), while
-    # admission opts in via its own rule. The old broad ``agent.`` exclusion is gone
-    # (it wrongly caught authored agent.* tool names).
-    rego = compile_to_rego(
-        {
-            "default_policy": {"mode": "allow"},
-            "agents": {"b": {"mode": "allow", "via": ["tool"]}},
-        }
-    )
+def test_rego_permissive_default_excludes_all_agent_keys() -> None:
+    # Every agent key (agent.run + reach prefixes) is excluded from the permissive
+    # catch-all, so an unlisted agent key denies. The exclusion is the exact
+    # reserved set (not a broad ``agent.`` prefix that would catch authored
+    # agent.*-named tools), matching is_agent_key (R-AGENT-002).
+    rego = compile_to_rego({"default_policy": {"mode": "allow"}})
+    assert 'input.tool != "agent.run"' in rego
     assert 'not startswith(input.tool, "agent.tool:")' in rego
     assert 'not startswith(input.tool, "agent.handoff:")' in rego
-    assert 'input.tool == "agent.run"' in rego  # opt-in admit rule
-    assert 'not startswith(input.tool, "agent.")' not in rego
+    assert 'not startswith(input.tool, "agent.")' not in rego  # not the broad prefix
 
 
 @needs_opa
 def test_closed_world_agent_parity_pydantic_vs_wasm() -> None:
     # The fallbacks must agree across engines under an allow-default: ordinary tools
-    # and authored agent.*-named tools follow the default (allow), admission opts in
-    # (allow), and unlisted reach keys deny — on both the pydantic and WASM paths.
+    # and authored agent.*-named tools follow the default (allow), while every agent
+    # key is closed-world — a declared admission allows, an unlisted agent.run and
+    # unlisted reach keys deny — on both the pydantic and WASM paths.
     from hexgate.security import compile_to_wasm, verdict_from_rego
     from hexgate.security.wasm_engine import WasmPolicy
 
     payload = {
         "default_policy": {"mode": "allow"},
+        "admission": {"mode": "allow"},
         "agents": {"billing-bot": {"mode": "allow", "via": ["tool"]}},
     }
     ps = load_policy_set_from_dict(payload)
@@ -244,7 +241,7 @@ def test_closed_world_agent_parity_pydantic_vs_wasm() -> None:
     cases = [
         "some_unlisted_tool",  # ordinary tool → default allow
         "agent.foo",  # authored agent.*-named tool (not a key) → default allow
-        AGENT_RUN_TOOL,  # admission opt-in → allow
+        AGENT_RUN_TOOL,  # admission declared allow → allow
         agent_target_key("tool", "billing-bot"),  # listed → allow
         agent_target_key("handoff", "billing-bot"),  # via not listed → deny
         agent_target_key("tool", "other-bot"),  # target not listed → deny

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -291,31 +291,48 @@ def test_file_scope_in_module_raises():
         link([guard], [])
 
 
-def test_link_rejects_agents_block_in_module() -> None:
-    # An ``agents`` egress rule authored in a module would be silently dropped by
-    # the fold (which composes ``.tools`` only) — the same fail-open file_scope
-    # guards against. Fail loud instead.
-    mod = ModuleContent(
+def test_boundary_agents_deny_composes_as_authoritative_deny() -> None:
+    # An ``agents`` block lowers to agent.* keys the fold composes like tools
+    # (R-AGENT-002). A boundary agent-deny is authoritative — it folds to a hard
+    # deny on the lowered reach key, exactly as a boundary tool deny would.
+    boundary = ModuleContent(
         name="b",
         kind="boundary",
         policy=AgentPolicy(agents={"evil-bot": {"mode": "deny"}}),
         source="b.yaml",
         content_hash="hash-b",
     )
-    with pytest.raises(LinkError, match=r"\['agents'\]"):
-        link([mod], [])
+    effective, _ = link([boundary], [])
+    denied = effective.effective_tools["agent.handoff:evil-bot"]
+    assert denied.mode == "deny"
 
 
-def test_link_rejects_admission_block_in_module() -> None:
-    mod = ModuleContent(
+def test_capability_admission_grant_composes() -> None:
+    # A capability may grant admission: an ``admission`` block lowers to agent.run,
+    # which the fold unions like any other capability grant.
+    cap = ModuleContent(
         name="c",
         kind="capability",
         policy=AgentPolicy(admission={"mode": "allow"}),
         source="c.yaml",
         content_hash="hash-c",
     )
-    with pytest.raises(LinkError, match=r"\['admission'\]"):
-        link([], [mod])
+    effective, _ = link([], [cap])
+    assert effective.effective_tools["agent.run"].mode == "allow"
+
+
+def test_capability_agents_deny_is_a_link_error() -> None:
+    # Capabilities grant only, agent keys included: a capability that denies a
+    # lowered agent key is a config error, same as a capability tool deny.
+    cap = ModuleContent(
+        name="c",
+        kind="capability",
+        policy=AgentPolicy(agents={"evil-bot": {"mode": "deny"}}),
+        source="c.yaml",
+        content_hash="hash-c",
+    )
+    with pytest.raises(LinkError, match=r"agent\.handoff:evil-bot"):
+        link([], [cap])
 
 
 # --- provenance + policy-set wiring ---

--- a/tests/security/test_naming.py
+++ b/tests/security/test_naming.py
@@ -1,0 +1,47 @@
+"""Tests for canonical agent-name derivation (``security/naming.py``)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hexgate.security.naming import (
+    DEFAULT_AGENT_NAME,
+    canonical_agent_name,
+    canonical_name,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("billing-bot", "billing-bot"),
+        ("  billing-bot  ", "billing-bot"),  # trimmed
+        ("", DEFAULT_AGENT_NAME),  # blank → default
+        ("   ", DEFAULT_AGENT_NAME),  # whitespace-only → default
+        (None, DEFAULT_AGENT_NAME),  # missing → default
+        (123, DEFAULT_AGENT_NAME),  # non-str → default
+    ],
+)
+def test_canonical_name(raw: object, expected: str) -> None:
+    assert canonical_name(raw) == expected  # type: ignore[arg-type]
+
+
+def test_canonical_agent_name_reads_name_attr() -> None:
+    assert (
+        canonical_agent_name(SimpleNamespace(name="  refund-agent ")) == "refund-agent"
+    )
+
+
+def test_canonical_agent_name_defaults_when_unnamed() -> None:
+    assert canonical_agent_name(SimpleNamespace()) == DEFAULT_AGENT_NAME
+    assert canonical_agent_name(SimpleNamespace(name=None)) == DEFAULT_AGENT_NAME
+    assert canonical_agent_name(SimpleNamespace(name="")) == DEFAULT_AGENT_NAME
+
+
+def test_own_and_target_derivation_agree() -> None:
+    # The whole point: an agent's own-name and its name as a reach target derive
+    # identically, so a target authored under the name it registers with matches.
+    agent = SimpleNamespace(name="Support Bot")
+    assert canonical_agent_name(agent) == canonical_name(agent.name)

--- a/tests/security/test_reach_gate.py
+++ b/tests/security/test_reach_gate.py
@@ -90,6 +90,15 @@ def test_reach_target_name_is_canonicalized() -> None:
         gate.check_reach("  billing-bot ", via="handoff")  # trimmed → matches
 
 
+def test_reach_authored_target_key_is_canonicalized() -> None:
+    # The other side of parity: a whitespace-padded *authored* target key lowers to
+    # the canonical reach key, so a canonical runtime target still matches (the
+    # lowering and the gate normalize identically).
+    gate = resolve_reach_gate(_enforcer({"  billing-bot ": {"mode": "allow"}}))
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")  # authored padding trimmed
+
+
 # --- approval --------------------------------------------------------------
 
 

--- a/tests/security/test_reach_gate.py
+++ b/tests/security/test_reach_gate.py
@@ -1,0 +1,144 @@
+"""Tests for the reach gate (``security/agent_gate.py``).
+
+The reach gate mirrors the admission gate but decides a target's lowered reach key
+(``agent.handoff:<target>`` / ``agent.tool:<target>``) at the handoff/delegation
+seam. These drive it through a real ``PolicySet`` enforcer under an open context
+scope. Engagement is opt-in: a policy with no ``agents`` block is a no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate.runtime.context import HexgateContext
+from hexgate.security import (
+    AgentPolicy,
+    BaseToolPolicy,
+    ReachNotAllowedError,
+    resolve_reach_gate,
+)
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import load_policy_set
+
+_ROLE = HexgateContext(user_id="u", user_roles=["support"])
+
+
+def _enforcer(agents: dict | None) -> PolicyEnforcer:
+    policy = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="allow"),  # permissive default...
+        agents=agents or {},
+    )
+    return PolicyEnforcer(load_policy_set(policy), agent_name="orchestrator")
+
+
+# --- engagement (opt-in) ---------------------------------------------------
+
+
+def test_no_agents_block_is_a_noop() -> None:
+    # No reach declared → gate never fires, even for an unknown target.
+    gate = resolve_reach_gate(_enforcer(None))
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")  # does not raise
+
+
+# --- verdicts --------------------------------------------------------------
+
+
+def test_reach_allow_passes() -> None:
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")  # listed → allowed
+
+
+def test_reach_unlisted_target_is_closed_world_denied() -> None:
+    # ...even under an allow default: an unlisted reach key denies once reach is
+    # declared (closed-world), so a permissive default cannot grant a handoff.
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    with _ROLE.sync_scope(), pytest.raises(ReachNotAllowedError):
+        gate.check_reach("evil-bot", via="handoff")
+
+
+def test_reach_via_is_distinguished() -> None:
+    # A target listed for handoff only is not reachable as a tool.
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "allow", "via": ["handoff"]}})
+    )
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")
+        with pytest.raises(ReachNotAllowedError):
+            gate.check_reach("billing-bot", via="tool")
+
+
+def test_reach_deny_raises_and_carries_decision() -> None:
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "allow", "via": ["handoff"]}})
+    )
+    with _ROLE.sync_scope():
+        try:
+            gate.check_reach("billing-bot", via="tool")
+        except ReachNotAllowedError as exc:
+            assert exc.decision.tool_name == "agent.tool:billing-bot"
+            assert not exc.decision.allowed
+        else:  # pragma: no cover
+            pytest.fail("expected ReachNotAllowedError")
+
+
+def test_reach_target_name_is_canonicalized() -> None:
+    # A whitespace-padded runtime target matches the listed target.
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    with _ROLE.sync_scope():
+        gate.check_reach("  billing-bot ", via="handoff")  # trimmed → matches
+
+
+# --- approval --------------------------------------------------------------
+
+
+def test_reach_approval_bool_true_passes() -> None:
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=True,
+    )
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")
+
+
+def test_reach_approval_bool_false_raises() -> None:
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=False,
+    )
+    with _ROLE.sync_scope(), pytest.raises(ReachNotAllowedError):
+        gate.check_reach("billing-bot", via="handoff")
+
+
+def test_reach_approval_handler_raises_fails_closed() -> None:
+    def boom(_decision: object) -> bool:
+        raise RuntimeError("handler blew up")
+
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=boom,
+    )
+    with _ROLE.sync_scope(), pytest.raises(ReachNotAllowedError):
+        gate.check_reach("billing-bot", via="handoff")
+
+
+# --- async path ------------------------------------------------------------
+
+
+async def test_async_reach_allow_passes() -> None:
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_reach_async("billing-bot", via="handoff")
+
+
+async def test_async_reach_approval_async_handler() -> None:
+    async def approve(_decision: object) -> bool:
+        return True
+
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=approve,
+    )
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_reach_async("billing-bot", via="handoff")

--- a/tests/security/test_reach_gate.py
+++ b/tests/security/test_reach_gate.py
@@ -8,6 +8,8 @@ scope. Engagement is opt-in: a policy with no ``agents`` block is a no-op.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from hexgate.runtime.context import HexgateContext
@@ -16,7 +18,9 @@ from hexgate.security import (
     BaseToolPolicy,
     ReachNotAllowedError,
     resolve_reach_gate,
+    warn_if_tool_reach_unenforced,
 )
+from hexgate.security import agent_gate as agent_gate_mod
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.policy_set import load_policy_set
 
@@ -151,3 +155,45 @@ async def test_async_reach_approval_async_handler() -> None:
     )
     async with HexgateContext(user_id="u", user_roles=["support"]):
         await gate.check_reach_async("billing-bot", via="handoff")
+
+
+# --- tool-reach detection + OpenAI-style warning ---------------------------
+
+
+def test_declares_tool_reach_distinguishes_via() -> None:
+    tool = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["tool"]}})
+    )
+    handoff = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["handoff"]}})
+    )
+    assert tool.declares_tool_reach() is True
+    assert tool.declares_reach() is True
+    assert handoff.declares_tool_reach() is False  # handoff-only
+    assert handoff.declares_reach() is True
+
+
+def test_warn_if_tool_reach_unenforced(caplog) -> None:
+    agent_gate_mod._reach_unenforced_warned.clear()
+    tool_engine = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["tool"]}})
+    )
+    handoff_engine = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["handoff"]}})
+    )
+    with caplog.at_level(logging.WARNING, logger=agent_gate_mod.__name__):
+        # handoff-only: enforced on OpenAI, so no tool-reach warning
+        warn_if_tool_reach_unenforced(
+            handoff_engine, framework="OpenAI Agents", agent_name="a"
+        )
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+        # tool-via declared: warns once
+        warn_if_tool_reach_unenforced(
+            tool_engine, framework="OpenAI Agents", agent_name="a"
+        )
+        warn_if_tool_reach_unenforced(
+            tool_engine, framework="OpenAI Agents", agent_name="a"
+        )
+    records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(records) == 1  # deduped
+    assert "as-tool" in records[0].getMessage()

--- a/tests/security/test_rego_compile.py
+++ b/tests/security/test_rego_compile.py
@@ -154,13 +154,12 @@ def test_emits_allow_rule_per_role_and_tool() -> None:
     rules = _allow_rules(rego)
     # support_bot: 3 roles (read_only is mixin, dropped) × 3 tools (web_search,
     # read_file each get an allow per role; refund_order is allow for support
-    # + billing, deny for default). Plus one agent.run opt-in allow per role,
-    # since no role lists admission (admission is opt-in, so an absent agent.run
-    # admits — emitted on every role to match the pydantic engine).
-    #   default  → web_search, read_file, agent.run (refund_order is deny, no rule)
-    #   support  → web_search, read_file, refund_order (2 constraints), agent.run
-    #   billing  → web_search, read_file, refund_order (2 constraints), agent.run
-    assert len(rules) == (2 + 1) + (3 + 1) + (3 + 1)
+    # + billing, deny for default). No role lists admission, and agent.run is
+    # closed-world (no opt-in rule) — so no agent.* rules are emitted (R-AGENT-002).
+    #   default  → web_search, read_file (refund_order is deny, no rule)
+    #   support  → web_search, read_file, refund_order (2 constraints)
+    #   billing  → web_search, read_file, refund_order (2 constraints)
+    assert len(rules) == 2 + 3 + 3
 
 
 def test_mixin_role_omitted_from_output() -> None:


### PR DESCRIPTION
A marimo demo of a governed customer-support system where the **whole policy — tool permissions *and* agent-to-agent reach — is composed from the same shared modules** and enforced. Stacked on #142 (agent reach + admission runtime), which it drives; retargets to `main` as the stack merges.

## What it does

Two agents — front-line `support_bot` and refunds specialist `billing_bot` — governed by one modular policy, fully local (no platform, no API key, no model call):

- **Tool policy (modular):** a shared boundary (org surface + a $1000 refund cap) and team capabilities (`read_only` / `support_leaf` / `payments`), bound to roles via `resolve_for_project`.
- **Agent reach (also modular):** the boundary sets the reach ceiling (`support_bot` may *hand off* to `billing_bot`, never call it as a tool); a `billing_reach` capability grants it. Reach is closed-world, so only `billing` (which imports `billing_reach`) may hand off — `support`/`default` are denied. This is the point of the demo: **agent-level policy rides the same module pipeline as tools** (it lowers to `agent.handoff:<target>` keys the linker folds), and is enforced live by #142's `ReachGate`.

Both tables below come from the **same** `resolve_for_project` call over the same modules.

| role | `send_email` | refund $800 USD | refund $2000 | `support_bot`→`billing_bot` (handoff) | (as tool) |
|---|---|---|---|---|---|
| default | ❌ | ❌ | ❌ | ❌ closed-world | ❌ |
| support | ✅ | ❌ | ❌ | ❌ closed-world | ❌ |
| billing | ❌ | ✅ | ❌ (cap) | ✅ granted | ❌ (handoff-only ceiling) |

A separate section shows the boundary **capping hand-off depth** (`args.depth <= 1`) — a #142 feature the framework's hand-off seam supplies at runtime.

## Try it

```
uv run --with marimo marimo edit deploy/support_bot_demo.py
```

Section 5: pick a role and a `via`, and watch the real `ReachGate` allow/refuse the hand-off, alongside the tool-side decision — all from the one composed policy.

## Important files

| File | What to look at |
| --- | --- |
| `deploy/support_bot_demo.py` | modules → `resolve_for_project` (tools + `agents` reach in one PolicySet) → live `ReachGate.check_reach` |

## Notes

- No SDK changes; composes over `resolve_for_project`, `resolve_reach_gate` / `ReachGate.check_reach`, and `PolicySet.evaluate`.
- Forces `HEXGATE_LOCAL_MODE=1` so the enforcer's audit sender stays inert — the demo is genuinely offline.
- The boundary's reach cap is depth-free for the live gate (the bare gate doesn't supply `args.depth`; the framework seam does at a real hand-off); the depth cap is shown separately as a decision with an explicit depth.
- Validated headlessly: every cell executes under `marimo export` with no errors.
