### PR TITLE
feat(sdk): enforce agent reach + admission at runtime, cap handoff depth (A3+A4)

### DIFF
--- a/docs/adapters/google-adk.mdx
+++ b/docs/adapters/google-adk.mdx
@@ -112,6 +112,15 @@ if __name__ == "__main__":
   executes inside `propagate_attributes(user_id=..., session_id=...,
   metadata={"user_roles": ...}, tags=["google.runner.run.<agent_name>"])`.
 
+## Agent-level enforcement
+
+The Google runner has the fullest [agent-level](/concepts/agent-level-enforcement)
+coverage, because ADK expresses both delegation modes as tool calls. It enforces
+**admission** at run entry, and **reach** at `before_tool_callback` for both
+`transfer_to_agent` (handoff, `agent.handoff:<name>`) and `AgentTool`
+(agent-as-tool, `agent.tool:<name>`) — a denied delegation is refused before it
+runs. Set `HexgateRunner(max_handoff_depth=N)` to cap a runaway handoff chain.
+
 ## Runnable example
 
 `examples/devops_google.py` — `HexgateRunner` (Google ADK) end-to-end with

--- a/docs/adapters/langchain.mdx
+++ b/docs/adapters/langchain.mdx
@@ -119,6 +119,17 @@ so the wrapper resolves the policy for an agent called `LangGraph` and fails
 with a 404 unless one is registered under that name.
 </Note>
 
+## Agent-level enforcement
+
+<Note>
+[Agent-level policy](/concepts/agent-level-enforcement) (`admission` / `agents`)
+is not yet enforced on the LangChain adapter — a declared block logs a warning at
+setup rather than gating. A sub-agent exposed as a tool is still gated normally by
+its **tool name**. (The native `create_agent` orchestrator does enforce admission;
+this adapter, which wraps a pre-built LangChain/LangGraph agent, is a planned
+follow-up.)
+</Note>
+
 ## Runnable example
 
 `examples/devops_langchain.py` — `wrap_langchain_agent` (LangChain / LangGraph)

--- a/docs/adapters/openai.mdx
+++ b/docs/adapters/openai.mdx
@@ -97,18 +97,23 @@ if __name__ == "__main__":
 ## Agent-level enforcement
 
 Beyond tool calls, `HexgateRunner` enforces [agent-level policy](/concepts/agent-level-enforcement):
-**admission** (may this caller run the agent) at run entry, and **handoff reach**
+**admission** (may this caller run the agent) at run entry, **handoff reach**
 (`agent.handoff:<name>`) at the SDK's `on_handoff` seam — a denied handoff is
-vetoed before the target runs. Set `HexgateRunner(max_handoff_depth=N)` to cap a
-runaway handoff chain.
+vetoed before the target runs — and **agent-as-tool reach** (`agent.tool:<name>`)
+at the tool seam. Set `HexgateRunner(max_handoff_depth=N)` to cap a runaway
+handoff chain.
 
-<Warning>
-**Agent-as-tool reach is not enforced on OpenAI.** `Agent.as_tool()` produces a
-plain function tool with no link back to the target agent, so the
-`agent.tool:<name>` reach key can't be resolved here — a policy that declares one
-logs a warning at setup. Gate a sub-agent-as-tool by its **tool name** instead
-(an ordinary `tools:` rule), which works normally.
-</Warning>
+<Note>
+**Agent-as-tool reach is enforced at the top level.** The SDK tags an
+`Agent.as_tool()` with its target agent, so when the top-level agent's policy
+declares an `agents` block, that as-tool call is gated under `agent.tool:<name>`
+(closed-world, `via`/constraints honored) rather than by tool name. A reach edge
+one level deeper — a sub-agent that itself calls another agent as a tool — is not
+gated yet, because the sub-agent runs unwrapped through the SDK's own runner;
+those deeper edges fall back to tool-name gating. On an `agents` SDK too old to
+expose the tool origin, even the top level falls back to name-gating and a
+declared `via: tool` rule warns at setup.
+</Note>
 
 ## Runnable example
 

--- a/docs/adapters/openai.mdx
+++ b/docs/adapters/openai.mdx
@@ -94,6 +94,22 @@ if __name__ == "__main__":
 
 `run_sync` and `run_streamed` work the same way.
 
+## Agent-level enforcement
+
+Beyond tool calls, `HexgateRunner` enforces [agent-level policy](/concepts/agent-level-enforcement):
+**admission** (may this caller run the agent) at run entry, and **handoff reach**
+(`agent.handoff:<name>`) at the SDK's `on_handoff` seam — a denied handoff is
+vetoed before the target runs. Set `HexgateRunner(max_handoff_depth=N)` to cap a
+runaway handoff chain.
+
+<Warning>
+**Agent-as-tool reach is not enforced on OpenAI.** `Agent.as_tool()` produces a
+plain function tool with no link back to the target agent, so the
+`agent.tool:<name>` reach key can't be resolved here — a policy that declares one
+logs a warning at setup. Gate a sub-agent-as-tool by its **tool name** instead
+(an ordinary `tools:` rule), which works normally.
+</Warning>
+
 ## Runnable example
 
 `examples/devops_openai.py` — `HexgateRunner` (OpenAI Agents SDK) end-to-end.

--- a/docs/adapters/pydantic-ai.mdx
+++ b/docs/adapters/pydantic-ai.mdx
@@ -96,6 +96,18 @@ if __name__ == "__main__":
   the caller identity. Global tracing is enabled via `Agent.instrument_all()` on
   construction.
 
+## Agent-level enforcement
+
+<Note>
+pydantic_ai has **no native handoff primitive** — multi-agent here is
+agent-as-tool, where one agent is called from inside another's tool. So there is
+no transfer seam for Hexgate to gate: a declared [`agents` or `admission`
+block](/concepts/agent-level-enforcement) logs a warning at setup rather than
+enforcing. Gate a sub-agent-as-tool by its **tool name** with an ordinary
+`tools:` rule, which works normally. Admission and reach enforcement on this
+adapter are planned follow-ups.
+</Note>
+
 ## Runnable example
 
 `examples/devops_pydantic_ai.py` — `wrap_pydantic_agent` (Pydantic AI) end-to-end.

--- a/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
+++ b/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
@@ -33,7 +33,7 @@ Warn-and-defer keeps closed-world honest across frameworks: enforcement lands on
 ## Deferred (follow-ups, warned in the interim)
 
 - **Per-sub-agent / post-handoff admission** (B re-checking admission at its run entry): needs resolving sub-agent policies and handling unregistered sub-agents, so it is out of this slice. Reach from the governed source is the boundary control today.
-- **Agent-as-tool reach on OpenAI** (`Agent.as_tool`): no metadata links the produced function tool back to a target agent name at the seam.
+- **Agent-as-tool reach on OpenAI** (`Agent.as_tool`): no metadata links the produced function tool back to a target agent name at the seam, so it cannot be *enforced* — but a policy that declares a `via: tool` target now *warns* (`warn_if_tool_reach_unenforced`, gated on `declares_tool_reach()` so handoff-only policies are not spammed), so the gap is no longer silent.
 - **pydantic_ai and native reach**: no runtime target handle.
 - **Manifest drift lint** (reach key vs declared sub-agents/handoffs): needs `AgentManifest` to carry target declarations, a cross-package change.
 

--- a/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
+++ b/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
@@ -1,0 +1,48 @@
+# R-AGENT-003: Reach and admission are enforced at per-framework runtime seams
+
+**Status:** Accepted · 2026-08-26 · builds on R-AGENT-002
+**Applies to:** `hexgate/security/agent_gate.py`, `hexgate/security/naming.py`, `hexgate/adapters/openai/runner.py`, `hexgate/adapters/google/runner.py`, `hexgate/adapters/pydantic_ai/wrapper.py`, `hexgate/adapters/langchain/wrapper.py`, `hexgate/agents/factory.py`
+
+## Decision
+
+Agent-level admission (`agent.run`) and reach (`agent.handoff:<t>` / `agent.tool:<t>`) are enforced at framework-specific runtime seams by two gates that reuse `PolicyEnforcer.decide`, mirroring the egress `Gate`. R-AGENT-002 defined the policy model; this defines where and how it runs.
+
+- **One canonical name.** A target's name at a seam derives identically to an agent's own name via `canonical_agent_name` (trim, blank/None → `"default"`, no case folding). Own-name and target-name must agree or a reach key would not match the name its target registers with. This is the one derivation; the two prior per-adapter spellings are gone.
+- **Reach is governed by the source agent's policy, at the seam, before control transfers.** `ReachGate.check_reach(target, via)` decides the lowered key and raises `ReachNotAllowedError` on a deny.
+  - **OpenAI:** the SDK `on_handoff` hook (awaited before the transfer completes, so raising vetoes it) → `via="handoff"`.
+  - **Google ADK:** a `BasePlugin.before_tool_callback` intercepting the two shapes ADK expresses as tool calls: `transfer_to_agent` (`via="handoff"`) and `AgentTool` (`via="tool"`).
+  - Only reach from a **Hexgate-governed source** (the resolved top-level agent) is gated; a transfer from an un-governed sub-agent is left alone (sub-agent governance is a later slice).
+- **Admission is enforced at run entry for the top-level agent**, inside the context scope so the caller's role is visible, on the OpenAI and Google runners. A non-admitted caller is refused before the run starts.
+- **Handoff depth is a per-run runaway cap, independent of reach policy.** A handoff transfers control forward, so the count of handoffs within one run is the chain depth; past `max_handoff_depth` the seam raises `HandoffDepthExceededError`. OpenAI counts on the per-run hook; Google counts per `invocation_id` on the shared plugin and clears it in `after_run_callback`.
+- **Where the framework hides the target, warn — never silently pass.** pydantic_ai (delegation inside a tool body), the native single-graph agent (no handoff seam), and agent-as-tool on OpenAI expose no target handle, so a declared block is surfaced by `warn_if_admission_unenforced` / `warn_if_reach_unenforced` at wrap time.
+
+## Why
+
+The two gates share `_PolicyGate` (enforcer + approval fold + fail-closed), so admission and reach behave identically and are defined once. Enforcing at the framework seam (not a wrapper around the whole run) is what lets reach fire at the exact moment control would transfer, so a denied handoff never starts the target. Governing reach by the **source** policy matches the model: the `agents` block on A says who A may reach; B's own admission is a separate direction (its run entry).
+
+Counting handoffs as depth is exact for these SDKs because a handoff is a forward transfer with no return, so a run is a chain and the handoff count is its length. The cap is deliberately policy-independent: it stops a runaway even when every hop is allowed.
+
+Warn-and-defer keeps closed-world honest across frameworks: enforcement lands only where a target handle exists, and everywhere else the gap is loud (one log per framework/agent) rather than a silent no-op, so an operator is never misled into thinking a declared block is enforced.
+
+## Consequences
+
+- Reach and admission are enforced end-to-end on OpenAI (handoff) and Google (handoff + agent-as-tool); the interim `warn_if_admission_unenforced` is gone from those adapters.
+- A denied reach or admission fails closed by raising, aborting the run rather than degrading to an ungoverned continuation.
+- `HexgateRunner(max_handoff_depth=N)` is opt-in on both adapters (None = no cap).
+
+## Deferred (follow-ups, warned in the interim)
+
+- **Per-sub-agent / post-handoff admission** (B re-checking admission at its run entry): needs resolving sub-agent policies and handling unregistered sub-agents, so it is out of this slice. Reach from the governed source is the boundary control today.
+- **Agent-as-tool reach on OpenAI** (`Agent.as_tool`): no metadata links the produced function tool back to a target agent name at the seam.
+- **pydantic_ai and native reach**: no runtime target handle.
+- **Manifest drift lint** (reach key vs declared sub-agents/handoffs): needs `AgentManifest` to carry target declarations, a cross-package change.
+
+## Verify
+
+```
+pytest tests/security/test_reach_gate.py tests/security/test_naming.py \
+       tests/adapters/openai/test_runner_reach_admission.py \
+       tests/adapters/google/test_runner.py -q
+# reach denies an unlisted/deny target and vetoes the transfer; admission refuses a
+# non-admitted caller at run entry; the depth cap raises past max_handoff_depth.
+```

--- a/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
+++ b/docs/adr/R-AGENT-003-reach-and-admission-runtime-seams.md
@@ -14,7 +14,11 @@ Agent-level admission (`agent.run`) and reach (`agent.handoff:<t>` / `agent.tool
   - Only reach from a **Hexgate-governed source** (the resolved top-level agent) is gated; a transfer from an un-governed sub-agent is left alone (sub-agent governance is a later slice).
 - **Admission is enforced at run entry for the top-level agent**, inside the context scope so the caller's role is visible, on the OpenAI and Google runners. A non-admitted caller is refused before the run starts.
 - **Handoff depth is a per-run runaway cap, independent of reach policy.** A handoff transfers control forward, so the count of handoffs within one run is the chain depth; past `max_handoff_depth` the seam raises `HandoffDepthExceededError`. OpenAI counts on the per-run hook; Google counts per `invocation_id` on the shared plugin and clears it in `after_run_callback`.
-- **Where the framework hides the target, warn — never silently pass.** pydantic_ai (delegation inside a tool body), the native single-graph agent (no handoff seam), and agent-as-tool on OpenAI expose no target handle, so a declared block is surfaced by `warn_if_admission_unenforced` / `warn_if_reach_unenforced` at wrap time.
+- **Where a seam does not exist or the framework hides the target, warn — never silently pass.** Two distinct limits, both surfaced by `warn_if_admission_unenforced` / `warn_if_reach_unenforced` / `warn_if_tool_reach_unenforced` at wrap time rather than failing open:
+  - **The transfer concept does not exist.** pydantic_ai has no native handoff primitive (multi-agent there is agent-as-tool, done inside a tool body); the native single-graph agent has no handoff/transfer seam at all. There is nothing to intercept, by nature — not a missing hook.
+  - **The concept exists but the SDK exposes no target handle.** OpenAI `Agent.as_tool()` produces a plain function tool with no back-link to the target agent, so agent-as-tool reach cannot be resolved to a name at the seam even though the delegation is real.
+
+  This is why the coverage is uneven and must be stated, not implied: OpenAI enforces handoff reach but only *warns* on agent-as-tool; Google enforces both (its `transfer_to_agent` and `AgentTool` both carry the target); pydantic_ai and native have no transfer seam and warn.
 
 ## Why
 
@@ -34,7 +38,7 @@ Warn-and-defer keeps closed-world honest across frameworks: enforcement lands on
 
 - **Per-sub-agent / post-handoff admission** (B re-checking admission at its run entry): needs resolving sub-agent policies and handling unregistered sub-agents, so it is out of this slice. Reach from the governed source is the boundary control today.
 - **Agent-as-tool reach on OpenAI** (`Agent.as_tool`): no metadata links the produced function tool back to a target agent name at the seam, so it cannot be *enforced* — but a policy that declares a `via: tool` target now *warns* (`warn_if_tool_reach_unenforced`, gated on `declares_tool_reach()` so handoff-only policies are not spammed), so the gap is no longer silent.
-- **pydantic_ai and native reach**: no runtime target handle.
+- **pydantic_ai and native reach**: no transfer seam exists to hook (the handoff concept is absent), so there is no follow-up to "wire" — reach there would require the framework to grow a transfer primitive, or Hexgate to model delegation at a different layer.
 - **Manifest drift lint** (reach key vs declared sub-agents/handoffs): needs `AgentManifest` to carry target declarations, a cross-package change.
 
 ## Verify

--- a/docs/concepts/agent-level-enforcement.mdx
+++ b/docs/concepts/agent-level-enforcement.mdx
@@ -99,7 +99,7 @@ a warning at setup, so you always know whether a rule is actually enforced.
 
 | framework | admission | handoff reach | agent-as-tool reach |
 |---|---|---|---|
-| [OpenAI Agents](/adapters/openai) | enforced | enforced | warns — the SDK's `Agent.as_tool()` exposes no target to gate |
+| [OpenAI Agents](/adapters/openai) | enforced | enforced | enforced at the top level (nested is name-gated — see Limits) |
 | [Google ADK](/adapters/google-adk) | enforced | enforced | enforced |
 | native agent (`create_agent`) | enforced | not applicable — no handoff concept | gated as an ordinary tool, by name |
 | [pydantic_ai](/adapters/pydantic-ai) | warns | not applicable — no handoff concept | gated as an ordinary tool, by name |
@@ -107,12 +107,14 @@ a warning at setup, so you always know whether a rule is actually enforced.
 
 <Note>
 **Agent-as-tool is still gated even where the reach key is not.** A sub-agent
-exposed as a tool is an ordinary tool: it is gated by its tool name through the
-normal enforcer, on every adapter, today. The `agent.tool:<name>` *reach* key is
-a separate, higher-level statement ("gate this as a delegation to agent B") that
-only fires where the framework hands Hexgate the target agent at the seam. So on
-OpenAI and the native agent you gate agent-as-tool by writing a `tools:` rule on
-the tool's name; on Google you can additionally use the `agent.tool:` reach key.
+exposed as a tool is also an ordinary tool: it is gated by its tool name through
+the normal enforcer, on every adapter, today. The `agent.tool:<name>` *reach* key
+is a separate, higher-level statement ("gate this as a delegation to agent B")
+that fires where the framework lets Hexgate recover the target agent. On Google
+(via `AgentTool`) and OpenAI (via the SDK's tool-origin metadata) an `agent.tool:`
+reach rule is enforced for the top-level agent; on the native agent, or when the
+policy declares no `agents` block, you gate agent-as-tool by writing a `tools:`
+rule on the tool's name.
 </Note>
 
 ## Limits
@@ -122,10 +124,15 @@ the tool's name; on Google you can additionally use the `agent.tool:` reach key.
   and the native single-graph agent has no transfer seam. There is nothing to
   intercept on those, by nature — a declared `agents` handoff rule warns rather
   than silently doing nothing.
-- **Agent-as-tool reach on OpenAI is not enforced.** `Agent.as_tool()` produces a
-  plain function tool with no link back to the target agent, so the
-  `agent.tool:<name>` key can't be resolved at the seam. Gate it by tool name
-  instead; a declared `via: tool` rule warns.
+- **Agent-as-tool reach on OpenAI is enforced only at the top level.** The SDK
+  tags an `Agent.as_tool()` with its target agent, so a top-level agent's
+  `agent.tool:<name>` reach rule *is* enforced. But a sub-agent reached as a tool
+  runs through the SDK's own runner on the *unwrapped* agent, so a reach edge one
+  level deeper (B calls C as a tool) is not gated — only B's tools were wrapped.
+  Governing nested agents needs each nested agent wrapped through Hexgate; until
+  then, deeper edges fall back to name-gating. (On an SDK too old to expose the
+  tool origin, even the top level falls back to name-gating and a `via: tool` rule
+  warns.)
 - **Reach is governed by the source agent's policy.** When A hands off to B,
   today the check is A's `agents:` rule. B re-checking its *own* admission when
   reached by a handoff is a planned addition.

--- a/docs/concepts/agent-level-enforcement.mdx
+++ b/docs/concepts/agent-level-enforcement.mdx
@@ -1,0 +1,133 @@
+---
+title: "Agent-level enforcement"
+description: "Gate who may run an agent, and which agents one agent may reach, through the same policy engine that gates tool calls."
+---
+
+Policy normally decides one thing: may this caller invoke this tool with these
+arguments. Agent-level enforcement asks the same kind of question in two new
+places:
+
+- **Admission** — may this caller, in this role, run *this agent at all*?
+  Checked at the top of a run, before the model sees anything.
+- **Reach** (delegation) — may this agent invoke or hand off to *another agent*?
+  Checked at the moment it tries to.
+
+Both reuse the same [`PolicyEnforcer`](/concepts/policy-decision) as tool calls,
+so the [decision](/concepts/policy-decision) type, the constraint language, the
+[audit trail](/concepts/audit-trail), and the [approval flow](/concepts/approval-required)
+all apply unchanged.
+
+## The two ways one agent reaches another
+
+They are genuinely different, so a policy can treat them differently, via the
+`via` modes:
+
+- **agent-as-tool** (`via: tool`) — the caller invokes a helper agent like a
+  tool and folds the result back into its own answer. Control stays with the
+  caller.
+- **handoff** (`via: handoff`) — the caller transfers the whole conversation to
+  another agent, which takes over and answers the user directly. Control does
+  not return.
+
+Handing the user to `billing-bot` is a bigger deal than asking it to compute one
+number, so a policy can allow the tool mode freely and gate the handoff.
+
+## Write the policy
+
+Agent rules sit next to `tools:` in a role and read the same way — a `mode` plus
+optional `constraints`:
+
+```yaml
+roles:
+  support:
+    default_policy: { mode: deny }
+
+    admission:                     # may a "support" caller run THIS agent?
+      mode: allow
+
+    agents:                        # which agents may "support" reach, and how?
+      billing-bot:
+        via: [tool, handoff]       # both modes are governed by this rule
+        mode: approval_required    # a human okays it either way
+      refund-bot:
+        via: [tool]                # callable as a tool; handoff is denied
+        mode: allow
+      admin-bot:
+        mode: deny                 # off limits, in any mode
+      # anything not listed here is denied (closed-world)
+```
+
+Under the hood each rule lowers to an ordinary tool key — `admission` to
+`agent.run`, and each `agents` target to `agent.tool:<name>` / `agent.handoff:<name>` —
+so the same `decide()` that gates every tool call runs on them, and the same
+policy authoring (including modular boundaries, capabilities, and roles) composes
+them. A deny written at a boundary is authoritative; grants union.
+
+## Closed-world, and opt-in
+
+- **Unlisted means denied.** Once you declare agent rules, any agent you did not
+  list is denied. You name what is in; everything else falls to deny. There is
+  no default block to set.
+- **It is opt-in.** An agent whose policy has no `admission` and no `agents`
+  block is not gated at all — it runs exactly as before. The gates engage only
+  once a block is present.
+- **Declare `admission` on every role that should get in.** Because admission is
+  closed-world, once any role declares it the gate is on for every caller, and a
+  role you did not grant admission is refused. Across several roles the check is
+  permissive: any role that grants admission admits the caller.
+
+## Approvals and the depth cap
+
+An `approval_required` agent rule uses the same [human-approval](/concepts/approval-required)
+path a tool does. On a handoff the model is told the transfer was refused or is
+pending and can re-plan; on admission the run waits for a yes before it starts.
+
+A handoff transfers control forward, so a chain of handoffs can run away. Set a
+per-run cap on the runner to bound it:
+
+```python
+from hexgate.adapters.openai import HexgateRunner
+
+runner = HexgateRunner(max_handoff_depth=3)  # refuse the 4th handoff in a chain
+```
+
+## Framework support
+
+Enforcement lands wherever the framework exposes the *target* agent at the
+delegation seam. Where it does not, Hexgate does not fail open silently — it logs
+a warning at setup, so you always know whether a rule is actually enforced.
+
+| framework | admission | handoff reach | agent-as-tool reach |
+|---|---|---|---|
+| [OpenAI Agents](/adapters/openai) | enforced | enforced | warns — the SDK's `Agent.as_tool()` exposes no target to gate |
+| [Google ADK](/adapters/google-adk) | enforced | enforced | enforced |
+| native agent (`create_agent`) | enforced | not applicable — no handoff concept | gated as an ordinary tool, by name |
+| [pydantic_ai](/adapters/pydantic-ai) | warns | not applicable — no handoff concept | gated as an ordinary tool, by name |
+| [LangChain](/adapters/langchain) | warns | warns | gated as an ordinary tool, by name |
+
+<Note>
+**Agent-as-tool is still gated even where the reach key is not.** A sub-agent
+exposed as a tool is an ordinary tool: it is gated by its tool name through the
+normal enforcer, on every adapter, today. The `agent.tool:<name>` *reach* key is
+a separate, higher-level statement ("gate this as a delegation to agent B") that
+only fires where the framework hands Hexgate the target agent at the seam. So on
+OpenAI and the native agent you gate agent-as-tool by writing a `tools:` rule on
+the tool's name; on Google you can additionally use the `agent.tool:` reach key.
+</Note>
+
+## Limits
+
+- **The handoff concept does not exist everywhere.** pydantic_ai has no native
+  handoff primitive (multi-agent there is agent-as-tool, run inside a tool body),
+  and the native single-graph agent has no transfer seam. There is nothing to
+  intercept on those, by nature — a declared `agents` handoff rule warns rather
+  than silently doing nothing.
+- **Agent-as-tool reach on OpenAI is not enforced.** `Agent.as_tool()` produces a
+  plain function tool with no link back to the target agent, so the
+  `agent.tool:<name>` key can't be resolved at the seam. Gate it by tool name
+  instead; a declared `via: tool` rule warns.
+- **Reach is governed by the source agent's policy.** When A hands off to B,
+  today the check is A's `agents:` rule. B re-checking its *own* admission when
+  reached by a handoff is a planned addition.
+- **Reach is gated only from a Hexgate-governed source.** A transfer originating
+  from an un-governed sub-agent is not gated.

--- a/docs/concepts/agent-level-enforcement.mdx
+++ b/docs/concepts/agent-level-enforcement.mdx
@@ -106,15 +106,16 @@ a warning at setup, so you always know whether a rule is actually enforced.
 | [LangChain](/adapters/langchain) | warns | warns | gated as an ordinary tool, by name |
 
 <Note>
-**Agent-as-tool is still gated even where the reach key is not.** A sub-agent
-exposed as a tool is also an ordinary tool: it is gated by its tool name through
-the normal enforcer, on every adapter, today. The `agent.tool:<name>` *reach* key
-is a separate, higher-level statement ("gate this as a delegation to agent B")
-that fires where the framework lets Hexgate recover the target agent. On Google
-(via `AgentTool`) and OpenAI (via the SDK's tool-origin metadata) an `agent.tool:`
-reach rule is enforced for the top-level agent; on the native agent, or when the
-policy declares no `agents` block, you gate agent-as-tool by writing a `tools:`
-rule on the tool's name.
+**Agent-as-tool falls back to name-gating where the reach key isn't engaged.** A
+sub-agent exposed as a tool is also an ordinary tool. When the policy declares a
+`via: tool` target — an `agent.tool:` key — the delegation is decided under that
+reach key (Google via `AgentTool`, OpenAI via the SDK's tool-origin metadata),
+closed-world with its `via`/constraints, and *not* also by the tool name. When the
+policy declares **no `via: tool` target** — or on the native agent, pydantic_ai,
+and LangChain, which expose no target handle — you gate agent-as-tool by writing a
+`tools:` rule on the tool's name instead. Both adapters engage on the same signal
+(a declared `via: tool` target), so a handoff-only policy leaves as-tools
+name-gated on both.
 </Note>
 
 ## Limits

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,6 +28,7 @@
               "concepts/policy-decision",
               "concepts/guards",
               "concepts/user-scope",
+              "concepts/agent-level-enforcement",
               "concepts/signed-bundles",
               "concepts/audit-trail",
               "concepts/mcp",

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -26,7 +26,11 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext, run_scope
-from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
+from hexgate.security.agent_gate import (
+    HandoffDepthExceededError,
+    resolve_agent_gate,
+    resolve_reach_gate,
+)
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.naming import canonical_agent_name, canonical_name
 
@@ -51,11 +55,24 @@ class _HexgateReachPlugin(BasePlugin):
     def __init__(self, runner: "HexgateRunner") -> None:
         super().__init__(name="hexgate_reach")
         self._runner = runner
+        # Handoff depth per invocation (this plugin is shared across runs, unlike
+        # the OpenAI per-run hook), cleared in after_run_callback.
+        self._depth: dict[str, int] = {}
 
     async def before_tool_callback(self, *, tool, tool_args, tool_context) -> None:
+        is_transfer = tool.name == "transfer_to_agent"
+        # Depth cap first, as a runaway guard independent of reach policy and of
+        # which agent transfers: a transfer moves control forward, so the count of
+        # transfers in one invocation is the chain depth.
+        cap = self._runner._max_handoff_depth
+        if is_transfer and cap is not None:
+            inv = tool_context.invocation_id
+            self._depth[inv] = self._depth.get(inv, 0) + 1
+            if self._depth[inv] > cap:
+                raise HandoffDepthExceededError(self._depth[inv], cap)
         if canonical_name(tool_context.agent_name) != self._runner._agent_name:
             return None  # source is not the governed root; reach from it isn't gated
-        if tool.name == "transfer_to_agent":
+        if is_transfer:
             target, via = tool_args.get("agent_name"), "handoff"
         elif isinstance(tool, AgentTool):
             target, via = getattr(tool.agent, "name", None), "tool"
@@ -68,6 +85,11 @@ class _HexgateReachPlugin(BasePlugin):
             approval_handler=self._runner._approval_handler,
         )
         await gate.check_reach_async(canonical_name(target), via=via)
+        return None
+
+    async def after_run_callback(self, *, invocation_context) -> None:
+        # Drop this invocation's depth counter so the map does not grow unbounded.
+        self._depth.pop(invocation_context.invocation_id, None)
         return None
 
 
@@ -84,6 +106,7 @@ class HexgateRunner:
         approval_handler: ApprovalHandler | None = None,
         guards: "Sequence[Guard] | None" = None,
         guard_observer: "GuardObserver | None" = None,
+        max_handoff_depth: int | None = None,
         **runner_kwargs: Any,
     ):
         # ``guards`` matches the OpenAI runner's constructor. ADK's ``run`` has
@@ -98,6 +121,9 @@ class HexgateRunner:
         # Runner is built once — refresh swaps the enforcer's policy
         # without touching it. One client is shared with the ban resolver.
         self._approval_handler = approval_handler
+        # Handoff-chain depth cap (None = no cap); enforced per invocation by the
+        # reach plugin.
+        self._max_handoff_depth = max_handoff_depth
         client = HexgateClient(HexgateConfig.from_env(api_key=self.api_key))
         self._wrapped_agent, self._binding = wrap_google_agent(
             agent,

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -11,8 +11,10 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator
 import nest_asyncio
 from google.adk.agents import BaseAgent
 from google.adk.apps import App
+from google.adk.plugins.base_plugin import BasePlugin
 from google.adk.runners import Runner
 from google.adk.sessions import BaseSessionService
+from google.adk.tools.agent_tool import AgentTool
 from google.genai import types
 from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
@@ -24,11 +26,49 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext, run_scope
+from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
 from hexgate.security.bans import resolve_ban_gate
-from hexgate.security.naming import canonical_agent_name
+from hexgate.security.naming import canonical_agent_name, canonical_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
+
+
+class _HexgateReachPlugin(BasePlugin):
+    """Enforce agent-to-agent reach at the ADK tool seam.
+
+    ADK expresses delegation as tool calls: ``transfer_to_agent(agent_name=...)``
+    (handoff, control transfers) and :class:`AgentTool` (agent-as-tool, the caller
+    keeps control). ``before_tool_callback`` fires before either runs, so deciding
+    the target's reach key here and raising :class:`ReachNotAllowedError` on a deny
+    stops the transfer/delegation before it happens. Reach is governed by the
+    source agent's policy; only the governed root's reach is gated (a transfer
+    originating from an un-governed sub-agent is left alone, matching the OpenAI
+    adapter). Ordinary tools fall through — they are already gated by the wrapped
+    enforcer.
+    """
+
+    def __init__(self, runner: "HexgateRunner") -> None:
+        super().__init__(name="hexgate_reach")
+        self._runner = runner
+
+    async def before_tool_callback(self, *, tool, tool_args, tool_context) -> None:
+        if canonical_name(tool_context.agent_name) != self._runner._agent_name:
+            return None  # source is not the governed root; reach from it isn't gated
+        if tool.name == "transfer_to_agent":
+            target, via = tool_args.get("agent_name"), "handoff"
+        elif isinstance(tool, AgentTool):
+            target, via = getattr(tool.agent, "name", None), "tool"
+        else:
+            return None  # ordinary tool; the wrapped enforcer already gates it
+        if not target:
+            return None
+        gate = resolve_reach_gate(
+            self._runner._binding.enforcer,
+            approval_handler=self._runner._approval_handler,
+        )
+        await gate.check_reach_async(canonical_name(target), via=via)
+        return None
 
 
 class HexgateRunner:
@@ -57,6 +97,7 @@ class HexgateRunner:
         # Policy resolves at construction (the loud-failure point); the
         # Runner is built once — refresh swaps the enforcer's policy
         # without touching it. One client is shared with the ban resolver.
+        self._approval_handler = approval_handler
         client = HexgateClient(HexgateConfig.from_env(api_key=self.api_key))
         self._wrapped_agent, self._binding = wrap_google_agent(
             agent,
@@ -68,6 +109,9 @@ class HexgateRunner:
         )
         plugins = list(runner_kwargs.pop("plugins", None) or [])
         plugins.append(HexgateUsagePlugin(api_key=self.api_key))
+        # Reach enforcement at the ADK transfer/AgentTool seam. Appended after the
+        # caller's plugins so it always runs; it never rewrites tool input.
+        plugins.append(_HexgateReachPlugin(self))
         app = App(name=app_name, root_agent=self._wrapped_agent, plugins=plugins)
         self._runner = Runner(
             app=app,
@@ -78,6 +122,22 @@ class HexgateRunner:
         self._ban_gate = resolve_ban_gate(
             self._agent_name, api_key=self.api_key, client=client
         )
+
+    async def _check_admission_async(self) -> None:
+        """Refuse a caller not admitted by the root agent's policy before the run
+        drives. Must run inside the active HexgateContext scope. No-op when the
+        policy declares no admission."""
+        gate = resolve_agent_gate(
+            self._binding.enforcer, approval_handler=self._approval_handler
+        )
+        await gate.check_admission_async()
+
+    def _check_admission_sync(self) -> None:
+        """Sync mirror of :meth:`_check_admission_async`."""
+        gate = resolve_agent_gate(
+            self._binding.enforcer, approval_handler=self._approval_handler
+        )
+        gate.check_admission()
 
     def _setup_observability(self):
         """Install Langfuse + GoogleADKInstrumentor (idempotent)."""
@@ -123,6 +183,7 @@ class HexgateRunner:
             run_scope(self._agent_name),
             self._propagate(hexgate_context),
         ):
+            self._check_admission_sync()  # in-scope: reads the caller's role
             agen = self._runner.run_async(
                 user_id=hexgate_context.user_id,
                 session_id=hexgate_context.session_id,
@@ -164,6 +225,7 @@ class HexgateRunner:
             session_id if session_id is not None else hexgate_context.session_id
         )
         async with hexgate_context:
+            await self._check_admission_async()  # in-scope: reads the caller's role
             with run_scope(self._agent_name), self._propagate(hexgate_context):
                 async for event in self._runner.run_async(
                     user_id=hexgate_context.user_id,

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -4,6 +4,7 @@ active role. Langfuse propagation mirrors HexgateContext identity into spans.
 """
 
 import asyncio
+from collections import OrderedDict
 from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, AsyncGenerator, Generator
@@ -52,12 +53,31 @@ class _HexgateReachPlugin(BasePlugin):
     enforcer.
     """
 
+    # Cap on tracked invocations. after_run_callback clears an invocation's depth
+    # on a normal run, but ADK skips it when the agent loop raises or the caller
+    # stops iterating early, so a shared, long-lived plugin would otherwise leak one
+    # entry per abnormally-terminated run. Bounding the map turns that unbounded
+    # leak into a fixed ceiling: the least-recently-transferred entry is evicted
+    # once this many distinct invocations are in flight (far above real concurrency).
+    _MAX_TRACKED_INVOCATIONS = 4096
+
     def __init__(self, runner: "HexgateRunner") -> None:
         super().__init__(name="hexgate_reach")
         self._runner = runner
         # Handoff depth per invocation (this plugin is shared across runs, unlike
-        # the OpenAI per-run hook), cleared in after_run_callback.
-        self._depth: dict[str, int] = {}
+        # the OpenAI per-run hook). Cleared in after_run_callback; bounded (see the
+        # class constant) so a skipped cleanup on an aborted run can't leak forever.
+        self._depth: OrderedDict[str, int] = OrderedDict()
+
+    def _bump_depth(self, invocation_id: str) -> int:
+        """Increment and return this invocation's handoff depth, keeping the most
+        recently active invocations and evicting the stalest past the cap."""
+        depth = self._depth.get(invocation_id, 0) + 1
+        self._depth[invocation_id] = depth
+        self._depth.move_to_end(invocation_id)
+        while len(self._depth) > self._MAX_TRACKED_INVOCATIONS:
+            self._depth.popitem(last=False)  # evict least-recently-transferred
+        return depth
 
     async def before_tool_callback(self, *, tool, tool_args, tool_context) -> None:
         # A raise here aborts the run, so after_run_callback never fires; drop this
@@ -76,10 +96,9 @@ class _HexgateReachPlugin(BasePlugin):
         # transfers in one invocation is the chain depth.
         cap = self._runner._max_handoff_depth
         if is_transfer and cap is not None:
-            inv = tool_context.invocation_id
-            self._depth[inv] = self._depth.get(inv, 0) + 1
-            if self._depth[inv] > cap:
-                raise HandoffDepthExceededError(self._depth[inv], cap)
+            depth = self._bump_depth(tool_context.invocation_id)
+            if depth > cap:
+                raise HandoffDepthExceededError(depth, cap)
         if canonical_name(tool_context.agent_name) != self._runner._agent_name:
             return None  # source is not the governed root; reach from it isn't gated
         if is_transfer:

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -60,6 +60,16 @@ class _HexgateReachPlugin(BasePlugin):
         self._depth: dict[str, int] = {}
 
     async def before_tool_callback(self, *, tool, tool_args, tool_context) -> None:
+        # A raise here aborts the run, so after_run_callback never fires; drop this
+        # invocation's depth entry on the way out to keep the shared map from
+        # leaking one entry per aborted (over-depth or reach-denied) run.
+        try:
+            return await self._gate_tool(tool, tool_args, tool_context)
+        except Exception:
+            self._depth.pop(tool_context.invocation_id, None)
+            raise
+
+    async def _gate_tool(self, tool, tool_args, tool_context) -> None:
         is_transfer = tool.name == "transfer_to_agent"
         # Depth cap first, as a runaway guard independent of reach policy and of
         # which agent transfers: a transfer moves control forward, so the count of

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -23,8 +23,9 @@ from hexgate.adapters.google.wrapper import wrap_google_agent
 from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
-from hexgate.runtime import DEFAULT_AGENT_NAME, HexgateContext, run_scope
+from hexgate.runtime import HexgateContext, run_scope
 from hexgate.security.bans import resolve_ban_gate
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -73,7 +74,7 @@ class HexgateRunner:
             session_service=session_service,
             **runner_kwargs,
         )
-        self._agent_name = getattr(agent, "name", DEFAULT_AGENT_NAME)
+        self._agent_name = canonical_agent_name(agent)
         self._ban_gate = resolve_ban_gate(
             self._agent_name, api_key=self.api_key, client=client
         )

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -90,6 +90,8 @@ class _HexgateReachPlugin(BasePlugin):
             return None  # ordinary tool; the wrapped enforcer already gates it
         if not target:
             return None
+        if not self._runner._binding.enforcer.policy.declares_reach():
+            return None  # no 'agents' block — skip building a gate on the hot seam
         gate = resolve_reach_gate(
             self._runner._binding.enforcer,
             approval_handler=self._runner._approval_handler,

--- a/hexgate/adapters/google/runner.py
+++ b/hexgate/adapters/google/runner.py
@@ -15,7 +15,6 @@ from google.adk.apps import App
 from google.adk.plugins.base_plugin import BasePlugin
 from google.adk.runners import Runner
 from google.adk.sessions import BaseSessionService
-from google.adk.tools.agent_tool import AgentTool
 from google.genai import types
 from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.google_adk import GoogleADKInstrumentor
@@ -29,6 +28,7 @@ from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext, run_scope
 from hexgate.security.agent_gate import (
     HandoffDepthExceededError,
+    ReachNotAllowedError,
     resolve_agent_gate,
     resolve_reach_gate,
 )
@@ -38,19 +38,35 @@ from hexgate.security.naming import canonical_agent_name, canonical_name
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
 
+# ADK's PluginManager re-raises every plugin exception as a fresh RuntimeError
+# (``Error in plugin '<name>' during '<cb>' callback: ...``), keeping the original
+# only as ``__cause__``. That would erase our typed seam errors and their
+# ``.decision`` / ``.depth`` payload (and leak the internal plugin name), so the
+# runner unwraps them back at the ADK boundary. ``except RuntimeError`` still
+# catches either form — all three seam errors subclass it by design.
+_TYPED_SEAM_ERRORS = (ReachNotAllowedError, HandoffDepthExceededError)
+
+
+def _unwrap_plugin_error(exc: RuntimeError) -> BaseException:
+    """Recover a typed seam error ADK wrapped into a bare ``RuntimeError``; return
+    ``exc`` unchanged when its cause is not one of ours."""
+    cause = exc.__cause__
+    return cause if isinstance(cause, _TYPED_SEAM_ERRORS) else exc
+
 
 class _HexgateReachPlugin(BasePlugin):
-    """Enforce agent-to-agent reach at the ADK tool seam.
+    """Enforce *handoff* reach and the handoff-depth cap at the ADK transfer seam.
 
-    ADK expresses delegation as tool calls: ``transfer_to_agent(agent_name=...)``
-    (handoff, control transfers) and :class:`AgentTool` (agent-as-tool, the caller
-    keeps control). ``before_tool_callback`` fires before either runs, so deciding
-    the target's reach key here and raising :class:`ReachNotAllowedError` on a deny
-    stops the transfer/delegation before it happens. Reach is governed by the
-    source agent's policy; only the governed root's reach is gated (a transfer
-    originating from an un-governed sub-agent is left alone, matching the OpenAI
-    adapter). Ordinary tools fall through — they are already gated by the wrapped
-    enforcer.
+    ADK expresses a handoff as the ``transfer_to_agent(agent_name=...)`` tool call;
+    ``before_tool_callback`` fires before it runs, so deciding ``agent.handoff:<target>``
+    here and raising :class:`ReachNotAllowedError` on a deny stops the transfer
+    before it happens. Reach is governed by the source agent's policy; only the
+    governed root's transfers are gated (a transfer from an un-governed sub-agent is
+    left alone, matching the OpenAI adapter). Agent-as-tool reach is *not* handled
+    here — an :class:`AgentTool` is an ordinary tool on ``agent.tools``, so
+    :func:`~hexgate.adapters.google.tools.wrap_tool` gates it under its reach key,
+    the same substitution the OpenAI adapter uses (gating it here as well would
+    decide one delegation twice and emit two audit events).
     """
 
     # Cap on tracked invocations. after_run_callback clears an invocation's depth
@@ -90,23 +106,23 @@ class _HexgateReachPlugin(BasePlugin):
             raise
 
     async def _gate_tool(self, tool, tool_args, tool_context) -> None:
-        is_transfer = tool.name == "transfer_to_agent"
-        # Depth cap first, as a runaway guard independent of reach policy and of
-        # which agent transfers: a transfer moves control forward, so the count of
-        # transfers in one invocation is the chain depth.
+        # Handoff reach + the depth cap only. Agent-as-tool reach is gated in
+        # wrap_tool (an AgentTool is a real tool on agent.tools) under the same
+        # reach-key substitution the OpenAI adapter uses, so gating it here too
+        # would double-decide it and emit two audit events for one delegation.
+        if tool.name != "transfer_to_agent":
+            return None  # ordinary tool / AgentTool — gated by the wrapped enforcer
+        # Depth cap first, as a runaway guard independent of reach policy: a
+        # transfer moves control forward, so the count of transfers in one
+        # invocation is the chain depth. Counts every transfer, governed or not.
         cap = self._runner._max_handoff_depth
-        if is_transfer and cap is not None:
+        if cap is not None:
             depth = self._bump_depth(tool_context.invocation_id)
             if depth > cap:
                 raise HandoffDepthExceededError(depth, cap)
         if canonical_name(tool_context.agent_name) != self._runner._agent_name:
             return None  # source is not the governed root; reach from it isn't gated
-        if is_transfer:
-            target, via = tool_args.get("agent_name"), "handoff"
-        elif isinstance(tool, AgentTool):
-            target, via = getattr(tool.agent, "name", None), "tool"
-        else:
-            return None  # ordinary tool; the wrapped enforcer already gates it
+        target = tool_args.get("agent_name")
         if not target:
             return None
         if not self._runner._binding.enforcer.policy.declares_reach():
@@ -115,7 +131,7 @@ class _HexgateReachPlugin(BasePlugin):
             self._runner._binding.enforcer,
             approval_handler=self._runner._approval_handler,
         )
-        await gate.check_reach_async(canonical_name(target), via=via)
+        await gate.check_reach_async(canonical_name(target), via="handoff")
         return None
 
     async def after_run_callback(self, *, invocation_context) -> None:
@@ -166,9 +182,13 @@ class HexgateRunner:
         )
         plugins = list(runner_kwargs.pop("plugins", None) or [])
         plugins.append(HexgateUsagePlugin(api_key=self.api_key))
-        # Reach enforcement at the ADK transfer/AgentTool seam. Appended after the
-        # caller's plugins so it always runs; it never rewrites tool input.
-        plugins.append(_HexgateReachPlugin(self))
+        # Reach + depth enforcement at the ADK transfer seam. Inserted *first*:
+        # ADK's PluginManager runs before_tool_callback in registration order and
+        # early-exits on the first plugin that returns non-None, so a caller plugin
+        # that overrides a tool result (replay, environment simulation, a cache)
+        # would otherwise short-circuit this gate — a silent fail-open. Ours only
+        # ever returns None or raises, so it can never short-circuit anything itself.
+        plugins.insert(0, _HexgateReachPlugin(self))
         app = App(name=app_name, root_agent=self._wrapped_agent, plugins=plugins)
         self._runner = Runner(
             app=app,
@@ -251,9 +271,16 @@ class HexgateRunner:
             try:
                 while True:
                     try:
-                        yield loop.run_until_complete(agen.__anext__())
+                        event = loop.run_until_complete(agen.__anext__())
                     except StopAsyncIteration:
                         break
+                    except RuntimeError as exc:
+                        # Recover a typed seam error ADK wrapped (see module top).
+                        unwrapped = _unwrap_plugin_error(exc)
+                        if unwrapped is exc:
+                            raise
+                        raise unwrapped from exc
+                    yield event
             finally:
                 loop.run_until_complete(agen.aclose())
                 loop.close()
@@ -284,10 +311,17 @@ class HexgateRunner:
         async with hexgate_context:
             await self._check_admission_async()  # in-scope: reads the caller's role
             with run_scope(self._agent_name), self._propagate(hexgate_context):
-                async for event in self._runner.run_async(
-                    user_id=hexgate_context.user_id,
-                    session_id=adk_session_id,
-                    new_message=new_message,
-                    **kwargs,
-                ):
-                    yield event
+                try:
+                    async for event in self._runner.run_async(
+                        user_id=hexgate_context.user_id,
+                        session_id=adk_session_id,
+                        new_message=new_message,
+                        **kwargs,
+                    ):
+                        yield event
+                except RuntimeError as exc:
+                    # Recover a typed seam error ADK wrapped (see module top).
+                    unwrapped = _unwrap_plugin_error(exc)
+                    if unwrapped is exc:
+                        raise
+                    raise unwrapped from exc

--- a/hexgate/adapters/google/tools.py
+++ b/hexgate/adapters/google/tools.py
@@ -15,14 +15,18 @@ import functools
 from collections.abc import Callable
 from typing import Any, Union
 
+from google.adk.tools.agent_tool import AgentTool
 from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.function_tool import FunctionTool
 from google.adk.tools.tool_context import ToolContext
 
 from hexgate.approvals import ApprovalHandler
-from hexgate.guards.runner import run_guarded_async
+from hexgate.guards.runner import RenderError, run_guarded_async
 from hexgate.guards.types import ToolPipeline
+from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.models import agent_target_key
+from hexgate.security.naming import canonical_name
 
 
 ToolEntry = Union[BaseTool, Callable[..., Any]]
@@ -31,6 +35,35 @@ ToolEntry = Union[BaseTool, Callable[..., Any]]
 def _render_error(decision: Any) -> str:
     """Google renders a blocked decision as a string tool result."""
     return decision.as_error_message()
+
+
+def _render_reach_error(target: str) -> RenderError:
+    """Model-facing renderer for a denied/held agent-as-tool reach — keeps the
+    ``[marker] …`` shape but names the bare target, not the ``agent.tool:`` key.
+    Mirrors the OpenAI adapter."""
+
+    def render(decision: Any) -> str:
+        marker = decision.error_type or decision.outcome.value
+        if decision.outcome is DecisionOutcome.NEEDS_APPROVAL:
+            body = f"reach to agent {target!r} requires human approval before it runs"
+        else:
+            body = f"reach to agent {target!r} is not permitted by this agent's policy"
+        return f"[{marker}] {body}. The sub-agent was not invoked."
+
+    return render
+
+
+def _agent_tool_target(base: BaseTool) -> str | None:
+    """Canonical target-agent name if ``base`` is an ``AgentTool``, else ``None``.
+
+    An ``AgentTool`` names itself after its wrapped agent (``AgentTool.name ==
+    agent.name``), so gating it by name would double-decide the delegation the
+    transfer plugin already governs; instead we gate it under its reach key."""
+    if isinstance(base, AgentTool):
+        target = getattr(base.agent, "name", None)
+        if target:
+            return canonical_name(target)
+    return None
 
 
 def _normalize(tool: ToolEntry) -> BaseTool:
@@ -60,11 +93,31 @@ def wrap_tool(
     base = _normalize(tool)
     name = base.name
     original_run_async = base.run_async
+    # An AgentTool is a reach edge; gate it under agent.tool:<target>, matching the
+    # OpenAI adapter. ``None`` for an ordinary tool.
+    reach_target = _agent_tool_target(base)
 
     @functools.wraps(original_run_async, updated=())
     async def guarded_run_async(
         *, args: dict[str, Any], tool_context: ToolContext
     ) -> Any:
+        # Engagement read per call (hot-reload-safe). Gate the reach key only when
+        # the policy declares *tool* reach — matching OpenAI, so a handoff-only
+        # policy leaves as-tools name-gated on both adapters rather than diverging.
+        if reach_target is not None and enforcer.policy.declares_tool_reach():
+            policy_key: str | None = agent_target_key("tool", reach_target)
+            policy_args: dict[str, Any] | None = {
+                "agent": enforcer.agent_name,
+                "target": reach_target,
+                "via": "tool",
+            }
+            # Reach wording on the policy denial only; a guard Halt still renders
+            # through _render_error (see run_guarded_async).
+            render_policy_error: RenderError | None = _render_reach_error(reach_target)
+        else:
+            policy_key = None
+            policy_args = None
+            render_policy_error = None
         return await run_guarded_async(
             name,
             args or {},
@@ -75,6 +128,9 @@ def wrap_tool(
                 args=final, tool_context=tool_context
             ),
             render_error=_render_error,
+            policy_key=policy_key,
+            policy_args=policy_args,
+            render_policy_error=render_policy_error,
         )
 
     wrapped = copy.copy(base)

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -18,7 +18,6 @@ from google.adk.agents import BaseAgent
 from hexgate.adapters.google.tools import wrap_tools
 from hexgate.approvals import ApprovalHandler
 from hexgate.guards.types import build_pipeline
-from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
 from hexgate.security.naming import canonical_agent_name
@@ -54,9 +53,8 @@ def wrap_google_agent(
 
     resolved = resolve_policy(agent_name, api_key=api_key, client=client)
     enforcer = build_enforcer(resolved.engine, agent_name=agent_name, api_key=api_key)
-    warn_if_admission_unenforced(
-        resolved.engine, framework="Google ADK", agent_name=agent_name
-    )
+    # No admission/reach warning here: the Google HexgateRunner enforces both
+    # (admission at run entry, reach at the transfer/AgentTool seam).
     pipeline = build_pipeline(guards, observer=guard_observer)
     guarded_tools = wrap_tools(
         tools, enforcer, approval_handler=approval_handler, pipeline=pipeline

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -21,6 +21,7 @@ from hexgate.guards.types import build_pipeline
 from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.cloud.client import HexgateClient
@@ -48,7 +49,7 @@ def wrap_google_agent(
     unregistered agent (platform 404) raises — register it first with
     ``hexgate register``.
     """
-    agent_name = getattr(agent, "name", "default")
+    agent_name = canonical_agent_name(agent)
     tools = list(getattr(agent, "tools", []) or [])
 
     resolved = resolve_policy(agent_name, api_key=api_key, client=client)

--- a/hexgate/adapters/google/wrapper.py
+++ b/hexgate/adapters/google/wrapper.py
@@ -53,8 +53,9 @@ def wrap_google_agent(
 
     resolved = resolve_policy(agent_name, api_key=api_key, client=client)
     enforcer = build_enforcer(resolved.engine, agent_name=agent_name, api_key=api_key)
-    # No admission/reach warning here: the Google HexgateRunner enforces both
-    # (admission at run entry, reach at the transfer/AgentTool seam).
+    # No admission/reach warning here: the Google adapter enforces both — admission
+    # at run entry, handoff reach + the depth cap at the runner's transfer plugin,
+    # and agent-as-tool reach in wrap_tools below (an AgentTool is a real tool).
     pipeline = build_pipeline(guards, observer=guard_observer)
     guarded_tools = wrap_tools(
         tools, enforcer, approval_handler=approval_handler, pipeline=pipeline

--- a/hexgate/adapters/langchain/wrapper.py
+++ b/hexgate/adapters/langchain/wrapper.py
@@ -22,7 +22,10 @@ from hexgate.adapters.langchain.tools import install_enforcer_on_tools
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.guards.types import build_pipeline
-from hexgate.security.agent_gate import warn_if_admission_unenforced
+from hexgate.security.agent_gate import (
+    warn_if_admission_unenforced,
+    warn_if_reach_unenforced,
+)
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -68,6 +71,9 @@ def wrap_langchain_agent(
         resolved.engine, agent_name=agent_name, api_key=resolved_key
     )
     warn_if_admission_unenforced(
+        resolved.engine, framework="LangChain", agent_name=agent_name
+    )
+    warn_if_reach_unenforced(
         resolved.engine, framework="LangChain", agent_name=agent_name
     )
     pipeline = build_pipeline(guards, observer=guard_observer)

--- a/hexgate/adapters/langchain/wrapper.py
+++ b/hexgate/adapters/langchain/wrapper.py
@@ -26,6 +26,7 @@ from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -56,7 +57,7 @@ def wrap_langchain_agent(
             "No API key provided. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
         )
 
-    agent_name = getattr(agent, "name", "default")
+    agent_name = canonical_agent_name(agent)
     tool_names = [tool.name for tool in tools]
 
     # One client shared by the policy and ban resolvers — avoids a second

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -35,7 +35,7 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext, run_scope, use_run_facts
-from hexgate.security.agent_gate import warn_if_admission_unenforced
+from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -84,6 +84,32 @@ class _CompositeRunHooks(RunHooks):
     async def on_tool_end(self, context, agent, tool, result) -> None:
         for hook in self._hooks:
             await hook.on_tool_end(context, agent, tool, result)
+
+
+class _HexgateReachHooks(RunHooks):
+    """Enforce agent-to-agent reach at the SDK handoff seam.
+
+    ``on_handoff`` fires (awaited, via ``asyncio.gather``) after the target agent
+    is resolved but before the handoff completes, so raising here vetoes the
+    transfer and the target never runs. Reach is governed by the *source* agent's
+    policy, so this looks up the source's cached binding and decides
+    ``agent.handoff:<target>``. Only handoffs from a Hexgate-governed source (the
+    resolved top-level agent) are gated; a handoff from an un-governed sub-agent is
+    left alone here (sub-agent governance is a later slice). Agent-as-tool reach
+    (``Agent.as_tool``) has no target handle at this seam and is not gated.
+    """
+
+    def __init__(self, runner: "HexgateRunner") -> None:
+        self._runner = runner
+
+    async def on_handoff(self, context, from_agent, to_agent) -> None:
+        binding = self._runner._bindings.get(canonical_agent_name(from_agent))
+        if binding is None:
+            return  # source is not Hexgate-governed; reach from it isn't gated here
+        gate = resolve_reach_gate(
+            binding.enforcer, approval_handler=self._runner._approval_handler
+        )
+        await gate.check_reach_async(canonical_agent_name(to_agent), via="handoff")
 
 
 class HexgateRunner:
@@ -136,9 +162,6 @@ class HexgateRunner:
             enforcer = build_enforcer(
                 resolved.engine, agent_name=name, api_key=self.api_key
             )
-            warn_if_admission_unenforced(
-                resolved.engine, framework="OpenAI Agents", agent_name=name
-            )
             binding = PolicyBinding(enforcer, resolved.source)
             self._bindings[name] = binding
         return binding
@@ -152,6 +175,22 @@ class HexgateRunner:
                 name, api_key=self.api_key, client=self._client
             )
         return self._ban_gates[name]
+
+    async def _check_admission_async(self, binding: PolicyBinding) -> None:
+        """Refuse a caller not admitted by the top-level agent's policy, before the
+        run starts. Must run inside the active HexgateContext scope (admission reads
+        the caller's role from it). No-op when the policy declares no admission."""
+        gate = resolve_agent_gate(
+            binding.enforcer, approval_handler=self._approval_handler
+        )
+        await gate.check_admission_async()
+
+    def _check_admission_sync(self, binding: PolicyBinding) -> None:
+        """Sync mirror of :meth:`_check_admission_async`."""
+        gate = resolve_agent_gate(
+            binding.enforcer, approval_handler=self._approval_handler
+        )
+        gate.check_admission()
 
     def _setup_observability(self):
         """Install Langfuse + OpenAIAgentsInstrumentor (idempotent)."""
@@ -173,21 +212,29 @@ class HexgateRunner:
             yield
 
     def _merge_hooks(self, hooks: RunHooks | None) -> RunHooks:
-        """Compose caller-supplied ``hooks`` with the usage hook — never
-        clobber a hooks object the caller already passed."""
-        usage_hooks = HexgateUsageHooks(api_key=self.api_key)
-        if hooks is None:
-            return usage_hooks
-        if not isinstance(hooks, RunHooksBase):
-            # A Hexgate guard list passed to run(hooks=...) instead of the
-            # constructor would otherwise crash at the first lifecycle callback,
-            # far from the mistake. Name it here.
-            raise TypeError(
-                f"run(hooks=...) takes an agents RunHooks object, got "
-                f"{type(hooks).__name__}. Hexgate guards go on the constructor: "
-                "HexgateRunner(guards=[...])."
-            )
-        return _CompositeRunHooks([hooks, usage_hooks])
+        """Compose the caller's ``hooks`` with Hexgate's own — never clobber a
+        hooks object the caller already passed.
+
+        Always installs the usage hook and the reach hook (which enforces
+        ``agent.handoff:*`` at the SDK handoff seam), so the result is always a
+        composite fanning out to every hook in turn.
+        """
+        installed: list[RunHooksBase] = [
+            HexgateUsageHooks(api_key=self.api_key),
+            _HexgateReachHooks(self),
+        ]
+        if hooks is not None:
+            if not isinstance(hooks, RunHooksBase):
+                # A Hexgate guard list passed to run(hooks=...) instead of the
+                # constructor would otherwise crash at the first lifecycle callback,
+                # far from the mistake. Name it here.
+                raise TypeError(
+                    f"run(hooks=...) takes an agents RunHooks object, got "
+                    f"{type(hooks).__name__}. Hexgate guards go on the constructor: "
+                    "HexgateRunner(guards=[...])."
+                )
+            installed.insert(0, hooks)
+        return _CompositeRunHooks(installed)
 
     async def run(
         self,
@@ -214,6 +261,7 @@ class HexgateRunner:
             guard_observer=self._guard_observer,
         )
         async with hexgate_context:
+            await self._check_admission_async(binding)  # in-scope: reads the role
             with run_scope(agent.name), self._propagate(hexgate_context, agent.name):
                 return await Runner.run(
                     wrapped_agent,
@@ -248,6 +296,7 @@ class HexgateRunner:
             guard_observer=self._guard_observer,
         )
         with hexgate_context.sync_scope():
+            self._check_admission_sync(binding)  # in-scope: reads the role
             with run_scope(agent.name), self._propagate(hexgate_context, agent.name):
                 return Runner.run_sync(
                     wrapped_agent,
@@ -360,6 +409,8 @@ class HexgateRunner:
         )
 
         with hexgate_context.sync_scope():
+            # Before run_streamed spawns its task, so a non-admitted run yields nothing.
+            self._check_admission_sync(binding)
             # Scope must be open around run_streamed(): it snapshots the
             # contextvars into the background task where tools fire, and that
             # snapshot keeps the facts alive after this block exits.

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -119,6 +119,8 @@ class _HexgateReachHooks(RunHooks):
         binding = self._runner._bindings.get(canonical_agent_name(from_agent))
         if binding is None:
             return  # source is not Hexgate-governed; reach from it isn't gated here
+        if not binding.enforcer.policy.declares_reach():
+            return  # no 'agents' block — skip building a gate on the hot handoff path
         gate = resolve_reach_gate(
             binding.enforcer, approval_handler=self._runner._approval_handler
         )

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -39,6 +39,7 @@ from hexgate.security.agent_gate import (
     HandoffDepthExceededError,
     resolve_agent_gate,
     resolve_reach_gate,
+    warn_if_tool_reach_unenforced,
 )
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
@@ -176,6 +177,11 @@ class HexgateRunner:
             resolved = resolve_policy(name, api_key=self.api_key, client=self._client)
             enforcer = build_enforcer(
                 resolved.engine, agent_name=name, api_key=self.api_key
+            )
+            # Handoff reach is enforced (on_handoff); agent-as-tool reach is not,
+            # so warn if the policy declares a via: tool target.
+            warn_if_tool_reach_unenforced(
+                resolved.engine, framework="OpenAI Agents", agent_name=name
             )
             binding = PolicyBinding(enforcer, resolved.source)
             self._bindings[name] = binding
@@ -338,6 +344,11 @@ class HexgateRunner:
         tools fire there, not in ``stream_events``. So the HexgateContext scope must be
         active around the ``run_streamed`` call for the task to inherit it —
         the wrapped iterator re-opens it for exit/audit semantics.
+
+        Admission is checked synchronously before the task spawns (so a refused run
+        yields nothing). Like any sync entrypoint, an *async* ``approval_handler``
+        cannot be awaited here and fails closed on a NEEDS_APPROVAL admission
+        verdict; use the async ``run`` entrypoint if admission approval is async.
         """
         self._setup_observability()
         binding = self._binding_for(agent)

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -35,7 +35,11 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.runtime import HexgateContext, run_scope, use_run_facts
-from hexgate.security.agent_gate import resolve_agent_gate, resolve_reach_gate
+from hexgate.security.agent_gate import (
+    HandoffDepthExceededError,
+    resolve_agent_gate,
+    resolve_reach_gate,
+)
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -101,8 +105,16 @@ class _HexgateReachHooks(RunHooks):
 
     def __init__(self, runner: "HexgateRunner") -> None:
         self._runner = runner
+        self._depth = 0  # per-run: this hook is rebuilt on every run
 
     async def on_handoff(self, context, from_agent, to_agent) -> None:
+        # Depth cap first, as a runaway guard independent of reach policy: a
+        # handoff transfers control forward, so the count of handoffs in this run
+        # is the chain depth. Counts every handoff, governed source or not.
+        self._depth += 1
+        cap = self._runner._max_handoff_depth
+        if cap is not None and self._depth > cap:
+            raise HandoffDepthExceededError(self._depth, cap)
         binding = self._runner._bindings.get(canonical_agent_name(from_agent))
         if binding is None:
             return  # source is not Hexgate-governed; reach from it isn't gated here
@@ -122,6 +134,7 @@ class HexgateRunner:
         approval_handler: ApprovalHandler | None = None,
         guards: "Sequence[Guard] | None" = None,
         guard_observer: "GuardObserver | None" = None,
+        max_handoff_depth: int | None = None,
     ):
         # ``guards`` (not ``hooks``) on purpose: ``run*`` below already take a
         # ``hooks=`` that means the agents SDK's ``RunHooks`` (we mirror the SDK
@@ -139,6 +152,8 @@ class HexgateRunner:
         # Ban gates cached per agent name too (None cached to avoid re-resolving).
         self._ban_gates: dict[str, BanGate | None] = {}
         self._approval_handler = approval_handler
+        # Handoff-chain depth cap (None = no cap); enforced per run by the reach hook.
+        self._max_handoff_depth = max_handoff_depth
         # Guards are fixed per runner; threaded into each per-call rewrap below,
         # where wrap_openai_agent builds the pipeline (matching the other adapters).
         self._guards = guards

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -39,6 +39,7 @@ from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import BanGate, resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -125,10 +126,10 @@ class HexgateRunner:
         unregistered agent (platform 404) raises — register it first with
         ``hexgate register``.
         """
-        # `or "default"` collapses a None/empty name to a real string (matches
-        # the pydantic_ai adapter) so a null identity never reaches the cache
-        # key or the platform resolve / enforcer / audit below.
-        name = getattr(agent, "name", None) or "default"
+        # Shared derivation (trim + blank/None → "default") so a null identity
+        # never reaches the cache key or the platform resolve / enforcer / audit
+        # below, and so it matches how a reach target would be named.
+        name = canonical_agent_name(agent)
         binding = self._bindings.get(name)
         if binding is None:
             resolved = resolve_policy(name, api_key=self.api_key, client=self._client)
@@ -145,7 +146,7 @@ class HexgateRunner:
     def _ban_gate_for(self, agent: Agent) -> BanGate | None:
         """Get-or-resolve the cached ban gate for ``agent``'s name (``None`` in
         local mode / no key). ``None`` is cached too, so we resolve once."""
-        name = getattr(agent, "name", None) or "default"
+        name = canonical_agent_name(agent)
         if name not in self._ban_gates:
             self._ban_gates[name] = resolve_ban_gate(
                 name, api_key=self.api_key, client=self._client

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -29,6 +29,7 @@ from langfuse import get_client, propagate_attributes
 from openinference.instrumentation.openai_agents import OpenAIAgentsInstrumentor
 
 from hexgate.adapters._common import langfuse_propagate_kwargs
+from hexgate.adapters.openai.tools import _CAN_DETECT_AGENT_TOOLS
 from hexgate.adapters.openai.usage import HexgateUsageHooks
 from hexgate.adapters.openai.wrapper import wrap_openai_agent
 from hexgate.approvals import ApprovalHandler
@@ -101,7 +102,9 @@ class _HexgateReachHooks(RunHooks):
     ``agent.handoff:<target>``. Only handoffs from a Hexgate-governed source (the
     resolved top-level agent) are gated; a handoff from an un-governed sub-agent is
     left alone here (sub-agent governance is a later slice). Agent-as-tool reach
-    (``Agent.as_tool``) has no target handle at this seam and is not gated.
+    (``Agent.as_tool``) is not handled here — it never fires ``on_handoff`` — but
+    is gated at the tool seam instead: :func:`~hexgate.adapters.openai.tools.wrap_tool`
+    reads the SDK's tool-origin metadata and decides ``agent.tool:<target>``.
     """
 
     def __init__(self, runner: "HexgateRunner") -> None:
@@ -180,11 +183,14 @@ class HexgateRunner:
             enforcer = build_enforcer(
                 resolved.engine, agent_name=name, api_key=self.api_key
             )
-            # Handoff reach is enforced (on_handoff); agent-as-tool reach is not,
-            # so warn if the policy declares a via: tool target.
-            warn_if_tool_reach_unenforced(
-                resolved.engine, framework="OpenAI Agents", agent_name=name
-            )
+            # Handoff reach is enforced (on_handoff). Agent-as-tool reach is
+            # enforced too when the SDK tags as-tools with their origin (wrap_tool
+            # gates the top edge under agent.tool:<target>); on an SDK too old to
+            # expose that, it is not, so warn only in that fallback case.
+            if not _CAN_DETECT_AGENT_TOOLS:
+                warn_if_tool_reach_unenforced(
+                    resolved.engine, framework="OpenAI Agents", agent_name=name
+                )
             binding = PolicyBinding(enforcer, resolved.source)
             self._bindings[name] = binding
         return binding

--- a/hexgate/adapters/openai/runner.py
+++ b/hexgate/adapters/openai/runner.py
@@ -402,6 +402,13 @@ class HexgateRunner:
         ban_gate = self._ban_gate_for(agent)
         if ban_gate is not None:
             await ban_gate.check_async(hexgate_context)
+        # Admission here, async — not the sync check in _launch_streamed — so an
+        # async approval_handler is awaited rather than fail-closed (hexgate serve
+        # drives arun_streamed with an async RelayApprovalHandler). This scope is
+        # opened only for the admission check and closes before _launch_streamed
+        # opens its own for the run; admitted=True below then skips its sync check.
+        with hexgate_context.sync_scope():
+            await self._check_admission_async(binding)  # in-scope: reads the role
         return self._launch_streamed(
             agent,
             input,
@@ -410,6 +417,7 @@ class HexgateRunner:
             run_config=run_config,
             hooks=hooks,
             kwargs=kwargs,
+            admitted=True,
         )
 
     def _launch_streamed(
@@ -422,6 +430,7 @@ class HexgateRunner:
         run_config: RunConfig | None,
         hooks: RunHooks | None,
         kwargs: dict[str, Any],
+        admitted: bool = False,
     ) -> RunResultStreaming:
         """Wrap the agent, launch ``Runner.run_streamed`` inside the context
         scope, and re-wrap ``stream_events`` to re-enter it. Shared by the sync
@@ -443,8 +452,11 @@ class HexgateRunner:
         )
 
         with hexgate_context.sync_scope():
-            # Before run_streamed spawns its task, so a non-admitted run yields nothing.
-            self._check_admission_sync(binding)
+            # Before run_streamed spawns its task, so a non-admitted run yields
+            # nothing. Skipped when the async entrypoint already admitted (with an
+            # async-aware check), so an async approval_handler isn't fail-closed.
+            if not admitted:
+                self._check_admission_sync(binding)
             # Scope must be open around run_streamed(): it snapshots the
             # contextvars into the background task where tools fire, and that
             # snapshot keeps the facts alive after this block exits.

--- a/hexgate/adapters/openai/tools.py
+++ b/hexgate/adapters/openai/tools.py
@@ -132,12 +132,21 @@ def wrap_tool(
         # on a handoff-only policy would deny every as-tool with no diagnostic. A
         # policy that declares no via:tool target keeps today's name-gating.
         if reach_target is not None and enforcer.policy.declares_tool_reach():
-            # Decide on the reach key, but keep ``name`` as the call/guard identity
-            # (policy_key), so a guard scoped to the tool's function name still fires.
+            # Decide on the reach key with the same {agent, target, via} reach args
+            # the handoff seam uses (ReachGate._decide), so a reach constraint reads
+            # args.target/args.via identically at both seams. ``name`` stays the
+            # call/guard identity (policy_key), so a guard scoped to the tool's
+            # function name still fires, and the sub-agent still receives its input.
             policy_key = agent_target_key("tool", reach_target)
+            policy_args: dict[str, Any] | None = {
+                "agent": enforcer.agent_name,
+                "target": reach_target,
+                "via": "tool",
+            }
             render_error = _render_reach_error(reach_target)
         else:
             policy_key = None
+            policy_args = None
             render_error = _render_error
 
         def invoke(final: dict[str, Any]) -> Any:
@@ -177,6 +186,7 @@ def wrap_tool(
             invoke=invoke,
             render_error=render_error,
             policy_key=policy_key,
+            policy_args=policy_args,
         )
 
     wrapped = copy.copy(tool)

--- a/hexgate/adapters/openai/tools.py
+++ b/hexgate/adapters/openai/tools.py
@@ -21,12 +21,63 @@ from agents.tool import ToolContext
 from hexgate.approvals import ApprovalHandler
 from hexgate.guards.runner import run_guarded_async
 from hexgate.guards.types import ToolPipeline
+from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.models import agent_target_key
+from hexgate.security.naming import canonical_name
+
+try:
+    # The Agents SDK tags an ``Agent.as_tool()`` tool with its origin (the target
+    # agent's name), which lets us gate the reach edge under ``agent.tool:<target>``.
+    from agents.tool import ToolOriginType, get_function_tool_origin
+
+    _CAN_DETECT_AGENT_TOOLS = True
+except ImportError:  # older SDK without tool-origin metadata
+    _CAN_DETECT_AGENT_TOOLS = False
+
+
+def _agent_tool_target(tool: FunctionTool) -> str | None:
+    """Canonical target-agent name if ``tool`` is an ``Agent.as_tool()``, else ``None``.
+
+    Reads the SDK's public tool-origin metadata so an agent reached *as a tool*
+    can be gated under its reach key rather than its plain tool name. Returns
+    ``None`` for an ordinary function tool, or on an SDK too old to expose the
+    origin (capability fallback — the caller keeps name-gating)."""
+    if not _CAN_DETECT_AGENT_TOOLS:
+        return None
+    origin = get_function_tool_origin(tool)
+    if (
+        origin is not None
+        and origin.type is ToolOriginType.AGENT_AS_TOOL
+        and origin.agent_name
+    ):
+        return canonical_name(origin.agent_name)
+    return None
 
 
 def _render_error(decision: Any) -> str:
     """OpenAI renders a blocked decision as a string tool result."""
     return decision.as_error_message()
+
+
+def _render_reach_error(target: str):
+    """Model-facing renderer for a denied/held agent-as-tool reach.
+
+    Keeps :meth:`Decision.as_error_message`'s ``[marker] …`` shape so adapters and
+    the dashboard still key off the ``policy_denied`` / ``approval_required``
+    marker, but names the bare target agent instead of the lowered
+    ``agent.tool:<target>`` key — the same no-leak stance as
+    :class:`~hexgate.security.agent_gate.ReachNotAllowedError`."""
+
+    def render(decision: Any) -> str:
+        marker = decision.error_type or decision.outcome.value
+        if decision.outcome is DecisionOutcome.NEEDS_APPROVAL:
+            body = f"reach to agent {target!r} requires human approval before it runs"
+        else:
+            body = f"reach to agent {target!r} is not permitted by this agent's policy"
+        return f"[{marker}] {body}. The sub-agent was not invoked."
+
+    return render
 
 
 def _parse_args(raw: str) -> dict[str, Any] | None:
@@ -60,6 +111,11 @@ def wrap_tool(
 
     name = tool.name
     original_invoke = tool.on_invoke_tool
+    # An ``Agent.as_tool()`` is a reach edge, not an ordinary tool. When the
+    # policy declares reach we gate it under its reach key ``agent.tool:<target>``
+    # (closed-world, ``via``/constraints honored) rather than its tool name.
+    # ``None`` for a normal tool, or an SDK too old to expose the origin.
+    reach_target = _agent_tool_target(tool)
     # Without guards nothing can rewrite the args, so we forward the model's
     # payload byte-for-byte. Re-serializing would be a silent change on every
     # call (reformatted whitespace, collapsed duplicate keys, 1e400 -> Infinity,
@@ -69,6 +125,20 @@ def wrap_tool(
     @functools.wraps(original_invoke, updated=())
     async def guarded_invoke(ctx: ToolContext[Any], input: str) -> Any:
         parsed = _parse_args(input)  # None when the payload is not a JSON object
+        # Engagement is read here, per call, so a hot-reloaded policy that adds or
+        # drops a via:tool target is honored on the next call. Gate under the reach
+        # key only when the policy declares *tool* reach (an ``agent.tool:`` key) —
+        # not merely any ``agents`` block: agent keys are closed-world, so engaging
+        # on a handoff-only policy would deny every as-tool with no diagnostic. A
+        # policy that declares no via:tool target keeps today's name-gating.
+        if reach_target is not None and enforcer.policy.declares_tool_reach():
+            # Decide on the reach key, but keep ``name`` as the call/guard identity
+            # (policy_key), so a guard scoped to the tool's function name still fires.
+            policy_key = agent_target_key("tool", reach_target)
+            render_error = _render_reach_error(reach_target)
+        else:
+            policy_key = None
+            render_error = _render_error
 
         def invoke(final: dict[str, Any]) -> Any:
             if not has_guards:
@@ -105,7 +175,8 @@ def wrap_tool(
             pipeline=pipeline,
             approval_handler=approval_handler,
             invoke=invoke,
-            render_error=_render_error,
+            render_error=render_error,
+            policy_key=policy_key,
         )
 
     wrapped = copy.copy(tool)

--- a/hexgate/adapters/openai/tools.py
+++ b/hexgate/adapters/openai/tools.py
@@ -19,7 +19,7 @@ from agents import FunctionTool
 from agents.tool import ToolContext
 
 from hexgate.approvals import ApprovalHandler
-from hexgate.guards.runner import run_guarded_async
+from hexgate.guards.runner import RenderError, run_guarded_async
 from hexgate.guards.types import ToolPipeline
 from hexgate.security.decision import DecisionOutcome
 from hexgate.security.enforcer import PolicyEnforcer
@@ -143,11 +143,15 @@ def wrap_tool(
                 "target": reach_target,
                 "via": "tool",
             }
-            render_error = _render_reach_error(reach_target)
+            # Reach wording renders *only* the policy denial (render_policy_error);
+            # a guard's Halt on the same call still renders through _render_error, so
+            # an after-guard rejecting the sub-agent's output isn't mislabeled as a
+            # reach denial ("the sub-agent was not invoked" when it in fact ran).
+            render_policy_error: RenderError | None = _render_reach_error(reach_target)
         else:
             policy_key = None
             policy_args = None
-            render_error = _render_error
+            render_policy_error = None
 
         def invoke(final: dict[str, Any]) -> Any:
             if not has_guards:
@@ -184,9 +188,10 @@ def wrap_tool(
             pipeline=pipeline,
             approval_handler=approval_handler,
             invoke=invoke,
-            render_error=render_error,
+            render_error=_render_error,
             policy_key=policy_key,
             policy_args=policy_args,
+            render_policy_error=render_policy_error,
         )
 
     wrapped = copy.copy(tool)

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -23,7 +23,10 @@ from hexgate.approvals import ApprovalHandler
 from hexgate.cloud.client import HexgateClient, HexgateConfig
 from hexgate.config.env import resolve_api_key
 from hexgate.guards.types import build_pipeline
-from hexgate.security.agent_gate import warn_if_admission_unenforced
+from hexgate.security.agent_gate import (
+    warn_if_admission_unenforced,
+    warn_if_reach_unenforced,
+)
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
@@ -92,6 +95,9 @@ def wrap_pydantic_agent(
         resolved.engine, agent_name=agent_name, api_key=resolved_key
     )
     warn_if_admission_unenforced(
+        resolved.engine, framework="pydantic_ai", agent_name=agent_name
+    )
+    warn_if_reach_unenforced(
         resolved.engine, framework="pydantic_ai", agent_name=agent_name
     )
     pipeline = build_pipeline(guards, observer=guard_observer)

--- a/hexgate/adapters/pydantic_ai/wrapper.py
+++ b/hexgate/adapters/pydantic_ai/wrapper.py
@@ -27,6 +27,7 @@ from hexgate.security.agent_gate import warn_if_admission_unenforced
 from hexgate.security.bans import resolve_ban_gate
 from hexgate.security.binding import PolicyBinding, resolve_policy
 from hexgate.security.enforcer import build_enforcer
+from hexgate.security.naming import canonical_agent_name
 
 if TYPE_CHECKING:
     from hexgate.guards.types import Guard, GuardObserver
@@ -80,7 +81,7 @@ def wrap_pydantic_agent(
             "No API key provided. Pass api_key= explicitly or set the HEXGATE_API_KEY environment variable."
         )
 
-    agent_name = getattr(agent, "name", None) or "default"
+    agent_name = canonical_agent_name(agent)
     tools = _extract_tools(agent)
 
     # One client shared by the policy and ban resolvers — avoids a second

--- a/hexgate/agents/factory.py
+++ b/hexgate/agents/factory.py
@@ -604,7 +604,10 @@ class HexgateAgent:
                 wrapped.append(tool_spec)
         rebuilt = self.with_tools(wrapped)
         if enforcer is not None:
-            from hexgate.security.agent_gate import resolve_agent_gate
+            from hexgate.security.agent_gate import (
+                resolve_agent_gate,
+                warn_if_reach_unenforced,
+            )
 
             # The binding pairs the enforcer the tools just closed over with the
             # refresh source, so refresh_policy() can swap the policy in place.
@@ -613,6 +616,12 @@ class HexgateAgent:
             # swaps the policy is reflected on the next run entry too.
             rebuilt._agent_gate = resolve_agent_gate(
                 enforcer, approval_handler=approval_handler
+            )
+            # Admission is enforced here, but reach is not: the native agent is a
+            # single graph with no agent-to-agent handoff seam. Warn if the policy
+            # declares reach, so it is not a silent no-op.
+            warn_if_reach_unenforced(
+                enforcer.policy, framework="native", agent_name=self.name or "default"
             )
         else:
             # Guards-only path: no enforcer, so no admission. Clear any gate a

--- a/hexgate/guards/runner.py
+++ b/hexgate/guards/runner.py
@@ -359,8 +359,15 @@ async def run_guarded_async(
     approval_handler: "ApprovalHandler | None",
     invoke: Callable[[dict[str, Any]], Awaitable[Any]],
     render_error: RenderError,
+    policy_key: str | None = None,
 ) -> Any:
-    """Run one guarded tool call, async. See module docstring for the order."""
+    """Run one guarded tool call, async. See module docstring for the order.
+
+    ``policy_key`` overrides the key the *policy* decision uses while ``tool_name``
+    still identifies the call for guards and audit-notify. The OpenAI adapter uses
+    this to gate an agent-as-tool under its reach key ``agent.tool:<target>``
+    without renaming the tool for guards; every other caller leaves it ``None`` so
+    the tool name governs both."""
     context = get_current_context() if _has_guards(pipeline) else None
     call = _new_call(tool_name, args, enforcer, context)
     mods: list[Modification] = []
@@ -399,7 +406,7 @@ async def run_guarded_async(
         # policy's are independent gates: if both fire on one call, the handler
         # is prompted for each. We do not merge them, because a guard's approval
         # must not silently satisfy the policy's separate requirement.
-        decision = enforcer.decide(call.tool_name, call.args)
+        decision = enforcer.decide(policy_key or call.tool_name, call.args)
         if not decision.allowed:
             # Counts the gate firing; whether it's granted is a separate count.
             _record_run_decision(decision.outcome)
@@ -538,8 +545,10 @@ def run_guarded_sync(
     approval_handler: "ApprovalHandler | None",
     invoke: Callable[[dict[str, Any]], Any],
     render_error: RenderError,
+    policy_key: str | None = None,
 ) -> Any:
-    """Run one guarded tool call, sync. Mirrors :func:`run_guarded_async`."""
+    """Run one guarded tool call, sync. Mirrors :func:`run_guarded_async`
+    (including ``policy_key``)."""
     context = get_current_context() if _has_guards(pipeline) else None
     call = _new_call(tool_name, args, enforcer, context)
     mods: list[Modification] = []
@@ -572,7 +581,7 @@ def run_guarded_sync(
                 call = _apply_pre(call, guard, outcome, mods)
 
     if enforcer is not None:
-        decision = enforcer.decide(call.tool_name, call.args)
+        decision = enforcer.decide(policy_key or call.tool_name, call.args)
         if not decision.allowed:
             # See the async path: the gate firing is counted, the grant is not.
             _record_run_decision(decision.outcome)

--- a/hexgate/guards/runner.py
+++ b/hexgate/guards/runner.py
@@ -361,6 +361,7 @@ async def run_guarded_async(
     render_error: RenderError,
     policy_key: str | None = None,
     policy_args: Mapping[str, Any] | None = None,
+    render_policy_error: RenderError | None = None,
 ) -> Any:
     """Run one guarded tool call, async. See module docstring for the order.
 
@@ -370,7 +371,12 @@ async def run_guarded_async(
     agent-as-tool under its reach key ``agent.tool:<target>`` with the same
     ``{agent, target, via}`` reach args the handoff seam decides on — so a reach
     constraint behaves identically at both seams — without renaming the tool or
-    rewriting the sub-agent's input. Every other caller leaves them ``None``."""
+    rewriting the sub-agent's input. Every other caller leaves them ``None``.
+
+    ``render_policy_error`` renders *only* a policy denial; ``render_error`` still
+    renders guard halts. The reach adapters pass reach-specific wording here so a
+    guard's ``Halt`` on the same call is not mislabeled as a reach denial; when it
+    is ``None`` the policy denial falls back to ``render_error``."""
     context = get_current_context() if _has_guards(pipeline) else None
     call = _new_call(tool_name, args, enforcer, context)
     mods: list[Modification] = []
@@ -427,7 +433,7 @@ async def run_guarded_async(
                 # consumer never reads it as a rewrite that took effect.
                 if mods:
                     _notify(pipeline, call, mods, blocked=True)
-                return render_error(decision)
+                return (render_policy_error or render_error)(decision)
 
     # Before dispatch, not after: see _record_run_execution.
     _record_run_execution(call.tool_name)
@@ -553,9 +559,10 @@ def run_guarded_sync(
     render_error: RenderError,
     policy_key: str | None = None,
     policy_args: Mapping[str, Any] | None = None,
+    render_policy_error: RenderError | None = None,
 ) -> Any:
     """Run one guarded tool call, sync. Mirrors :func:`run_guarded_async`
-    (including ``policy_key`` / ``policy_args``)."""
+    (including ``policy_key`` / ``policy_args`` / ``render_policy_error``)."""
     context = get_current_context() if _has_guards(pipeline) else None
     call = _new_call(tool_name, args, enforcer, context)
     mods: list[Modification] = []
@@ -605,7 +612,7 @@ def run_guarded_sync(
                 # blocked, never as one that took effect.
                 if mods:
                     _notify(pipeline, call, mods, blocked=True)
-                return render_error(decision)
+                return (render_policy_error or render_error)(decision)
 
     # See the async path: counted after the decision, before dispatch.
     _record_run_execution(call.tool_name)

--- a/hexgate/guards/runner.py
+++ b/hexgate/guards/runner.py
@@ -360,14 +360,17 @@ async def run_guarded_async(
     invoke: Callable[[dict[str, Any]], Awaitable[Any]],
     render_error: RenderError,
     policy_key: str | None = None,
+    policy_args: Mapping[str, Any] | None = None,
 ) -> Any:
     """Run one guarded tool call, async. See module docstring for the order.
 
-    ``policy_key`` overrides the key the *policy* decision uses while ``tool_name``
-    still identifies the call for guards and audit-notify. The OpenAI adapter uses
-    this to gate an agent-as-tool under its reach key ``agent.tool:<target>``
-    without renaming the tool for guards; every other caller leaves it ``None`` so
-    the tool name governs both."""
+    ``policy_key`` / ``policy_args`` override the key and args the *policy*
+    decision uses while ``tool_name`` and the model's args still identify the call
+    for guards, invoke, and audit-notify. The OpenAI adapter uses these to gate an
+    agent-as-tool under its reach key ``agent.tool:<target>`` with the same
+    ``{agent, target, via}`` reach args the handoff seam decides on — so a reach
+    constraint behaves identically at both seams — without renaming the tool or
+    rewriting the sub-agent's input. Every other caller leaves them ``None``."""
     context = get_current_context() if _has_guards(pipeline) else None
     call = _new_call(tool_name, args, enforcer, context)
     mods: list[Modification] = []
@@ -406,7 +409,10 @@ async def run_guarded_async(
         # policy's are independent gates: if both fire on one call, the handler
         # is prompted for each. We do not merge them, because a guard's approval
         # must not silently satisfy the policy's separate requirement.
-        decision = enforcer.decide(policy_key or call.tool_name, call.args)
+        decision = enforcer.decide(
+            policy_key or call.tool_name,
+            call.args if policy_args is None else policy_args,
+        )
         if not decision.allowed:
             # Counts the gate firing; whether it's granted is a separate count.
             _record_run_decision(decision.outcome)
@@ -546,9 +552,10 @@ def run_guarded_sync(
     invoke: Callable[[dict[str, Any]], Any],
     render_error: RenderError,
     policy_key: str | None = None,
+    policy_args: Mapping[str, Any] | None = None,
 ) -> Any:
     """Run one guarded tool call, sync. Mirrors :func:`run_guarded_async`
-    (including ``policy_key``)."""
+    (including ``policy_key`` / ``policy_args``)."""
     context = get_current_context() if _has_guards(pipeline) else None
     call = _new_call(tool_name, args, enforcer, context)
     mods: list[Modification] = []
@@ -581,7 +588,10 @@ def run_guarded_sync(
                 call = _apply_pre(call, guard, outcome, mods)
 
     if enforcer is not None:
-        decision = enforcer.decide(policy_key or call.tool_name, call.args)
+        decision = enforcer.decide(
+            policy_key or call.tool_name,
+            call.args if policy_args is None else policy_args,
+        )
         if not decision.allowed:
             # See the async path: the gate firing is counted, the grant is not.
             _record_run_decision(decision.outcome)

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -22,6 +22,7 @@ from hexgate.security.bans import (
 from hexgate.security.agent_gate import (
     AgentGate,
     AgentNotAdmittedError,
+    HandoffDepthExceededError,
     ReachGate,
     ReachNotAllowedError,
     resolve_agent_gate,
@@ -161,6 +162,7 @@ __all__ = [
     "AgentBannedError",
     "AgentGate",
     "AgentNotAdmittedError",
+    "HandoffDepthExceededError",
     "ReachGate",
     "ReachNotAllowedError",
     "AgentPolicy",

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -1,9 +1,23 @@
 """Security helpers for policies and enforcement."""
 
-from hexgate.security.errors import (
-    AgentBannedError,
-    ApprovalRequiredError,
-    PolicyDeniedError,
+from hexgate.security.agent_gate import (
+    AgentGate,
+    AgentNotAdmittedError,
+    HandoffDepthExceededError,
+    ReachGate,
+    ReachNotAllowedError,
+    resolve_agent_gate,
+    resolve_reach_gate,
+    warn_if_admission_unenforced,
+    warn_if_reach_unenforced,
+    warn_if_tool_reach_unenforced,
+)
+from hexgate.security.analyzer import (
+    PolicyLint,
+    analyze,
+    analyze_project,
+    check,
+    check_project,
 )
 from hexgate.security.bans import (
     EMPTY_BAN_SET,
@@ -19,17 +33,45 @@ from hexgate.security.bans import (
     get_ban_source,
     resolve_ban_gate,
 )
-from hexgate.security.agent_gate import (
-    AgentGate,
-    AgentNotAdmittedError,
-    HandoffDepthExceededError,
-    ReachGate,
-    ReachNotAllowedError,
-    resolve_agent_gate,
-    resolve_reach_gate,
-    warn_if_admission_unenforced,
-    warn_if_reach_unenforced,
-    warn_if_tool_reach_unenforced,
+from hexgate.security.binding import (
+    PolicyBinding,
+    PolicyBindingError,
+    ResolvedPolicy,
+    resolve_policy,
+)
+from hexgate.security.builder import C, PolicyBuilder, RolePolicyBuilder
+from hexgate.security.bundle import (
+    BundleIntegrityError,
+    BundleLoadError,
+    BundleSignatureError,
+    PolicyBundle,
+    SignedBundle,
+    build_signed_bundle,
+)
+from hexgate.security.constraints import (
+    Constraint,
+    ConstraintParseError,
+    check_constraints,
+    evaluate_constraint,
+    parse_constraint,
+)
+from hexgate.security.decision import (
+    Decision,
+    DecisionOutcome,
+    PolicyEngine,
+    Verdict,
+    combine_role_verdicts,
+)
+from hexgate.security.errors import (
+    AgentBannedError,
+    ApprovalRequiredError,
+    PolicyDeniedError,
+)
+from hexgate.security.linker import (
+    effective_policy_by_role,
+    link,
+    link_policy_set,
+    resolve_for_project,
 )
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
@@ -43,42 +85,22 @@ from hexgate.security.models import (
     ToolPolicy,
     agent_target_key,
 )
-from hexgate.security.constraints import (
-    Constraint,
-    ConstraintParseError,
-    check_constraints,
-    evaluate_constraint,
-    parse_constraint,
+from hexgate.security.module_loader import (
+    ModuleLoader,
+    load_local_modules,
+    load_roles,
 )
-from hexgate.security.binding import (
-    PolicyBinding,
-    PolicyBindingError,
-    ResolvedPolicy,
-    resolve_policy,
-)
-from hexgate.security.bundle import (
-    BundleIntegrityError,
-    BundleLoadError,
-    BundleSignatureError,
-    PolicyBundle,
-    SignedBundle,
-    build_signed_bundle,
-)
-from hexgate.security.signing import (
-    SignatureError,
-    decode_key,
-    encode_key,
-    generate_keypair,
-    public_key_for,
-    sign_bytes,
-    verify_bytes,
-)
-from hexgate.security.decision import (
-    Decision,
-    DecisionOutcome,
-    PolicyEngine,
-    Verdict,
-    combine_role_verdicts,
+from hexgate.security.modules import (
+    DEFAULT_AGENT,
+    AgentBinding,
+    LayerKind,
+    LinkError,
+    LinkResult,
+    ModuleContent,
+    ProjectLinkResult,
+    Provenance,
+    RoleMatrix,
+    RuleTrace,
 )
 from hexgate.security.policy import (
     authorize_tool_call,
@@ -99,36 +121,6 @@ from hexgate.security.policy_set import (
     load_policy_set,
     load_policy_set_from_dict,
 )
-from hexgate.security.modules import (
-    DEFAULT_AGENT,
-    AgentBinding,
-    LayerKind,
-    LinkError,
-    LinkResult,
-    ModuleContent,
-    ProjectLinkResult,
-    Provenance,
-    RoleMatrix,
-    RuleTrace,
-)
-from hexgate.security.linker import (
-    effective_policy_by_role,
-    link,
-    link_policy_set,
-    resolve_for_project,
-)
-from hexgate.security.analyzer import (
-    PolicyLint,
-    analyze,
-    analyze_project,
-    check,
-    check_project,
-)
-from hexgate.security.module_loader import (
-    ModuleLoader,
-    load_local_modules,
-    load_roles,
-)
 from hexgate.security.rego import compile_default_only, compile_to_rego
 from hexgate.security.rego_wasm import (
     DEFAULT_ENTRYPOINTS,
@@ -137,6 +129,15 @@ from hexgate.security.rego_wasm import (
     WasmCompileError,
     compile_to_wasm,
 )
+from hexgate.security.signing import (
+    SignatureError,
+    decode_key,
+    encode_key,
+    generate_keypair,
+    public_key_for,
+    sign_bytes,
+    verify_bytes,
+)
 from hexgate.security.source import (
     BundleDirPolicySource,
     PlatformPolicySource,
@@ -144,18 +145,17 @@ from hexgate.security.source import (
     PolicySource,
     YamlPolicySource,
 )
-from hexgate.security.wasm_engine import (
-    DEFAULT_ENTRYPOINT,
-    RegoVerdict,
-    WasmEvalError,
-    WasmPolicy,
-)
-from hexgate.security.builder import C, PolicyBuilder, RolePolicyBuilder
 from hexgate.security.testing import (
     assert_allows,
     assert_denies,
     assert_needs_approval,
     run_namespace,
+)
+from hexgate.security.wasm_engine import (
+    DEFAULT_ENTRYPOINT,
+    RegoVerdict,
+    WasmEvalError,
+    WasmPolicy,
 )
 
 __all__ = [

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -29,6 +29,7 @@ from hexgate.security.agent_gate import (
     resolve_reach_gate,
     warn_if_admission_unenforced,
     warn_if_reach_unenforced,
+    warn_if_tool_reach_unenforced,
 )
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
@@ -279,4 +280,5 @@ __all__ = [
     "resolve_reach_gate",
     "warn_if_admission_unenforced",
     "warn_if_reach_unenforced",
+    "warn_if_tool_reach_unenforced",
 ]

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -22,8 +22,12 @@ from hexgate.security.bans import (
 from hexgate.security.agent_gate import (
     AgentGate,
     AgentNotAdmittedError,
+    ReachGate,
+    ReachNotAllowedError,
     resolve_agent_gate,
+    resolve_reach_gate,
     warn_if_admission_unenforced,
+    warn_if_reach_unenforced,
 )
 from hexgate.security.models import (
     AGENT_RUN_TOOL,
@@ -157,6 +161,8 @@ __all__ = [
     "AgentBannedError",
     "AgentGate",
     "AgentNotAdmittedError",
+    "ReachGate",
+    "ReachNotAllowedError",
     "AgentPolicy",
     "AgentTargetPolicy",
     "AgentVia",
@@ -268,5 +274,7 @@ __all__ = [
     "load_policy_set",
     "load_policy_set_from_dict",
     "parse_constraint",
+    "resolve_reach_gate",
     "warn_if_admission_unenforced",
+    "warn_if_reach_unenforced",
 ]

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -157,6 +157,24 @@ class ReachNotAllowedError(RuntimeError):
         )
 
 
+class HandoffDepthExceededError(Exception):
+    """Raised when a run's handoff chain grows past its depth cap.
+
+    A handoff transfers control forward (A → B → C …), so the count of handoffs
+    within one run is the depth of the chain. The cap is a runaway guard,
+    independent of reach policy: even an all-allowed chain stops here. Carries the
+    observed ``depth`` and the ``cap`` it exceeded.
+    """
+
+    def __init__(self, depth: int, cap: int) -> None:
+        self.depth = depth
+        self.cap = cap
+        super().__init__(
+            f"handoff depth {depth} exceeds the cap of {cap}; refusing further "
+            "delegation in this run"
+        )
+
+
 # ---- gates ----------------------------------------------------------------
 
 

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -47,6 +47,11 @@ _log = logging.getLogger(__name__)
 # fail open in silence. Deduped so a long-lived process logs it once, not per run.
 _admission_unenforced_warned: set[tuple[str, str]] = set()
 _reach_unenforced_warned: set[tuple[str, str]] = set()
+# Separate from _reach_unenforced_warned: the two reach warnings describe distinct
+# gaps (no reach at all vs. handoff-only, so agent-as-tool is unenforced). Sharing a
+# set would let whichever fires first suppress the other for the same (framework,
+# agent), hiding the second gap.
+_tool_reach_unenforced_warned: set[tuple[str, str]] = set()
 
 
 def warn_if_admission_unenforced(
@@ -106,7 +111,7 @@ def warn_if_tool_reach_unenforced(
     declared (``declares_tool_reach``), so a handoff-only policy is not warned."""
     if not engine.declares_tool_reach():
         return
-    if not _mark_warned(_reach_unenforced_warned, framework, agent_name):
+    if not _mark_warned(_tool_reach_unenforced_warned, framework, agent_name):
         return
     _log.warning(
         "policy for agent %r declares agent-as-tool reach ('agents' target with "
@@ -180,13 +185,18 @@ class ReachNotAllowedError(RuntimeError):
         )
 
 
-class HandoffDepthExceededError(Exception):
+class HandoffDepthExceededError(RuntimeError):
     """Raised when a run's handoff chain grows past its depth cap.
 
     A handoff transfers control forward (A → B → C …), so the count of handoffs
     within one run is the depth of the chain. The cap is a runaway guard,
     independent of reach policy: even an all-allowed chain stops here. Carries the
     observed ``depth`` and the ``cap`` it exceeded.
+
+    Subclasses ``RuntimeError`` for the same reason as :class:`AgentNotAdmittedError`
+    and :class:`ReachNotAllowedError`: it aborts the run at the same handoff seam, so
+    a caller that handles run refusals with ``except RuntimeError`` catches this one
+    too rather than letting the depth cap escape uncaught.
     """
 
     def __init__(self, depth: int, cap: int) -> None:

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -94,6 +94,29 @@ def warn_if_reach_unenforced(
     )
 
 
+def warn_if_tool_reach_unenforced(
+    engine: PolicyEngine, *, framework: str, agent_name: str
+) -> None:
+    """Warn once when a policy declares agent-as-tool reach on an adapter that
+    enforces handoff reach but not agent-as-tool reach (OpenAI).
+
+    OpenAI gates handoffs at ``on_handoff`` but ``Agent.as_tool`` produces a plain
+    function tool with no link back to the target agent, so ``via: tool`` targets
+    are not enforceable at that seam. Fires only when a tool-via target is actually
+    declared (``declares_tool_reach``), so a handoff-only policy is not warned."""
+    if not engine.declares_tool_reach():
+        return
+    if not _mark_warned(_reach_unenforced_warned, framework, agent_name):
+        return
+    _log.warning(
+        "policy for agent %r declares agent-as-tool reach ('agents' target with "
+        "via: tool), but the %s adapter enforces handoff reach only; as-tool "
+        "delegations will proceed without a reach check.",
+        agent_name,
+        framework,
+    )
+
+
 def _mark_warned(seen: set[tuple[str, str]], framework: str, agent_name: str) -> bool:
     """Record ``(framework, agent_name)`` in ``seen``; return True the first time."""
     key = (framework, agent_name)
@@ -237,6 +260,28 @@ class _PolicyGate:
             )
             return False
 
+    def _cleared_sync(self, decision: Decision) -> bool:
+        """Whether ``decision`` clears the gate (sync): allowed outright, or a
+        NEEDS_APPROVAL that a handler approves. The one place the pass/refuse
+        condition lives, so admission and reach can never drift."""
+        if decision.allowed:
+            return True
+        return (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and self._resolve_approval_sync(decision)
+        )
+
+    async def _cleared_async(self, decision: Decision) -> bool:
+        """Async mirror of :meth:`_cleared_sync` — awaits an async handler."""
+        if decision.allowed:
+            return True
+        return (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and await self._resolve_approval_async(decision)
+        )
+
 
 class AgentGate(_PolicyGate):
     """Reduce an agent run to an admit/refuse verdict via the enforcer.
@@ -259,30 +304,16 @@ class AgentGate(_PolicyGate):
         if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and self._resolve_approval_sync(decision)
-        ):
-            return
-        raise AgentNotAdmittedError(decision)
+        if not self._cleared_sync(decision):
+            raise AgentNotAdmittedError(decision)
 
     async def check_admission_async(self) -> None:
         """Async mirror of :meth:`check_admission` — awaits an async handler."""
         if not self._enforcer.policy.declares_admission():
             return
         decision = self._decide()
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and await self._resolve_approval_async(decision)
-        ):
-            return
-        raise AgentNotAdmittedError(decision)
+        if not await self._cleared_async(decision):
+            raise AgentNotAdmittedError(decision)
 
     def _decide(self) -> Decision:
         # agent name rides in args so a constraint can read args.agent; the
@@ -313,30 +344,16 @@ class ReachGate(_PolicyGate):
         if not self._enforcer.policy.declares_reach():
             return
         decision = self._decide(target, via)
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and self._resolve_approval_sync(decision)
-        ):
-            return
-        raise ReachNotAllowedError(decision)
+        if not self._cleared_sync(decision):
+            raise ReachNotAllowedError(decision)
 
     async def check_reach_async(self, target: str, *, via: AgentVia) -> None:
         """Async mirror of :meth:`check_reach` — awaits an async handler."""
         if not self._enforcer.policy.declares_reach():
             return
         decision = self._decide(target, via)
-        if decision.allowed:
-            return
-        if (
-            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
-            and self._approval_handler is not None
-            and await self._resolve_approval_async(decision)
-        ):
-            return
-        raise ReachNotAllowedError(decision)
+        if not await self._cleared_async(decision):
+            raise ReachNotAllowedError(decision)
 
     def _decide(self, target: str, via: AgentVia) -> Decision:
         # target/via ride in args so a constraint can read args.target / args.via;

--- a/hexgate/security/agent_gate.py
+++ b/hexgate/security/agent_gate.py
@@ -1,20 +1,24 @@
-"""Agent-level admission enforcement.
+"""Agent-level admission and reach enforcement.
 
-:class:`AgentGate` is to a whole agent run what the egress :class:`~hexgate.egress.gate.Gate`
-is to a network request: one place that reuses :meth:`PolicyEnforcer.decide` for
-a non-tool subject. It gates *admission* — may this caller, in this role, run this
-agent — by deciding the synthetic ``agent.run`` key at run entry, before the model
-sees anything.
+Two gates that are to a whole agent run what the egress :class:`~hexgate.egress.gate.Gate`
+is to a network request: one place that reuses :meth:`PolicyEnforcer.decide` for a
+non-tool subject, folds approval, and fails closed.
 
-Engagement is opt-in. The gate enforces only when the current policy declares an
-``admission`` block anywhere, read per run via ``PolicyEngine.declares_admission()``
-(not at build time), so an agent whose policy never mentions admission runs exactly
-as before, and a hot-reloaded policy that adds or drops admission is honored on the
-next run. Once admission is declared, agent keys are closed-world (R-AGENT-002): a
-caller whose role is not granted admission is refused, so a silent co-role can
-neither admit an unknown caller nor defeat an explicit deny. A denial is
-caller-facing: admission fires before the model runs, so there is no tool result to
-render into, the run simply does not start.
+* :class:`AgentGate` gates *admission* — may this caller, in this role, run this
+  agent at all — by deciding the synthetic ``agent.run`` key at run entry, before
+  the model sees anything.
+* :class:`ReachGate` gates *reach* — may this agent hand off to (or delegate
+  as-tool to) another agent — by deciding the synthetic ``agent.handoff:<target>``
+  / ``agent.tool:<target>`` key at the handoff/delegation seam.
+
+Both share one shape (:class:`_PolicyGate`): hold the enforcer + approval handler,
+decide, fold approval, fail closed. Engagement is opt-in and read per run from the
+policy (``declares_admission()`` / ``declares_reach()``), not frozen at build time,
+so a hot-reloaded policy that adds or drops a block is honored on the next run and
+an agent whose policy never mentions admission/reach runs exactly as before. Once a
+block is declared, agent keys are closed-world (R-AGENT-002): a caller/agent not
+granted the key is refused, so a silent co-role can neither grant an unknown subject
+nor defeat an explicit deny.
 """
 
 from __future__ import annotations
@@ -24,19 +28,25 @@ from inspect import isawaitable
 from typing import TYPE_CHECKING, Any
 
 from hexgate.security.decision import Decision, DecisionOutcome
-from hexgate.security.models import AGENT_RUN_TOOL
+from hexgate.security.models import AGENT_RUN_TOOL, agent_target_key
+from hexgate.security.naming import canonical_name
 
 if TYPE_CHECKING:
     from hexgate.approvals import ApprovalHandler
     from hexgate.security.decision import PolicyEngine
     from hexgate.security.enforcer import PolicyEnforcer
+    from hexgate.security.models import AgentVia
 
 _log = logging.getLogger(__name__)
 
-# Dedupe key: admission is enforced only on the native HexgateAgent in A2, so the
-# framework adapters warn once per (framework, agent) that a declared admission
-# block is not enforced there yet. Per-adapter run-entry admission lands in A3.
+
+# ---- interim adapter warnings ---------------------------------------------
+#
+# Admission and reach are wired into some adapters incrementally. Where an adapter
+# cannot enforce a declared block yet, warn once per (framework, agent) rather than
+# fail open in silence. Deduped so a long-lived process logs it once, not per run.
 _admission_unenforced_warned: set[tuple[str, str]] = set()
+_reach_unenforced_warned: set[tuple[str, str]] = set()
 
 
 def warn_if_admission_unenforced(
@@ -44,28 +54,56 @@ def warn_if_admission_unenforced(
 ) -> None:
     """Warn once when a policy declares admission on an adapter that can't enforce it.
 
-    Admission (the ``agent.run`` run-entry gate) is wired only into the native
-    :class:`~hexgate.agents.factory.HexgateAgent` in A2; the OpenAI/Google/
-    pydantic_ai/LangChain adapters check the ban gate at run entry but not
-    admission. Until per-adapter admission lands (A3), a declared ``admission``
-    block is a silent no-op on those adapters — so surface it loudly at wrap time
-    rather than fail open without a trace. No-op when the policy declares no
-    admission (the common case), and deduped per ``(framework, agent_name)`` so a
-    long-lived process logs it once, not per run."""
+    Admission (the ``agent.run`` run-entry gate) is not wired into every framework
+    adapter yet. Where it is not, a declared ``admission`` block is a silent no-op,
+    so surface it loudly at wrap time. No-op when the policy declares no admission
+    (the common case)."""
     if not engine.declares_admission():
         return
-    key = (framework, agent_name)
-    if key in _admission_unenforced_warned:
+    if not _mark_warned(_admission_unenforced_warned, framework, agent_name):
         return
-    _admission_unenforced_warned.add(key)
     _log.warning(
         "policy for agent %r declares an 'admission' block, but admission is not "
-        "enforced on the %s adapter yet (only on the native HexgateAgent); this run "
-        "will proceed without an admission check. Per-adapter admission lands in a "
-        "follow-up (A3); use the native agent to enforce admission today.",
+        "enforced on the %s adapter yet; this run will proceed without an admission "
+        "check. Use the native agent (or a supported adapter) to enforce admission.",
         agent_name,
         framework,
     )
+
+
+def warn_if_reach_unenforced(
+    engine: PolicyEngine, *, framework: str, agent_name: str
+) -> None:
+    """Warn once when a policy declares reach on an adapter that can't enforce it.
+
+    Reach (``agent.handoff:`` / ``agent.tool:``) is enforced only where the
+    framework exposes a target-agent handle at the seam (OpenAI handoffs, Google
+    sub-agents/AgentTool). On adapters that hide the target (pydantic_ai delegation
+    inside a tool body, the native single-graph agent), a declared reach block is a
+    silent no-op, so surface it loudly. No-op when no reach is declared."""
+    if not engine.declares_reach():
+        return
+    if not _mark_warned(_reach_unenforced_warned, framework, agent_name):
+        return
+    _log.warning(
+        "policy for agent %r declares agent reach ('agents' block), but reach is not "
+        "enforced on the %s adapter yet (it exposes no target-agent handle at the "
+        "handoff/delegation seam); handoffs will proceed without a reach check.",
+        agent_name,
+        framework,
+    )
+
+
+def _mark_warned(seen: set[tuple[str, str]], framework: str, agent_name: str) -> bool:
+    """Record ``(framework, agent_name)`` in ``seen``; return True the first time."""
+    key = (framework, agent_name)
+    if key in seen:
+        return False
+    seen.add(key)
+    return True
+
+
+# ---- errors ---------------------------------------------------------------
 
 
 class AgentNotAdmittedError(RuntimeError):
@@ -94,14 +132,44 @@ class AgentNotAdmittedError(RuntimeError):
         )
 
 
-class AgentGate:
-    """Reduce an agent run to an admit/refuse verdict via the enforcer.
+class ReachNotAllowedError(RuntimeError):
+    """Raised at a handoff/delegation seam when reach policy refuses the target.
 
-    Always built; whether it enforces is decided per run from
-    ``PolicyEngine.declares_admission()``, so its presence does not mean "enforce".
-    Mirrors the egress ``Gate``: hold the enforcer and the approval handler, decide,
-    fold approval, fail closed.
+    The reach counterpart to :class:`AgentNotAdmittedError` (and, like it, a
+    ``RuntimeError`` so ``except RuntimeError`` catches it): it fires when the
+    source agent may not reach the target agent, before control transfers. Carries
+    the :class:`Decision`.
+
+    Like admission, the message is subject-specific and does not interpolate
+    ``decision.reason`` — that reason is phrased against the lowered
+    ``agent.tool:``/``agent.handoff:`` reach key and would leak it; read it off
+    ``.decision`` instead. The bare target name is recovered from the reach key
+    (``agent.<via>:<target>``) so the message stays informative without exposing
+    the synthetic key shape.
     """
+
+    def __init__(self, decision: Decision) -> None:
+        self.decision = decision
+        _, _, target = decision.tool_name.partition(":")
+        super().__init__(
+            f"reach denied: this agent may not reach {target!r}. "
+            "The transfer did not happen."
+        )
+
+
+# ---- gates ----------------------------------------------------------------
+
+
+class _PolicyGate:
+    """Shared machinery for the admission and reach gates.
+
+    Holds the enforcer and approval handler and folds a NEEDS_APPROVAL verdict
+    through the handler (fail-closed on any error, or on an async handler reached
+    from a sync entrypoint). Subclasses add their subject-specific ``decide`` and
+    the engagement check; ``_SUBJECT`` labels the fail-closed log lines.
+    """
+
+    _SUBJECT = "policy"
 
     def __init__(
         self,
@@ -111,6 +179,55 @@ class AgentGate:
     ) -> None:
         self._enforcer = enforcer
         self._approval_handler = approval_handler
+
+    def _resolve_approval_sync(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                # A sync run entrypoint has no loop to await on; deny rather than
+                # silently skip the human check. Close the coroutine so it does
+                # not leak as a never-awaited warning.
+                if hasattr(result, "close"):
+                    result.close()
+                _log.error(
+                    "%s approval_handler is async on a sync run; denying (fail-closed)",
+                    self._SUBJECT,
+                )
+                return False
+            return bool(result)
+        except Exception:
+            _log.exception(
+                "%s approval_handler raised; denying (fail-closed)", self._SUBJECT
+            )
+            return False
+
+    async def _resolve_approval_async(self, decision: Decision) -> bool:
+        handler = self._approval_handler
+        if isinstance(handler, bool):
+            return handler
+        try:
+            result: Any = handler(decision)  # type: ignore[misc]
+            if isawaitable(result):
+                result = await result
+            return bool(result)
+        except Exception:
+            _log.exception(
+                "%s approval_handler raised; denying (fail-closed)", self._SUBJECT
+            )
+            return False
+
+
+class AgentGate(_PolicyGate):
+    """Reduce an agent run to an admit/refuse verdict via the enforcer.
+
+    Always built; whether it enforces is decided per run from
+    ``PolicyEngine.declares_admission()``, so its presence does not mean "enforce".
+    """
+
+    _SUBJECT = "admission"
 
     def check_admission(self) -> None:
         """Raise :class:`AgentNotAdmittedError` if admission policy refuses (sync).
@@ -156,40 +273,64 @@ class AgentGate:
             AGENT_RUN_TOOL, {"agent": self._enforcer.agent_name}
         )
 
-    def _resolve_approval_sync(self, decision: Decision) -> bool:
-        handler = self._approval_handler
-        if isinstance(handler, bool):
-            return handler
-        try:
-            result: Any = handler(decision)  # type: ignore[misc]
-            if isawaitable(result):
-                # A sync run entrypoint has no loop to await on; deny rather than
-                # silently skip the human check. Close the coroutine so it does
-                # not leak as a never-awaited warning.
-                if hasattr(result, "close"):
-                    result.close()
-                _log.error(
-                    "admission approval_handler is async on a sync run; "
-                    "denying (fail-closed)"
-                )
-                return False
-            return bool(result)
-        except Exception:
-            _log.exception("admission approval_handler raised; denying (fail-closed)")
-            return False
 
-    async def _resolve_approval_async(self, decision: Decision) -> bool:
-        handler = self._approval_handler
-        if isinstance(handler, bool):
-            return handler
-        try:
-            result: Any = handler(decision)  # type: ignore[misc]
-            if isawaitable(result):
-                result = await result
-            return bool(result)
-        except Exception:
-            _log.exception("admission approval_handler raised; denying (fail-closed)")
-            return False
+class ReachGate(_PolicyGate):
+    """Reduce an agent-to-agent reach to an allow/refuse verdict via the enforcer.
+
+    Always built; whether it enforces is decided per seam from
+    ``PolicyEngine.declares_reach()``. The source agent's policy governs reach, so
+    this gate is built from the source agent's enforcer and decides the target's
+    lowered key (``agent.handoff:<target>`` / ``agent.tool:<target>``).
+    """
+
+    _SUBJECT = "reach"
+
+    def check_reach(self, target: str, *, via: AgentVia) -> None:
+        """Raise :class:`ReachNotAllowedError` if reach to ``target`` is refused (sync).
+
+        ``target`` is the target agent's name (canonicalized here so it matches the
+        policy key derived from the same name). No-op when the current policy
+        declares no reach.
+        """
+        if not self._enforcer.policy.declares_reach():
+            return
+        decision = self._decide(target, via)
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and self._resolve_approval_sync(decision)
+        ):
+            return
+        raise ReachNotAllowedError(decision)
+
+    async def check_reach_async(self, target: str, *, via: AgentVia) -> None:
+        """Async mirror of :meth:`check_reach` — awaits an async handler."""
+        if not self._enforcer.policy.declares_reach():
+            return
+        decision = self._decide(target, via)
+        if decision.allowed:
+            return
+        if (
+            decision.outcome is DecisionOutcome.NEEDS_APPROVAL
+            and self._approval_handler is not None
+            and await self._resolve_approval_async(decision)
+        ):
+            return
+        raise ReachNotAllowedError(decision)
+
+    def _decide(self, target: str, via: AgentVia) -> Decision:
+        # target/via ride in args so a constraint can read args.target / args.via;
+        # the key encodes the same (canonical) target so the policy match is exact.
+        canonical = canonical_name(target)
+        return self._enforcer.decide(
+            agent_target_key(via, canonical),
+            {"agent": self._enforcer.agent_name, "target": canonical, "via": via},
+        )
+
+
+# ---- builders -------------------------------------------------------------
 
 
 def resolve_agent_gate(
@@ -206,3 +347,15 @@ def resolve_agent_gate(
     rebuilding the gate. A policy with no admission block makes every check a no-op.
     """
     return AgentGate(enforcer, approval_handler=approval_handler)
+
+
+def resolve_reach_gate(
+    enforcer: PolicyEnforcer,
+    *,
+    approval_handler: ApprovalHandler | None = None,
+) -> ReachGate:
+    """Build the reach gate for ``enforcer`` (the reach counterpart to
+    :func:`resolve_agent_gate`). Always returns a gate; enforcement is decided per
+    seam from the current policy, so a policy with no ``agents`` block is a no-op.
+    """
+    return ReachGate(enforcer, approval_handler=approval_handler)

--- a/hexgate/security/bundle.py
+++ b/hexgate/security/bundle.py
@@ -324,6 +324,11 @@ class PolicyBundle:
         """Read the reach-configured flag from the signed manifest (reach counterpart)."""
         return bool(self.manifest.get("agent_gating", {}).get("reach", False))
 
+    def declares_tool_reach(self) -> bool:
+        """Read the agent-as-tool reach flag from the signed manifest. Absent (an
+        older bundle) reads False, so no spurious warning fires."""
+        return bool(self.manifest.get("agent_gating", {}).get("reach_tool", False))
+
     # ---- Metadata ------------------------------------------------------
 
     @property
@@ -404,6 +409,7 @@ def build_signed_bundle(
     agent_gating = {
         "admission": resolved.declares_admission(),
         "reach": resolved.declares_reach(),
+        "reach_tool": resolved.declares_tool_reach(),
     }
 
     wasm_bytes: bytes | None = None

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -86,6 +86,14 @@ class PolicyEngine(Protocol):
         :meth:`declares_admission` (consumed once handoff interception lands)."""
         ...
 
+    def declares_tool_reach(self) -> bool:
+        """Whether this policy configures agent-as-tool (``via: tool``) reach.
+
+        A finer signal than :meth:`declares_reach`: an adapter that enforces
+        handoff reach but not agent-as-tool reach (OpenAI) warns only when this is
+        true, so a handoff-only policy is not spammed."""
+        ...
+
 
 # Over the platform's ``DecisionEvent.reason`` max_length the audit event is
 # rejected outright, losing the record for the calls most worth keeping.

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, get_args
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
 from hexgate.security.constraints import parse_constraint
+from hexgate.security.naming import canonical_name
 
 PolicyMode = Literal["allow", "deny", "approval_required"]
 
@@ -217,6 +218,11 @@ class AgentPolicy(BaseModel):
         ``via`` mode (``agent.tool:<name>`` / ``agent.handoff:<name>``). Only the
         *listed* rules are lowered; the fallback for an unlisted target is the
         agent gate's concern, not this map's.
+
+        The target name is canonicalized (:func:`~hexgate.security.naming.canonical_name`)
+        so the lowered key matches the one the reach gate derives from the runtime
+        target's name — both sides normalize identically, or a padded authored name
+        would never match and a policy-allowed handoff would fall to closed-world deny.
         """
         lowered: dict[str, BaseToolPolicy] = {}
         if self.admission is not None:
@@ -226,7 +232,7 @@ class AgentPolicy(BaseModel):
             # rebuild would silently drop any field later added to BaseToolPolicy.
             # via is an extra field the engines ignore.
             for via in target_policy.via:
-                lowered[agent_target_key(via, target)] = target_policy
+                lowered[agent_target_key(via, canonical_name(target))] = target_policy
         return lowered
 
     @cached_property

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -75,6 +75,14 @@ def agent_target_key(via: AgentVia, target: str) -> str:
     return f"agent.{via}:{target}"
 
 
+def is_agent_via_key(name: str, via: AgentVia) -> bool:
+    """True for a reach key of a specific ``via`` mode (``agent.<via>:``).
+
+    Lets a caller tell agent-as-tool reach from handoff reach, e.g. to warn only
+    about the mode a given adapter cannot enforce."""
+    return name.startswith(f"agent.{via}:")
+
+
 def is_agent_reach_key(name: str) -> bool:
     """True for an ``agent.tool:`` / ``agent.handoff:`` reach key.
 

--- a/hexgate/security/naming.py
+++ b/hexgate/security/naming.py
@@ -1,0 +1,41 @@
+"""Canonical agent-name derivation, shared by every adapter and the reach gate.
+
+An agent's name is the identity a policy references two ways: its *own* name selects
+its policy, and a *reach* key (``agent.handoff:<name>`` / ``agent.tool:<name>``)
+names a *target* agent. Both the own-name lookup and the target-name match must
+derive the name the same way, or a target authored under the name it registers with
+would silently fail to match at the handoff seam. Before this module the derivation
+was duplicated across adapters in two subtly different spellings
+(``getattr(agent, "name", "default")`` vs ``... or "default"``); this is now the
+one place it lives.
+
+Matching is exact on the trimmed name (no case folding): a policy target name must
+equal the name its agent registers with. Case-insensitive matching would have to be
+applied to both the policy key (at lowering) and the runtime name to stay in parity,
+so it is deliberately left as a possible follow-up rather than a silent half-fix.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# The identity a null/blank-named agent collapses to, so it never reaches a policy
+# lookup, a cache key, or a reach match as ``None``/``""``.
+DEFAULT_AGENT_NAME = "default"
+
+
+def canonical_name(name: str | None) -> str:
+    """Normalize an agent name string: trim whitespace, blank/None → ``"default"``."""
+    if not isinstance(name, str):
+        return DEFAULT_AGENT_NAME
+    return name.strip() or DEFAULT_AGENT_NAME
+
+
+def canonical_agent_name(agent: Any) -> str:
+    """The name a framework ``Agent`` object is known by for policy.
+
+    Reads the framework-agnostic ``name`` attribute (every supported SDK agent has
+    one) through :func:`canonical_name`. Used for both an agent's own-name lookup
+    and, at the handoff/delegation seam, for the target agent's reach match, so the
+    two can never drift."""
+    return canonical_name(getattr(agent, "name", None))

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -55,6 +55,7 @@ from hexgate.security.models import (
     BaseToolPolicy,
     ToolPolicy,
     is_agent_reach_key,
+    is_agent_via_key,
 )
 
 DEFAULT_ROLE_NAME = "default"
@@ -168,6 +169,13 @@ class PolicySet:
         """True if any resolved role carries an ``agent.tool:`` / ``agent.handoff:`` key."""
         return any(
             any(is_agent_reach_key(key) for key in policy.effective_tools)
+            for policy in self._policies.values()
+        )
+
+    def declares_tool_reach(self) -> bool:
+        """True if any resolved role carries an ``agent.tool:`` (agent-as-tool) key."""
+        return any(
+            any(is_agent_via_key(key, "tool") for key in policy.effective_tools)
             for policy in self._policies.values()
         )
 

--- a/nested-agent-as-tool-reach-design.md
+++ b/nested-agent-as-tool-reach-design.md
@@ -1,0 +1,173 @@
+# Nested agent-as-tool reach — design & implementation plan
+
+**Status:** proposal · **Scope:** OpenAI Agents adapter (Google ADK already covers this at its `before_tool_callback` seam) · **Depends on:** #142 (ReachGate, `agent.tool:`/`agent.handoff:` keys)
+
+## 1. Problem
+
+Reach isn't a flat "top agent → sub-agent" relation. An agent-as-tool can itself contain agent-as-tools, and those can contain handoffs, recursively:
+
+```
+orchestrator (A)
+├─ tool: web_search              # ordinary tool
+├─ tool: billing_bot  = B.as_tool()
+│         └─ B.tools:
+│            ├─ tool: ledger_lookup
+│            └─ tool: refund_agent = C.as_tool()   # A→B→C, two reach hops deep
+└─ handoff: escalation_agent (D)
+             └─ D.handoffs: [ ... ]                # keeps going
+```
+
+So the agents form a **directed graph**: nodes are agents, edges are either **agent-as-tool** (`via: tool`, control stays with the caller) or **handoff** (`via: handoff`, control transfers). Each edge is governed by the **source** agent's policy on the synthetic key `agent.tool:<target>` / `agent.handoff:<target>`.
+
+Two things make this non-trivial:
+
+1. **Reach must be checked at every edge, not just the first.** Today `wrap_openai_agent` wraps only the *top* agent's `tools` (`hexgate/adapters/openai/wrapper.py:48-51`). When `billing_bot` runs, `Agent.as_tool()` drives the **original, unwrapped** `B` through the SDK's own `Runner.run` (the nested run closes over `self` in `_run_agent_impl`, `agents/agent.py:563`). So the `B→C` edge is never seen — deeper reach is invisible.
+2. **The graph can loop.** `A.as_tool()` inside `B`, and `B.as_tool()` inside `A`. A naïve recursive wrap would recurse forever. We need cycle detection, and a decision on what a cycle *means* for enforcement.
+
+The user-visible symptom: you can write `agents: { refund_agent: { via: [tool], mode: deny } }` on `B`'s policy, and nothing enforces it, because `B` never runs through Hexgate when it's invoked as a tool.
+
+## 2. What we can rely on (verified against the installed SDK)
+
+- **Agent-as-tools are self-identifying.** `Agent.as_tool()` stamps the returned `FunctionTool` (`agents/agent.py:891-898`): `_tool_origin = ToolOrigin(type=AGENT_AS_TOOL, agent_name=<target>, agent_tool_name=<tool name>)`, `_is_agent_tool = True`, `_agent_instance = <the target Agent object>`. Public accessor: `get_function_tool_origin(tool)` (`agents/tool.py:525`) → `ToolOrigin` with `.type` and `.agent_name`.
+- **Handoffs are a first-class list.** `Agent.handoffs: list[Agent | Handoff]` (`agents/agent.py:258`).
+- **Agents are cloneable without mutation.** `Agent.clone()` / `dataclasses.replace` shallow-copy `tools`/`handoffs` (`agents/agent.py:461`); our wrapper already returns clones, never mutates the caller's agent.
+- **Our tool gate is name-keyed today.** `wrap_tool` decides `run_guarded_async(tool.name, …)` on the enforcer it closed over (`hexgate/adapters/openai/tools.py:61,101-104`).
+
+## 3. Design
+
+### 3.1 The agent graph
+
+```
+node   = an Agent (identified by id(); labelled by canonical_agent_name)
+edge   = (source_agent, target_agent, via)   via ∈ {tool, handoff}
+  tool     edge: a FunctionTool in source.tools with get_function_tool_origin().type == AGENT_AS_TOOL
+  handoff  edge: an entry in source.handoffs
+governance: edge (S, T, via) is decided by S's policy on agent_target_key(via, canonical_agent_name(T))
+```
+
+### 3.2 Split into two capabilities (scope discipline)
+
+| capability | what it is | needs |
+|---|---|---|
+| **R** reach-edge enforcement | at every edge, refuse S→T if S's policy denies `agent.<via>:T` | discover edges + gate them under the source's key |
+| **G** nested governance | when T runs (nested), T's own tools are gated and T's admission fires | drive T through Hexgate instead of the SDK's raw nested run |
+
+R is the thing the matrix flags as a red cell; G is the deeper win. They share the same traversal but land in different phases (§5).
+
+### 3.3 Core algorithm — bottom-up recursive rewrap, memoized
+
+We rebuild the agent graph bottom-up: each agent is cloned with (a) its ordinary tools gated by its own enforcer, (b) each agent-as-tool edge replaced by a gated edge to the **wrapped** child, (c) each handoff pointing at the wrapped child. Memoize by `id()` so a shared sub-agent (DAG) is wrapped once and cycles terminate.
+
+```python
+def wrap_agent_graph(agent, *, resolve_binding, visiting, done):
+    key = id(agent)
+    if key in done:            # already fully wrapped (DAG sharing)
+        return done[key]
+    if key in visiting:        # cycle: A→…→A — don't recurse again
+        return visiting[key]   # a placeholder clone; edge is still gated below
+
+    binding = resolve_binding(agent)          # agent's OWN resolved policy/enforcer
+    placeholder = shallow_clone(agent)        # so a cycle can reference us
+    visiting[key] = placeholder
+
+    new_tools = []
+    for tool in agent.tools:
+        origin = get_function_tool_origin(tool)        # capability-guarded (§4)
+        if origin and origin.type is AGENT_AS_TOOL:
+            child = wrap_agent_graph(tool._agent_instance, ...)   # recurse
+            new_tools.append(gate_reach_edge(tool, source=binding, child=child, via="tool"))
+        else:
+            new_tools.append(wrap_tool(tool, binding.enforcer, ...))   # ordinary gate
+
+    new_handoffs = [wrap_agent_graph(h, ...) if is_agent(h) else h
+                    for h in agent.handoffs]
+
+    wrapped = dataclasses.replace(agent, tools=new_tools, handoffs=new_handoffs)
+    populate(placeholder, wrapped)   # fill the placeholder so cyclic refs resolve
+    done[key] = wrapped
+    visiting.pop(key)
+    return wrapped
+```
+
+- **`resolve_binding(agent)`** resolves that agent's platform policy and builds an enforcer, exactly like `HexgateRunner._binding_for` — memoized by canonical name so shared nodes resolve once, and **fail-loud** on an unregistered sub-agent (same contract as today).
+- **`gate_reach_edge`** is the crux; see §3.4.
+- **Cycle semantics:** on a back-edge we still gate the reach at that edge (the check is per-source, computed from the source's binding we already have), but we do **not** re-enter the target — it is (or will be) wrapped via its own `visiting`/`done` entry. So `A→B→A` gates all three edges once and terminates.
+
+### 3.4 The rebuild problem — a pick-2-of-3, rooted in `as_tool` being a one-way compile
+
+To enforce the `B→C` edge, `B`'s nested run must use **wrapped-B** (whose C-edge carries the check), not the original `B`. But `Agent.as_tool()` is a **one-way compile**: its ~16 options (`custom_output_extractor`, `max_turns` `agent.py:590`, `run_config` `:591`, `on_stream`, `hooks`, `session`, `input_builder`, structured `parameters`, …) are baked into the returned tool's `on_invoke_tool` closure and are **not** readable back off the `FunctionTool` (its only real fields are `name`, `description`, `params_json_schema`, `on_invoke_tool`, `is_enabled`, guardrails, `needs_approval`, `timeout_*`, and the `_tool_origin`/`_agent_instance`/`_is_agent_tool` markers — `tool.py:287-388`). That single fact forces a **pick-2-of-3** for any pre-built tree:
+
+1. **enforce deep edges** — the nested run uses the *wrapped* child
+2. **preserve all `as_tool` options**
+3. **don't mutate the caller's agents**
+
+| approach | deep | options | no-mutate | notes |
+|---|---|---|---|---|
+| **(A) reconstruct** `child'.as_tool(name, description, …readable…)` + wrap `on_invoke_tool` | ✓ | ✗ | ✓ | unreadable options revert to defaults — silent behaviour change (e.g. a `max_turns=3` cap disappears) |
+| **(B) clone-and-swap** `_agent_instance` | ✓ | ✗ | ✓ | **rejected** — `_agent_instance` is only metadata; the run uses the closure's `self`, so behaviour and metadata diverge |
+| **mutate child's tools in place** | ✓ | ✓ | ✗ | reuses the original closure (options intact) but violates our no-mutation invariant |
+| **(C) wrap `on_invoke_tool`, then call the *original* closure** | ✗ | ✓ | ✓ | lossless, but the original closure still runs the *unwrapped* child, so only the **top** edge is gated — not `B→C` |
+| **`hexgate_as_tool(child, …)` constructor** | ✓ | ✓ | ✓ | all three — but the user must build the tree with our helper; not automatic for a tree already built with `.as_tool()` |
+
+The key correction to an earlier draft of this doc: **(C) is not a free lunch.** It is lossless *only when it calls the original closure*, which means it cannot swap in the wrapped child and therefore cannot reach deep. To reach deep, (C) must re-drive the child itself and then hits the same unreadable-options wall as (A). There is no automatic approach that gets all three for a pre-built tree — that is a direct consequence of the one-way compile.
+
+**Recommendation:**
+- **Phase 1 (R, top edge, lossless):** wrap `on_invoke_tool` and call the original closure — gate the *top* reach edge under `agent.tool:<target>` with zero option loss. This already beats today (name-gating → real reach key) for the common single-level case.
+- **Deep edges + nested governance (G):** offer **`hexgate_as_tool(child, …)`** as the *supported, lossless* path (the user passes options to us, so nothing is lost, and we own the nested run → deep reach + nested admission + nested handoffs all fall out). For trees already built with plain `.as_tool()`, offer **(A)** as an *opt-in, documented-lossy* auto-rewrap that detects exotic options and falls back to top-edge-only + a warning rather than silently dropping them.
+
+In short: **the moment you need to govern *inside* a nested agent, you need to influence how its run is built — which means owning the `as_tool` construction.** Automatic recursion over a foreign tree can only ever be lossy or shallow.
+
+### 3.5 Semantics decisions
+
+- **Whose policy at each edge:** the **source** agent's. A shared child `T` reached by both `A` and `X` is *wrapped once* (its own tools use `T`'s policy), but the **edge check is computed per parent** — `A`'s binding for `A→T`, `X`'s binding for `X→T`. So memoize the wrapped *node*, not the edge.
+- **Unregistered sub-agent:** fail-loud at wrap time, matching `_binding_for` (`register first`), so a typo in a nested agent name isn't a silent open door.
+- **No mutation:** the caller's agents are never mutated; the whole graph is rebuilt from clones (matches `wrapper.py`'s existing invariant).
+- **`via` correctness:** as-tool edges are `via: tool` (no control transfer, no depth increment); handoff edges are `via: handoff` (counts toward the runtime handoff-depth cap).
+
+### 3.6 Two different "depths"
+
+- **Structural nesting depth** — how deep the *build-time* graph goes. Bounded by the memoized traversal (finite graph); add a defensive cap + clear error to guard against pathological inputs.
+- **Runtime handoff-chain depth** — already enforced via `max_handoff_depth` at the `on_handoff` seam (#142). Unchanged; as-tool nesting does **not** feed it (no control transfer).
+
+## 4. SDK-capability guarding
+
+`_is_agent_tool` / `_agent_instance` are semi-private and `get_function_tool_origin` lives in `agents.tool`; a different SDK version may lack them. Detect once:
+
+```python
+try:
+    from agents.tool import get_function_tool_origin, ToolOriginType
+    _CAN_DETECT_AGENT_TOOLS = True
+except ImportError:
+    _CAN_DETECT_AGENT_TOOLS = False
+```
+
+When detection is unavailable, fall back to **today's** behaviour: gate agent-as-tools by name and emit `warn_if_tool_reach_unenforced`. When it *is* available, enforce the reach key and drop the warning.
+
+## 5. Implementation plan (phased)
+
+### Phase 1 — top-edge reach enforcement, lossless (capability **R**, single level)
+The 80% case (one level of `as_tool`) with zero option loss and no mutation.
+- `hexgate/adapters/openai/tools.py`: in `wrap_tool`, detect agent-as-tools (`get_function_tool_origin`, capability-guarded) and gate them under `agent_target_key("tool", origin.agent_name)` — the reach key — instead of the raw tool name, while **calling the original `on_invoke_tool` unchanged** (options preserved). Ordinary tools unchanged.
+- `hexgate/adapters/openai/runner.py`: emit `warn_if_tool_reach_unenforced` only when detection is unavailable.
+- Tests: top `A→B` as-tool denied by `agent.tool:B`; `via`/constraints honoured; SDK-without-markers falls back to name-gating without crashing; a tool with exotic `as_tool` options still runs identically (we never rebuilt it).
+
+### Phase 2 — deep + nested governance via `hexgate_as_tool` (capability **G**, lossless path)
+The supported way to govern *inside* nested agents — the user opts in at construction, so nothing is lost.
+- `hexgate/adapters/openai/as_tool.py` (new): `hexgate_as_tool(child, *, source_enforcer, **as_tool_kwargs)` that builds the `FunctionTool` itself: reach-check `source → agent.tool:child`, then drive a **Hexgate-wrapped** child through a nested run (its admission + `run_scope` + gated tools), forwarding every `as_tool` option the user gave us. Because we own construction, this recurses cleanly (the child's own `hexgate_as_tool` edges gate `B→C`), with memoized cycle/DAG handling and a structural-depth cap.
+- Docs: position `hexgate_as_tool` as the way to get nested reach + admission on OpenAI.
+- Tests: `A→B→C` deny at depth 2; nested admission refuses a caller not admitted to `B`; `B`'s own tools gated during the nested run; cycle `A→B→A` terminates; per-parent edge checks for a shared child.
+
+### Phase 2b (optional) — opt-in lossy auto-rewrap of foreign trees
+For trees already built with plain `.as_tool()`, an explicit opt-in (`HexgateRunner(deep_reach=True)`) that recursively rebuilds via approach **(A)**, detecting exotic `as_tool` options and falling back to top-edge-only + a warning for those tools rather than silently dropping them. Clearly documented as best-effort, since the one-way compile makes it lossy by nature.
+
+### Phase 3 — parity + docs
+- Confirm handoff-graph parity (nested handoffs now enforced via Phase 2) and the structural-depth cap.
+- Correct the now-inaccurate claims: `docs/concepts/agent-level-enforcement.mdx` (as-tool-reach cell for OpenAI), the `_HexgateReachHooks` docstring (`runner.py:105`), and `docs/adapters/openai.mdx`. Update the framework matrix so OpenAI reads **enforced** for agent-as-tool reach.
+
+## 6. Risks & open questions
+
+- **SDK drift** on the private markers → mitigated by §4 capability detection + fallback.
+- **`as_tool` option loss** under approach (A) → detect exotic options and fall back per-tool; fully resolved by (C) in Phase 2.
+- **Context propagation** across the nested-run task in (C) — verify the caller's `HexgateContext` scope reaches the nested run (asyncio copies contextvars into new tasks, so the role should propagate; add a regression test that asserts it).
+- **Per-node policy resolution cost** — one platform resolve per distinct sub-agent; memoized by name, and the per-handoff `ReachGate` allocation is already short-circuited on `declares_reach()` (#142 review fix).
+- **Where does Google stand?** Google already gates both `transfer_to_agent` and `AgentTool` at `before_tool_callback`, but only for the *governed root* — the same "nested source isn't gated" gap exists there. Phase 2's approach generalizes; track a Google follow-up so the two adapters stay in step.

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -25,6 +25,7 @@ from hexgate.security import (
     AgentNotAdmittedError,
     AgentPolicy,
     BaseToolPolicy,
+    HandoffDepthExceededError,
     PolicySet,
     ReachNotAllowedError,
     ResolvedPolicy,
@@ -670,6 +671,30 @@ def test_admission_sync_noop_without_admission(
     runner = _runner_with_policy(monkeypatch)  # no admission declared
     with _user().sync_scope():
         runner._check_admission_sync()  # no raise
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_enforces_depth_cap_per_invocation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(monkeypatch, agents={"b": {"mode": "allow"}})
+    runner._max_handoff_depth = 1
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="transfer_to_agent")
+    ctx = SimpleNamespace(agent_name="orchestrator", invocation_id="inv-1")
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"agent_name": "b"}, tool_context=ctx
+        )  # depth 1 == cap → ok
+        with pytest.raises(HandoffDepthExceededError):
+            await plugin.before_tool_callback(
+                tool=tool, tool_args={"agent_name": "b"}, tool_context=ctx
+            )  # depth 2 > cap
+    # after_run clears this invocation's counter so it does not leak.
+    await plugin.after_run_callback(
+        invocation_context=SimpleNamespace(invocation_id="inv-1")
+    )
+    assert "inv-1" not in plugin._depth
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -695,6 +695,18 @@ async def test_reach_plugin_enforces_depth_cap_per_invocation(
     assert "inv-1" not in plugin._depth
 
 
+def test_reach_plugin_depth_map_is_bounded() -> None:
+    """ADK skips after_run_callback on an abnormally-terminated run, so the shared
+    depth map must be bounded rather than leaking one entry per aborted run."""
+    plugin = _HexgateReachPlugin(SimpleNamespace())
+    cap = _HexgateReachPlugin._MAX_TRACKED_INVOCATIONS
+    for i in range(cap + 500):
+        plugin._bump_depth(f"inv-{i}")
+    assert len(plugin._depth) == cap
+    assert f"inv-{cap + 499}" in plugin._depth  # most recent retained
+    assert "inv-0" not in plugin._depth  # stalest evicted
+
+
 # ---------------------------------------------------------------------------
 # Usage plugin: merge behavior + HexgateContext contextvar survives into
 # after_model_callback

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -616,7 +616,7 @@ async def test_reach_plugin_gates_transfer_to_agent(
     )
     plugin = _HexgateReachPlugin(runner)
     tool = SimpleNamespace(name="transfer_to_agent")
-    ctx = SimpleNamespace(agent_name="orchestrator")  # the governed root
+    ctx = SimpleNamespace(agent_name="orchestrator", invocation_id="i")  # governed root
     async with _user():
         await plugin.before_tool_callback(
             tool=tool, tool_args={"agent_name": "billing-bot"}, tool_context=ctx
@@ -636,7 +636,7 @@ async def test_reach_plugin_skips_non_root_source(
     )
     plugin = _HexgateReachPlugin(runner)
     tool = SimpleNamespace(name="transfer_to_agent")
-    ctx = SimpleNamespace(agent_name="a-sub-agent")  # not the governed root
+    ctx = SimpleNamespace(agent_name="a-sub-agent", invocation_id="i")  # not root
     async with _user():
         await plugin.before_tool_callback(
             tool=tool, tool_args={"agent_name": "evil-bot"}, tool_context=ctx
@@ -652,7 +652,7 @@ async def test_reach_plugin_ignores_ordinary_tool(
     )
     plugin = _HexgateReachPlugin(runner)
     tool = SimpleNamespace(name="search")  # a normal tool, not a transfer/AgentTool
-    ctx = SimpleNamespace(agent_name="orchestrator")
+    ctx = SimpleNamespace(agent_name="orchestrator", invocation_id="i")
     async with _user():
         await plugin.before_tool_callback(
             tool=tool, tool_args={"q": "x"}, tool_context=ctx
@@ -690,10 +690,8 @@ async def test_reach_plugin_enforces_depth_cap_per_invocation(
             await plugin.before_tool_callback(
                 tool=tool, tool_args={"agent_name": "b"}, tool_context=ctx
             )  # depth 2 > cap
-    # after_run clears this invocation's counter so it does not leak.
-    await plugin.after_run_callback(
-        invocation_context=SimpleNamespace(invocation_id="inv-1")
-    )
+    # The raise aborts the run (after_run_callback never fires), so the callback
+    # must have already dropped this invocation's counter — no leak.
     assert "inv-1" not in plugin._depth
 
 

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -17,12 +17,20 @@ from google.genai import types
 
 from hexgate.adapters.google import runner as runner_mod
 from hexgate.adapters.google import wrapper as wrapper_mod
-from hexgate.adapters.google.runner import HexgateRunner
+from hexgate.adapters.google.runner import HexgateRunner, _HexgateReachPlugin
 from hexgate.adapters.google.usage import HexgateUsagePlugin
 from hexgate.runtime import HexgateContext
 from hexgate.runtime.context import get_current_context
-from hexgate.security import AgentPolicy, BaseToolPolicy, PolicySet, ResolvedPolicy
+from hexgate.security import (
+    AgentNotAdmittedError,
+    AgentPolicy,
+    BaseToolPolicy,
+    PolicySet,
+    ReachNotAllowedError,
+    ResolvedPolicy,
+)
 from hexgate.security.bans import BanEntry, BanGate, BanSet
+from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.errors import AgentBannedError
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME
 from hexgate.tracing import usage as tracing_usage_mod
@@ -512,6 +520,10 @@ def test_not_banned_passes_through(monkeypatch: pytest.MonkeyPatch) -> None:
 class _CountingBinding:
     def __init__(self) -> None:
         self.refreshes = 0
+        # A real enforcer with a plain policy, so the run-entry admission check is
+        # a no-op (declares_admission() is False) rather than an AttributeError.
+        engine = PolicySet({DEFAULT_ROLE_NAME: AgentPolicy()})
+        self.enforcer = PolicyEnforcer(engine, agent_name="my-agent")
 
     def refresh(self) -> None:
         self.refreshes += 1
@@ -564,6 +576,100 @@ def test_construction_does_not_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
     runner, binding = _runner_with_counting_binding(monkeypatch)
 
     assert binding.refreshes == 0
+
+
+# ---------------------------------------------------------------------------
+# Agent-level reach + admission (A3)
+# ---------------------------------------------------------------------------
+
+
+def _runner_with_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    agents: dict | None = None,
+    admission: str | None = None,
+) -> HexgateRunner:
+    """A runner whose binding carries a chosen agent-level policy, for driving the
+    reach plugin and admission helpers directly."""
+    runner, binding = _runner_with_counting_binding(monkeypatch)
+    runner._agent_name = "orchestrator"
+    engine = PolicySet(
+        {
+            DEFAULT_ROLE_NAME: AgentPolicy(
+                default_policy=BaseToolPolicy(mode="allow"),
+                agents=agents or {},
+                admission=BaseToolPolicy(mode=admission) if admission else None,
+            )
+        }
+    )
+    binding.enforcer = PolicyEnforcer(engine, agent_name="orchestrator")
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_gates_transfer_to_agent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(
+        monkeypatch, agents={"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="transfer_to_agent")
+    ctx = SimpleNamespace(agent_name="orchestrator")  # the governed root
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"agent_name": "billing-bot"}, tool_context=ctx
+        )
+        with pytest.raises(ReachNotAllowedError):
+            await plugin.before_tool_callback(
+                tool=tool, tool_args={"agent_name": "evil-bot"}, tool_context=ctx
+            )
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_skips_non_root_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(
+        monkeypatch, agents={"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="transfer_to_agent")
+    ctx = SimpleNamespace(agent_name="a-sub-agent")  # not the governed root
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"agent_name": "evil-bot"}, tool_context=ctx
+        )  # not gated → no raise
+
+
+@pytest.mark.asyncio
+async def test_reach_plugin_ignores_ordinary_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(
+        monkeypatch, agents={"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    plugin = _HexgateReachPlugin(runner)
+    tool = SimpleNamespace(name="search")  # a normal tool, not a transfer/AgentTool
+    ctx = SimpleNamespace(agent_name="orchestrator")
+    async with _user():
+        await plugin.before_tool_callback(
+            tool=tool, tool_args={"q": "x"}, tool_context=ctx
+        )  # falls through → no raise
+
+
+def test_admission_sync_denies_non_admitted(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = _runner_with_policy(monkeypatch, admission="deny")
+    with _user().sync_scope(), pytest.raises(AgentNotAdmittedError):
+        runner._check_admission_sync()
+
+
+def test_admission_sync_noop_without_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _runner_with_policy(monkeypatch)  # no admission declared
+    with _user().sync_scope():
+        runner._check_admission_sync()  # no raise
 
 
 # ---------------------------------------------------------------------------
@@ -630,8 +736,10 @@ def test_constructor_passes_a_usage_plugin_when_no_plugins_supplied(
 
     [fake_runner] = fake.instances
     plugins = fake_runner.kwargs["app"].plugins
-    assert len(plugins) == 1
-    assert isinstance(plugins[0], HexgateUsagePlugin)
+    # usage plugin + the reach-enforcement plugin
+    assert len(plugins) == 2
+    assert any(isinstance(p, HexgateUsagePlugin) for p in plugins)
+    assert any(isinstance(p, _HexgateReachPlugin) for p in plugins)
 
 
 def test_constructor_preserves_caller_supplied_plugins(
@@ -654,7 +762,8 @@ def test_constructor_preserves_caller_supplied_plugins(
     plugins = fake_runner.kwargs["app"].plugins
     assert custom_plugin in plugins
     assert any(isinstance(p, HexgateUsagePlugin) for p in plugins)
-    assert len(plugins) == 2
+    assert any(isinstance(p, _HexgateReachPlugin) for p in plugins)
+    assert len(plugins) == 3  # custom + usage + reach
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/google/test_runner.py
+++ b/tests/adapters/google/test_runner.py
@@ -707,6 +707,63 @@ def test_reach_plugin_depth_map_is_bounded() -> None:
     assert "inv-0" not in plugin._depth  # stalest evicted
 
 
+def test_reach_plugin_registered_before_caller_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ADK's PluginManager early-exits on the first before_tool_callback that
+    returns non-None, so the reach plugin must be registered first — otherwise a
+    caller plugin could preempt the gate (a silent fail-open)."""
+    fake = _install_fake_runner(monkeypatch)
+
+    HexgateRunner(
+        agent=_make_agent(),
+        app_name="app",
+        session_service=InMemorySessionService(),
+        api_key="k",
+        plugins=[BasePlugin(name="caller")],
+    )
+
+    app = fake.instances[0].kwargs["app"]
+    assert isinstance(app.plugins[0], _HexgateReachPlugin)
+
+
+@pytest.mark.asyncio
+async def test_reach_survives_adk_plugin_wrapping_and_preceding_plugin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Driven through the real ADK PluginManager: a denied reach still surfaces as
+    the typed error after the runner unwraps ADK's RuntimeError re-wrap (#5), and —
+    registered first — our gate runs before a short-circuiting caller plugin can
+    preempt it (#1). One test for both, since both slipped past the direct-callback
+    unit tests."""
+    from google.adk.plugins.plugin_manager import PluginManager
+
+    from hexgate.adapters.google.runner import _unwrap_plugin_error
+    from hexgate.security.agent_gate import ReachNotAllowedError
+
+    runner = _runner_with_policy(
+        monkeypatch, agents={"evil": {"via": ["handoff"], "mode": "deny"}}
+    )
+    plugin = _HexgateReachPlugin(runner)
+
+    class _ShortCircuit(BasePlugin):
+        async def before_tool_callback(self, **_kw: Any) -> dict:
+            return {"result": "preempted"}  # would skip the gate if it ran first
+
+    # Reach plugin first, exactly as the runner registers it (insert(0)).
+    manager = PluginManager(plugins=[plugin, _ShortCircuit(name="sc")])
+    tool = SimpleNamespace(name="transfer_to_agent")
+    ctx = SimpleNamespace(agent_name="orchestrator", invocation_id="i")
+    async with _user():
+        with pytest.raises(RuntimeError) as exc_info:
+            await manager.run_before_tool_callback(
+                tool=tool, tool_args={"agent_name": "evil"}, tool_context=ctx
+            )
+    recovered = _unwrap_plugin_error(exc_info.value)
+    assert isinstance(recovered, ReachNotAllowedError)
+    assert recovered.decision is not None  # typed payload intact, not erased
+
+
 # ---------------------------------------------------------------------------
 # Usage plugin: merge behavior + HexgateContext contextvar survives into
 # after_model_callback

--- a/tests/adapters/google/test_tools_reach.py
+++ b/tests/adapters/google/test_tools_reach.py
@@ -1,0 +1,131 @@
+"""Agent-as-tool reach gating on the Google ADK adapter.
+
+An ``AgentTool`` names itself after its wrapped agent, so ``wrap_tool`` gates it
+under its reach key ``agent.tool:<target>`` (the same substitution the OpenAI
+adapter uses) instead of by tool name — otherwise the transfer plugin *and* the
+name gate would both decide one delegation, and the documented `via: tool` grant
+would be overridden by the default-deny name gate.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from google.adk.agents import LlmAgent
+from google.adk.tools.agent_tool import AgentTool
+
+from hexgate.adapters.google.tools import _agent_tool_target, wrap_tool
+from hexgate.security import AgentPolicy, PolicySet
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+
+
+def _enforcer(spec: dict[str, Any]) -> PolicyEnforcer:
+    return PolicyEnforcer(
+        PolicySet({DEFAULT_ROLE_NAME: AgentPolicy.model_validate(spec)}),
+        agent_name="orchestrator",
+    )
+
+
+def _agent_tool(
+    target: str = "refund_bot", calls: list[Any] | None = None
+) -> AgentTool:
+    """An ``AgentTool`` whose ``run_async`` is stubbed (the real one runs the
+    sub-agent through a model)."""
+    record: list[Any] = calls if calls is not None else []
+
+    class _StubAgentTool(AgentTool):
+        async def run_async(self, *, args: dict[str, Any], tool_context: Any) -> Any:
+            record.append(args)
+            return "ran-subagent"
+
+    return _StubAgentTool(agent=LlmAgent(name=target, model="gemini-2.0-flash"))
+
+
+async def _run(tool: AgentTool) -> Any:
+    return await tool.run_async(args={"request": "refund"}, tool_context=None)
+
+
+def test_detects_agent_tool_target() -> None:
+    assert _agent_tool_target(_agent_tool(target="refund_bot")) == "refund_bot"
+
+
+@pytest.mark.asyncio
+async def test_documented_example_via_tool_allow_is_gated_by_reach_key() -> None:
+    """The doc example: default deny + ``refund_bot: {via: [tool], allow}``. The
+    AgentTool is *not* in ``tools:``, so a name gate would deny it under the default
+    — the reach-key substitution is what makes the documented grant work."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"refund_bot": {"via": ["tool"], "mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await _run(wrapped)
+
+    assert result == "ran-subagent"
+    assert calls  # the sub-agent ran — the via:tool grant was honored
+
+
+@pytest.mark.asyncio
+async def test_closed_world_denies_unlisted_agent_tool() -> None:
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"other_bot": {"via": ["tool"], "mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await _run(wrapped)
+
+    assert calls == []
+    assert "[policy_denied]" in result
+    assert "refund_bot" in result
+    assert "agent.tool" not in result  # no synthetic-key leak
+
+
+@pytest.mark.asyncio
+async def test_handoff_only_policy_leaves_agent_tool_name_gated() -> None:
+    """Matches OpenAI: no ``via: tool`` target declared → the AgentTool falls back
+    to name-gating, so the default-deny denies it (rather than closed-world)."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"refund_bot": {"via": ["handoff"], "mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await _run(wrapped)
+
+    assert calls == []
+    assert "[policy_denied]" in result
+    # name-gated: message names the tool, not a bare reach target
+    assert "refund_bot" in result
+
+
+@pytest.mark.asyncio
+async def test_handoff_only_via_tool_grant_allows_by_name() -> None:
+    """A handoff-only ``agents`` policy that also allows the tool by name lets the
+    AgentTool through the name-gate fallback (proving it isn't closed-world-denied)."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"refund_bot": {"via": ["handoff"], "mode": "allow"}},
+            "tools": {"refund_bot": {"mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await _run(wrapped)
+
+    assert result == "ran-subagent"
+    assert calls

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -12,7 +12,11 @@ from agents.items import ModelResponse
 from agents.usage import Usage
 
 from hexgate.adapters.openai import runner as runner_mod
-from hexgate.adapters.openai.runner import HexgateRunner
+from hexgate.adapters.openai.runner import (
+    HexgateRunner,
+    _CompositeRunHooks,
+    _HexgateReachHooks,
+)
 from hexgate.adapters.openai.usage import HexgateUsageHooks
 from hexgate.runtime import HexgateContext
 from hexgate.runtime.context import get_current_context
@@ -201,7 +205,10 @@ async def test_run_wraps_agent_opens_user_scope_and_calls_runner_run(
     assert captured["agent"].name == agent.name
     assert captured["input"] == "hello"
     assert captured["kwargs"]["run_config"] is None
-    assert isinstance(captured["kwargs"]["hooks"], HexgateUsageHooks)
+    hooks = captured["kwargs"]["hooks"]
+    assert isinstance(hooks, _CompositeRunHooks)
+    assert any(isinstance(h, HexgateUsageHooks) for h in hooks._hooks)
+    assert any(isinstance(h, _HexgateReachHooks) for h in hooks._hooks)
     # HexgateContext scope was live for the duration of Runner.run.
     assert captured["active_user"] is context
     # Scope unwound on exit — no leak.
@@ -697,7 +704,7 @@ def _fake_llm_response(
 
 
 @pytest.mark.asyncio
-async def test_run_passes_a_usage_hooks_instance_when_caller_passes_none(
+async def test_run_installs_usage_and_reach_hooks_when_caller_passes_none(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _silence_observability(monkeypatch)
@@ -714,7 +721,10 @@ async def test_run_passes_a_usage_hooks_instance_when_caller_passes_none(
     runner = HexgateRunner(api_key="k")
     await runner.run(_make_agent(), "hi", hexgate_context=_user())
 
-    assert isinstance(captured["hooks"], HexgateUsageHooks)
+    hooks = captured["hooks"]
+    assert isinstance(hooks, _CompositeRunHooks)
+    assert any(isinstance(h, HexgateUsageHooks) for h in hooks._hooks)
+    assert any(isinstance(h, _HexgateReachHooks) for h in hooks._hooks)
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/openai/test_runner.py
+++ b/tests/adapters/openai/test_runner.py
@@ -24,8 +24,8 @@ from hexgate.security import AgentPolicy, BaseToolPolicy, PolicySet, ResolvedPol
 from hexgate.security.bans import BanEntry, BanGate, BanSet
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.errors import AgentBannedError
-from hexgate.tracing import usage as tracing_usage_mod
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+from hexgate.tracing import usage as tracing_usage_mod
 
 
 class _StaticBanSource:

--- a/tests/adapters/openai/test_runner_reach_admission.py
+++ b/tests/adapters/openai/test_runner_reach_admission.py
@@ -1,0 +1,159 @@
+"""Agent-level reach + admission wiring for the OpenAI runner (A3).
+
+Reach is enforced at the SDK handoff seam via ``_HexgateReachHooks.on_handoff``
+(governed by the *source* agent's policy); admission is enforced at run entry via
+the top-level agent's policy. These drive the seams directly rather than through a
+full SDK handoff, which needs a live model.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agents import Agent, FunctionTool
+
+from hexgate.adapters.openai import runner as runner_mod
+from hexgate.adapters.openai.runner import HexgateRunner, _HexgateReachHooks
+from hexgate.runtime import HexgateContext
+from hexgate.security import (
+    AgentNotAdmittedError,
+    AgentPolicy,
+    BaseToolPolicy,
+    PolicySet,
+    ReachNotAllowedError,
+    ResolvedPolicy,
+)
+from hexgate.security.binding import PolicyBinding
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+
+
+def _user() -> HexgateContext:
+    return HexgateContext(user_id="u-1", session_id="s-1", user_roles=["developer"])
+
+
+def _agent(name: str) -> Agent:
+    async def on_invoke(_ctx: Any, raw: str) -> str:
+        return raw
+
+    tool = FunctionTool(
+        name="echo",
+        description="echo",
+        params_json_schema={"type": "object"},
+        on_invoke_tool=on_invoke,
+    )
+    return Agent(name=name, tools=[tool])
+
+
+def _silence_observability(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(HexgateRunner, "_setup_observability", lambda self: None)
+    monkeypatch.setattr(runner_mod, "resolve_ban_gate", lambda *a, **k: None)
+
+
+# --- reach at the handoff seam ---------------------------------------------
+
+
+def _reach_binding(agents: dict) -> PolicyBinding:
+    engine = PolicySet(
+        {
+            DEFAULT_ROLE_NAME: AgentPolicy(
+                default_policy=BaseToolPolicy(mode="allow"), agents=agents
+            )
+        }
+    )
+    return PolicyBinding(PolicyEnforcer(engine, agent_name="orchestrator"), None)
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_gates_handoff_by_source_policy() -> None:
+    runner = HexgateRunner(api_key="k")
+    runner._bindings["orchestrator"] = _reach_binding(
+        {"billing-bot": {"mode": "allow", "via": ["handoff"]}}
+    )
+    hook = _HexgateReachHooks(runner)
+    source = _agent("orchestrator")
+    async with _user():
+        await hook.on_handoff(None, source, _agent("billing-bot"))  # listed → ok
+        with pytest.raises(ReachNotAllowedError):
+            await hook.on_handoff(None, source, _agent("evil-bot"))  # unlisted → deny
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_skips_ungoverned_source() -> None:
+    # A handoff from an agent with no cached binding (not Hexgate-governed) is not
+    # gated here — no resolve, no raise.
+    runner = HexgateRunner(api_key="k")
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        await hook.on_handoff(None, _agent("stranger"), _agent("evil-bot"))
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_noop_without_reach_policy() -> None:
+    runner = HexgateRunner(api_key="k")
+    runner._bindings["orchestrator"] = _reach_binding({})  # declares no reach
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        await hook.on_handoff(None, _agent("orchestrator"), _agent("anyone"))
+
+
+# --- admission at run entry ------------------------------------------------
+
+
+def _patch_admission_resolve(
+    monkeypatch: pytest.MonkeyPatch, admission_mode: str
+) -> None:
+    def fake_resolve(name: str, *, api_key: str, client: object = None):
+        engine = PolicySet(
+            {
+                DEFAULT_ROLE_NAME: AgentPolicy(
+                    default_policy=BaseToolPolicy(mode="allow"),
+                    admission=BaseToolPolicy(mode=admission_mode),
+                )
+            }
+        )
+        return ResolvedPolicy(engine, None)
+
+    monkeypatch.setattr(runner_mod, "resolve_policy", fake_resolve)
+
+
+@pytest.mark.asyncio
+async def test_run_refuses_non_admitted_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "deny")
+    called = {"run": False}
+
+    async def fake_run(*_a: Any, **_k: Any) -> str:
+        called["run"] = True
+        return "ok"
+
+    monkeypatch.setattr(runner_mod.Runner, "run", staticmethod(fake_run))
+    runner = HexgateRunner(api_key="k")
+    with pytest.raises(AgentNotAdmittedError):
+        await runner.run(_agent("my-agent"), "hi", hexgate_context=_user())
+    assert called["run"] is False  # refused before the underlying run
+
+
+@pytest.mark.asyncio
+async def test_run_admits_when_policy_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "allow")
+
+    async def fake_run(*_a: Any, **_k: Any) -> str:
+        return "ok"
+
+    monkeypatch.setattr(runner_mod.Runner, "run", staticmethod(fake_run))
+    runner = HexgateRunner(api_key="k")
+    assert await runner.run(_agent("my-agent"), "hi", hexgate_context=_user()) == "ok"
+
+
+def test_run_sync_refuses_non_admitted_caller(monkeypatch: pytest.MonkeyPatch) -> None:
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "deny")
+    monkeypatch.setattr(
+        runner_mod.Runner, "run_sync", staticmethod(lambda *a, **k: "ok")
+    )
+    runner = HexgateRunner(api_key="k")
+    with pytest.raises(AgentNotAdmittedError):
+        runner.run_sync(_agent("my-agent"), "hi", hexgate_context=_user())

--- a/tests/adapters/openai/test_runner_reach_admission.py
+++ b/tests/adapters/openai/test_runner_reach_admission.py
@@ -20,6 +20,7 @@ from hexgate.security import (
     AgentNotAdmittedError,
     AgentPolicy,
     BaseToolPolicy,
+    HandoffDepthExceededError,
     PolicySet,
     ReachNotAllowedError,
     ResolvedPolicy,
@@ -96,6 +97,30 @@ async def test_reach_hook_noop_without_reach_policy() -> None:
     hook = _HexgateReachHooks(runner)
     async with _user():
         await hook.on_handoff(None, _agent("orchestrator"), _agent("anyone"))
+
+
+# --- handoff depth cap (A4) ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_enforces_depth_cap() -> None:
+    # Depth counts every handoff in the run (the hook is per-run), independent of
+    # reach policy: an un-governed source still counts toward the cap.
+    runner = HexgateRunner(api_key="k", max_handoff_depth=1)
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        await hook.on_handoff(None, _agent("a"), _agent("b"))  # depth 1 == cap → ok
+        with pytest.raises(HandoffDepthExceededError):
+            await hook.on_handoff(None, _agent("a"), _agent("c"))  # depth 2 > cap
+
+
+@pytest.mark.asyncio
+async def test_reach_hook_no_cap_by_default() -> None:
+    runner = HexgateRunner(api_key="k")  # no cap
+    hook = _HexgateReachHooks(runner)
+    async with _user():
+        for _ in range(5):
+            await hook.on_handoff(None, _agent("a"), _agent("b"))  # never raises
 
 
 # --- admission at run entry ------------------------------------------------

--- a/tests/adapters/openai/test_runner_reach_admission.py
+++ b/tests/adapters/openai/test_runner_reach_admission.py
@@ -8,6 +8,7 @@ full SDK handoff, which needs a live model.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -182,3 +183,61 @@ def test_run_sync_refuses_non_admitted_caller(monkeypatch: pytest.MonkeyPatch) -
     runner = HexgateRunner(api_key="k")
     with pytest.raises(AgentNotAdmittedError):
         runner.run_sync(_agent("my-agent"), "hi", hexgate_context=_user())
+
+
+def _fake_streaming() -> SimpleNamespace:
+    """Stand in for a RunResultStreaming — _launch_streamed only reads/rewrites
+    ``stream_events`` (never iterated here)."""
+    return SimpleNamespace(stream_events=lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_arun_streamed_admission_awaits_async_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """arun_streamed resolves admission via the ASYNC path, so an async
+    approval_handler is awaited (not fail-closed like the sync check). This is what
+    `hexgate serve` relies on — an async RelayApprovalHandler over arun_streamed."""
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "approval_required")
+    seen = {"handler": False, "launched": False}
+
+    async def handler(_decision: Any) -> bool:
+        seen["handler"] = True
+        return True  # approve
+
+    def fake_run_streamed(*_a: Any, **_k: Any) -> SimpleNamespace:
+        seen["launched"] = True
+        return _fake_streaming()
+
+    monkeypatch.setattr(
+        runner_mod.Runner, "run_streamed", staticmethod(fake_run_streamed)
+    )
+    runner = HexgateRunner(api_key="k", approval_handler=handler)
+
+    await runner.arun_streamed(_agent("my-agent"), "hi", hexgate_context=_user())
+
+    assert seen["handler"] is True  # awaited, not fail-closed
+    assert seen["launched"] is True  # approved → the run launched
+
+
+def test_run_streamed_async_handler_is_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The *sync* run_streamed keeps its documented limitation: an async handler on
+    the sync admission check fails closed. (arun_streamed is the async entrypoint.)"""
+    _silence_observability(monkeypatch)
+    _patch_admission_resolve(monkeypatch, "approval_required")
+
+    async def handler(_decision: Any) -> bool:
+        return True
+
+    monkeypatch.setattr(
+        runner_mod.Runner,
+        "run_streamed",
+        staticmethod(lambda *a, **k: _fake_streaming()),
+    )
+    runner = HexgateRunner(api_key="k", approval_handler=handler)
+
+    with pytest.raises(AgentNotAdmittedError):
+        runner.run_streamed(_agent("my-agent"), "hi", hexgate_context=_user())

--- a/tests/adapters/openai/test_tools_reach.py
+++ b/tests/adapters/openai/test_tools_reach.py
@@ -200,6 +200,60 @@ async def test_name_scoped_guard_fires_on_as_tool_under_reach() -> None:
     assert seen == ["billing"]  # matched by tool name, not agent.tool:billing_bot
 
 
+@pytest.mark.asyncio
+async def test_reach_constraint_reads_reach_args_not_tool_input() -> None:
+    """A constraint on the reach rule sees ``{agent, target, via}`` (as at the
+    handoff seam), not the sub-agent's tool-call payload — so the same rule shape
+    behaves identically at both seams."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {
+                "billing_bot": {
+                    "via": ["tool"],
+                    "mode": "allow",
+                    "constraints": [
+                        'args.target == "billing_bot"',
+                        'args.via == "tool"',
+                    ],
+                }
+            },
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert result == 'ran-subagent:{"query": "balance"}'
+    assert calls
+
+
+@pytest.mark.asyncio
+async def test_reach_constraint_target_mismatch_denies() -> None:
+    """The reach args are the real decision input, so a constraint that doesn't
+    match the actual target denies (proving the args aren't ignored)."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {
+                "billing_bot": {
+                    "via": ["tool"],
+                    "mode": "allow",
+                    "constraints": ['args.target == "someone_else"'],
+                }
+            },
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert calls == []
+    assert "[policy_denied]" in result
+
+
 # --- name-gating fallback (no reach declared) — non-breaking -----------------
 
 

--- a/tests/adapters/openai/test_tools_reach.py
+++ b/tests/adapters/openai/test_tools_reach.py
@@ -1,0 +1,262 @@
+"""Phase 1: top-edge agent-as-tool reach gating on the OpenAI adapter.
+
+An ``Agent.as_tool()`` is a reach edge, not an ordinary tool. When the policy
+declares reach, ``wrap_tool`` gates the call under ``agent.tool:<target>``
+(closed-world, ``via``/constraints honored) instead of the tool name; without an
+``agents`` block it keeps today's name-gating unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from agents import FunctionTool
+from agents.tool import ToolOrigin, ToolOriginType
+
+from hexgate.adapters.openai import tools as tools_mod
+from hexgate.adapters.openai.tools import _agent_tool_target, wrap_tool
+from hexgate.security import AgentPolicy, PolicySet
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"query": {"type": "string"}},
+    "required": ["query"],
+}
+
+
+def _enforcer(spec: dict[str, Any]) -> PolicyEnforcer:
+    return PolicyEnforcer(
+        PolicySet({DEFAULT_ROLE_NAME: AgentPolicy.model_validate(spec)})
+    )
+
+
+def _agent_tool(
+    target: str = "billing_bot",
+    name: str = "billing",
+    calls: list[Any] | None = None,
+) -> FunctionTool:
+    """A FunctionTool tagged the way ``Agent.as_tool()`` tags one — its origin
+    points at ``target`` — but with a benign body we control (the real one would
+    run the sub-agent through the SDK)."""
+    record: list[Any] = calls if calls is not None else []
+
+    async def on_invoke(ctx: Any, raw_args: str) -> str:
+        record.append({"ctx": ctx, "args": raw_args})
+        return f"ran-subagent:{raw_args}"
+
+    return FunctionTool(
+        name=name,
+        description="consult the billing sub-agent",
+        params_json_schema=_SCHEMA,
+        on_invoke_tool=on_invoke,
+        _tool_origin=ToolOrigin(type=ToolOriginType.AGENT_AS_TOOL, agent_name=target),
+        _is_agent_tool=True,
+    )
+
+
+def _plain_tool(name: str = "echo") -> FunctionTool:
+    async def on_invoke(ctx: Any, raw_args: str) -> str:
+        return f"invoked:{raw_args}"
+
+    return FunctionTool(
+        name=name,
+        description="echo",
+        params_json_schema=_SCHEMA,
+        on_invoke_tool=on_invoke,
+    )
+
+
+# --- detection --------------------------------------------------------------
+
+
+def test_detects_agent_as_tool_target() -> None:
+    assert _agent_tool_target(_agent_tool(target="billing_bot")) == "billing_bot"
+
+
+def test_plain_tool_is_not_an_agent_tool() -> None:
+    assert _agent_tool_target(_plain_tool()) is None
+
+
+def test_detection_falls_back_when_sdk_cannot_expose_origin(monkeypatch) -> None:
+    monkeypatch.setattr(tools_mod, "_CAN_DETECT_AGENT_TOOLS", False)
+    assert _agent_tool_target(_agent_tool()) is None
+
+
+# --- reach-key gating (policy declares reach) -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_allowed_when_reach_grants_tool_via() -> None:
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"billing_bot": {"via": ["tool"], "mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert result == 'ran-subagent:{"query": "balance"}'
+    assert calls  # the sub-agent body ran
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_closed_world_denies_unlisted_target() -> None:
+    """Reach is declared but this target isn't listed — closed-world denies, and
+    the sub-agent never runs. The message names the bare target, not the key."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"other_bot": {"via": ["tool"], "mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert calls == []
+    assert "[policy_denied]" in result
+    assert "billing_bot" in result
+    assert "agent.tool" not in result  # no synthetic-key leak
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_denied_when_target_listed_handoff_only() -> None:
+    """Tool-reach is engaged (another target is ``via: tool``) and billing_bot is
+    listed ``via: handoff`` only — reaching it *as a tool* closed-world denies."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {
+                "billing_bot": {"via": ["handoff"], "mode": "allow"},
+                "research_bot": {
+                    "via": ["tool"],
+                    "mode": "allow",
+                },  # engages tool-reach
+            },
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert calls == []
+    assert "[policy_denied]" in result
+    assert "billing_bot" in result
+
+
+@pytest.mark.asyncio
+async def test_handoff_only_policy_does_not_engage_tool_reach() -> None:
+    """A policy that declares only handoff reach must NOT closed-world-deny every
+    agent-as-tool: with no ``via: tool`` target declared, as-tools fall back to
+    name-gating (so a ``tools`` allow lets the call through)."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"billing_bot": {"via": ["handoff"], "mode": "allow"}},
+            "tools": {"billing": {"mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(name="billing", calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert result == 'ran-subagent:{"query": "balance"}'
+    assert calls  # not silently denied
+
+
+@pytest.mark.asyncio
+async def test_name_scoped_guard_fires_on_as_tool_under_reach() -> None:
+    """A guard scoped to the as-tool's function name still fires when reach is
+    engaged — the reach key drives only the policy decision, not guard matching."""
+    from hexgate.guards import before_tool, build_pipeline
+    from hexgate.guards.types import Proceed
+
+    seen: list[str] = []
+
+    def watcher(call: Any) -> Proceed:
+        seen.append(call.tool_name)
+        return Proceed()
+
+    pipe = build_pipeline([before_tool(watcher, tool_names="billing")])
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"billing_bot": {"via": ["tool"], "mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(name="billing"), enforcer, pipeline=pipe)
+
+    await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert seen == ["billing"]  # matched by tool name, not agent.tool:billing_bot
+
+
+# --- name-gating fallback (no reach declared) — non-breaking -----------------
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_name_gated_deny_without_reach_block() -> None:
+    """No ``agents`` block → today's behavior: gated by the tool name, so a
+    ``tools`` deny still blocks it (and no closed-world surprise fires)."""
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "tools": {"billing": {"mode": "deny"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(name="billing", calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert calls == []
+    assert "[policy_denied]" in result
+    assert "billing" in result  # named by tool name on the fallback path
+
+
+@pytest.mark.asyncio
+async def test_agent_tool_name_gated_allow_without_reach_block() -> None:
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "tools": {"billing": {"mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(name="billing", calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert result == 'ran-subagent:{"query": "balance"}'
+    assert calls
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_name_gating_when_sdk_undetectable(monkeypatch) -> None:
+    """SDK too old to expose origins → the as-tool is treated as a plain tool
+    (name-gated), even when the policy declares reach that would grant it."""
+    monkeypatch.setattr(tools_mod, "_CAN_DETECT_AGENT_TOOLS", False)
+    calls: list[Any] = []
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            # reach would grant billing_bot, but detection is off, so the
+            # tool-name 'billing' governs — and it is denied by default.
+            "agents": {"billing_bot": {"via": ["tool"], "mode": "allow"}},
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(name="billing", calls=calls), enforcer)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert calls == []
+    assert "[policy_denied]" in result

--- a/tests/adapters/openai/test_tools_reach.py
+++ b/tests/adapters/openai/test_tools_reach.py
@@ -201,6 +201,29 @@ async def test_name_scoped_guard_fires_on_as_tool_under_reach() -> None:
 
 
 @pytest.mark.asyncio
+async def test_guard_halt_on_as_tool_uses_guard_wording_not_reach() -> None:
+    """A guard Halt renders through ``render_error`` (guard wording), not the
+    reach ``render_policy_error`` — so a guard rejecting an as-tool call is not
+    mislabeled 'reach not permitted / sub-agent was not invoked'."""
+    from hexgate.guards import before_tool, build_pipeline
+    from hexgate.guards.types import Halt
+
+    pipe = build_pipeline([before_tool(lambda call: Halt(reason="blocked by guard"))])
+    enforcer = _enforcer(
+        {
+            "default_policy": {"mode": "deny"},
+            "agents": {"billing_bot": {"via": ["tool"], "mode": "allow"}},  # reach ok
+        }
+    )
+    wrapped = wrap_tool(_agent_tool(), enforcer, pipeline=pipe)
+
+    result = await wrapped.on_invoke_tool("ctx", '{"query": "balance"}')
+
+    assert "blocked by guard" in result  # the guard's reason
+    assert "reach to agent" not in result  # not the reach denial wording
+
+
+@pytest.mark.asyncio
 async def test_reach_constraint_reads_reach_args_not_tool_input() -> None:
     """A constraint on the reach rule sees ``{agent, target, via}`` (as at the
     handoff seam), not the sub-agent's tool-call payload — so the same rule shape

--- a/tests/security/test_naming.py
+++ b/tests/security/test_naming.py
@@ -1,0 +1,47 @@
+"""Tests for canonical agent-name derivation (``security/naming.py``)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from hexgate.security.naming import (
+    DEFAULT_AGENT_NAME,
+    canonical_agent_name,
+    canonical_name,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("billing-bot", "billing-bot"),
+        ("  billing-bot  ", "billing-bot"),  # trimmed
+        ("", DEFAULT_AGENT_NAME),  # blank → default
+        ("   ", DEFAULT_AGENT_NAME),  # whitespace-only → default
+        (None, DEFAULT_AGENT_NAME),  # missing → default
+        (123, DEFAULT_AGENT_NAME),  # non-str → default
+    ],
+)
+def test_canonical_name(raw: object, expected: str) -> None:
+    assert canonical_name(raw) == expected  # type: ignore[arg-type]
+
+
+def test_canonical_agent_name_reads_name_attr() -> None:
+    assert (
+        canonical_agent_name(SimpleNamespace(name="  refund-agent ")) == "refund-agent"
+    )
+
+
+def test_canonical_agent_name_defaults_when_unnamed() -> None:
+    assert canonical_agent_name(SimpleNamespace()) == DEFAULT_AGENT_NAME
+    assert canonical_agent_name(SimpleNamespace(name=None)) == DEFAULT_AGENT_NAME
+    assert canonical_agent_name(SimpleNamespace(name="")) == DEFAULT_AGENT_NAME
+
+
+def test_own_and_target_derivation_agree() -> None:
+    # The whole point: an agent's own-name and its name as a reach target derive
+    # identically, so a target authored under the name it registers with matches.
+    agent = SimpleNamespace(name="Support Bot")
+    assert canonical_agent_name(agent) == canonical_name(agent.name)

--- a/tests/security/test_reach_gate.py
+++ b/tests/security/test_reach_gate.py
@@ -90,6 +90,15 @@ def test_reach_target_name_is_canonicalized() -> None:
         gate.check_reach("  billing-bot ", via="handoff")  # trimmed → matches
 
 
+def test_reach_authored_target_key_is_canonicalized() -> None:
+    # The other side of parity: a whitespace-padded *authored* target key lowers to
+    # the canonical reach key, so a canonical runtime target still matches (the
+    # lowering and the gate normalize identically).
+    gate = resolve_reach_gate(_enforcer({"  billing-bot ": {"mode": "allow"}}))
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")  # authored padding trimmed
+
+
 # --- approval --------------------------------------------------------------
 
 

--- a/tests/security/test_reach_gate.py
+++ b/tests/security/test_reach_gate.py
@@ -1,0 +1,144 @@
+"""Tests for the reach gate (``security/agent_gate.py``).
+
+The reach gate mirrors the admission gate but decides a target's lowered reach key
+(``agent.handoff:<target>`` / ``agent.tool:<target>``) at the handoff/delegation
+seam. These drive it through a real ``PolicySet`` enforcer under an open context
+scope. Engagement is opt-in: a policy with no ``agents`` block is a no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate.runtime.context import HexgateContext
+from hexgate.security import (
+    AgentPolicy,
+    BaseToolPolicy,
+    ReachNotAllowedError,
+    resolve_reach_gate,
+)
+from hexgate.security.enforcer import PolicyEnforcer
+from hexgate.security.policy_set import load_policy_set
+
+_ROLE = HexgateContext(user_id="u", user_roles=["support"])
+
+
+def _enforcer(agents: dict | None) -> PolicyEnforcer:
+    policy = AgentPolicy(
+        default_policy=BaseToolPolicy(mode="allow"),  # permissive default...
+        agents=agents or {},
+    )
+    return PolicyEnforcer(load_policy_set(policy), agent_name="orchestrator")
+
+
+# --- engagement (opt-in) ---------------------------------------------------
+
+
+def test_no_agents_block_is_a_noop() -> None:
+    # No reach declared → gate never fires, even for an unknown target.
+    gate = resolve_reach_gate(_enforcer(None))
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")  # does not raise
+
+
+# --- verdicts --------------------------------------------------------------
+
+
+def test_reach_allow_passes() -> None:
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")  # listed → allowed
+
+
+def test_reach_unlisted_target_is_closed_world_denied() -> None:
+    # ...even under an allow default: an unlisted reach key denies once reach is
+    # declared (closed-world), so a permissive default cannot grant a handoff.
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    with _ROLE.sync_scope(), pytest.raises(ReachNotAllowedError):
+        gate.check_reach("evil-bot", via="handoff")
+
+
+def test_reach_via_is_distinguished() -> None:
+    # A target listed for handoff only is not reachable as a tool.
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "allow", "via": ["handoff"]}})
+    )
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")
+        with pytest.raises(ReachNotAllowedError):
+            gate.check_reach("billing-bot", via="tool")
+
+
+def test_reach_deny_raises_and_carries_decision() -> None:
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "allow", "via": ["handoff"]}})
+    )
+    with _ROLE.sync_scope():
+        try:
+            gate.check_reach("billing-bot", via="tool")
+        except ReachNotAllowedError as exc:
+            assert exc.decision.tool_name == "agent.tool:billing-bot"
+            assert not exc.decision.allowed
+        else:  # pragma: no cover
+            pytest.fail("expected ReachNotAllowedError")
+
+
+def test_reach_target_name_is_canonicalized() -> None:
+    # A whitespace-padded runtime target matches the listed target.
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    with _ROLE.sync_scope():
+        gate.check_reach("  billing-bot ", via="handoff")  # trimmed → matches
+
+
+# --- approval --------------------------------------------------------------
+
+
+def test_reach_approval_bool_true_passes() -> None:
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=True,
+    )
+    with _ROLE.sync_scope():
+        gate.check_reach("billing-bot", via="handoff")
+
+
+def test_reach_approval_bool_false_raises() -> None:
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=False,
+    )
+    with _ROLE.sync_scope(), pytest.raises(ReachNotAllowedError):
+        gate.check_reach("billing-bot", via="handoff")
+
+
+def test_reach_approval_handler_raises_fails_closed() -> None:
+    def boom(_decision: object) -> bool:
+        raise RuntimeError("handler blew up")
+
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=boom,
+    )
+    with _ROLE.sync_scope(), pytest.raises(ReachNotAllowedError):
+        gate.check_reach("billing-bot", via="handoff")
+
+
+# --- async path ------------------------------------------------------------
+
+
+async def test_async_reach_allow_passes() -> None:
+    gate = resolve_reach_gate(_enforcer({"billing-bot": {"mode": "allow"}}))
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_reach_async("billing-bot", via="handoff")
+
+
+async def test_async_reach_approval_async_handler() -> None:
+    async def approve(_decision: object) -> bool:
+        return True
+
+    gate = resolve_reach_gate(
+        _enforcer({"billing-bot": {"mode": "approval_required"}}),
+        approval_handler=approve,
+    )
+    async with HexgateContext(user_id="u", user_roles=["support"]):
+        await gate.check_reach_async("billing-bot", via="handoff")

--- a/tests/security/test_reach_gate.py
+++ b/tests/security/test_reach_gate.py
@@ -8,6 +8,8 @@ scope. Engagement is opt-in: a policy with no ``agents`` block is a no-op.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from hexgate.runtime.context import HexgateContext
@@ -16,7 +18,9 @@ from hexgate.security import (
     BaseToolPolicy,
     ReachNotAllowedError,
     resolve_reach_gate,
+    warn_if_tool_reach_unenforced,
 )
+from hexgate.security import agent_gate as agent_gate_mod
 from hexgate.security.enforcer import PolicyEnforcer
 from hexgate.security.policy_set import load_policy_set
 
@@ -151,3 +155,45 @@ async def test_async_reach_approval_async_handler() -> None:
     )
     async with HexgateContext(user_id="u", user_roles=["support"]):
         await gate.check_reach_async("billing-bot", via="handoff")
+
+
+# --- tool-reach detection + OpenAI-style warning ---------------------------
+
+
+def test_declares_tool_reach_distinguishes_via() -> None:
+    tool = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["tool"]}})
+    )
+    handoff = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["handoff"]}})
+    )
+    assert tool.declares_tool_reach() is True
+    assert tool.declares_reach() is True
+    assert handoff.declares_tool_reach() is False  # handoff-only
+    assert handoff.declares_reach() is True
+
+
+def test_warn_if_tool_reach_unenforced(caplog) -> None:
+    agent_gate_mod._reach_unenforced_warned.clear()
+    tool_engine = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["tool"]}})
+    )
+    handoff_engine = load_policy_set(
+        AgentPolicy(agents={"b": {"mode": "allow", "via": ["handoff"]}})
+    )
+    with caplog.at_level(logging.WARNING, logger=agent_gate_mod.__name__):
+        # handoff-only: enforced on OpenAI, so no tool-reach warning
+        warn_if_tool_reach_unenforced(
+            handoff_engine, framework="OpenAI Agents", agent_name="a"
+        )
+        assert not [r for r in caplog.records if r.levelno == logging.WARNING]
+        # tool-via declared: warns once
+        warn_if_tool_reach_unenforced(
+            tool_engine, framework="OpenAI Agents", agent_name="a"
+        )
+        warn_if_tool_reach_unenforced(
+            tool_engine, framework="OpenAI Agents", agent_name="a"
+        )
+    records = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(records) == 1  # deduped
+    assert "as-tool" in records[0].getMessage()


### PR DESCRIPTION
> **📚 Stacked on #124 — review/merge #124 first.** This PR's base branch is `lhq/feat/agent-admission-gate` (#124's head), so the diff below shows **only** the reach/handoff commits on top of #124, not #124's own changes. GitHub retargets this base to `main` automatically once #124 merges. Merge order: **#124 → then this.**
>
> **Update (as-tool reach on OpenAI):** OpenAI agent-as-tool reach is now enforced at the **top level** too — the SDK tags an `Agent.as_tool()` with its target, so `wrap_tool` gates it under `agent.tool:<target>`. Nested/deeper as-tool edges remain name-gated (a follow-up); see `nested-agent-as-tool-reach-design.md`.

---

Enforce agent-to-agent reach (handoff and agent-as-tool) and admission at runtime across the framework adapters, and cap handoff-chain depth. This is A3 + A4 of the agent-level enforcement series, building on the policy model and gates from #124 (which it is stacked on). Pure SDK, no platform or dashboard change, no migration.

Before this PR the reach policy layer was complete but nothing enforced it at runtime (`declares_reach()` only fed the bundle manifest), and admission was enforced only on the native agent. This wires both into the OpenAI and Google adapters at their real handoff/delegation seams, adds a handoff-depth runaway cap, and warns loudly where a framework exposes no target handle.

Scope was chosen deliberately: only OpenAI (handoff) and Google (handoff + agent-as-tool) expose a first-class target-agent handle at the seam, so enforcement lands there; pydantic_ai and the native single-graph agent get a loud warn-and-defer. Full rationale and the explicit follow-ups are in `docs/adr/R-AGENT-003`.

## Design

- **`ReachGate`** (`security/agent_gate.py`): the reach counterpart to `AgentGate`, sharing a new `_PolicyGate` base (enforcer + approval fold + fail-closed). `check_reach(target, via)` decides `agent.{via}:<target>` against the source agent's policy, engages per-seam via `declares_reach()`, and raises `ReachNotAllowedError` on a deny.
- **`canonical_agent_name`** (`security/naming.py`): one derivation for an agent's own name and its name as a reach target, so a target authored under the name it registers with matches at the seam. Replaces two divergent per-adapter spellings.
- **OpenAI**: a per-run `_HexgateReachHooks` intercepts the SDK `on_handoff` (awaited before the transfer completes, so raising vetoes it); admission is checked at run entry for the top-level agent. Only reach from the governed source is gated.
- **Google ADK**: a `_HexgateReachPlugin` (`BasePlugin.before_tool_callback`) intercepts `transfer_to_agent` (handoff) and `AgentTool` (agent-as-tool); admission is checked at run entry in `run`/`run_async`.
- **A4 depth cap**: `HexgateRunner(max_handoff_depth=N)` on both adapters. A handoff transfers control forward, so the per-run handoff count is the chain depth; past the cap the seam raises `HandoffDepthExceededError`. OpenAI counts on the per-run hook; Google counts per `invocation_id` and clears in `after_run_callback`.
- **Warn-and-defer**: `warn_if_reach_unenforced` on pydantic_ai, LangChain, and the native agent (native keeps enforcing admission, so reach-only warning).

## Important files

| File | What to look at |
| --- | --- |
| `hexgate/security/agent_gate.py` | `_PolicyGate` base; `ReachGate.check_reach`; `ReachNotAllowedError`, `HandoffDepthExceededError`; `warn_if_reach_unenforced` |
| `hexgate/security/naming.py` | `canonical_agent_name` / `canonical_name` — the one name derivation |
| `hexgate/adapters/openai/runner.py` | `_HexgateReachHooks.on_handoff` (reach + depth), run-entry admission, `_merge_hooks` always composing |
| `hexgate/adapters/google/runner.py` | `_HexgateReachPlugin.before_tool_callback` (transfer_to_agent + AgentTool, reach + per-invocation depth), run-entry admission |
| `docs/adr/R-AGENT-003-...md` | the runtime-seam decisions, the source-governed rule, and the deferred follow-ups |
| `tests/security/test_reach_gate.py`, `tests/adapters/{openai,google}/...` | the reach/admission/depth behaviour, driven at the seams |

## Test plan

Ran the SDK suite against the hexanlp-demo env: `pytest tests/ -q` gives 2128 passed, 6 skipped (opt-in integration), 20 deselected. `ruff check` and `ruff format --check` clean over `hexgate/` and `tests/`.

Verified against the installed SDKs (not assumed): the OpenAI `on_handoff` is awaited via `asyncio.gather` before the SDK returns `NextStepHandoff`, so raising there vetoes the transfer; ADK's `before_tool_callback` sees `transfer_to_agent(agent_name=...)` and `AgentTool` (with `tool_context.agent_name` identifying the source), and `after_run_callback` carries the `invocation_id` used to clear the depth counter. By hand I checked: an unlisted/deny reach target raises and stops the transfer; a non-admitted caller is refused at run entry before the underlying run; a handoff past `max_handoff_depth` raises; a handoff from an un-governed source is not gated; ordinary tools fall through to the wrapped enforcer. A reviewer catches a regression through `test_reach_gate.py` (gate semantics) and the per-adapter seam tests (governed-source, via distinction, depth cap, admission refuse/allow).

## Try it

```
uv run pytest tests/security/test_reach_gate.py tests/security/test_naming.py -q
uv run pytest tests/adapters/openai/test_runner_reach_admission.py -q
uv run pytest tests/adapters/google/test_runner.py -q
```

## Notes

- Stacked on #124 (`lhq/feat/agent-admission-gate`); review/merge that first, or read this PR's diff against it. No platform/dashboard change.
- Fail-closed throughout: a denied reach/admission or an over-depth handoff raises and aborts the run rather than continuing ungoverned.
- Deferred (warned in the interim, tracked in R-AGENT-003): per-sub-agent/post-handoff admission (needs sub-agent policy resolution); agent-as-tool reach on OpenAI (no target handle at the seam); pydantic_ai/native reach; the manifest drift lint (reach key vs declared sub-agents), which needs a cross-package `AgentManifest` change.

