### PR TITLE
feat(sdk): serve OpenAI, Google ADK, and Pydantic AI agents (framework-agnostic streaming)

### DIFF
--- a/deploy/google_demo_notebook.py
+++ b/deploy/google_demo_notebook.py
@@ -1,0 +1,217 @@
+"""Hexgate live-demo notebook (marimo) — Google ADK edition.
+
+Twin of ``openai_demo_notebook.py`` / ``demo_notebook.py``, but the agent is a
+raw Google ADK ``Agent``. It exercises the Google serve path end to end:
+``serve_manager`` runs the ``hexgate serve`` loop bound to the live ``Agent``,
+``hexgate serve`` dispatches on the manifest framework to the Google runtime
+(``GoogleServeDriver`` owns the ADK session + SSE streaming), and every turn
+streams through the Google → hexgate ``StreamEvent`` normalizer to the dashboard
+Playground.
+
+BYOK is an OpenAI key: the ADK agent runs on OpenAI via ``LiteLlm``. Your key
+lives only in this throwaway container and is never written to disk. Run by
+boot.py via ``marimo edit``.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import sys
+    from pathlib import Path
+
+    import marimo as mo
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import serve_manager
+
+    return Path, mo, serve_manager
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    # 🛡️ Hexgate — run a live **Google ADK** agent
+
+    A **throwaway sandbox** — everything vanishes when it scales down. The
+    Google-framework twin of the native demo: same gate, same dashboard, a
+    `google.adk.agents.Agent` instead of a hexgate agent.
+
+    1. **Define your tools** (plain Python functions).
+    2. **Define your agent** (a factory — built on Start, after your key).
+    3. **Enter your OpenAI key and start it** (the ADK agent runs on OpenAI via LiteLlm).
+    4. **Open the playground** to chat and watch policy decisions stream.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 1 · Define your tools
+    """)
+    return
+
+
+@app.cell
+def _():
+    # Plain Python functions — ADK wraps them as tools. The function name is the
+    # tool name the policy references below.
+    def get_order_status(order_id: str) -> str:
+        """Look up the delivery status of an order by its id."""
+        return f"Order {order_id}: shipped, arriving Tuesday."
+
+    def refund_order(order_id: str, amount: float) -> str:
+        """Issue a refund of `amount` USD for `order_id`. A side-effecting tool."""
+        return f"Refunded ${amount:.2f} for order {order_id}."
+
+    TOOLS = [get_order_status, refund_order]
+    return (TOOLS,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 2 · Define your agent
+    """)
+    return
+
+
+@app.cell
+def _(TOOLS):
+    # A factory — built on Start (step 3), after your key. The `name` is the
+    # manifest name and the policy lookup key on the platform.
+    from google.adk.agents import Agent
+    from google.adk.models.lite_llm import LiteLlm
+
+    def build_agent():
+        return Agent(
+            name="demo_google_agent",
+            model=LiteLlm(model="openai/gpt-4o-mini"),
+            instruction=(
+                "You are a customer support agent. Help with orders and refunds. "
+                "Confirm details before issuing a refund."
+            ),
+            tools=TOOLS,
+        )
+
+    return (build_agent,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 3 · Add your OpenAI key & start
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    api_key = mo.ui.text(kind="password", placeholder="sk-...", full_width=True)
+    start = mo.ui.run_button(label="▶ Start agent")
+    mo.vstack([mo.md("**OpenAI API key**"), api_key, start])
+    return api_key, start
+
+
+@app.cell
+def _(api_key, build_agent, mo, serve_manager, start):
+    # serve_manager is framework-agnostic — build_runtime_from_local_agent
+    # dispatches on the manifest framework and builds the Google runtime.
+    import os
+    import time
+
+    if start.value:
+        if not api_key.value:
+            out = mo.md("⚠️ **Enter your OpenAI key above**, then click Start.")
+        else:
+            os.environ["OPENAI_API_KEY"] = api_key.value  # BYOK
+            agent = build_agent()
+            serve_manager.apply(agent)
+            time.sleep(3)  # let it build the runtime, auto-register + dial /v1/serve
+            st = serve_manager.status()
+            if st == "running":
+                out = mo.md(
+                    f"✅ **Agent running** (key `…{api_key.value[-4:]}`). "
+                    "Open the playground below."
+                )
+            elif st.startswith("error"):
+                out = mo.md(f"❌ **Failed to start:** `{st}`")
+            else:
+                out = mo.md(
+                    f"⏳ **{st}** — give it a few seconds and click Start again."
+                )
+    else:
+        out = mo.md(
+            f"Agent status: **{serve_manager.status()}** — "
+            "enter your key above and click **Start agent**."
+        )
+    out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## The policy that governs it
+
+    Keyed by the agent name (`demo_google_agent`) — view and edit it live in the
+    Playground's **Policies** tab.
+
+    ```yaml
+    version: 1
+
+    default_policy:
+      mode: deny
+
+    tools:
+      get_order_status:
+        mode: allow
+      refund_order:
+        mode: approval_required
+        constraints:
+          - args.amount <= 100
+    ```
+
+    A status lookup **runs**, a small refund **pauses for approval**, and a
+    refund over $100 is **denied** — enforced by the ADK `HexgateRunner`, not
+    the model.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 4 · Open the playground
+    """)
+    return
+
+
+@app.cell
+def _(Path, mo):
+    dash_url = Path("/tmp/hexgate_dash_url").read_text().strip().rstrip("/")
+    login_url = f"{dash_url}/v1/demo-login"
+
+    mo.md(
+        f"""
+        ### [▶ Chat with your agent →]({login_url})
+
+        Opens the dashboard signed in. Send a message and watch the text, tool
+        calls, and **policy decisions** stream live from the Google agent.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/deploy/openai_demo_notebook.py
+++ b/deploy/openai_demo_notebook.py
@@ -1,0 +1,276 @@
+"""Hexgate live-demo notebook (marimo) — OpenAI Agents SDK edition.
+
+Same shape as ``demo_notebook.py`` (the native/LangChain demo), but the agent is
+a raw OpenAI Agents SDK ``Agent`` instead of a hexgate ``create_agent``. It
+exercises the OpenAI serve path end to end: ``serve_manager`` runs the
+``hexgate serve`` loop bound to the live ``Agent`` object, ``hexgate serve``
+dispatches on the manifest framework to the OpenAI runtime, and every turn
+streams through the OpenAI → hexgate ``StreamEvent`` normalizer to the dashboard
+Playground.
+
+Read top to bottom:
+  1. define your tools (``@function_tool``),
+  2. define your agent (a factory — built on Start),
+  3. enter your OpenAI key and start it,
+  4. open the dashboard playground to chat.
+
+BYOK: your key lives only in this throwaway container and is never written to
+disk. Run by boot.py via ``marimo edit``.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import sys
+    from pathlib import Path
+
+    import marimo as mo
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import serve_manager
+
+    return Path, mo, serve_manager
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    # 🛡️ Hexgate — run a live **OpenAI Agents SDK** agent
+
+    A **throwaway sandbox** — everything vanishes when it scales down. This is the
+    OpenAI-framework twin of the native demo: same gate, same dashboard, an
+    `agents.Agent` instead of a hexgate agent.
+
+    1. **Define your tools** (`@function_tool`).
+    2. **Define your agent** (a factory — built on Start, after your key).
+    3. **Enter your OpenAI key and start it.**
+    4. **Open the playground** to chat and watch policy decisions stream.
+
+    Edit the tools/agent cells anytime, then click **Start** again to reload.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    # A picture of the one idea: every tool call detours through the gate, which
+    # answers allow / deny / approval from the policy + the caller's role.
+    _diagram = mo.mermaid(
+        """
+        flowchart LR
+            You["🧑 you<br/>define agent + tools"] --> Agent["🤖 OpenAI agent"]
+            Agent -->|"tool call + args"| Gate
+            subgraph HG ["🛡️ hexgate"]
+                Gate["PolicyEnforcer"] --> Q{"role +<br/>args ok?"}
+            end
+            Q -->|allow| Tool["🔧 tool runs"]
+            Q -->|deny| Blk["⛔ blocked"]
+            Q -->|approval| Human["🙋 you approve<br/>in the Playground"]
+            Human -->|approved| Tool
+        """
+    )
+    mo.vstack(
+        [
+            mo.md("## How hexgate works"),
+            _diagram,
+            mo.md(
+                "Your OpenAI agent runs behind the **gate**: every tool call is "
+                "checked against a **policy** — the caller's **role** and the "
+                "call's **arguments** — and comes back **allow / deny / approval** "
+                "before it runs. The `HexgateRunner` enforces it; you watch the "
+                "decisions and approve them live in the dashboard **Playground**."
+            ),
+        ]
+    )
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 1 · Define your tools
+    """)
+    return
+
+
+@app.cell
+def _():
+    # Plain OpenAI Agents SDK tools — edit / add freely, then re-run this cell.
+    # The function name becomes the tool name the policy references below.
+    from agents import function_tool
+
+    @function_tool
+    def get_order_status(order_id: str) -> str:
+        """Look up the delivery status of an order by its id."""
+        return f"Order {order_id}: shipped, arriving Tuesday."
+
+    @function_tool
+    def refund_order(order_id: str, amount: float) -> str:
+        """Issue a refund of `amount` USD for `order_id`. A side-effecting tool."""
+        return f"Refunded ${amount:.2f} for order {order_id}."
+
+    TOOLS = [get_order_status, refund_order]
+    return (TOOLS,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 2 · Define your agent
+    """)
+    return
+
+
+@app.cell
+def _(TOOLS):
+    # A factory — the actual agent is built on Start (step 3). Unlike the native
+    # demo (create_agent eagerly builds ChatOpenAI), an `agents.Agent` with a
+    # model string is lazy, but we keep the same build-on-Start shape so editing
+    # the agent + clicking Start reloads it into the playground. The `name` is
+    # the manifest name and the policy lookup key on the platform.
+    from agents import Agent
+
+    def build_agent():
+        return Agent(
+            name="demo_openai_agent",
+            instructions=(
+                "You are a customer support agent. Help with orders and refunds. "
+                "Confirm details before issuing a refund."
+            ),
+            tools=TOOLS,
+            model="gpt-4o-mini",
+        )
+
+    return (build_agent,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 3 · Add your OpenAI key & start
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    # Value is live as you type (no Enter needed); the button starts the agent.
+    # The key lives only in the running kernel — never written to this file.
+    api_key = mo.ui.text(kind="password", placeholder="sk-...", full_width=True)
+    start = mo.ui.run_button(label="▶ Start agent")
+    mo.vstack([mo.md("**OpenAI API key**"), api_key, start])
+    return api_key, start
+
+
+@app.cell
+def _(api_key, build_agent, mo, serve_manager, start):
+    # Fires on button click: set the key in the env, build the OpenAI agent,
+    # (re)start the in-kernel serve loop bound to that live agent, then report the
+    # REAL status so you see it actually connected. serve_manager is framework-
+    # agnostic — build_runtime_from_local_agent dispatches on the manifest
+    # framework and builds the OpenAI runtime for this Agent.
+    import os
+    import time
+
+    if start.value:
+        if not api_key.value:
+            out = mo.md("⚠️ **Enter your OpenAI key above**, then click Start.")
+        else:
+            os.environ["OPENAI_API_KEY"] = api_key.value  # BYOK
+            agent = build_agent()
+            serve_manager.apply(agent)
+            time.sleep(3)  # let it build the runtime, auto-register + dial /v1/serve
+            st = serve_manager.status()
+            if st == "running":
+                out = mo.md(
+                    f"✅ **Agent running** (key `…{api_key.value[-4:]}`). "
+                    "Open the playground below."
+                )
+            elif st.startswith("error"):
+                out = mo.md(f"❌ **Failed to start:** `{st}`")
+            else:
+                out = mo.md(
+                    f"⏳ **{st}** — give it a few seconds and click Start again."
+                )
+    else:
+        out = mo.md(
+            f"Agent status: **{serve_manager.status()}** — "
+            "enter your key above and click **Start agent**."
+        )
+    out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## The policy that governs it
+
+    A policy is a small YAML file: **default-deny**, then per-tool rules with
+    optional **argument constraints**. It's keyed by the agent name
+    (`demo_openai_agent`) — view and edit it live in the Playground's
+    **Policies** tab, and the next message obeys it.
+
+    ```yaml
+    version: 1
+
+    default_policy:
+      mode: deny                 # nothing runs unless a rule allows it
+
+    tools:
+      get_order_status:
+        mode: allow              # safe read — always allowed
+
+      refund_order:
+        mode: approval_required  # side-effecting — a human approves it
+        constraints:
+          - args.amount <= 100   # ...and only up to $100; larger is denied
+    ```
+
+    So a status lookup just **runs**, a small refund **pauses for your approval**
+    in the Playground, and a refund over $100 is **denied** — enforced by the
+    `HexgateRunner` around the OpenAI agent, not by the model.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 4 · Open the playground
+    """)
+    return
+
+
+@app.cell
+def _(Path, mo):
+    # Dashboard URL written by boot.py (the public tunnel, or localhost in dev).
+    # /v1/demo-login signs the visitor in, then redirects to /playground.
+    dash_url = Path("/tmp/hexgate_dash_url").read_text().strip().rstrip("/")
+    login_url = f"{dash_url}/v1/demo-login"
+
+    mo.md(
+        f"""
+        ### [▶ Chat with your agent →]({login_url})
+
+        Opens the dashboard in a new tab, signed in. Send a message and watch the
+        text, tool calls, and **policy decisions** (allow / deny / approval)
+        stream live from the OpenAI agent. Edit the policy in the **Policies**
+        tab — the next message picks it up.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/deploy/pydantic_demo_notebook.py
+++ b/deploy/pydantic_demo_notebook.py
@@ -1,0 +1,216 @@
+"""Hexgate live-demo notebook (marimo) — Pydantic AI edition.
+
+Twin of ``openai_demo_notebook.py`` / ``demo_notebook.py``, but the agent is a
+raw ``pydantic_ai.Agent``. It exercises the Pydantic serve path end to end:
+``serve_manager`` runs the ``hexgate serve`` loop bound to the live ``Agent``,
+``hexgate serve`` dispatches on the manifest framework to the Pydantic runtime
+(``PydanticServeDriver`` iterates the agent graph + carries history), and every
+turn streams through the Pydantic → hexgate ``StreamEvent`` normalizer to the
+dashboard Playground.
+
+BYOK is an OpenAI key (the agent runs on ``openai:gpt-4o-mini``). Your key lives
+only in this throwaway container and is never written to disk. Run by boot.py via
+``marimo edit``.
+"""
+
+import marimo
+
+__generated_with = "0.23.10"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import sys
+    from pathlib import Path
+
+    import marimo as mo
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import serve_manager
+
+    return Path, mo, serve_manager
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    # 🛡️ Hexgate — run a live **Pydantic AI** agent
+
+    A **throwaway sandbox** — everything vanishes when it scales down. The
+    Pydantic-framework twin of the native demo: same gate, same dashboard, a
+    `pydantic_ai.Agent` instead of a hexgate agent.
+
+    1. **Define your tools** (plain Python functions).
+    2. **Define your agent** (a factory — built on Start, after your key).
+    3. **Enter your OpenAI key and start it.**
+    4. **Open the playground** to chat and watch policy decisions stream.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 1 · Define your tools
+    """)
+    return
+
+
+@app.cell
+def _():
+    # Plain Python functions — pydantic-ai wraps them as tools. The function name
+    # is the tool name the policy references below.
+    def get_order_status(order_id: str) -> str:
+        """Look up the delivery status of an order by its id."""
+        return f"Order {order_id}: shipped, arriving Tuesday."
+
+    def refund_order(order_id: str, amount: float) -> str:
+        """Issue a refund of `amount` USD for `order_id`. A side-effecting tool."""
+        return f"Refunded ${amount:.2f} for order {order_id}."
+
+    TOOLS = [get_order_status, refund_order]
+    return (TOOLS,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 2 · Define your agent
+    """)
+    return
+
+
+@app.cell
+def _(TOOLS):
+    # A factory — built on Start (step 3). The `name` is the manifest name and
+    # the policy lookup key on the platform.
+    from pydantic_ai import Agent
+
+    def build_agent():
+        return Agent(
+            "openai:gpt-4o-mini",
+            name="demo_pydantic_agent",
+            instructions=(
+                "You are a customer support agent. Help with orders and refunds. "
+                "Confirm details before issuing a refund."
+            ),
+            tools=TOOLS,
+        )
+
+    return (build_agent,)
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 3 · Add your OpenAI key & start
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    api_key = mo.ui.text(kind="password", placeholder="sk-...", full_width=True)
+    start = mo.ui.run_button(label="▶ Start agent")
+    mo.vstack([mo.md("**OpenAI API key**"), api_key, start])
+    return api_key, start
+
+
+@app.cell
+def _(api_key, build_agent, mo, serve_manager, start):
+    # serve_manager is framework-agnostic — build_runtime_from_local_agent
+    # dispatches on the manifest framework and builds the Pydantic runtime.
+    import os
+    import time
+
+    if start.value:
+        if not api_key.value:
+            out = mo.md("⚠️ **Enter your OpenAI key above**, then click Start.")
+        else:
+            os.environ["OPENAI_API_KEY"] = api_key.value  # BYOK
+            agent = build_agent()
+            serve_manager.apply(agent)
+            time.sleep(3)  # let it build the runtime, auto-register + dial /v1/serve
+            st = serve_manager.status()
+            if st == "running":
+                out = mo.md(
+                    f"✅ **Agent running** (key `…{api_key.value[-4:]}`). "
+                    "Open the playground below."
+                )
+            elif st.startswith("error"):
+                out = mo.md(f"❌ **Failed to start:** `{st}`")
+            else:
+                out = mo.md(
+                    f"⏳ **{st}** — give it a few seconds and click Start again."
+                )
+    else:
+        out = mo.md(
+            f"Agent status: **{serve_manager.status()}** — "
+            "enter your key above and click **Start agent**."
+        )
+    out
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## The policy that governs it
+
+    Keyed by the agent name (`demo_pydantic_agent`) — view and edit it live in
+    the Playground's **Policies** tab.
+
+    ```yaml
+    version: 1
+
+    default_policy:
+      mode: deny
+
+    tools:
+      get_order_status:
+        mode: allow
+      refund_order:
+        mode: approval_required
+        constraints:
+          - args.amount <= 100
+    ```
+
+    A status lookup **runs**, a small refund **pauses for approval**, and a
+    refund over $100 is **denied** — enforced by the wrapped pydantic agent, not
+    the model.
+    """)
+    return
+
+
+@app.cell
+def _(mo):
+    mo.md("""
+    ## 4 · Open the playground
+    """)
+    return
+
+
+@app.cell
+def _(Path, mo):
+    dash_url = Path("/tmp/hexgate_dash_url").read_text().strip().rstrip("/")
+    login_url = f"{dash_url}/v1/demo-login"
+
+    mo.md(
+        f"""
+        ### [▶ Chat with your agent →]({login_url})
+
+        Opens the dashboard signed in. Send a message and watch the text, tool
+        calls, and **policy decisions** stream live from the Pydantic agent.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/hexgate/adapters/google/streaming.py
+++ b/hexgate/adapters/google/streaming.py
@@ -1,0 +1,170 @@
+"""Google ADK → hexgate ``StreamEvent`` normalizer + serve driver.
+
+Maps ADK ``Event``s (``runner.run_async`` output) onto the framework-agnostic
+:class:`~hexgate.streaming.StreamEvent` contract. The accumulator bookkeeping
+lives in :mod:`hexgate.streaming._accumulator`; this module defines the ADK
+``consume`` mapping and the serve driver.
+
+Two ADK specifics shape this:
+
+* **Session-based history.** ADK holds conversation history in a
+  ``session_service``; a run takes only the new user message and a
+  ``(user_id, session_id)``. :class:`GoogleServeDriver` owns an in-memory
+  session and mints a fresh id at the start of a conversation (first turn or
+  after a dashboard reset, detected via ``len(agent_input) <= 1``), giving
+  multi-turn memory that resets cleanly.
+* **SSE double-emit.** Progressive streaming (``StreamingMode.SSE``) emits
+  ``partial=True`` text chunks *and* a final aggregated ``partial=False`` event
+  for the same text. Text/reasoning is emitted only from ``partial`` events so
+  the aggregate isn't duplicated; the final non-partial event is the run-end
+  signal, not a delta.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from hexgate.runtime import HexgateContext
+from hexgate.streaming import BlockType, StreamEvent
+from hexgate.streaming._accumulator import StreamAccumulator, run_normalizer
+
+if TYPE_CHECKING:
+    from hexgate.approvals import ApprovalHandler
+
+
+class _GoogleRunAccumulator(StreamAccumulator):
+    """Map ADK ``Event``s onto the shared accumulator."""
+
+    def consume(self, event: Any) -> list[StreamEvent]:
+        emitted: list[StreamEvent] = []
+
+        error_code = getattr(event, "error_code", None)
+        if error_code:
+            message = getattr(event, "error_message", None) or str(error_code)
+            emitted.extend(self.emit_error(message))
+
+        get_calls = getattr(event, "get_function_calls", None)
+        for call in (get_calls() if callable(get_calls) else None) or []:
+            emitted.extend(
+                self.emit_tool_start(
+                    getattr(call, "id", None) or getattr(call, "name", None),
+                    getattr(call, "name", None) or "tool",
+                    dict(getattr(call, "args", None) or {}),
+                )
+            )
+
+        get_responses = getattr(event, "get_function_responses", None)
+        for response in (get_responses() if callable(get_responses) else None) or []:
+            emitted.extend(
+                self.emit_tool_end(
+                    getattr(response, "id", None) or getattr(response, "name", None),
+                    getattr(response, "response", None),
+                )
+            )
+
+        # Text/reasoning: only from partial deltas (skip the SSE aggregate).
+        if getattr(event, "partial", False):
+            content = getattr(event, "content", None)
+            for part in getattr(content, "parts", None) or []:
+                text = getattr(part, "text", None)
+                if not text:
+                    continue
+                if getattr(part, "thought", False):
+                    emitted.extend(
+                        self.emit_delta("reasoning", BlockType.REASONING, text)
+                    )
+                else:
+                    emitted.extend(self.emit_delta("text", BlockType.TEXT, text))
+
+        return emitted
+
+
+async def normalize_google_events(
+    events: AsyncIterator[Any], *, query: str
+) -> AsyncIterator[StreamEvent]:
+    """Normalize an ADK ``run_async`` event stream into ``StreamEvent``s."""
+    async for event in run_normalizer(
+        _GoogleRunAccumulator(query), events, error_log="google serve stream failed"
+    ):
+        yield event
+
+
+class GoogleServeDriver:
+    """Owns the ADK runner + in-memory session for one serve connection.
+
+    Built once by ``build_runtime_from_local_agent``; :meth:`astream` is bound as
+    the runtime's framework-agnostic streaming seam.
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: Any,
+        app_name: str,
+        approval_handler: ApprovalHandler | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        from google.adk.sessions import InMemorySessionService
+
+        from hexgate.adapters.google.runner import HexgateRunner
+
+        self._session_service = InMemorySessionService()
+        self._app_name = app_name
+        self._runner = HexgateRunner(
+            agent=agent,
+            app_name=app_name,
+            session_service=self._session_service,
+            approval_handler=approval_handler,
+            api_key=api_key,
+        )
+        self._session_id: str | None = None
+        self._created: set[tuple[str, str]] = set()
+
+    async def _ensure_session(self, user_id: str, agent_input: Any) -> str:
+        """Return an ADK session id, minting a fresh one at conversation start.
+
+        ``len(agent_input) <= 1`` marks the first message of a conversation
+        (including right after a dashboard reset clears ChatState), so a new
+        session id there resets ADK's memory in lockstep with the UI.
+        """
+        turns = len(agent_input) if isinstance(agent_input, (list, tuple)) else 0
+        if self._session_id is None or turns <= 1:
+            self._session_id = str(uuid4())
+        key = (user_id, self._session_id)
+        if key not in self._created:
+            await self._session_service.create_session(
+                app_name=self._app_name, user_id=user_id, session_id=self._session_id
+            )
+            self._created.add(key)
+        return self._session_id
+
+    async def astream(
+        self, agent_input: Any, ctx: HexgateContext | None, query: str
+    ) -> AsyncIterator[StreamEvent]:
+        from google.adk.agents.run_config import RunConfig, StreamingMode
+        from google.genai import types
+
+        # ADK needs a non-empty user id; normalize identity + guarantee a
+        # session id, keeping the caller's role/attributes for policy.
+        user_id = ctx.user_id if ctx and ctx.user_id else "serve"
+        session_id = await self._ensure_session(user_id, agent_input)
+        run_ctx = HexgateContext(
+            user_id=user_id,
+            user_roles=list(ctx.user_roles) if ctx else [],
+            session_id=session_id,
+            attributes=dict(ctx.attributes) if ctx else {},
+        )
+        new_message = types.Content(role="user", parts=[types.Part(text=query)])
+
+        async def _events() -> AsyncIterator[Any]:
+            async for event in self._runner.run_async(
+                new_message=new_message,
+                hexgate_context=run_ctx,
+                run_config=RunConfig(streaming_mode=StreamingMode.SSE),
+            ):
+                yield event
+
+        async for normalized in normalize_google_events(_events(), query=query):
+            yield normalized

--- a/hexgate/adapters/google/streaming.py
+++ b/hexgate/adapters/google/streaming.py
@@ -127,10 +127,13 @@ class GoogleServeDriver:
 
         ``len(agent_input) <= 1`` marks the first message of a conversation
         (including right after a dashboard reset clears ChatState), so a new
-        session id there resets ADK's memory in lockstep with the UI.
+        session id there resets ADK's memory in lockstep with the UI. The
+        previous session is evicted so a long-lived serve process doesn't
+        accumulate abandoned sessions across resets.
         """
         turns = len(agent_input) if isinstance(agent_input, (list, tuple)) else 0
         if self._session_id is None or turns <= 1:
+            await self._evict_current_session()
             self._session_id = str(uuid4())
         key = (user_id, self._session_id)
         if key not in self._created:
@@ -139,6 +142,21 @@ class GoogleServeDriver:
             )
             self._created.add(key)
         return self._session_id
+
+    async def _evict_current_session(self) -> None:
+        """Delete the current conversation's session(s) from the ADK store."""
+        if self._session_id is None:
+            return
+        for user_id, session_id in list(self._created):
+            if session_id != self._session_id:
+                continue
+            try:
+                await self._session_service.delete_session(
+                    app_name=self._app_name, user_id=user_id, session_id=session_id
+                )
+            except Exception:  # noqa: BLE001 — best-effort cleanup, never fatal
+                pass
+            self._created.discard((user_id, session_id))
 
     async def astream(
         self, agent_input: Any, ctx: HexgateContext | None, query: str

--- a/hexgate/adapters/openai/streaming.py
+++ b/hexgate/adapters/openai/streaming.py
@@ -2,10 +2,9 @@
 
 Maps the ``agents`` SDK's ``RunResultStreaming.stream_events()`` output onto the
 framework-agnostic :class:`~hexgate.streaming.StreamEvent` contract the dashboard
-Playground consumes. This is the OpenAI sibling of the LangChain normalizer in
-:mod:`hexgate.streaming.normalize`; it reuses the same accumulator shape
-(sequence counter, one open text/reasoning block, persisted ``steps``, an
-assembled ``message``, ``finish()`` → :class:`~hexgate.streaming.RunEndEvent`).
+Playground consumes. The accumulator bookkeeping lives in
+:mod:`hexgate.streaming._accumulator`; this module only defines the OpenAI
+``consume`` mapping and the serve driver.
 
 ``agents`` yields three event kinds (``agents/stream_events.py``):
 
@@ -26,40 +25,15 @@ raising.
 from __future__ import annotations
 
 import json
-import logging
 from collections.abc import AsyncIterator
-from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
-from uuid import uuid4
 
-from hexgate.streaming import (
-    AgentRunResult,
-    BlockDeltaEvent,
-    BlockEndEvent,
-    BlockStartEvent,
-    BlockType,
-    ErrorEvent,
-    ReasoningStep,
-    RunEndEvent,
-    RunStartEvent,
-    StreamEvent,
-    TextStep,
-    ToolCallStep,
-    ToolEndEvent,
-    ToolStartEvent,
-)
-
-# Reuse the framework-agnostic tool-output inference the LangChain normalizer
-# uses, so summaries and success/failure render identically across adapters:
-# ``_tool_end_state`` returns ``(state, summary)`` and detects ``{"ok": false}``
-# failure payloads, including hexgate's own GuardedTool refusals.
-from hexgate.streaming.normalize import _tool_end_state
+from hexgate.streaming import BlockType, StreamEvent
+from hexgate.streaming._accumulator import StreamAccumulator, run_normalizer
 
 if TYPE_CHECKING:
     from hexgate.adapters.openai.runner import HexgateRunner
     from hexgate.runtime import HexgateContext
-
-logger = logging.getLogger(__name__)
 
 # Raw Responses-API streaming-event ``.type`` discriminators we consume. Other
 # raw event types (item added/done, function-call-arg deltas, completed, …) are
@@ -73,139 +47,8 @@ _REASONING_DELTAS = frozenset(
 )
 
 
-def _jsonable(value: Any) -> Any:
-    """Return a JSON-serializable form of a tool's raw output.
-
-    ``ToolCallStep.raw_output`` is serialized when serve ships the terminal
-    ``RunEndEvent`` via ``model_dump_json()``; an OpenAI ``@function_tool`` may
-    return an arbitrary object that pydantic can't serialize, which would raise
-    and drop the run-end frame. Keep JSON-native values as-is; stringify
-    anything else so serialization always succeeds.
-    """
-    try:
-        json.dumps(value)
-    except (TypeError, ValueError):
-        return str(value)
-    return value
-
-
-@dataclass
-class _OpenBlock:
-    """One streamed text or reasoning block before finalization."""
-
-    block_id: str
-    block_type: BlockType
-    parts: list[str] = field(default_factory=list)
-
-
-class _OpenAIRunAccumulator:
-    """Fold OpenAI stream events into normalized :class:`StreamEvent`s.
-
-    OpenAI runs are flat (no LangChain-style ``parent_ids`` tree), so every
-    event shares one synthesized root ``run_id`` at depth 0. ``sequence`` is
-    assigned monotonically here, exactly like the LangChain accumulator.
-    """
-
-    def __init__(self, query: str) -> None:
-        self.query = query
-        self.run_id = str(uuid4())
-        self.sequence = 0
-        self.started = False
-        # Open text/reasoning blocks, keyed by the SDK output item_id so a
-        # message block and a reasoning block never collide.
-        self.blocks: dict[str, _OpenBlock] = {}
-        # call_id → (tool_name, arguments) recorded at tool_called, so the
-        # matching tool_output (which carries neither) can be labeled.
-        self.tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
-        # Synthesized ids for the rare tool call that carries no call_id (hosted
-        # computer/shell calls). Reused FIFO at tool_output so a start and its
-        # end still share a tool_id and correlate in ChatState.
-        self._pending_callless: list[str] = []
-        self.steps: list[TextStep | ReasoningStep | ToolCallStep] = []
-        self.message_parts: list[str] = []
-
-    def _next_sequence(self) -> int:
-        self.sequence += 1
-        return self.sequence
-
-    def _node(self) -> dict[str, Any]:
-        """Shared ancestry kwargs for a flat single-run event."""
-        return {
-            "run_id": self.run_id,
-            "root_run_id": self.run_id,
-            "parent_run_id": None,
-            "depth": 0,
-        }
-
-    def _run_start(self) -> RunStartEvent:
-        self.started = True
-        return RunStartEvent(
-            **self._node(), sequence=self._next_sequence(), query=self.query
-        )
-
-    # -- deltas ---------------------------------------------------------------
-
-    def _delta(
-        self, item_id: str | None, block_type: BlockType, text: str
-    ) -> list[StreamEvent]:
-        if not text:
-            return []
-        emitted: list[StreamEvent] = []
-        # Fall back to the block-type name when the SDK omits item_id, so text
-        # and reasoning still stay in separate blocks.
-        key = item_id or block_type.value
-        block = self.blocks.get(key)
-        if block is None:
-            block = _OpenBlock(block_id=str(uuid4()), block_type=block_type)
-            self.blocks[key] = block
-            emitted.append(
-                BlockStartEvent(
-                    **self._node(),
-                    sequence=self._next_sequence(),
-                    block_id=block.block_id,
-                    block_type=block_type,
-                )
-            )
-        block.parts.append(text)
-        if block_type == BlockType.TEXT:
-            self.message_parts.append(text)
-        emitted.append(
-            BlockDeltaEvent(
-                **self._node(),
-                sequence=self._next_sequence(),
-                block_id=block.block_id,
-                block_type=block_type,
-                text=text,
-            )
-        )
-        return emitted
-
-    def _finalize_blocks(self) -> list[StreamEvent]:
-        emitted: list[StreamEvent] = []
-        for block in self.blocks.values():
-            emitted.append(
-                BlockEndEvent(
-                    **self._node(),
-                    sequence=self._next_sequence(),
-                    block_id=block.block_id,
-                    block_type=block.block_type,
-                )
-            )
-            text = "".join(block.parts)
-            if block.block_type == BlockType.REASONING:
-                self.steps.append(
-                    ReasoningStep(
-                        **self._node(), sequence=self._next_sequence(), text=text
-                    )
-                )
-            else:
-                self.steps.append(
-                    TextStep(**self._node(), sequence=self._next_sequence(), text=text)
-                )
-        self.blocks.clear()
-        return emitted
-
-    # -- tool calls -----------------------------------------------------------
+class _OpenAIRunAccumulator(StreamAccumulator):
+    """Map OpenAI stream events onto the shared accumulator."""
 
     @staticmethod
     def _extract_args(item: Any) -> dict[str, Any]:
@@ -229,140 +72,38 @@ class _OpenAIRunAccumulator:
             return args
         return {}
 
-    def _tool_start(self, item: Any) -> ToolStartEvent:
-        call_id = getattr(item, "call_id", None)
-        if not call_id:
-            call_id = str(uuid4())
-            self._pending_callless.append(call_id)
-        tool_name = getattr(item, "tool_name", None) or "tool"
-        arguments = self._extract_args(item)
-        self.tool_calls[call_id] = (tool_name, arguments)
-        return ToolStartEvent(
-            **self._node(),
-            sequence=self._next_sequence(),
-            tool_id=call_id,
-            tool_name=tool_name,
-            arguments=arguments,
-        )
-
-    def _tool_end(self, item: Any) -> ToolEndEvent:
-        call_id = getattr(item, "call_id", None)
-        if not call_id:
-            # Match the FIFO id minted for the corresponding callless start so
-            # start↔end share a tool_id; a truly orphan end gets a fresh id.
-            call_id = (
-                self._pending_callless.pop(0)
-                if self._pending_callless
-                else str(uuid4())
-            )
-        tool_name, arguments = self.tool_calls.get(call_id, ("tool", {}))
-        output = getattr(item, "output", None)
-        # Reuse the shared inference: a structured ``{"ok": false}`` failure
-        # (e.g. a hexgate GuardedTool refusal) is marked FAILED, matching the
-        # native adapter. A tool error the SDK folds into plain output text has
-        # no structured marker and still reads as COMPLETED — a known limit.
-        state, summary = _tool_end_state(output)
-        self.steps.append(
-            ToolCallStep(
-                **self._node(),
-                sequence=self._next_sequence(),
-                tool_name=tool_name,
-                arguments=arguments,
-                state=state,
-                output_summary=summary,
-                raw_output=_jsonable(output),
-            )
-        )
-        return ToolEndEvent(
-            **self._node(),
-            sequence=self._next_sequence(),
-            tool_id=call_id,
-            tool_name=tool_name,
-            state=state,
-            output_summary=summary,
-        )
-
-    # -- dispatch -------------------------------------------------------------
-
     def consume(self, event: Any) -> list[StreamEvent]:
-        """Convert one OpenAI stream event into zero or more normalized events."""
-        emitted: list[StreamEvent] = []
-        if not self.started:
-            emitted.append(self._run_start())
-
         etype = getattr(event, "type", None)
         if etype == "raw_response_event":
             data = getattr(event, "data", None)
             dtype = getattr(data, "type", None)
+            delta = getattr(data, "delta", "") or ""
+            item_id = getattr(data, "item_id", None)
             if dtype == _TEXT_DELTA:
-                emitted.extend(
-                    self._delta(
-                        getattr(data, "item_id", None),
-                        BlockType.TEXT,
-                        getattr(data, "delta", "") or "",
-                    )
+                return self.emit_delta(item_id or "text", BlockType.TEXT, delta)
+            if dtype in _REASONING_DELTAS:
+                return self.emit_delta(
+                    item_id or "reasoning", BlockType.REASONING, delta
                 )
-            elif dtype in _REASONING_DELTAS:
-                emitted.extend(
-                    self._delta(
-                        getattr(data, "item_id", None),
-                        BlockType.REASONING,
-                        getattr(data, "delta", "") or "",
-                    )
-                )
-            return emitted
+            return []
 
         if etype == "run_item_stream_event":
             name = getattr(event, "name", None)
             item = getattr(event, "item", None)
             if name == "tool_called":
-                # A tool call ends any open assistant text block first.
-                emitted.extend(self._finalize_blocks())
-                emitted.append(self._tool_start(item))
-            elif name == "tool_output":
-                emitted.append(self._tool_end(item))
-            return emitted
+                return self.emit_tool_start(
+                    getattr(item, "call_id", None),
+                    getattr(item, "tool_name", None) or "tool",
+                    self._extract_args(item),
+                )
+            if name == "tool_output":
+                return self.emit_tool_end(
+                    getattr(item, "call_id", None), getattr(item, "output", None)
+                )
+            return []
 
         # agent_updated_stream_event and unhandled run-item names: no-op.
-        return emitted
-
-    def _ensure_started(self) -> list[StreamEvent]:
-        """Emit the run-start first if nothing did (empty stream / immediate
-        raise), so a terminal event is never sent unbracketed."""
-        return [self._run_start()] if not self.started else []
-
-    def finish(self) -> list[StreamEvent]:
-        """Flush open blocks and emit the terminal run-end event."""
-        emitted = self._ensure_started()
-        emitted.extend(self._finalize_blocks())
-        result = AgentRunResult(
-            run_id=self.run_id,
-            root_run_id=self.run_id,
-            message="".join(self.message_parts),
-            steps=self.steps,
-        )
-        emitted.append(
-            RunEndEvent(
-                run_id=self.run_id,
-                root_run_id=self.run_id,
-                sequence=self._next_sequence(),
-                result=result,
-            )
-        )
-        return emitted
-
-    def error(self, message: str) -> list[StreamEvent]:
-        """Flush open blocks and emit a terminal error event.
-
-        Terminal on its own — no trailing run-end — since a fatal stream error
-        ends the turn; :meth:`ChatState.apply_event` marks streaming stopped.
-        """
-        emitted = self._ensure_started()
-        emitted.extend(self._finalize_blocks())
-        emitted.append(
-            ErrorEvent(**self._node(), sequence=self._next_sequence(), message=message)
-        )
-        return emitted
+        return []
 
 
 async def normalize_openai_events(
@@ -372,22 +113,13 @@ async def normalize_openai_events(
 
     Fatal errors are *raised* out of the OpenAI SDK's ``stream_events()``
     (``MaxTurnsExceeded``, guardrail tripwires, or a tool exception when
-    ``failure_error_function=None``). Catch them and emit a terminal
-    :class:`~hexgate.streaming.ErrorEvent` so the dashboard closes the turn
-    cleanly instead of the exception tearing the relay task down.
+    ``failure_error_function=None``); ``run_normalizer`` turns them into a
+    terminal :class:`~hexgate.streaming.ErrorEvent`.
     """
-    accumulator = _OpenAIRunAccumulator(query)
-    try:
-        async for event in events:
-            for normalized in accumulator.consume(event):
-                yield normalized
-    except Exception as exc:  # noqa: BLE001 — surface any failure as an event
-        logger.exception("openai serve stream failed")
-        for normalized in accumulator.error(str(exc)):
-            yield normalized
-        return
-    for normalized in accumulator.finish():
-        yield normalized
+    async for event in run_normalizer(
+        _OpenAIRunAccumulator(query), events, error_log="openai serve stream failed"
+    ):
+        yield event
 
 
 async def astream_openai(

--- a/hexgate/adapters/openai/streaming.py
+++ b/hexgate/adapters/openai/streaming.py
@@ -1,0 +1,410 @@
+"""OpenAI Agents SDK → hexgate ``StreamEvent`` normalizer + serve driver.
+
+Maps the ``agents`` SDK's ``RunResultStreaming.stream_events()`` output onto the
+framework-agnostic :class:`~hexgate.streaming.StreamEvent` contract the dashboard
+Playground consumes. This is the OpenAI sibling of the LangChain normalizer in
+:mod:`hexgate.streaming.normalize`; it reuses the same accumulator shape
+(sequence counter, one open text/reasoning block, persisted ``steps``, an
+assembled ``message``, ``finish()`` → :class:`~hexgate.streaming.RunEndEvent`).
+
+``agents`` yields three event kinds (``agents/stream_events.py``):
+
+* ``RawResponsesStreamEvent`` (``type == "raw_response_event"``) — the raw
+  Responses-API stream event passed straight through; text/reasoning deltas
+  live here.
+* ``RunItemStreamEvent`` (``type == "run_item_stream_event"``) — a ``.name`` +
+  ``.item``; tool calls (``tool_called`` → ``ToolCallItem``) and tool outputs
+  (``tool_output`` → ``ToolCallOutputItem``) live here.
+* ``AgentUpdatedStreamEvent`` — ignored.
+
+Field access is defensive (``getattr``) so we don't bind to a specific
+``openai`` Responses-types version, and so a ``raw_item`` that is a dict or a
+computer/shell call (not a function call) degrades to empty args rather than
+raising.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from hexgate.streaming import (
+    AgentRunResult,
+    BlockDeltaEvent,
+    BlockEndEvent,
+    BlockStartEvent,
+    BlockType,
+    ErrorEvent,
+    ReasoningStep,
+    RunEndEvent,
+    RunStartEvent,
+    StreamEvent,
+    TextStep,
+    ToolCallStep,
+    ToolEndEvent,
+    ToolStartEvent,
+)
+
+# Reuse the framework-agnostic tool-output inference the LangChain normalizer
+# uses, so summaries and success/failure render identically across adapters:
+# ``_tool_end_state`` returns ``(state, summary)`` and detects ``{"ok": false}``
+# failure payloads, including hexgate's own GuardedTool refusals.
+from hexgate.streaming.normalize import _tool_end_state
+
+if TYPE_CHECKING:
+    from hexgate.adapters.openai.runner import HexgateRunner
+    from hexgate.runtime import HexgateContext
+
+logger = logging.getLogger(__name__)
+
+# Raw Responses-API streaming-event ``.type`` discriminators we consume. Other
+# raw event types (item added/done, function-call-arg deltas, completed, …) are
+# ignored: the aggregated ``run_item_stream_event`` items carry what we need.
+_TEXT_DELTA = "response.output_text.delta"
+# Reasoning models stream chain-of-thought as raw reasoning deltas. Summarized
+# reasoning (the default for the o-series / gpt-5) arrives as the *summary*
+# variant, so both must be captured or the reasoning block renders empty.
+_REASONING_DELTAS = frozenset(
+    {"response.reasoning_text.delta", "response.reasoning_summary_text.delta"}
+)
+
+
+def _jsonable(value: Any) -> Any:
+    """Return a JSON-serializable form of a tool's raw output.
+
+    ``ToolCallStep.raw_output`` is serialized when serve ships the terminal
+    ``RunEndEvent`` via ``model_dump_json()``; an OpenAI ``@function_tool`` may
+    return an arbitrary object that pydantic can't serialize, which would raise
+    and drop the run-end frame. Keep JSON-native values as-is; stringify
+    anything else so serialization always succeeds.
+    """
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return value
+
+
+@dataclass
+class _OpenBlock:
+    """One streamed text or reasoning block before finalization."""
+
+    block_id: str
+    block_type: BlockType
+    parts: list[str] = field(default_factory=list)
+
+
+class _OpenAIRunAccumulator:
+    """Fold OpenAI stream events into normalized :class:`StreamEvent`s.
+
+    OpenAI runs are flat (no LangChain-style ``parent_ids`` tree), so every
+    event shares one synthesized root ``run_id`` at depth 0. ``sequence`` is
+    assigned monotonically here, exactly like the LangChain accumulator.
+    """
+
+    def __init__(self, query: str) -> None:
+        self.query = query
+        self.run_id = str(uuid4())
+        self.sequence = 0
+        self.started = False
+        # Open text/reasoning blocks, keyed by the SDK output item_id so a
+        # message block and a reasoning block never collide.
+        self.blocks: dict[str, _OpenBlock] = {}
+        # call_id → (tool_name, arguments) recorded at tool_called, so the
+        # matching tool_output (which carries neither) can be labeled.
+        self.tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
+        # Synthesized ids for the rare tool call that carries no call_id (hosted
+        # computer/shell calls). Reused FIFO at tool_output so a start and its
+        # end still share a tool_id and correlate in ChatState.
+        self._pending_callless: list[str] = []
+        self.steps: list[TextStep | ReasoningStep | ToolCallStep] = []
+        self.message_parts: list[str] = []
+
+    def _next_sequence(self) -> int:
+        self.sequence += 1
+        return self.sequence
+
+    def _node(self) -> dict[str, Any]:
+        """Shared ancestry kwargs for a flat single-run event."""
+        return {
+            "run_id": self.run_id,
+            "root_run_id": self.run_id,
+            "parent_run_id": None,
+            "depth": 0,
+        }
+
+    def _run_start(self) -> RunStartEvent:
+        self.started = True
+        return RunStartEvent(
+            **self._node(), sequence=self._next_sequence(), query=self.query
+        )
+
+    # -- deltas ---------------------------------------------------------------
+
+    def _delta(
+        self, item_id: str | None, block_type: BlockType, text: str
+    ) -> list[StreamEvent]:
+        if not text:
+            return []
+        emitted: list[StreamEvent] = []
+        # Fall back to the block-type name when the SDK omits item_id, so text
+        # and reasoning still stay in separate blocks.
+        key = item_id or block_type.value
+        block = self.blocks.get(key)
+        if block is None:
+            block = _OpenBlock(block_id=str(uuid4()), block_type=block_type)
+            self.blocks[key] = block
+            emitted.append(
+                BlockStartEvent(
+                    **self._node(),
+                    sequence=self._next_sequence(),
+                    block_id=block.block_id,
+                    block_type=block_type,
+                )
+            )
+        block.parts.append(text)
+        if block_type == BlockType.TEXT:
+            self.message_parts.append(text)
+        emitted.append(
+            BlockDeltaEvent(
+                **self._node(),
+                sequence=self._next_sequence(),
+                block_id=block.block_id,
+                block_type=block_type,
+                text=text,
+            )
+        )
+        return emitted
+
+    def _finalize_blocks(self) -> list[StreamEvent]:
+        emitted: list[StreamEvent] = []
+        for block in self.blocks.values():
+            emitted.append(
+                BlockEndEvent(
+                    **self._node(),
+                    sequence=self._next_sequence(),
+                    block_id=block.block_id,
+                    block_type=block.block_type,
+                )
+            )
+            text = "".join(block.parts)
+            if block.block_type == BlockType.REASONING:
+                self.steps.append(
+                    ReasoningStep(
+                        **self._node(), sequence=self._next_sequence(), text=text
+                    )
+                )
+            else:
+                self.steps.append(
+                    TextStep(**self._node(), sequence=self._next_sequence(), text=text)
+                )
+        self.blocks.clear()
+        return emitted
+
+    # -- tool calls -----------------------------------------------------------
+
+    @staticmethod
+    def _extract_args(item: Any) -> dict[str, Any]:
+        """Best-effort dict of a ToolCallItem's arguments.
+
+        Function calls carry ``arguments`` as a JSON *string*; parse it. Non
+        function calls (computer/shell) or unparseable args degrade to ``{}``.
+        """
+        raw = getattr(item, "raw_item", None)
+        if isinstance(raw, dict):
+            args = raw.get("arguments")
+        else:
+            args = getattr(raw, "arguments", None)
+        if isinstance(args, str):
+            try:
+                parsed = json.loads(args)
+            except (json.JSONDecodeError, ValueError):
+                return {}
+            return parsed if isinstance(parsed, dict) else {}
+        if isinstance(args, dict):
+            return args
+        return {}
+
+    def _tool_start(self, item: Any) -> ToolStartEvent:
+        call_id = getattr(item, "call_id", None)
+        if not call_id:
+            call_id = str(uuid4())
+            self._pending_callless.append(call_id)
+        tool_name = getattr(item, "tool_name", None) or "tool"
+        arguments = self._extract_args(item)
+        self.tool_calls[call_id] = (tool_name, arguments)
+        return ToolStartEvent(
+            **self._node(),
+            sequence=self._next_sequence(),
+            tool_id=call_id,
+            tool_name=tool_name,
+            arguments=arguments,
+        )
+
+    def _tool_end(self, item: Any) -> ToolEndEvent:
+        call_id = getattr(item, "call_id", None)
+        if not call_id:
+            # Match the FIFO id minted for the corresponding callless start so
+            # start↔end share a tool_id; a truly orphan end gets a fresh id.
+            call_id = (
+                self._pending_callless.pop(0)
+                if self._pending_callless
+                else str(uuid4())
+            )
+        tool_name, arguments = self.tool_calls.get(call_id, ("tool", {}))
+        output = getattr(item, "output", None)
+        # Reuse the shared inference: a structured ``{"ok": false}`` failure
+        # (e.g. a hexgate GuardedTool refusal) is marked FAILED, matching the
+        # native adapter. A tool error the SDK folds into plain output text has
+        # no structured marker and still reads as COMPLETED — a known limit.
+        state, summary = _tool_end_state(output)
+        self.steps.append(
+            ToolCallStep(
+                **self._node(),
+                sequence=self._next_sequence(),
+                tool_name=tool_name,
+                arguments=arguments,
+                state=state,
+                output_summary=summary,
+                raw_output=_jsonable(output),
+            )
+        )
+        return ToolEndEvent(
+            **self._node(),
+            sequence=self._next_sequence(),
+            tool_id=call_id,
+            tool_name=tool_name,
+            state=state,
+            output_summary=summary,
+        )
+
+    # -- dispatch -------------------------------------------------------------
+
+    def consume(self, event: Any) -> list[StreamEvent]:
+        """Convert one OpenAI stream event into zero or more normalized events."""
+        emitted: list[StreamEvent] = []
+        if not self.started:
+            emitted.append(self._run_start())
+
+        etype = getattr(event, "type", None)
+        if etype == "raw_response_event":
+            data = getattr(event, "data", None)
+            dtype = getattr(data, "type", None)
+            if dtype == _TEXT_DELTA:
+                emitted.extend(
+                    self._delta(
+                        getattr(data, "item_id", None),
+                        BlockType.TEXT,
+                        getattr(data, "delta", "") or "",
+                    )
+                )
+            elif dtype in _REASONING_DELTAS:
+                emitted.extend(
+                    self._delta(
+                        getattr(data, "item_id", None),
+                        BlockType.REASONING,
+                        getattr(data, "delta", "") or "",
+                    )
+                )
+            return emitted
+
+        if etype == "run_item_stream_event":
+            name = getattr(event, "name", None)
+            item = getattr(event, "item", None)
+            if name == "tool_called":
+                # A tool call ends any open assistant text block first.
+                emitted.extend(self._finalize_blocks())
+                emitted.append(self._tool_start(item))
+            elif name == "tool_output":
+                emitted.append(self._tool_end(item))
+            return emitted
+
+        # agent_updated_stream_event and unhandled run-item names: no-op.
+        return emitted
+
+    def _ensure_started(self) -> list[StreamEvent]:
+        """Emit the run-start first if nothing did (empty stream / immediate
+        raise), so a terminal event is never sent unbracketed."""
+        return [self._run_start()] if not self.started else []
+
+    def finish(self) -> list[StreamEvent]:
+        """Flush open blocks and emit the terminal run-end event."""
+        emitted = self._ensure_started()
+        emitted.extend(self._finalize_blocks())
+        result = AgentRunResult(
+            run_id=self.run_id,
+            root_run_id=self.run_id,
+            message="".join(self.message_parts),
+            steps=self.steps,
+        )
+        emitted.append(
+            RunEndEvent(
+                run_id=self.run_id,
+                root_run_id=self.run_id,
+                sequence=self._next_sequence(),
+                result=result,
+            )
+        )
+        return emitted
+
+    def error(self, message: str) -> list[StreamEvent]:
+        """Flush open blocks and emit a terminal error event.
+
+        Terminal on its own — no trailing run-end — since a fatal stream error
+        ends the turn; :meth:`ChatState.apply_event` marks streaming stopped.
+        """
+        emitted = self._ensure_started()
+        emitted.extend(self._finalize_blocks())
+        emitted.append(
+            ErrorEvent(**self._node(), sequence=self._next_sequence(), message=message)
+        )
+        return emitted
+
+
+async def normalize_openai_events(
+    events: AsyncIterator[Any], *, query: str
+) -> AsyncIterator[StreamEvent]:
+    """Normalize an OpenAI ``stream_events()`` iterator into ``StreamEvent``s.
+
+    Fatal errors are *raised* out of the OpenAI SDK's ``stream_events()``
+    (``MaxTurnsExceeded``, guardrail tripwires, or a tool exception when
+    ``failure_error_function=None``). Catch them and emit a terminal
+    :class:`~hexgate.streaming.ErrorEvent` so the dashboard closes the turn
+    cleanly instead of the exception tearing the relay task down.
+    """
+    accumulator = _OpenAIRunAccumulator(query)
+    try:
+        async for event in events:
+            for normalized in accumulator.consume(event):
+                yield normalized
+    except Exception as exc:  # noqa: BLE001 — surface any failure as an event
+        logger.exception("openai serve stream failed")
+        for normalized in accumulator.error(str(exc)):
+            yield normalized
+        return
+    for normalized in accumulator.finish():
+        yield normalized
+
+
+async def astream_openai(
+    runner: HexgateRunner,
+    agent: Any,
+    input: Any,
+    *,
+    hexgate_context: HexgateContext,
+    query: str,
+) -> AsyncIterator[StreamEvent]:
+    """Stream a policy-enforced OpenAI agent as normalized ``StreamEvent``s.
+
+    ``runner.run_streamed`` opens the :class:`HexgateContext` scope internally
+    (its wrapped ``stream_events()`` re-enters it), refreshes the cached policy
+    binding for this run, and enforces the ban gate before spawning the agent
+    loop — so this driver only wires the raw stream into the normalizer.
+    """
+    result = runner.run_streamed(agent, input, hexgate_context=hexgate_context)
+    async for event in normalize_openai_events(result.stream_events(), query=query):
+        yield event

--- a/hexgate/adapters/pydantic_ai/streaming.py
+++ b/hexgate/adapters/pydantic_ai/streaming.py
@@ -1,0 +1,186 @@
+"""Pydantic AI → hexgate ``StreamEvent`` normalizer + serve driver.
+
+Maps pydantic-ai ``AgentStreamEvent``s onto the framework-agnostic
+:class:`~hexgate.streaming.StreamEvent` contract. The accumulator bookkeeping
+lives in :mod:`hexgate.streaming._accumulator`; this module defines the pydantic
+``consume`` mapping and the serve driver.
+
+Two pydantic specifics shape this:
+
+* **Node iteration.** Streaming comes from ``agent.iter()`` → per-node
+  ``node.stream()``: a model-request node yields ``PartStartEvent`` /
+  ``PartDeltaEvent`` (text/thinking), a call-tools node yields
+  ``FunctionToolCallEvent`` / ``FunctionToolResultEvent``. The driver flattens
+  both into one event stream for the accumulator. Tool *calls* are taken from
+  ``FunctionToolCallEvent`` (fully assembled), not the model stream's
+  ``ToolCallPart``, so args need no delta reassembly.
+* **In-band failures.** A tool failure surfaces as ``ToolReturnPart.outcome`` in
+  ``{failed, denied}`` or a ``RetryPromptPart`` — not an exception — so the tool
+  end carries an explicit state. Only fatal ``AgentRunError`` subclasses raise.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any
+
+from hexgate.runtime import HexgateContext
+from hexgate.streaming import BlockType, StreamEvent, ToolCallState
+from hexgate.streaming._accumulator import StreamAccumulator, run_normalizer
+
+if TYPE_CHECKING:
+    from hexgate.adapters.pydantic_ai.agent import HexgatePydanticAgent
+    from hexgate.approvals import ApprovalHandler
+
+
+class _PydanticRunAccumulator(StreamAccumulator):
+    """Map pydantic-ai stream events onto the shared accumulator."""
+
+    @staticmethod
+    def _args(part: Any) -> dict[str, Any]:
+        as_dict = getattr(part, "args_as_dict", None)
+        if callable(as_dict):
+            try:
+                return as_dict()
+            except Exception:  # noqa: BLE001 — malformed args degrade to empty
+                return {}
+        args = getattr(part, "args", None)
+        return args if isinstance(args, dict) else {}
+
+    def _part(self, index: int, part: Any) -> list[StreamEvent]:
+        """A newly-started part carrying its first chunk (text/thinking only).
+
+        ``ToolCallPart`` here is ignored — the authoritative tool-call event is
+        ``FunctionToolCallEvent`` from the call-tools node.
+        """
+        kind = getattr(part, "part_kind", None)
+        if kind == "text":
+            return self.emit_delta(
+                f"text-{index}", BlockType.TEXT, getattr(part, "content", "") or ""
+            )
+        if kind == "thinking":
+            return self.emit_delta(
+                f"thinking-{index}",
+                BlockType.REASONING,
+                getattr(part, "content", "") or "",
+            )
+        return []
+
+    def _part_delta(self, index: int, delta: Any) -> list[StreamEvent]:
+        kind = getattr(delta, "part_delta_kind", None)
+        if kind == "text":
+            return self.emit_delta(
+                f"text-{index}",
+                BlockType.TEXT,
+                getattr(delta, "content_delta", "") or "",
+            )
+        if kind == "thinking":
+            return self.emit_delta(
+                f"thinking-{index}",
+                BlockType.REASONING,
+                getattr(delta, "content_delta", "") or "",
+            )
+        return []
+
+    def _tool_result(self, result: Any) -> list[StreamEvent]:
+        call_id = getattr(result, "tool_call_id", None)
+        outcome = getattr(result, "outcome", None)
+        if outcome is not None:  # ToolReturnPart — explicit success/failed/denied
+            output = getattr(result, "content", None)
+            state = (
+                ToolCallState.COMPLETED
+                if outcome == "success"
+                else ToolCallState.FAILED
+            )
+        else:  # RetryPromptPart — a tool error / validation retry
+            content = getattr(result, "content", None)
+            output = content if isinstance(content, str) else str(content)
+            state = ToolCallState.FAILED
+        return self.emit_tool_end(call_id, output, state_override=state)
+
+    def consume(self, event: Any) -> list[StreamEvent]:
+        kind = getattr(event, "event_kind", None)
+        if kind == "part_start":
+            return self._part(getattr(event, "index", 0), getattr(event, "part", None))
+        if kind == "part_delta":
+            return self._part_delta(
+                getattr(event, "index", 0), getattr(event, "delta", None)
+            )
+        if kind == "function_tool_call":
+            part = getattr(event, "part", None)
+            return self.emit_tool_start(
+                getattr(part, "tool_call_id", None),
+                getattr(part, "tool_name", None) or "tool",
+                self._args(part),
+            )
+        if kind == "function_tool_result":
+            return self._tool_result(getattr(event, "result", None))
+        return []
+
+
+async def normalize_pydantic_events(
+    events: AsyncIterator[Any], *, query: str
+) -> AsyncIterator[StreamEvent]:
+    """Normalize a flattened pydantic-ai event stream into ``StreamEvent``s."""
+    async for event in run_normalizer(
+        _PydanticRunAccumulator(query), events, error_log="pydantic serve stream failed"
+    ):
+        yield event
+
+
+class PydanticServeDriver:
+    """Owns the wrapped pydantic proxy + conversation history for one serve
+    connection. Built once by ``build_runtime_from_local_agent``; :meth:`astream`
+    is bound as the runtime's streaming seam."""
+
+    def __init__(
+        self,
+        *,
+        agent: Any,
+        approval_handler: ApprovalHandler | None = None,
+        api_key: str | None = None,
+    ) -> None:
+        from hexgate.adapters.pydantic_ai.wrapper import wrap_pydantic_agent
+
+        self._proxy: HexgatePydanticAgent = wrap_pydantic_agent(
+            agent=agent, approval_handler=approval_handler, api_key=api_key
+        )
+        # pydantic's own message objects, carried across turns for memory.
+        self._history: list[Any] = []
+
+    async def astream(
+        self, agent_input: Any, ctx: HexgateContext | None, query: str
+    ) -> AsyncIterator[StreamEvent]:
+        from pydantic_ai import Agent
+
+        run_ctx = ctx or HexgateContext(user_id="")
+        # A fresh conversation (first turn / post-reset) drops prior history.
+        turns = len(agent_input) if isinstance(agent_input, (list, tuple)) else 0
+        if turns <= 1:
+            self._history = []
+
+        result_box: dict[str, Any] = {}
+
+        async def _events() -> AsyncIterator[Any]:
+            async with self._proxy.iter(
+                query,
+                hexgate_context=run_ctx,
+                message_history=self._history or None,
+            ) as run:
+                async for node in run:
+                    if Agent.is_model_request_node(node) or Agent.is_call_tools_node(
+                        node
+                    ):
+                        async with node.stream(run.ctx) as node_stream:
+                            async for event in node_stream:
+                                yield event
+                result_box["result"] = run.result
+
+        async for normalized in normalize_pydantic_events(_events(), query=query):
+            yield normalized
+
+        result = result_box.get("result")
+        if result is not None:
+            all_messages = getattr(result, "all_messages", None)
+            if callable(all_messages):
+                self._history = list(all_messages())

--- a/hexgate/adapters/pydantic_ai/streaming.py
+++ b/hexgate/adapters/pydantic_ai/streaming.py
@@ -87,6 +87,9 @@ class _PydanticRunAccumulator(StreamAccumulator):
         outcome = getattr(result, "outcome", None)
         if outcome is not None:  # ToolReturnPart — explicit success/failed/denied
             output = getattr(result, "content", None)
+            # A 'denied' outcome collapses to FAILED: the StreamEvent contract
+            # has no dedicated DENIED tool state today, so approval/policy
+            # denials render like a failure (fidelity limit, not a bug).
             state = (
                 ToolCallState.COMPLETED
                 if outcome == "success"
@@ -115,6 +118,11 @@ class _PydanticRunAccumulator(StreamAccumulator):
             )
         if kind == "function_tool_result":
             return self._tool_result(getattr(event, "result", None))
+        # Builtin/hosted-tool events (web search, code execution) are not
+        # rendered: they run provider-side, aren't hexgate-enforced, and their
+        # event shape is in flux (deprecated ``builtin_tool_*`` events vs. newer
+        # ``BuiltinToolCallPart`` parts). Only ``@agent.tool`` function calls,
+        # which go through the policy enforcer, are surfaced.
         return []
 
 

--- a/hexgate/cli/_common.py
+++ b/hexgate/cli/_common.py
@@ -375,13 +375,8 @@ def _build_openai_serve_runtime(
     from hexgate.adapters.openai.runner import HexgateRunner
     from hexgate.adapters.openai.streaming import astream_openai
     from hexgate.runtime import HexgateContext
-    from hexgate.tracing.langfuse import get_langfuse_handler
 
     runner = HexgateRunner(approval_handler=approval_handler)
-    handler = get_langfuse_handler(
-        session_id="hexgate-serve",
-        tags=["hexgate", "hexgate-serve", agent_name],
-    )
 
     def _astream(agent_input: Any, ctx: Any, query: str) -> AsyncIterator[StreamEvent]:
         # The runner requires a context to open its enforcement scope; with no
@@ -395,28 +390,24 @@ def _build_openai_serve_runtime(
             query=query,
         )
 
-    return AgentRuntime(
-        agent=agent_obj,
-        handler=handler,
-        agent_name=agent_name,
-        agent_source="hexgate",
-        model=settings.model,
-        tools_by_name={
-            getattr(t, "name", getattr(t, "__name__", "tool")): t
-            for t in getattr(agent_obj, "tools", [])
-        },
-        astream_normalized=_astream,
+    return _serve_runtime_envelope(
+        agent_obj=agent_obj, agent_name=agent_name, settings=settings, astream=_astream
     )
 
 
-def _serve_runtime_over_driver(
-    *, agent_obj: Any, agent_name: str, settings: Settings, driver: Any
+def _serve_runtime_envelope(
+    *,
+    agent_obj: Any,
+    agent_name: str,
+    settings: Settings,
+    astream: "ServeStreamFn",
 ) -> AgentRuntime:
-    """Assemble the ``AgentRuntime`` envelope for a driver-backed framework.
+    """Assemble the ``AgentRuntime`` envelope shared by every framework adapter.
 
-    Google and Pydantic each own a stateful driver (ADK session / pydantic
-    history) whose ``astream`` is the streaming seam; the runtime envelope is
-    otherwise identical to the OpenAI path.
+    OpenAI binds a closure; Google and Pydantic bind a stateful driver's
+    ``astream`` method (ADK session / pydantic history). Everything else — the
+    langfuse handler, ``tools_by_name``, the runtime fields — is identical, so it
+    lives here once.
     """
     from hexgate.tracing.langfuse import get_langfuse_handler
 
@@ -434,7 +425,7 @@ def _serve_runtime_over_driver(
             getattr(t, "name", getattr(t, "__name__", "tool")): t
             for t in getattr(agent_obj, "tools", [])
         },
-        astream_normalized=driver.astream,
+        astream_normalized=astream,
     )
 
 
@@ -456,8 +447,11 @@ def _build_google_serve_runtime(
     driver = GoogleServeDriver(
         agent=agent_obj, app_name=agent_name, approval_handler=approval_handler
     )
-    return _serve_runtime_over_driver(
-        agent_obj=agent_obj, agent_name=agent_name, settings=settings, driver=driver
+    return _serve_runtime_envelope(
+        agent_obj=agent_obj,
+        agent_name=agent_name,
+        settings=settings,
+        astream=driver.astream,
     )
 
 
@@ -476,8 +470,11 @@ def _build_pydantic_serve_runtime(
     from hexgate.adapters.pydantic_ai.streaming import PydanticServeDriver
 
     driver = PydanticServeDriver(agent=agent_obj, approval_handler=approval_handler)
-    return _serve_runtime_over_driver(
-        agent_obj=agent_obj, agent_name=agent_name, settings=settings, driver=driver
+    return _serve_runtime_envelope(
+        agent_obj=agent_obj,
+        agent_name=agent_name,
+        settings=settings,
+        astream=driver.astream,
     )
 
 

--- a/hexgate/cli/_common.py
+++ b/hexgate/cli/_common.py
@@ -254,10 +254,24 @@ def build_runtime_from_local_agent(
             agent_name=agent_name,
             approval_handler=approval_handler,
         )
+    if manifest.framework == AgentFramework.GOOGLE:
+        return _build_google_serve_runtime(
+            settings,
+            agent_obj=agent_obj,
+            agent_name=agent_name,
+            approval_handler=approval_handler,
+        )
+    if manifest.framework == AgentFramework.PYDANTIC_AI:
+        return _build_pydantic_serve_runtime(
+            settings,
+            agent_obj=agent_obj,
+            agent_name=agent_name,
+            approval_handler=approval_handler,
+        )
+    # Unreachable in practice — create_manifest only yields the frameworks above
+    # (raw LangGraph is rejected there). Kept as a defensive guard.
     raise NotImplementedError(
-        f"hexgate serve does not yet support {manifest.framework.value} agents "
-        "— supported frameworks are native (hexgate) and OpenAI. "
-        "Google ADK and Pydantic AI serve support is planned."
+        f"hexgate serve does not support {manifest.framework.value} agents"
     )
 
 
@@ -392,6 +406,78 @@ def _build_openai_serve_runtime(
             for t in getattr(agent_obj, "tools", [])
         },
         astream_normalized=_astream,
+    )
+
+
+def _serve_runtime_over_driver(
+    *, agent_obj: Any, agent_name: str, settings: Settings, driver: Any
+) -> AgentRuntime:
+    """Assemble the ``AgentRuntime`` envelope for a driver-backed framework.
+
+    Google and Pydantic each own a stateful driver (ADK session / pydantic
+    history) whose ``astream`` is the streaming seam; the runtime envelope is
+    otherwise identical to the OpenAI path.
+    """
+    from hexgate.tracing.langfuse import get_langfuse_handler
+
+    handler = get_langfuse_handler(
+        session_id="hexgate-serve",
+        tags=["hexgate", "hexgate-serve", agent_name],
+    )
+    return AgentRuntime(
+        agent=agent_obj,
+        handler=handler,
+        agent_name=agent_name,
+        agent_source="hexgate",
+        model=settings.model,
+        tools_by_name={
+            getattr(t, "name", getattr(t, "__name__", "tool")): t
+            for t in getattr(agent_obj, "tools", [])
+        },
+        astream_normalized=driver.astream,
+    )
+
+
+def _build_google_serve_runtime(
+    settings: Settings,
+    *,
+    agent_obj: Any,
+    agent_name: str,
+    approval_handler: ApprovalHandler | None,
+) -> AgentRuntime:
+    """Build the serve runtime for a Google ADK agent.
+
+    The ``GoogleServeDriver`` owns the ADK runner (which fetches + hot-reloads
+    its own policy binding and enforces the ban gate) and the in-memory session
+    that carries conversation history — so no ``enforce_policy`` here.
+    """
+    from hexgate.adapters.google.streaming import GoogleServeDriver
+
+    driver = GoogleServeDriver(
+        agent=agent_obj, app_name=agent_name, approval_handler=approval_handler
+    )
+    return _serve_runtime_over_driver(
+        agent_obj=agent_obj, agent_name=agent_name, settings=settings, driver=driver
+    )
+
+
+def _build_pydantic_serve_runtime(
+    settings: Settings,
+    *,
+    agent_obj: Any,
+    agent_name: str,
+    approval_handler: ApprovalHandler | None,
+) -> AgentRuntime:
+    """Build the serve runtime for a Pydantic AI agent.
+
+    ``wrap_pydantic_agent`` (inside the driver) resolves + refreshes the policy
+    binding and installs the ban gate, so no ``enforce_policy`` here.
+    """
+    from hexgate.adapters.pydantic_ai.streaming import PydanticServeDriver
+
+    driver = PydanticServeDriver(agent=agent_obj, approval_handler=approval_handler)
+    return _serve_runtime_over_driver(
+        agent_obj=agent_obj, agent_name=agent_name, settings=settings, driver=driver
     )
 
 

--- a/hexgate/cli/_common.py
+++ b/hexgate/cli/_common.py
@@ -11,7 +11,20 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Callable
+
+    from hexgate.agents.factory import AgentInput
+    from hexgate.runtime import HexgateContext
     from hexgate.security.enforcer import DecisionObserver
+    from hexgate.streaming import StreamEvent
+
+    # The framework-agnostic serve streaming seam: given the turn's input, the
+    # caller's (optional) attenuation context, and the user query, yield
+    # normalized StreamEvents. Bound per framework in
+    # ``build_runtime_from_local_agent`` so ``hexgate serve`` stays framework-blind.
+    ServeStreamFn = Callable[
+        ["AgentInput", "HexgateContext | None", str], "AsyncIterator[StreamEvent]"
+    ]
 
 from rich.console import Console, Group
 from rich.panel import Panel
@@ -36,6 +49,10 @@ class AgentRuntime:
     agent_source: str
     model: str
     tools_by_name: dict[str, object]
+    # Serve-only: the per-framework normalized streaming seam. ``None`` for
+    # runtimes built by ``build_runtime`` (terminal chat), which streams via
+    # ``stream_agent`` directly; set by ``build_runtime_from_local_agent``.
+    astream_normalized: "ServeStreamFn | None" = None
 
 
 def build_runtime(
@@ -192,24 +209,17 @@ def build_runtime_from_local_agent(
          to ``/v1/agents``. Idempotent — server short-circuits when the
          content_hash hasn't changed. Print "Registered" / "unchanged" so
          the operator sees what just happened.
-      3. Fetch the cloud's policy YAML for this agent name via the bearer
-         GET ``/v1/agents/{name}`` route. The operator may have edited it
-         in the dashboard since last register; we pick up that edit.
-      4. ``enforce_policy(agent_obj, policy, approval_handler=...)`` —
-         wraps the LOCAL agent's tools with the cloud's policy. Local
-         code stays authoritative for code (tools / model / prompt);
-         platform is authoritative for policy.
+      3. Dispatch on ``manifest.framework`` to a per-framework builder that
+         wires enforcement + a normalized streaming seam
+         (``AgentRuntime.astream_normalized``). ``hexgate serve`` itself stays
+         framework-blind — it only calls that seam.
 
-    Returns an :class:`AgentRuntime` whose ``agent`` is the policy-wrapped
-    HexgateAgent and ``agent_name`` is the manifest's name (matches what
-    we'll announce to the relay's ``hello`` message).
+    Returns an :class:`AgentRuntime` whose ``agent_name`` is the manifest's name
+    (matches what we'll announce to the relay's ``hello`` message).
     """
-    from hexgate.agents.factory import enforce_policy
     from hexgate.cli.register.register import post_manifest
-    from hexgate.cloud.client import HexgateClient, HexgateConfig
     from hexgate.manifest import create_manifest
-    from hexgate.security.binding import platform_policy_from_payload
-    from hexgate.tracing.langfuse import get_langfuse_handler
+    from hexgate.manifest.models import AgentFramework
 
     manifest = create_manifest(agent_obj, description=description)
     agent_name = manifest.name
@@ -229,6 +239,45 @@ def build_runtime_from_local_agent(
                 f"[dim]ℹ Agent[/] [cyan]{agent_name}[/] "
                 f"[dim]already registered (manifest unchanged)[/]"
             )
+
+    if manifest.framework == AgentFramework.HEXGATE:
+        return _build_hexgate_serve_runtime(
+            settings,
+            agent_obj=agent_obj,
+            agent_name=agent_name,
+            approval_handler=approval_handler,
+        )
+    if manifest.framework == AgentFramework.OPENAI:
+        return _build_openai_serve_runtime(
+            settings,
+            agent_obj=agent_obj,
+            agent_name=agent_name,
+            approval_handler=approval_handler,
+        )
+    raise NotImplementedError(
+        f"hexgate serve does not yet support {manifest.framework.value} agents "
+        "— supported frameworks are native (hexgate) and OpenAI. "
+        "Google ADK and Pydantic AI serve support is planned."
+    )
+
+
+def _build_hexgate_serve_runtime(
+    settings: Settings,
+    *,
+    agent_obj: Any,
+    agent_name: str,
+    approval_handler: ApprovalHandler | None,
+) -> AgentRuntime:
+    """Build the serve runtime for a native (LangChain) HexgateAgent.
+
+    Fetches the platform's (possibly dashboard-edited) policy, wraps the local
+    agent's tools with it, and binds a ``stream_agent`` streaming seam. Local
+    code stays authoritative for tools/model/prompt; the platform for policy.
+    """
+    from hexgate.agents.factory import enforce_policy, stream_agent
+    from hexgate.cloud.client import HexgateClient, HexgateConfig
+    from hexgate.security.binding import platform_policy_from_payload
+    from hexgate.tracing.langfuse import get_langfuse_handler
 
     config = HexgateConfig.from_env()
     client = HexgateClient(config)
@@ -266,6 +315,21 @@ def build_runtime_from_local_agent(
         tags=["hexgate", "hexgate-serve", agent_name],
     )
 
+    def _astream(agent_input: Any, ctx: Any, query: str) -> AsyncIterator[StreamEvent]:
+        # stream_agent reads the ambient HexgateContext and derives its own
+        # query; open the caller's attenuation scope around it when present,
+        # else run with no scope (default role) exactly as before.
+        async def _gen() -> AsyncIterator[StreamEvent]:
+            if ctx is None:
+                async for event in stream_agent(enforced, handler, agent_input):
+                    yield event
+            else:
+                async with ctx:
+                    async for event in stream_agent(enforced, handler, agent_input):
+                        yield event
+
+        return _gen()
+
     return AgentRuntime(
         agent=enforced,
         handler=handler,
@@ -276,6 +340,58 @@ def build_runtime_from_local_agent(
             getattr(t, "name", getattr(t, "__name__", "tool")): t
             for t in getattr(enforced, "tools", [])
         },
+        astream_normalized=_astream,
+    )
+
+
+def _build_openai_serve_runtime(
+    settings: Settings,
+    *,
+    agent_obj: Any,
+    agent_name: str,
+    approval_handler: ApprovalHandler | None,
+) -> AgentRuntime:
+    """Build the serve runtime for an OpenAI Agents SDK agent.
+
+    Unlike the native path, the OpenAI ``HexgateRunner`` fetches and hot-reloads
+    its own per-run policy binding (ETag/304) and enforces the ban gate, so we
+    build the runner once and bind a normalized streaming seam over it — no
+    ``enforce_policy`` here, the runner owns enforcement.
+    """
+    from hexgate.adapters.openai.runner import HexgateRunner
+    from hexgate.adapters.openai.streaming import astream_openai
+    from hexgate.runtime import HexgateContext
+    from hexgate.tracing.langfuse import get_langfuse_handler
+
+    runner = HexgateRunner(approval_handler=approval_handler)
+    handler = get_langfuse_handler(
+        session_id="hexgate-serve",
+        tags=["hexgate", "hexgate-serve", agent_name],
+    )
+
+    def _astream(agent_input: Any, ctx: Any, query: str) -> AsyncIterator[StreamEvent]:
+        # The runner requires a context to open its enforcement scope; with no
+        # dashboard attenuation, run as an anonymous default-role caller (empty
+        # user_id, no roles), mirroring the native path's no-scope default.
+        return astream_openai(
+            runner,
+            agent_obj,
+            agent_input,
+            hexgate_context=ctx or HexgateContext(user_id=""),
+            query=query,
+        )
+
+    return AgentRuntime(
+        agent=agent_obj,
+        handler=handler,
+        agent_name=agent_name,
+        agent_source="hexgate",
+        model=settings.model,
+        tools_by_name={
+            getattr(t, "name", getattr(t, "__name__", "tool")): t
+            for t in getattr(agent_obj, "tools", [])
+        },
+        astream_normalized=_astream,
     )
 
 

--- a/hexgate/cli/serve.py
+++ b/hexgate/cli/serve.py
@@ -8,17 +8,18 @@ back echoed on the accepted handshake; a missing echo means the
 platform is older than Phase 6 and we error out fast.
 
 Receives chat messages sent by dashboard Playground tabs, runs the
-agent via the same ``stream_agent`` engine the terminal chat uses,
+agent through the runtime's framework-agnostic ``astream_normalized`` seam
+(``stream_agent`` for native agents, the OpenAI normalizer for OpenAI ones),
 and ships every normalized ``StreamEvent`` back over the socket.
 
 Handles reconnection with exponential backoff so a backend bounce
 doesn't permanently break the connection.
 
 When a payload includes ``user_attenuation`` metadata (the Playground's
-"Act as alice" affordance), the turn is wrapped in an ``async with
-HexgateContext(...)`` scope. The runtime then lazily attenuates the agent's
-bound HexgateClient token inside ``stream_agent`` — same code path a
-production dev's backend uses when serving a real user.
+"Act as alice" affordance), the turn runs inside a ``HexgateContext(...)``
+scope opened by the framework's streaming seam. The runtime then lazily
+attenuates the agent's bound token — the same code path a production dev's
+backend uses when serving a real user.
 """
 
 from __future__ import annotations
@@ -27,7 +28,6 @@ import argparse
 import asyncio
 import json
 import logging
-from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
@@ -39,7 +39,6 @@ from rich.console import Console
 from websockets.asyncio.client import connect
 from websockets.exceptions import ConnectionClosed
 
-from hexgate.agents.factory import stream_agent
 from hexgate.bootstrap import bootstrap
 from hexgate.cli._common import (
     AgentRuntime,
@@ -301,16 +300,6 @@ def _context_from_payload(attenuation: Any) -> HexgateContext | None:
         return None
 
 
-@asynccontextmanager
-async def _maybe_user_scope(context: HexgateContext | None):
-    """No-op async context manager when ``context`` is ``None``."""
-    if context is None:
-        yield
-    else:
-        async with context:
-            yield
-
-
 async def _run_chat_turn(
     context: ServeContext, ws: Any, text: str, payload: dict
 ) -> None:
@@ -321,20 +310,24 @@ async def _run_chat_turn(
     outbound event goes through ``_safe_send`` so a mid-turn approval
     request from the enforcer serializes cleanly with these stream
     deltas rather than interleaving on the wire.
+
+    Streaming goes through the runtime's ``astream_normalized`` seam, bound
+    per framework in ``build_runtime_from_local_agent``, so serve stays
+    framework-blind. Each seam owns its own attenuation-scope handling and
+    per-turn policy refresh (the PolicySource / runner sends If-None-Match and
+    reuses the cached bundle on 304).
     """
-    # Policy refresh is handled inside stream_agent now (Phase 8a) —
-    # the attached PolicySource sends If-None-Match and reuses the
-    # cached bundle on 304. No need for serve to rebuild the runtime.
     context.state.start_turn(text)
     hexgate_context = _context_from_payload(payload.get("user_attenuation"))
-    async with _maybe_user_scope(hexgate_context):
-        async for event in stream_agent(
-            context.runtime.agent,
-            context.runtime.handler,
-            context.state.build_input(),
-        ):
-            context.state.apply_event(event)
-            await _safe_send(context, ws, event.model_dump_json())
+    astream = context.runtime.astream_normalized
+    if astream is None:  # pragma: no cover — serve always binds a seam
+        raise RuntimeError(
+            "serve runtime has no astream_normalized seam bound; "
+            "build_runtime_from_local_agent must set one per framework"
+        )
+    async for event in astream(context.state.build_input(), hexgate_context, text):
+        context.state.apply_event(event)
+        await _safe_send(context, ws, event.model_dump_json())
 
 
 async def _handle_message(

--- a/hexgate/streaming/_accumulator.py
+++ b/hexgate/streaming/_accumulator.py
@@ -96,7 +96,10 @@ class StreamAccumulator:
         self.tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
         # Synthesized ids for a tool call that carries no id (e.g. hosted
         # computer/shell calls). Reused FIFO at tool-end so start↔end share a
-        # tool_id and correlate in ChatState.
+        # tool_id and correlate in ChatState. This assumes id-less calls
+        # complete in order; all three frameworks supply real ids for function
+        # tools, so the FIFO only ever covers rare hosted calls, which are
+        # effectively sequential in practice.
         self._pending_callless: list[str] = []
         self.steps: list[TextStep | ReasoningStep | ToolCallStep] = []
         self.message_parts: list[str] = []

--- a/hexgate/streaming/_accumulator.py
+++ b/hexgate/streaming/_accumulator.py
@@ -1,0 +1,342 @@
+"""Shared accumulator for framework → hexgate ``StreamEvent`` normalizers.
+
+The OpenAI, Google, and Pydantic serve adapters each fold their framework's
+native run events into the framework-agnostic
+:class:`~hexgate.streaming.StreamEvent` contract. The bookkeeping is identical —
+a monotonic ``sequence``, one synthesized flat run id, open text/reasoning blocks,
+a ``call_id → (name, args)`` correlation map, persisted ``steps``, an assembled
+``message``, and terminal ``finish()`` / ``error()`` — so it lives here once.
+
+A subclass implements only :meth:`StreamAccumulator.consume`, extracting the
+framework-specific fields and calling the shared ``emit_*`` helpers.
+:func:`run_normalizer` drives the accumulator over an event iterator with the
+common bracket-and-fail-safe loop.
+
+The LangChain normalizer in :mod:`hexgate.streaming.normalize` predates this and
+keeps its own inline accumulator; this module imports its ``_summarize_output`` /
+``_tool_end_state`` helpers rather than the other way round (one-directional, no
+import cycle), so that module is untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import uuid4
+
+from hexgate.streaming import (
+    AgentRunResult,
+    BlockDeltaEvent,
+    BlockEndEvent,
+    BlockStartEvent,
+    BlockType,
+    ErrorEvent,
+    ReasoningStep,
+    RunEndEvent,
+    RunStartEvent,
+    StreamEvent,
+    TextStep,
+    ToolCallState,
+    ToolCallStep,
+    ToolEndEvent,
+    ToolStartEvent,
+)
+from hexgate.streaming.normalize import _tool_end_state
+
+logger = logging.getLogger(__name__)
+
+
+def _jsonable(value: Any) -> Any:
+    """Return a JSON-serializable form of a tool's raw output.
+
+    ``ToolCallStep.raw_output`` is serialized when serve ships the terminal
+    ``RunEndEvent`` via ``model_dump_json()``; a tool may return an arbitrary
+    object that pydantic can't serialize, which would raise and drop the run-end
+    frame. Keep JSON-native values as-is; stringify anything else so
+    serialization always succeeds.
+    """
+    try:
+        json.dumps(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return value
+
+
+@dataclass
+class _OpenBlock:
+    """One streamed text or reasoning block before finalization."""
+
+    block_id: str
+    block_type: BlockType
+    parts: list[str] = field(default_factory=list)
+
+
+class StreamAccumulator:
+    """Fold one framework's run events into normalized :class:`StreamEvent`s.
+
+    Runs are treated as flat (no LangChain-style ``parent_ids`` tree): every
+    event shares one synthesized root ``run_id`` at depth 0, and ``sequence`` is
+    assigned monotonically. Subclasses override :meth:`consume`.
+    """
+
+    def __init__(self, query: str) -> None:
+        self.query = query
+        self.run_id = str(uuid4())
+        self.sequence = 0
+        self.started = False
+        # Open text/reasoning blocks, keyed by a framework-supplied string (an
+        # item id or part index) so a message block and a reasoning block that
+        # stream interleaved never collide.
+        self.blocks: dict[str, _OpenBlock] = {}
+        # call_id → (tool_name, arguments) recorded at tool-start, so a
+        # tool-result that carries neither can be labeled.
+        self.tool_calls: dict[str, tuple[str, dict[str, Any]]] = {}
+        # Synthesized ids for a tool call that carries no id (e.g. hosted
+        # computer/shell calls). Reused FIFO at tool-end so start↔end share a
+        # tool_id and correlate in ChatState.
+        self._pending_callless: list[str] = []
+        self.steps: list[TextStep | ReasoningStep | ToolCallStep] = []
+        self.message_parts: list[str] = []
+
+    # -- primitives -----------------------------------------------------------
+
+    def _next_sequence(self) -> int:
+        self.sequence += 1
+        return self.sequence
+
+    def _node(self) -> dict[str, Any]:
+        """Shared ancestry kwargs for a flat single-run event."""
+        return {
+            "run_id": self.run_id,
+            "root_run_id": self.run_id,
+            "parent_run_id": None,
+            "depth": 0,
+        }
+
+    def _run_start(self) -> RunStartEvent:
+        self.started = True
+        return RunStartEvent(
+            **self._node(), sequence=self._next_sequence(), query=self.query
+        )
+
+    def _ensure_started(self) -> list[StreamEvent]:
+        """Emit the run-start first if nothing did (empty stream / immediate
+        raise), so a terminal event is never sent unbracketed."""
+        return [self._run_start()] if not self.started else []
+
+    # -- text / reasoning blocks ---------------------------------------------
+
+    def emit_delta(
+        self, key: str, block_type: BlockType, text: str
+    ) -> list[StreamEvent]:
+        """Open the block for ``key`` on first delta, then emit the delta.
+
+        ``key`` separates concurrent blocks (a text item vs a reasoning item);
+        pass a stable per-block identifier (item id or part index as a string).
+        """
+        if not text:
+            return []
+        emitted: list[StreamEvent] = []
+        block = self.blocks.get(key)
+        if block is None:
+            block = _OpenBlock(block_id=str(uuid4()), block_type=block_type)
+            self.blocks[key] = block
+            emitted.append(
+                BlockStartEvent(
+                    **self._node(),
+                    sequence=self._next_sequence(),
+                    block_id=block.block_id,
+                    block_type=block_type,
+                )
+            )
+        block.parts.append(text)
+        if block_type == BlockType.TEXT:
+            self.message_parts.append(text)
+        emitted.append(
+            BlockDeltaEvent(
+                **self._node(),
+                sequence=self._next_sequence(),
+                block_id=block.block_id,
+                block_type=block_type,
+                text=text,
+            )
+        )
+        return emitted
+
+    def finalize_blocks(self) -> list[StreamEvent]:
+        """Close every open block, emitting a BlockEnd + persisting a step."""
+        emitted: list[StreamEvent] = []
+        for block in self.blocks.values():
+            emitted.append(
+                BlockEndEvent(
+                    **self._node(),
+                    sequence=self._next_sequence(),
+                    block_id=block.block_id,
+                    block_type=block.block_type,
+                )
+            )
+            text = "".join(block.parts)
+            if block.block_type == BlockType.REASONING:
+                self.steps.append(
+                    ReasoningStep(
+                        **self._node(), sequence=self._next_sequence(), text=text
+                    )
+                )
+            else:
+                self.steps.append(
+                    TextStep(**self._node(), sequence=self._next_sequence(), text=text)
+                )
+        self.blocks.clear()
+        return emitted
+
+    # -- tool calls -----------------------------------------------------------
+
+    def emit_tool_start(
+        self, call_id: str | None, tool_name: str, arguments: dict[str, Any]
+    ) -> list[StreamEvent]:
+        """Close any open block, then start a tool call, recording it for the
+        matching end. A tool call ends the current assistant text block."""
+        emitted = self.finalize_blocks()
+        if not call_id:
+            call_id = str(uuid4())
+            self._pending_callless.append(call_id)
+        self.tool_calls[call_id] = (tool_name, arguments)
+        emitted.append(
+            ToolStartEvent(
+                **self._node(),
+                sequence=self._next_sequence(),
+                tool_id=call_id,
+                tool_name=tool_name,
+                arguments=arguments,
+            )
+        )
+        return emitted
+
+    def emit_tool_end(
+        self,
+        call_id: str | None,
+        output: Any,
+        *,
+        state_override: ToolCallState | None = None,
+    ) -> list[StreamEvent]:
+        """End a tool call and persist its step.
+
+        ``state_override`` is for frameworks that report success/failure
+        explicitly (pydantic's ``ToolReturnPart.outcome``); otherwise the state
+        is inferred from the output (``{"ok": false}`` / an ``"error"`` key).
+        """
+        if not call_id:
+            call_id = (
+                self._pending_callless.pop(0)
+                if self._pending_callless
+                else str(uuid4())
+            )
+        tool_name, arguments = self.tool_calls.get(call_id, ("tool", {}))
+        inferred_state, summary = _tool_end_state(output)
+        state = state_override or inferred_state
+        self.steps.append(
+            ToolCallStep(
+                **self._node(),
+                sequence=self._next_sequence(),
+                tool_name=tool_name,
+                arguments=arguments,
+                state=state,
+                output_summary=summary,
+                raw_output=_jsonable(output),
+            )
+        )
+        return [
+            ToolEndEvent(
+                **self._node(),
+                sequence=self._next_sequence(),
+                tool_id=call_id,
+                tool_name=tool_name,
+                state=state,
+                output_summary=summary,
+            )
+        ]
+
+    def emit_error(self, message: str) -> list[StreamEvent]:
+        """Emit a non-terminal error event (an in-stream failure signal)."""
+        return [
+            ErrorEvent(**self._node(), sequence=self._next_sequence(), message=message)
+        ]
+
+    # -- dispatch + terminals -------------------------------------------------
+
+    def consume(self, event: Any) -> list[StreamEvent]:
+        """Convert one framework event into zero or more normalized events.
+
+        Subclasses override this. They should call :meth:`_ensure_started`'s
+        counterpart by emitting the run-start before their first output — the
+        base does this in :meth:`_consume_wrapped`.
+        """
+        raise NotImplementedError
+
+    def _consume_wrapped(self, event: Any) -> list[StreamEvent]:
+        """Emit the run-start on the first event, then dispatch to ``consume``."""
+        emitted = self._ensure_started()
+        emitted.extend(self.consume(event))
+        return emitted
+
+    def finish(self) -> list[StreamEvent]:
+        """Flush open blocks and emit the terminal run-end event."""
+        emitted = self._ensure_started()
+        emitted.extend(self.finalize_blocks())
+        result = AgentRunResult(
+            run_id=self.run_id,
+            root_run_id=self.run_id,
+            message="".join(self.message_parts),
+            steps=self.steps,
+        )
+        emitted.append(
+            RunEndEvent(
+                run_id=self.run_id,
+                root_run_id=self.run_id,
+                sequence=self._next_sequence(),
+                result=result,
+            )
+        )
+        return emitted
+
+    def error(self, message: str) -> list[StreamEvent]:
+        """Flush open blocks and emit a terminal error event.
+
+        Terminal on its own — no trailing run-end — since a fatal stream error
+        ends the turn; :meth:`ChatState.apply_event` marks streaming stopped.
+        """
+        emitted = self._ensure_started()
+        emitted.extend(self.finalize_blocks())
+        emitted.append(
+            ErrorEvent(**self._node(), sequence=self._next_sequence(), message=message)
+        )
+        return emitted
+
+
+async def run_normalizer(
+    accumulator: StreamAccumulator,
+    events: AsyncIterator[Any],
+    *,
+    error_log: str = "serve stream failed",
+) -> AsyncIterator[StreamEvent]:
+    """Drive ``accumulator`` over ``events`` with the shared bracket loop.
+
+    Emits run-start on the first event (via ``_consume_wrapped``), then either
+    ``finish()`` on clean completion or a terminal ``error()`` if the framework
+    stream raises — so a mid-stream exception surfaces as an event instead of
+    tearing down the relay task.
+    """
+    try:
+        async for event in events:
+            for normalized in accumulator._consume_wrapped(event):
+                yield normalized
+    except Exception as exc:  # noqa: BLE001 — surface any failure as an event
+        logger.exception(error_log)
+        for normalized in accumulator.error(str(exc)):
+            yield normalized
+        return
+    for normalized in accumulator.finish():
+        yield normalized

--- a/tests/adapters/google/test_streaming.py
+++ b/tests/adapters/google/test_streaming.py
@@ -131,6 +131,32 @@ async def test_error_code_event_emits_error() -> None:
     assert isinstance(out[-1], RunEndEvent)
 
 
+async def test_session_evicted_on_new_conversation(
+    monkeypatch: Any,
+) -> None:
+    """A new conversation mints a fresh ADK session and evicts the previous one,
+    so a long-lived serve process doesn't leak sessions across resets."""
+    from hexgate.adapters.google.streaming import GoogleServeDriver
+
+    class _StubRunner:
+        def __init__(self, **_kw: Any) -> None:
+            pass
+
+    monkeypatch.setattr("hexgate.adapters.google.runner.HexgateRunner", _StubRunner)
+
+    driver = GoogleServeDriver(agent=object(), app_name="app")
+
+    first = await driver._ensure_session("u", ["only-one"])  # turns<=1 → new
+    same = await driver._ensure_session("u", ["a", "b", "c"])  # continue
+    assert same == first
+    assert ("u", first) in driver._created
+
+    fresh = await driver._ensure_session("u", ["reset"])  # turns<=1 → new + evict
+    assert fresh != first
+    assert ("u", first) not in driver._created  # old one evicted
+    assert ("u", fresh) in driver._created
+
+
 async def test_full_sequence_brackets_run() -> None:
     out = await _collect(
         [

--- a/tests/adapters/google/test_streaming.py
+++ b/tests/adapters/google/test_streaming.py
@@ -1,0 +1,147 @@
+"""Unit tests for the Google ADK → hexgate StreamEvent normalizer.
+
+Drives ``normalize_google_events`` with hand-built fakes shaped like ADK
+``Event``s (``partial``, ``content.parts[].text/thought``, ``error_code``, and
+the ``get_function_calls`` / ``get_function_responses`` helpers). No live model.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+from hexgate.adapters.google.streaming import normalize_google_events
+from hexgate.streaming import (
+    BlockDeltaEvent,
+    BlockType,
+    ErrorEvent,
+    EventType,
+    RunEndEvent,
+    ToolCallState,
+    ToolEndEvent,
+    ToolStartEvent,
+)
+
+
+def _event(
+    *,
+    parts: list[Any] | None = None,
+    partial: bool = False,
+    calls: list[Any] | None = None,
+    responses: list[Any] | None = None,
+    error_code: str | None = None,
+    error_message: str | None = None,
+) -> SimpleNamespace:
+    content = SimpleNamespace(parts=parts) if parts is not None else None
+    return SimpleNamespace(
+        content=content,
+        partial=partial,
+        error_code=error_code,
+        error_message=error_message,
+        get_function_calls=lambda: calls or [],
+        get_function_responses=lambda: responses or [],
+    )
+
+
+def _text(text: str, *, partial: bool = True, thought: bool = False) -> SimpleNamespace:
+    return _event(parts=[SimpleNamespace(text=text, thought=thought)], partial=partial)
+
+
+def _call(call_id: str | None, name: str, args: dict) -> SimpleNamespace:
+    return _event(calls=[SimpleNamespace(id=call_id, name=name, args=args)])
+
+
+def _response(call_id: str | None, name: str, response: Any) -> SimpleNamespace:
+    return _event(responses=[SimpleNamespace(id=call_id, name=name, response=response)])
+
+
+async def _aiter(events: list[Any]) -> AsyncIterator[Any]:
+    for event in events:
+        yield event
+
+
+async def _collect(events: list[Any], *, query: str = "hi") -> list[Any]:
+    return [e async for e in normalize_google_events(_aiter(events), query=query)]
+
+
+async def test_partial_text_streams_and_aggregate_is_deduped() -> None:
+    out = await _collect(
+        [
+            _text("Hel", partial=True),
+            _text("lo", partial=True),
+            _text("Hello", partial=False),  # SSE aggregate — must be skipped
+        ]
+    )
+    deltas = [e for e in out if isinstance(e, BlockDeltaEvent)]
+    assert [d.text for d in deltas] == ["Hel", "lo"]
+    run_end = next(e for e in out if isinstance(e, RunEndEvent))
+    assert run_end.result.message == "Hello"
+
+
+async def test_thought_part_opens_reasoning_block() -> None:
+    out = await _collect([_text("planning", partial=True, thought=True)])
+    delta = next(e for e in out if isinstance(e, BlockDeltaEvent))
+    assert delta.block_type == BlockType.REASONING
+
+
+async def test_function_call_becomes_tool_start() -> None:
+    out = await _collect([_call("c1", "refund_order", {"amount": 5})])
+    start = next(e for e in out if isinstance(e, ToolStartEvent))
+    assert start.tool_id == "c1"
+    assert start.tool_name == "refund_order"
+    assert start.arguments == {"amount": 5}
+
+
+async def test_missing_call_id_falls_back_to_name() -> None:
+    out = await _collect(
+        [_call(None, "lookup", {}), _response(None, "lookup", {"ok": True})]
+    )
+    start = next(e for e in out if isinstance(e, ToolStartEvent))
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+    assert start.tool_id == "lookup"
+    assert end.tool_id == "lookup"  # correlated by name when id is absent
+
+
+async def test_function_response_ok_false_marks_failed() -> None:
+    out = await _collect(
+        [
+            _call("c1", "refund_order", {}),
+            _response("c1", "refund_order", {"ok": False, "error": {"message": "no"}}),
+        ]
+    )
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+    assert end.state == ToolCallState.FAILED
+    assert end.output_summary == "no"
+
+
+async def test_function_response_plain_is_completed() -> None:
+    out = await _collect([_call("c1", "t", {}), _response("c1", "t", {"status": "ok"})])
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+    assert end.state == ToolCallState.COMPLETED
+
+
+async def test_error_code_event_emits_error() -> None:
+    out = await _collect(
+        [_event(error_code="SAFETY", error_message="blocked by filter")]
+    )
+    err = next(e for e in out if isinstance(e, ErrorEvent))
+    assert "blocked by filter" in err.message
+    # Non-terminal: the run still closes cleanly.
+    assert isinstance(out[-1], RunEndEvent)
+
+
+async def test_full_sequence_brackets_run() -> None:
+    out = await _collect(
+        [
+            _text("Look", partial=True),
+            _call("c1", "get_order_status", {"order_id": "42"}),
+            _response("c1", "get_order_status", "shipped"),
+            _text(" done", partial=True),
+        ]
+    )
+    kinds = [e.event_type for e in out]
+    assert kinds[0] == EventType.RUN_START
+    assert kinds[-1] == EventType.RUN_END
+    assert EventType.TOOL_START in kinds
+    assert EventType.TOOL_END in kinds

--- a/tests/adapters/openai/test_streaming.py
+++ b/tests/adapters/openai/test_streaming.py
@@ -1,0 +1,230 @@
+"""Unit tests for the OpenAI Agents → hexgate StreamEvent normalizer.
+
+Drives ``normalize_openai_events`` with hand-built fakes shaped like the
+``agents`` SDK's stream events (``RawResponsesStreamEvent`` /
+``RunItemStreamEvent`` and the ``ToolCallItem`` / ``ToolCallOutputItem`` fields
+the normalizer reads via ``getattr``). No live model.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+from hexgate.adapters.openai.streaming import normalize_openai_events
+from hexgate.streaming import (
+    BlockDeltaEvent,
+    BlockType,
+    ErrorEvent,
+    EventType,
+    RunEndEvent,
+    RunStartEvent,
+    ToolCallState,
+    ToolEndEvent,
+    ToolStartEvent,
+)
+
+
+def _text_delta(item_id: str, delta: str) -> SimpleNamespace:
+    """A raw_response_event carrying an output-text delta."""
+    data = SimpleNamespace(
+        type="response.output_text.delta", item_id=item_id, delta=delta
+    )
+    return SimpleNamespace(type="raw_response_event", data=data)
+
+
+def _reasoning_delta(item_id: str, delta: str) -> SimpleNamespace:
+    data = SimpleNamespace(
+        type="response.reasoning_text.delta", item_id=item_id, delta=delta
+    )
+    return SimpleNamespace(type="raw_response_event", data=data)
+
+
+def _reasoning_summary_delta(item_id: str, delta: str) -> SimpleNamespace:
+    """The summarized-reasoning variant the o-series / gpt-5 emit by default."""
+    data = SimpleNamespace(
+        type="response.reasoning_summary_text.delta", item_id=item_id, delta=delta
+    )
+    return SimpleNamespace(type="raw_response_event", data=data)
+
+
+def _tool_called(call_id: str, name: str, arguments_json: str) -> SimpleNamespace:
+    """A run_item_stream_event(name=tool_called) with a ToolCallItem-shaped item."""
+    raw_item = SimpleNamespace(call_id=call_id, name=name, arguments=arguments_json)
+    item = SimpleNamespace(
+        type="tool_call_item", raw_item=raw_item, tool_name=name, call_id=call_id
+    )
+    return SimpleNamespace(type="run_item_stream_event", name="tool_called", item=item)
+
+
+def _tool_output(call_id: str, output: Any) -> SimpleNamespace:
+    item = SimpleNamespace(
+        type="tool_call_output_item",
+        raw_item={"call_id": call_id},
+        call_id=call_id,
+        output=output,
+    )
+    return SimpleNamespace(type="run_item_stream_event", name="tool_output", item=item)
+
+
+async def _aiter(events: list[Any]) -> AsyncIterator[Any]:
+    for event in events:
+        yield event
+
+
+async def _collect(events: list[Any], *, query: str = "hi") -> list[Any]:
+    return [
+        event async for event in normalize_openai_events(_aiter(events), query=query)
+    ]
+
+
+async def test_full_sequence_text_tool_text() -> None:
+    out = await _collect(
+        [
+            _text_delta("m1", "Hel"),
+            _text_delta("m1", "lo"),
+            _tool_called("c1", "refund_order", '{"amount": 5}'),
+            _tool_output("c1", {"ok": True}),
+            _text_delta("m2", " done"),
+        ]
+    )
+    kinds = [e.event_type for e in out]
+
+    # Run brackets the whole stream.
+    assert kinds[0] == EventType.RUN_START
+    assert kinds[-1] == EventType.RUN_END
+    assert isinstance(out[0], RunStartEvent) and out[0].query == "hi"
+
+    # A tool call closes the open text block before the tool events.
+    assert kinds == [
+        EventType.RUN_START,
+        EventType.BLOCK_START,
+        EventType.BLOCK_DELTA,
+        EventType.BLOCK_DELTA,
+        EventType.BLOCK_END,
+        EventType.TOOL_START,
+        EventType.TOOL_END,
+        EventType.BLOCK_START,
+        EventType.BLOCK_DELTA,
+        EventType.BLOCK_END,
+        EventType.RUN_END,
+    ]
+
+    # Sequence numbers are strictly monotonic.
+    seqs = [e.sequence for e in out]
+    assert seqs == sorted(seqs) and len(set(seqs)) == len(seqs)
+
+
+async def test_tool_start_end_correlate_and_label() -> None:
+    out = await _collect(
+        [
+            _tool_called("call-42", "refund_order", '{"amount": 5, "currency": "USD"}'),
+            _tool_output("call-42", {"ok": True}),
+        ]
+    )
+    start = next(e for e in out if isinstance(e, ToolStartEvent))
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+
+    # Same tool_id links start↔end; args parsed from the JSON string to a dict.
+    assert start.tool_id == "call-42"
+    assert start.tool_name == "refund_order"
+    assert start.arguments == {"amount": 5, "currency": "USD"}
+    # tool_output carries no name; it is labeled from the recorded call.
+    assert end.tool_id == "call-42"
+    assert end.tool_name == "refund_order"
+    assert end.state == ToolCallState.COMPLETED
+
+
+async def test_bad_json_args_degrade_to_empty_dict() -> None:
+    out = await _collect([_tool_called("c1", "t", "not json")])
+    start = next(e for e in out if isinstance(e, ToolStartEvent))
+    assert start.arguments == {}
+
+
+async def test_reasoning_delta_opens_reasoning_block() -> None:
+    out = await _collect([_reasoning_delta("r1", "thinking...")])
+    delta = next(e for e in out if isinstance(e, BlockDeltaEvent))
+    assert delta.block_type == BlockType.REASONING
+    assert delta.text == "thinking..."
+
+
+async def test_run_end_assembles_message_and_steps() -> None:
+    out = await _collect(
+        [
+            _text_delta("m1", "Hello"),
+            _text_delta("m1", " world"),
+            _tool_called("c1", "search", "{}"),
+            _tool_output("c1", "result-text"),
+        ]
+    )
+    run_end = next(e for e in out if isinstance(e, RunEndEvent))
+    assert run_end.result.message == "Hello world"
+    # One text step + one tool-call step persisted.
+    step_kinds = {step.type for step in run_end.result.steps}
+    assert "text_step" in step_kinds
+    assert "tool_call_step" in step_kinds
+
+
+async def test_fatal_stream_error_emits_terminal_error_event() -> None:
+    async def _boom() -> AsyncIterator[Any]:
+        yield _text_delta("m1", "partial")
+        raise RuntimeError("kaboom")
+
+    out = [event async for event in normalize_openai_events(_boom(), query="q")]
+
+    # The stream terminates on an ErrorEvent — no RunEnd after a fatal error.
+    assert isinstance(out[-1], ErrorEvent)
+    assert "kaboom" in out[-1].message
+    assert not any(isinstance(e, RunEndEvent) for e in out)
+    # The open text block was finalized before the error.
+    assert out[-1].event_type == EventType.ERROR
+
+
+async def test_reasoning_summary_delta_opens_reasoning_block() -> None:
+    # Summarized reasoning (the o-series / gpt-5 default) must render too.
+    out = await _collect([_reasoning_summary_delta("r1", "let me think")])
+    delta = next(e for e in out if isinstance(e, BlockDeltaEvent))
+    assert delta.block_type == BlockType.REASONING
+    assert delta.text == "let me think"
+
+
+async def test_structured_failure_output_marks_tool_failed() -> None:
+    # A hexgate GuardedTool refusal surfaces as {"ok": false, "error": {...}};
+    # it must render as FAILED, not a green completed call.
+    out = await _collect(
+        [
+            _tool_called("c1", "refund_order", "{}"),
+            _tool_output("c1", {"ok": False, "error": {"message": "denied by policy"}}),
+        ]
+    )
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+    assert end.state == ToolCallState.FAILED
+    assert end.output_summary == "denied by policy"
+
+
+async def test_empty_stream_is_bracketed_by_run_start_and_end() -> None:
+    out = await _collect([])
+    assert [e.event_type for e in out] == [EventType.RUN_START, EventType.RUN_END]
+
+
+async def test_non_serializable_tool_output_still_serializes_run_end() -> None:
+    class _Weird:
+        pass
+
+    out = await _collect([_tool_called("c1", "t", "{}"), _tool_output("c1", _Weird())])
+    run_end = next(e for e in out if isinstance(e, RunEndEvent))
+    # Must not raise PydanticSerializationError — serve ships this over the wire.
+    dumped = run_end.model_dump_json()
+    assert "tool_call_step" in dumped
+
+
+async def test_callless_tool_start_end_share_tool_id() -> None:
+    # Hosted calls can omit call_id; start and end must still correlate.
+    out = await _collect(
+        [_tool_called(None, "shell", "{}"), _tool_output(None, "ok")]  # type: ignore[arg-type]
+    )
+    start = next(e for e in out if isinstance(e, ToolStartEvent))
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+    assert start.tool_id == end.tool_id
+    assert end.tool_name == "shell"

--- a/tests/adapters/pydantic_ai/test_streaming.py
+++ b/tests/adapters/pydantic_ai/test_streaming.py
@@ -1,0 +1,183 @@
+"""Unit tests for the Pydantic AI → hexgate StreamEvent normalizer.
+
+Drives ``normalize_pydantic_events`` with hand-built fakes shaped like pydantic
+``AgentStreamEvent``s (``event_kind`` + the part/delta/result fields the
+normalizer reads via ``getattr``). No live model.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+from hexgate.adapters.pydantic_ai.streaming import normalize_pydantic_events
+from hexgate.streaming import (
+    BlockDeltaEvent,
+    BlockType,
+    ErrorEvent,
+    EventType,
+    RunEndEvent,
+    ToolCallState,
+    ToolEndEvent,
+    ToolStartEvent,
+)
+
+
+def _part_start(index: int, part: Any) -> SimpleNamespace:
+    return SimpleNamespace(event_kind="part_start", index=index, part=part)
+
+
+def _part_delta(index: int, delta: Any) -> SimpleNamespace:
+    return SimpleNamespace(event_kind="part_delta", index=index, delta=delta)
+
+
+def _text_part(content: str) -> SimpleNamespace:
+    return SimpleNamespace(part_kind="text", content=content)
+
+
+def _thinking_part(content: str) -> SimpleNamespace:
+    return SimpleNamespace(part_kind="thinking", content=content)
+
+
+def _text_delta(content: str) -> SimpleNamespace:
+    return SimpleNamespace(part_delta_kind="text", content_delta=content)
+
+
+def _tool_call(index: int, call_id: str, name: str, args: dict) -> SimpleNamespace:
+    part = SimpleNamespace(
+        part_kind="tool-call",
+        tool_call_id=call_id,
+        tool_name=name,
+        args_as_dict=lambda: args,
+    )
+    return SimpleNamespace(event_kind="function_tool_call", part=part)
+
+
+def _tool_return(
+    call_id: str, name: str, content: Any, outcome: str
+) -> SimpleNamespace:
+    result = SimpleNamespace(
+        tool_call_id=call_id, tool_name=name, content=content, outcome=outcome
+    )
+    return SimpleNamespace(event_kind="function_tool_result", result=result)
+
+
+def _retry_prompt(call_id: str, name: str, content: str) -> SimpleNamespace:
+    # No ``outcome`` attribute → the normalizer treats it as a RetryPromptPart.
+    result = SimpleNamespace(tool_call_id=call_id, tool_name=name, content=content)
+    return SimpleNamespace(event_kind="function_tool_result", result=result)
+
+
+async def _aiter(events: list[Any]) -> AsyncIterator[Any]:
+    for event in events:
+        yield event
+
+
+async def _collect(events: list[Any], *, query: str = "hi") -> list[Any]:
+    return [e async for e in normalize_pydantic_events(_aiter(events), query=query)]
+
+
+async def test_text_part_and_deltas_stream() -> None:
+    out = await _collect(
+        [
+            _part_start(0, _text_part("Hel")),
+            _part_delta(0, _text_delta("lo")),
+        ]
+    )
+    deltas = [e.text for e in out if isinstance(e, BlockDeltaEvent)]
+    assert deltas == ["Hel", "lo"]
+    run_end = next(e for e in out if isinstance(e, RunEndEvent))
+    assert run_end.result.message == "Hello"
+
+
+async def test_thinking_part_opens_reasoning_block() -> None:
+    out = await _collect([_part_start(0, _thinking_part("hmm"))])
+    delta = next(e for e in out if isinstance(e, BlockDeltaEvent))
+    assert delta.block_type == BlockType.REASONING
+
+
+async def test_text_blocks_separate_by_index() -> None:
+    out = await _collect(
+        [_part_start(0, _text_part("a")), _part_start(1, _text_part("b"))]
+    )
+    starts = [e for e in out if e.event_type == EventType.BLOCK_START]
+    assert len(starts) == 2
+
+
+async def test_function_tool_call_becomes_tool_start() -> None:
+    out = await _collect([_tool_call(0, "c1", "refund_order", {"amount": 5})])
+    start = next(e for e in out if isinstance(e, ToolStartEvent))
+    assert start.tool_id == "c1"
+    assert start.tool_name == "refund_order"
+    assert start.arguments == {"amount": 5}
+
+
+async def test_tool_call_part_in_model_stream_is_not_a_duplicate_start() -> None:
+    # A ToolCallPart arriving via the model-request stream must be ignored;
+    # only FunctionToolCallEvent starts a tool.
+    out = await _collect(
+        [_part_start(0, SimpleNamespace(part_kind="tool-call", tool_name="x"))]
+    )
+    assert not any(isinstance(e, ToolStartEvent) for e in out)
+
+
+async def test_tool_return_success_is_completed() -> None:
+    out = await _collect(
+        [
+            _tool_call(0, "c1", "refund", {}),
+            _tool_return("c1", "refund", "Refunded $5", "success"),
+        ]
+    )
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+    assert end.state == ToolCallState.COMPLETED
+    assert end.tool_id == "c1"
+    assert end.output_summary == "Refunded $5"
+
+
+async def test_tool_return_denied_and_failed_are_failed() -> None:
+    for outcome in ("denied", "failed"):
+        out = await _collect(
+            [
+                _tool_call(0, "c1", "refund", {}),
+                _tool_return("c1", "refund", "blocked", outcome),
+            ]
+        )
+        end = next(e for e in out if isinstance(e, ToolEndEvent))
+        assert end.state == ToolCallState.FAILED, outcome
+
+
+async def test_retry_prompt_marks_tool_failed() -> None:
+    out = await _collect(
+        [
+            _tool_call(0, "c1", "refund", {}),
+            _retry_prompt("c1", "refund", "amount must be a number"),
+        ]
+    )
+    end = next(e for e in out if isinstance(e, ToolEndEvent))
+    assert end.state == ToolCallState.FAILED
+
+
+async def test_fatal_error_emits_terminal_error() -> None:
+    async def _boom() -> AsyncIterator[Any]:
+        yield _part_start(0, _text_part("partial"))
+        raise RuntimeError("model exploded")
+
+    out = [e async for e in normalize_pydantic_events(_boom(), query="q")]
+    assert isinstance(out[-1], ErrorEvent)
+    assert "model exploded" in out[-1].message
+    assert not any(isinstance(e, RunEndEvent) for e in out)
+
+
+async def test_full_sequence_brackets_run() -> None:
+    out = await _collect(
+        [
+            _part_start(0, _text_part("Let me check")),
+            _tool_call(1, "c1", "get_order_status", {"order_id": "42"}),
+            _tool_return("c1", "get_order_status", "shipped", "success"),
+        ]
+    )
+    kinds = [e.event_type for e in out]
+    assert kinds[0] == EventType.RUN_START
+    assert kinds[-1] == EventType.RUN_END
+    assert EventType.TOOL_START in kinds and EventType.TOOL_END in kinds

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -625,23 +625,94 @@ def test_build_runtime_openai_uses_runner_and_skips_enforce(
     assert "enforced_agent" not in captured
 
 
-@pytest.mark.parametrize(
-    "framework", [AgentFramework.GOOGLE, AgentFramework.PYDANTIC_AI]
-)
-def test_build_runtime_rejects_unsupported_framework(
+def test_build_runtime_google_uses_driver_and_skips_enforce(
     _patched_runtime_deps: dict[str, Any],
-    framework: AgentFramework,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Google / Pydantic AI serve isn't built yet — fail loud, not obscure."""
+    """A Google agent builds a GoogleServeDriver and binds its seam, skipping
+    the native policy-fetch path (the ADK runner owns enforcement)."""
     captured = _patched_runtime_deps
-    captured["framework"] = framework
+    captured["framework"] = AgentFramework.GOOGLE
 
-    with pytest.raises(NotImplementedError, match="does not yet support"):
-        build_runtime_from_local_agent(
-            _stub_settings(),
-            agent_obj=object(),
-            description=None,
-            approval_handler=None,
-            auto_register=False,
-            console=Console(),
-        )
+    class _FakeDriver:
+        def __init__(
+            self,
+            *,
+            agent: Any,
+            app_name: str,
+            approval_handler: Any = None,
+            api_key: Any = None,
+        ) -> None:
+            captured["google_agent"] = agent
+            captured["google_app_name"] = app_name
+            captured["google_approval"] = approval_handler
+
+        async def astream(self, *_a: Any, **_k: Any):
+            if False:  # pragma: no cover — empty async generator
+                yield None
+
+    monkeypatch.setattr(
+        "hexgate.adapters.google.streaming.GoogleServeDriver", _FakeDriver
+    )
+
+    sentinel_agent = object()
+    handler = object()
+    runtime = build_runtime_from_local_agent(
+        _stub_settings(),
+        agent_obj=sentinel_agent,
+        description=None,
+        approval_handler=handler,
+        auto_register=False,
+        console=Console(),
+    )
+
+    assert captured["google_agent"] is sentinel_agent
+    assert captured["google_app_name"] == "customer_bot"
+    assert captured["google_approval"] is handler
+    assert runtime.agent is sentinel_agent
+    assert runtime.astream_normalized is not None
+    assert "get_agent_name" not in captured
+    assert "enforced_agent" not in captured
+
+
+def test_build_runtime_pydantic_uses_driver_and_skips_enforce(
+    _patched_runtime_deps: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Pydantic AI agent builds a PydanticServeDriver and binds its seam,
+    skipping the native policy-fetch path (wrap_pydantic_agent owns it)."""
+    captured = _patched_runtime_deps
+    captured["framework"] = AgentFramework.PYDANTIC_AI
+
+    class _FakeDriver:
+        def __init__(
+            self, *, agent: Any, approval_handler: Any = None, api_key: Any = None
+        ) -> None:
+            captured["pydantic_agent"] = agent
+            captured["pydantic_approval"] = approval_handler
+
+        async def astream(self, *_a: Any, **_k: Any):
+            if False:  # pragma: no cover — empty async generator
+                yield None
+
+    monkeypatch.setattr(
+        "hexgate.adapters.pydantic_ai.streaming.PydanticServeDriver", _FakeDriver
+    )
+
+    sentinel_agent = object()
+    handler = object()
+    runtime = build_runtime_from_local_agent(
+        _stub_settings(),
+        agent_obj=sentinel_agent,
+        description=None,
+        approval_handler=handler,
+        auto_register=False,
+        console=Console(),
+    )
+
+    assert captured["pydantic_agent"] is sentinel_agent
+    assert captured["pydantic_approval"] is handler
+    assert runtime.agent is sentinel_agent
+    assert runtime.astream_normalized is not None
+    assert "get_agent_name" not in captured
+    assert "enforced_agent" not in captured

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -111,34 +111,35 @@ class _FakeWebSocket:
 
 
 class _FakeRuntime:
-    """Runtime stand-in — what `_handle_message` reads off ``context.runtime``."""
+    """Runtime stand-in — what `_handle_message` reads off ``context.runtime``.
+
+    Records the ``(input, ctx, query)`` the serve loop threads into the
+    framework streaming seam. Post-refactor, serve's job is to parse
+    ``user_attenuation`` and hand the resulting context to the seam; opening
+    the HexgateContext scope is each framework closure's own responsibility.
+    """
 
     def __init__(self) -> None:
         self.agent_name = "fake-agent"
         self.agent = object()
         self.handler = object()
+        self.received: dict[str, Any] = {}
+
+    async def astream_normalized(self, agent_input: object, ctx: object, query: str):
+        self.received["input"] = agent_input
+        self.received["ctx"] = ctx
+        self.received["query"] = query
+        if False:
+            yield None  # pragma: no cover — empty async generator
 
 
 @pytest.mark.asyncio
-async def test_handle_message_chat_with_attenuation_enters_user_scope(
+async def test_handle_message_chat_threads_attenuation_context_to_seam(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A chat payload with ``user_attenuation`` enters a HexgateContext scope around stream_agent."""
-    captured: dict[str, Any] = {"user_during_stream": None}
-
-    async def fake_stream_agent(
-        agent: object, handler: object, input: object, **kw: Any
-    ):
-        captured["user_during_stream"] = get_current_context()
-        if False:
-            yield None  # pragma: no cover
-
-    monkeypatch.setattr(serve, "stream_agent", fake_stream_agent)
-
-    # ``api_key`` is required on ServeContext post-Phase-6 (used to
-    # build the WS bearer subprotocol). _handle_message doesn't touch
-    # it, so a placeholder is fine for these unit-level tests.
-    context = ServeContext(runtime=_FakeRuntime(), state=ChatState(), api_key="")
+    """A chat payload with ``user_attenuation`` reaches the seam as a parsed context."""
+    runtime = _FakeRuntime()
+    context = ServeContext(runtime=runtime, state=ChatState(), api_key="")
     ws = _FakeWebSocket()
 
     await serve._handle_message(
@@ -154,62 +155,37 @@ async def test_handle_message_chat_with_attenuation_enters_user_scope(
         },
     )
 
-    captured_user: HexgateContext | None = captured["user_during_stream"]
-    assert captured_user is not None
-    assert captured_user.user_id == "alice"
-    assert captured_user.user_roles == ["billing"]
-
-    # After the handler returns the scope must be cleanly popped.
+    ctx: HexgateContext | None = runtime.received["ctx"]
+    assert ctx is not None
+    assert ctx.user_id == "alice"
+    assert ctx.user_roles == ["billing"]
+    # The user's message is threaded as the query for the run-start event.
+    assert runtime.received["query"] == "refund 30"
+    # serve itself never opens a scope now — it stays clean.
     assert get_current_context() is None
 
 
 @pytest.mark.asyncio
-async def test_handle_message_chat_without_attenuation_runs_with_no_user(
+async def test_handle_message_chat_without_attenuation_passes_none_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Backward-compat: messages without ``user_attenuation`` see no HexgateContext scope."""
-    captured: dict[str, Any] = {"user_during_stream": "sentinel"}
-
-    async def fake_stream_agent(
-        agent: object, handler: object, input: object, **kw: Any
-    ):
-        captured["user_during_stream"] = get_current_context()
-        if False:
-            yield None  # pragma: no cover
-
-    monkeypatch.setattr(serve, "stream_agent", fake_stream_agent)
-
-    # ``api_key`` is required on ServeContext post-Phase-6 (used to
-    # build the WS bearer subprotocol). _handle_message doesn't touch
-    # it, so a placeholder is fine for these unit-level tests.
-    context = ServeContext(runtime=_FakeRuntime(), state=ChatState(), api_key="")
+    """Messages without ``user_attenuation`` reach the seam with ``ctx=None``."""
+    runtime = _FakeRuntime()
+    context = ServeContext(runtime=runtime, state=ChatState(), api_key="")
     ws = _FakeWebSocket()
 
     await serve._handle_message(context, ws, {"type": "chat", "message": "hello"})
 
-    assert captured["user_during_stream"] is None
+    assert runtime.received["ctx"] is None
 
 
 @pytest.mark.asyncio
-async def test_handle_message_malformed_attenuation_runs_without_scope(
+async def test_handle_message_malformed_attenuation_passes_none_context(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A malformed user_attenuation payload still lets the turn run (no scope)."""
-    captured: dict[str, Any] = {"user_during_stream": "sentinel"}
-
-    async def fake_stream_agent(
-        agent: object, handler: object, input: object, **kw: Any
-    ):
-        captured["user_during_stream"] = get_current_context()
-        if False:
-            yield None  # pragma: no cover
-
-    monkeypatch.setattr(serve, "stream_agent", fake_stream_agent)
-
-    # ``api_key`` is required on ServeContext post-Phase-6 (used to
-    # build the WS bearer subprotocol). _handle_message doesn't touch
-    # it, so a placeholder is fine for these unit-level tests.
-    context = ServeContext(runtime=_FakeRuntime(), state=ChatState(), api_key="")
+    """A malformed ``user_attenuation`` payload still runs the turn with ``ctx=None``."""
+    runtime = _FakeRuntime()
+    context = ServeContext(runtime=runtime, state=ChatState(), api_key="")
     ws = _FakeWebSocket()
 
     await serve._handle_message(
@@ -218,11 +194,11 @@ async def test_handle_message_malformed_attenuation_runs_without_scope(
         {
             "type": "chat",
             "message": "hello",
-            "user_attenuation": "not-a-dict",  # ignored, no scope
+            "user_attenuation": "not-a-dict",  # ignored → ctx None
         },
     )
 
-    assert captured["user_during_stream"] is None
+    assert runtime.received["ctx"] is None
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +312,7 @@ async def test_serve_loop_aborts_when_marker_not_echoed(
 
 
 from hexgate.cli._common import build_runtime_from_local_agent, load_spec  # noqa: E402  — section-scoped import keeps phase-7 tests visually grouped
+from hexgate.manifest.models import AgentFramework  # noqa: E402  — section-scoped
 
 
 def test_load_spec_resolves_module_attr_form() -> None:
@@ -383,13 +360,15 @@ def _patched_runtime_deps(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """
     captured: dict[str, Any] = {}
 
-    # Pre-built manifest the test rebuilds the spy responses around.
-    fake_manifest_obj = type("FakeManifest", (), {"name": "customer_bot"})()
-
     def fake_create_manifest(agent_obj: Any, *, description: str | None = None):
         captured["create_manifest_called_with"] = agent_obj
         captured["description"] = description
-        return fake_manifest_obj
+        # Framework drives dispatch in build_runtime_from_local_agent; default
+        # to the native path, tests override via ``captured["framework"]``.
+        framework = captured.get("framework", AgentFramework.HEXGATE)
+        return type(
+            "FakeManifest", (), {"name": "customer_bot", "framework": framework}
+        )()
 
     def fake_post_manifest(manifest: Any, *, timeout: float = 5.0) -> dict:
         captured["posted_manifest"] = manifest
@@ -579,3 +558,90 @@ def test_build_runtime_attaches_platform_policy_source_for_per_turn_refresh(
     assert isinstance(kwargs["source"], PlatformPolicySource), (
         f"expected PlatformPolicySource, got {type(kwargs['source']).__name__}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Framework dispatch — serve builds the right runtime per manifest.framework
+# ---------------------------------------------------------------------------
+
+
+def test_build_runtime_native_binds_streaming_seam(
+    _patched_runtime_deps: dict[str, Any],
+) -> None:
+    """The native (hexgate) path binds an ``astream_normalized`` seam.
+
+    serve streams exclusively through this seam, so a runtime built
+    without one would raise at the first chat turn.
+    """
+    runtime = build_runtime_from_local_agent(
+        _stub_settings(),
+        agent_obj=object(),
+        description=None,
+        approval_handler=None,
+        auto_register=False,
+        console=Console(),
+    )
+    assert runtime.astream_normalized is not None
+
+
+def test_build_runtime_openai_uses_runner_and_skips_enforce(
+    _patched_runtime_deps: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An OpenAI agent builds a HexgateRunner and binds the OpenAI seam.
+
+    The OpenAI runner owns enforcement (it fetches + hot-reloads its own
+    binding per run), so the native ``enforce_policy`` / ``get_agent``
+    path must NOT run for an OpenAI agent.
+    """
+    captured = _patched_runtime_deps
+    captured["framework"] = AgentFramework.OPENAI
+
+    class _FakeRunner:
+        def __init__(self, *, approval_handler: Any = None) -> None:
+            captured["runner_approval_handler"] = approval_handler
+
+    monkeypatch.setattr("hexgate.adapters.openai.runner.HexgateRunner", _FakeRunner)
+
+    sentinel_agent = object()
+    handler = object()
+    runtime = build_runtime_from_local_agent(
+        _stub_settings(),
+        agent_obj=sentinel_agent,
+        description=None,
+        approval_handler=handler,
+        auto_register=False,
+        console=Console(),
+    )
+
+    # The OpenAI runner was constructed with the serve approval handler.
+    assert captured["runner_approval_handler"] is handler
+    # The runtime wraps the raw OpenAI agent and binds a streaming seam.
+    assert runtime.agent is sentinel_agent
+    assert runtime.astream_normalized is not None
+    assert runtime.agent_name == "customer_bot"
+    # The native policy-fetch path did NOT run for OpenAI.
+    assert "get_agent_name" not in captured
+    assert "enforced_agent" not in captured
+
+
+@pytest.mark.parametrize(
+    "framework", [AgentFramework.GOOGLE, AgentFramework.PYDANTIC_AI]
+)
+def test_build_runtime_rejects_unsupported_framework(
+    _patched_runtime_deps: dict[str, Any],
+    framework: AgentFramework,
+) -> None:
+    """Google / Pydantic AI serve isn't built yet — fail loud, not obscure."""
+    captured = _patched_runtime_deps
+    captured["framework"] = framework
+
+    with pytest.raises(NotImplementedError, match="does not yet support"):
+        build_runtime_from_local_agent(
+            _stub_settings(),
+            agent_obj=object(),
+            description=None,
+            approval_handler=None,
+            auto_register=False,
+            console=Console(),
+        )

--- a/tests/cli/test_serve_approval.py
+++ b/tests/cli/test_serve_approval.py
@@ -718,19 +718,20 @@ async def test_chat_lock_serializes_concurrent_chat_turns() -> None:
         async def send(self, _: str) -> None:
             pass
 
-    async def _fake_stream_agent(agent, handler, inp):  # noqa: ARG001
-        nonlocal concurrent_in_chat, max_seen_concurrent
-        concurrent_in_chat += 1
-        max_seen_concurrent = max(max_seen_concurrent, concurrent_in_chat)
-        # Yield so a lock-free second chat would race in here.
-        await asyncio.sleep(0.01)
-        concurrent_in_chat -= 1
-        if False:  # pragma: no cover — never yields, keeps signature async iter
-            yield None
-
     class _StubRuntime:
         agent = object()
         handler = object()
+
+        # The framework streaming seam serve now drives per turn. Counts
+        # overlap so a lock-free second chat would be detected racing in here.
+        async def astream_normalized(self, agent_input, ctx, query):  # noqa: ARG002
+            nonlocal concurrent_in_chat, max_seen_concurrent
+            concurrent_in_chat += 1
+            max_seen_concurrent = max(max_seen_concurrent, concurrent_in_chat)
+            await asyncio.sleep(0.01)
+            concurrent_in_chat -= 1
+            if False:  # pragma: no cover — never yields, keeps signature async iter
+                yield None
 
     context = ServeContext(
         runtime=_StubRuntime(),  # type: ignore[arg-type]
@@ -741,18 +742,11 @@ async def test_chat_lock_serializes_concurrent_chat_turns() -> None:
         chat_lock=asyncio.Lock(),
     )
 
-    import hexgate.cli.serve as serve_mod
-
-    original = serve_mod.stream_agent
-    serve_mod.stream_agent = _fake_stream_agent
-    try:
-        ws = _NoopWS()
-        await asyncio.gather(
-            _handle_message(context, ws, {"type": "chat", "message": "first"}),
-            _handle_message(context, ws, {"type": "chat", "message": "second"}),
-        )
-    finally:
-        serve_mod.stream_agent = original
+    ws = _NoopWS()
+    await asyncio.gather(
+        _handle_message(context, ws, {"type": "chat", "message": "first"}),
+        _handle_message(context, ws, {"type": "chat", "message": "second"}),
+    )
 
     assert max_seen_concurrent == 1, (
         "two chat frames overlapped — chat_lock did not serialize them"

--- a/tests/streaming/test_accumulator.py
+++ b/tests/streaming/test_accumulator.py
@@ -1,0 +1,168 @@
+"""Unit tests for the shared StreamAccumulator base + run_normalizer.
+
+Exercises the framework-agnostic bookkeeping (blocks, tool correlation, state
+inference, run bracketing) directly via a trivial subclass, plus the
+``run_normalizer`` drive loop, so each adapter's tests only need to cover its
+own ``consume`` mapping.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+from hexgate.streaming import (
+    BlockDeltaEvent,
+    BlockStartEvent,
+    BlockType,
+    ErrorEvent,
+    EventType,
+    RunEndEvent,
+    ToolCallState,
+    ToolEndEvent,
+    ToolStartEvent,
+)
+from hexgate.streaming._accumulator import (
+    StreamAccumulator,
+    _jsonable,
+    run_normalizer,
+)
+
+
+class _Acc(StreamAccumulator):
+    """Minimal subclass — tests drive the emit_* helpers directly."""
+
+    def consume(self, event: Any) -> list:
+        # Echo helper: a ("delta", text) tuple emits a text delta, so
+        # run_normalizer can be driven end to end.
+        if isinstance(event, tuple) and event[0] == "delta":
+            return self.emit_delta("text", BlockType.TEXT, event[1])
+        return []
+
+
+def test_jsonable_passes_native_and_stringifies_unknown() -> None:
+    assert _jsonable({"a": 1}) == {"a": 1}
+    assert _jsonable("x") == "x"
+
+    class _Weird:
+        def __repr__(self) -> str:
+            return "WEIRD"
+
+    assert _jsonable(_Weird()) == "WEIRD"
+
+
+def test_emit_delta_opens_block_once_then_appends() -> None:
+    acc = _Acc("q")
+    first = acc.emit_delta("text", BlockType.TEXT, "Hel")
+    second = acc.emit_delta("text", BlockType.TEXT, "lo")
+
+    assert [type(e) for e in first] == [BlockStartEvent, BlockDeltaEvent]
+    # Same key → no second BlockStart, just a delta.
+    assert [type(e) for e in second] == [BlockDeltaEvent]
+    assert "".join(acc.message_parts) == "Hello"
+
+
+def test_emit_delta_separates_text_and_reasoning() -> None:
+    acc = _Acc("q")
+    acc.emit_delta("text", BlockType.TEXT, "answer")
+    acc.emit_delta("reasoning", BlockType.REASONING, "thinking")
+    assert len(acc.blocks) == 2
+    # Reasoning text does not leak into the assistant message.
+    assert "".join(acc.message_parts) == "answer"
+
+
+def test_empty_delta_is_noop() -> None:
+    acc = _Acc("q")
+    assert acc.emit_delta("text", BlockType.TEXT, "") == []
+    assert acc.blocks == {}
+
+
+def test_tool_start_closes_open_block_and_records_call() -> None:
+    acc = _Acc("q")
+    acc.emit_delta("text", BlockType.TEXT, "hi")
+    events = acc.emit_tool_start("c1", "refund", {"amount": 5})
+    kinds = [e.event_type for e in events]
+    # Open text block is finalized before the tool starts.
+    assert kinds == [EventType.BLOCK_END, EventType.TOOL_START]
+    assert acc.tool_calls["c1"] == ("refund", {"amount": 5})
+
+
+def test_tool_end_infers_failed_from_ok_false() -> None:
+    acc = _Acc("q")
+    acc.emit_tool_start("c1", "refund", {})
+    [end] = acc.emit_tool_end("c1", {"ok": False, "error": {"message": "nope"}})
+    assert isinstance(end, ToolEndEvent)
+    assert end.state == ToolCallState.FAILED
+    assert end.output_summary == "nope"
+    assert end.tool_name == "refund"
+
+
+def test_tool_end_state_override_wins() -> None:
+    acc = _Acc("q")
+    acc.emit_tool_start("c1", "t", {})
+    [end] = acc.emit_tool_end("c1", "fine", state_override=ToolCallState.FAILED)
+    assert end.state == ToolCallState.FAILED
+
+
+def test_callless_tool_start_end_share_id() -> None:
+    acc = _Acc("q")
+    start = acc.emit_tool_start(None, "shell", {})
+    [end] = acc.emit_tool_end(None, "ok")
+    tool_start = next(e for e in start if isinstance(e, ToolStartEvent))
+    assert tool_start.tool_id == end.tool_id
+
+
+def test_tool_end_raw_output_is_jsonable() -> None:
+    acc = _Acc("q")
+    acc.emit_tool_start("c1", "t", {})
+
+    class _Weird:
+        pass
+
+    acc.emit_tool_end("c1", _Weird())
+    step = acc.steps[-1]
+    # Stored form must be a string (json-safe), not the raw object.
+    assert isinstance(step.raw_output, str)
+
+
+def test_finish_brackets_empty_run() -> None:
+    acc = _Acc("q")
+    out = acc.finish()
+    assert [e.event_type for e in out] == [EventType.RUN_START, EventType.RUN_END]
+
+
+def test_error_emits_run_start_then_error_no_run_end() -> None:
+    acc = _Acc("q")
+    out = acc.error("boom")
+    assert [e.event_type for e in out] == [EventType.RUN_START, EventType.ERROR]
+    assert not any(isinstance(e, RunEndEvent) for e in out)
+
+
+async def _aiter(items: list[Any]) -> AsyncIterator[Any]:
+    for item in items:
+        yield item
+
+
+async def test_run_normalizer_brackets_a_clean_stream() -> None:
+    acc = _Acc("hello")
+    out = [
+        e async for e in run_normalizer(acc, _aiter([("delta", "hi"), ("delta", "!")]))
+    ]
+    kinds = [e.event_type for e in out]
+    assert kinds[0] == EventType.RUN_START
+    assert kinds[-1] == EventType.RUN_END
+    run_end = out[-1]
+    assert isinstance(run_end, RunEndEvent)
+    assert run_end.result.message == "hi!"
+
+
+async def test_run_normalizer_turns_a_raise_into_terminal_error() -> None:
+    async def _boom() -> AsyncIterator[Any]:
+        yield ("delta", "partial")
+        raise RuntimeError("kaboom")
+
+    acc = _Acc("q")
+    out = [e async for e in run_normalizer(acc, _boom())]
+    assert isinstance(out[-1], ErrorEvent)
+    assert "kaboom" in out[-1].message
+    assert not any(isinstance(e, RunEndEvent) for e in out)


### PR DESCRIPTION
Serve every supported agent framework, not just the native one. `hexgate serve` relays a local agent to the dashboard Playground over a WebSocket, streaming normalized `StreamEvent`s; until now it only worked for the native (LangChain) `HexgateAgent` and `AttributeError`'d on an OpenAI, Google, or Pydantic agent. This makes all four frameworks serve, with policy enforcement, audit, and approvals intact. Blast radius: pure SDK, no platform change, no migration.

## Design

serve was welded to LangChain in two places: `build_runtime_from_local_agent` called `HexgateAgent.enforce_policy`, and `_run_chat_turn` streamed through `stream_agent` + `normalize_langchain_events`. The fix introduces one seam, `AgentRuntime.astream_normalized(input, ctx, query)`, bound per framework in `build_runtime_from_local_agent` (dispatching on `manifest.framework`, which `create_manifest` already computes). serve itself is now framework-blind.

Each framework maps its native run stream onto the existing `StreamEvent` contract (run-start, text/reasoning block deltas, tool start/end, run-end, error). Since that bookkeeping is identical across adapters, it lives once in `StreamAccumulator` (sequence, flat run id, blocks, tool-call correlation, `_tool_end_state` inference, JSON-safe `raw_output`, finish/error bracketing) driven by `run_normalizer`; each adapter is a thin `consume()` plus a small driver.

| Framework | How it streams | Notes handled |
| --- | --- | --- |
| OpenAI | `HexgateRunner.run_streamed().stream_events()` | args are a JSON string (parsed); errors are raised out of the stream |
| Google ADK | `HexgateRunner.run_async(..., RunConfig(SSE))` | session-based history (driver owns an in-memory session, fresh per conversation); SSE emits a duplicate final aggregate, deduped to partial deltas |
| Pydantic AI | `agent.iter()` node graph, flattened | tool failures are in-band (`ToolReturnPart.outcome` / `RetryPromptPart`), mapped to an explicit FAILED state; history carried across turns |

Enforcement ownership differs by design: the native path calls `enforce_policy`; OpenAI/Google/Pydantic each let their own runner/proxy resolve and hot-reload the policy binding, so the driver builders skip `enforce_policy`.

## Important files

| File | What to look at |
| --- | --- |
| `hexgate/streaming/_accumulator.py` | the shared base + `run_normalizer`; read this first, the adapters lean on it |
| `hexgate/adapters/{openai,google,pydantic_ai}/streaming.py` | each `consume()` mapping + the serve driver (Google session mgmt, Pydantic node flattening) |
| `hexgate/cli/_common.py` | `build_runtime_from_local_agent` dispatch + the shared `_serve_runtime_envelope` |
| `hexgate/cli/serve.py` | `_run_chat_turn` now drives the seam (dropped the direct `stream_agent` coupling) |
| `tests/streaming/test_accumulator.py`, `tests/adapters/*/test_streaming.py` | the base + per-framework normalizer coverage; `tests/cli/test_serve.py` for dispatch |

## Test plan

Full SDK suite green (exit 0) on `pytest -m "not integration and not framework_compat"`, ruff check + format clean. New coverage: the shared accumulator (13 cases: blocks, tool correlation, callless FIFO, state inference, run bracketing, `run_normalizer` clean + raise paths), the OpenAI/Google/Pydantic normalizers (~10 cases each, incl. the SSE dedup, the pydantic outcome→FAILED mapping, fatal-error termination), and serve dispatch for all four frameworks with the runners/wrappers mocked so no network is touched. I also verified against the actually-installed `agents`, `google.adk`, and `pydantic_ai` that `create_manifest` routes each demo agent to the right `framework` with the expected tools. A reviewer catches a regression by running the adapter test suites; the mapping tests use hand-built fakes shaped like each SDK's real events. Not yet done: the live browser BYOK smoke (needs provider + platform keys), which is the "Try it" below.

## Try it

```
make demo-notebook-build   # one-time
HEXGATE_NOTEBOOK=deploy/openai_demo_notebook.py   make demo-notebook   # or google_/pydantic_
# open http://localhost:2718, paste an OpenAI key, Start, open the Playground
# get_order_status streams + is allowed; refund <= $100 prompts for approval; > $100 is denied
```

## Notes

- Unchanged on purpose: the LangChain normalizer (`hexgate/streaming/normalize.py`) and `hexgate chat` (a separate REPL loop; this PR is serve only).
- Rollback: pure SDK, revert the three commits; no state or schema touched.
- Known limitations, documented in code: a pydantic `denied` outcome renders as FAILED (the `StreamEvent` contract has no DENIED state yet); builtin/hosted pydantic tools are not rendered (provider-side, not enforced, event shape in flux); an OpenAI tool error the SDK folds into plain output text reads as COMPLETED (no structured marker). Enforcement and audit are unaffected in every case.
