### PR TITLE
fix(docs): match brand blue to the platform indigo

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "hexgate",
   "colors": {
-    "primary": "#3B82F6",
-    "light": "#60A5FA",
-    "dark": "#2563EB"
+    "primary": "#2F57DA",
+    "light": "#6081EB",
+    "dark": "#2647B0"
   },
   "favicon": "/favicon.svg",
   "navigation": {


### PR DESCRIPTION
The Mintlify docs and the platform dashboard were using two different blues — the docs on Tailwind blue-500 (hue ~217) and the platform on its own indigo (hue 226). Side by side they read as a slight brand mismatch. This aligns the docs to the platform.

## What it does
Repoints `docs.json`'s three brand colors to the platform's `--primary` indigo:

| role | before | after |
|---|---|---|
| `primary` | `#3B82F6` | `#2F57DA` (platform light `--primary`) |
| `light` | `#60A5FA` | `#6081EB` (platform dark `--primary`) |
| `dark` | `#2563EB` | `#2647B0` (darker indigo for light-mode accents) |

## Try it
`mint dev` in `docs/` — the sidebar accent, links, and the "Get started" button now match the dashboard's blue.

## Important files
- `docs/docs.json` — `colors` block.

## Notes
Mintlify can't read the dashboard's CSS vars, so these hexes are a manual mirror of `platform/dashboard/src/index.css` `--primary`. If that token is ever retuned, this file has to follow by hand.