### PR TITLE
 feat(clickhouse, platform-api): run_id and run counters on policy_decision

### DIFF
--- a/platform/api/hexgate_api/core/clickhouse.py
+++ b/platform/api/hexgate_api/core/clickhouse.py
@@ -10,7 +10,8 @@ import re
 from collections.abc import Callable, Sequence
 from dataclasses import KW_ONLY, dataclass
 from functools import lru_cache
-from typing import Generic, Protocol, TypeVar
+from typing import Final, Generic, Protocol, TypeVar
+from uuid import UUID
 
 import clickhouse_connect
 from clickhouse_connect.driver.client import Client
@@ -19,6 +20,13 @@ from clickhouse_connect.driver.exceptions import DatabaseError, OperationalError
 from hexgate_api.settings import get_settings
 
 _log = logging.getLogger(__name__)
+
+# The `run_id` columns on policy_decision / llm_invocation are UUID, not
+# Nullable(UUID) — matching every other advisory column in this schema. This
+# is what a decision/invocation outside any run scope, or from an SDK that
+# does not yet send it, writes: "not attributed to a run" is a value, not an
+# absence.
+ZERO_RUN_ID: Final[UUID] = UUID(int=0)
 
 
 @lru_cache

--- a/platform/api/hexgate_api/features/audit/service.py
+++ b/platform/api/hexgate_api/features/audit/service.py
@@ -20,7 +20,12 @@ from collections.abc import Sequence
 
 from clickhouse_connect.driver.client import Client
 
-from hexgate_api.core.clickhouse import BatchItem, insert_batch, verify_written_columns
+from hexgate_api.core.clickhouse import (
+    ZERO_RUN_ID,
+    BatchItem,
+    insert_batch,
+    verify_written_columns,
+)
 from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import (
     AnomalySeverity,
@@ -76,6 +81,12 @@ _DECISION_COLUMNS = [
     "attributes",
     "user_roles",
     "deciding_role",
+    "run_id",
+    "run_tool_calls",
+    "run_llm_calls",
+    "run_denials",
+    "run_total_tokens",
+    "run_elapsed_ms",
 ]
 
 # async_insert batches small inserts; wait_for_async_insert=1 blocks until flush
@@ -138,6 +149,12 @@ def _decision_row(
         attributes_json,
         user_roles,
         event.deciding_role,
+        event.run_id or ZERO_RUN_ID,
+        event.run_tool_calls,
+        event.run_llm_calls,
+        event.run_denials,
+        event.run_total_tokens,
+        event.run_elapsed_ms,
     ]
 
 

--- a/platform/api/hexgate_api/features/llm_invocations/router.py
+++ b/platform/api/hexgate_api/features/llm_invocations/router.py
@@ -4,7 +4,11 @@ import asyncio
 import logging
 from datetime import datetime
 
-from clickhouse_connect.driver.exceptions import ClickHouseError, OperationalError
+from clickhouse_connect.driver.exceptions import (
+    ClickHouseError,
+    OperationalError,
+    ProgrammingError,
+)
 from fastapi import APIRouter, Depends, HTTPException
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -78,6 +82,14 @@ async def ingest_llm_invocation(
         )
     except OperationalError as exc:  # transient transport failure — retryable
         _log.warning("llm invocation insert failed (transient): %s", exc)
+        raise _audit_unavailable()
+    except ProgrammingError as exc:
+        # Schema behind this build: the driver rejects our column names before
+        # sending. 503, not 422 — the event is fine, and 422 would make the
+        # SDK discard a record the migration would let through. Startup
+        # normally catches this (this module's verify_schema, run via
+        # core.clickhouse.verify_all in main.py's lifespan).
+        _log.error("llm invocation insert impossible against current schema: %s", exc)
         raise _audit_unavailable()
     except ClickHouseError as exc:  # storage rejected the row — retry won't help
         _log.error("llm invocation insert rejected by ClickHouse: %s", exc)

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -4,9 +4,16 @@ from clickhouse_connect.driver.client import Client
 
 from datetime import datetime
 
-from hexgate_api.core.clickhouse import BatchItem, insert_batch, verify_written_columns
+from hexgate_api.core.clickhouse import (
+    ZERO_RUN_ID,
+    BatchItem,
+    insert_batch,
+    verify_written_columns,
+)
 from hexgate_api.query_scope import scope_filters
 from hexgate_api.schemas import LlmInvocationEvent
+
+LLM_INVOCATION_TABLE = "llm_invocation"
 
 # Order matches schema.sql; received_at absent (server-stamped via column default).
 _LLM_INVOCATION_COLUMNS = [
@@ -23,9 +30,8 @@ _LLM_INVOCATION_COLUMNS = [
     "latency_ms",
     "status",
     "error_code",
+    "run_id",
 ]
-
-LLM_INVOCATION_TABLE = "llm_invocation"
 
 
 def verify_schema(client: Client) -> None:
@@ -66,6 +72,7 @@ def _llm_invocation_row(
         event.latency_ms,
         event.status,
         event.error_code,
+        event.run_id or ZERO_RUN_ID,
     ]
 
 
@@ -190,7 +197,7 @@ def summarize_llm_invocations(
     where_sql = " AND ".join(where)
     summary_sql = (
         f"SELECT {', '.join(_SELECT_COLS)} "
-        f"FROM llm_invocation WHERE {where_sql} GROUP BY {_GROUPING_SETS}"
+        f"FROM {LLM_INVOCATION_TABLE} WHERE {where_sql} GROUP BY {_GROUPING_SETS}"
     )
     result = client.query(summary_sql, parameters=params)
 

--- a/platform/api/hexgate_api/features/llm_invocations/service.py
+++ b/platform/api/hexgate_api/features/llm_invocations/service.py
@@ -122,7 +122,7 @@ def insert_llm_invocations_batch(
     """
     insert_batch(
         clickhouse_client,
-        "llm_invocation",
+        LLM_INVOCATION_TABLE,
         _LLM_INVOCATION_COLUMNS,
         _llm_invocation_row,
         items,

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -543,6 +543,17 @@ class DecisionEvent(AuditEnvelope):
     # against. Advisory: contextvar-sourced and client-assertable, exactly like
     # ``role`` and ``user_id``.
     attributes: Optional[dict] = None
+    # Run attribution — same advisory + client-assertable tier as user_id /
+    # user_roles. Populated from hexgate/security/enforcer.py's run_ns dict;
+    # an SDK that doesn't yet send it, and a decision made outside a run
+    # scope, omit run_id here and the platform substitutes the zero UUID at
+    # insert time (core.clickhouse.ZERO_RUN_ID) — never NULL.
+    run_id: Optional[UUID] = None
+    run_tool_calls: int = Field(default=0, ge=0)
+    run_llm_calls: int = Field(default=0, ge=0)
+    run_denials: int = Field(default=0, ge=0)
+    run_total_tokens: int = Field(default=0, ge=0)
+    run_elapsed_ms: int = Field(default=0, ge=0)
 
 
 class LlmInvocationEvent(AuditEnvelope):
@@ -558,6 +569,9 @@ class LlmInvocationEvent(AuditEnvelope):
     latency_ms: int = Field(ge=0, le=UINT32_MAX)
     status: str = Field(default="success", max_length=64)
     error_code: str = Field(default="", max_length=64)
+    # Run attribution — same tier and same zero-UUID-at-insert-time
+    # substitution as DecisionEvent.run_id.
+    run_id: Optional[UUID] = None
 
 
 class DecisionAccepted(BaseModel):

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -549,11 +549,14 @@ class DecisionEvent(AuditEnvelope):
     # scope, omit run_id here and the platform substitutes the zero UUID at
     # insert time (core.clickhouse.ZERO_RUN_ID) — never NULL.
     run_id: Optional[UUID] = None
-    run_tool_calls: int = Field(default=0, ge=0)
-    run_llm_calls: int = Field(default=0, ge=0)
-    run_denials: int = Field(default=0, ge=0)
-    run_total_tokens: int = Field(default=0, ge=0)
-    run_elapsed_ms: int = Field(default=0, ge=0)
+    # Upper bound for the same reason as the usage counters below: the columns
+    # are UInt32, and an over-range value that passes validation is a permanent
+    # insert error the enricher retries forever instead of DLQ-ing the span.
+    run_tool_calls: int = Field(default=0, ge=0, le=UINT32_MAX)
+    run_llm_calls: int = Field(default=0, ge=0, le=UINT32_MAX)
+    run_denials: int = Field(default=0, ge=0, le=UINT32_MAX)
+    run_total_tokens: int = Field(default=0, ge=0, le=UINT32_MAX)
+    run_elapsed_ms: int = Field(default=0, ge=0, le=UINT32_MAX)
 
 
 class LlmInvocationEvent(AuditEnvelope):

--- a/platform/api/tests/features/audit/test_audit.py
+++ b/platform/api/tests/features/audit/test_audit.py
@@ -115,6 +115,31 @@ def test_oversized_agent_name_rejected() -> None:
     assert "agent_name" in str(exc.value)
 
 
+def test_run_fields_default_to_unattributed() -> None:
+    """No run_id / run_* keys in the payload — an SDK that doesn't yet send
+    them, or a decision made outside a run scope — constructs with None /
+    zero, not a required field."""
+    e = DecisionEvent(**_event())
+    assert e.run_id is None
+    assert e.run_tool_calls == 0
+    assert e.run_llm_calls == 0
+    assert e.run_denials == 0
+    assert e.run_total_tokens == 0
+    assert e.run_elapsed_ms == 0
+
+
+def test_malformed_run_id_rejected() -> None:
+    with pytest.raises(ValidationError) as exc:
+        DecisionEvent(**_event(run_id="not-a-uuid"))
+    assert "run_id" in str(exc.value)
+
+
+def test_negative_run_counter_rejected() -> None:
+    with pytest.raises(ValidationError) as exc:
+        DecisionEvent(**_event(run_tool_calls=-1))
+    assert "run_tool_calls" in str(exc.value)
+
+
 # ---------------------------------------------------------------------------
 # Endpoint behaviour — auth + ClickHouse stubbed
 # ---------------------------------------------------------------------------
@@ -304,6 +329,45 @@ def test_explicit_user_roles_win_over_the_legacy_scalar(
     )
     assert r.status_code == 202
     assert _inserted(fake_clickhouse, "user_roles") == ["support"]
+
+
+def test_run_id_defaults_to_the_zero_uuid_when_omitted(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    """The columns are UUID, not Nullable(UUID) — an absent run_id must not
+    reach ClickHouse as None."""
+    r = client.post("/v1/audit/decisions", json=_event())
+    assert r.status_code == 202
+    assert _inserted(fake_clickhouse, "run_id") == audit.ZERO_RUN_ID
+    assert _inserted(fake_clickhouse, "run_tool_calls") == 0
+    assert _inserted(fake_clickhouse, "run_llm_calls") == 0
+    assert _inserted(fake_clickhouse, "run_denials") == 0
+    assert _inserted(fake_clickhouse, "run_total_tokens") == 0
+    assert _inserted(fake_clickhouse, "run_elapsed_ms") == 0
+
+
+def test_run_fields_round_trip_when_present(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    run_id = str(uuid.uuid4())
+    r = client.post(
+        "/v1/audit/decisions",
+        json=_event(
+            run_id=run_id,
+            run_tool_calls=7,
+            run_llm_calls=3,
+            run_denials=1,
+            run_total_tokens=4200,
+            run_elapsed_ms=15000,
+        ),
+    )
+    assert r.status_code == 202
+    assert str(_inserted(fake_clickhouse, "run_id")) == run_id
+    assert _inserted(fake_clickhouse, "run_tool_calls") == 7
+    assert _inserted(fake_clickhouse, "run_llm_calls") == 3
+    assert _inserted(fake_clickhouse, "run_denials") == 1
+    assert _inserted(fake_clickhouse, "run_total_tokens") == 4200
+    assert _inserted(fake_clickhouse, "run_elapsed_ms") == 15000
 
 
 def test_too_many_roles_rejected(client: TestClient) -> None:
@@ -1565,17 +1629,21 @@ def test_real_clickhouse_round_trip() -> None:
 
     try:
         rows = clickhouse_client.query(
-            "SELECT event_id, project_id, outcome, received_at, agent_version_id "
+            "SELECT event_id, project_id, outcome, received_at, agent_version_id, "
+            "run_id, run_tool_calls "
             "FROM policy_decision WHERE project_id = {pid:String}",
             parameters={"pid": project_id},
         ).result_rows
         assert len(rows) == 1
-        ev_id, pid, outcome, received_at, av_id = rows[0]
+        ev_id, pid, outcome, received_at, av_id, run_id, run_tool_calls = rows[0]
         assert str(ev_id) == str(event_id)
         assert pid == project_id
         assert outcome == "deny"
         assert received_at is not None  # server-stamped via column default
         assert av_id == "9f1e3c5a-test"
+        # No run_id sent — the migrated column reads back the zero UUID, not NULL.
+        assert str(run_id) == "00000000-0000-0000-0000-000000000000"
+        assert run_tool_calls == 0
     finally:
         clickhouse_client.command(
             "ALTER TABLE policy_decision DELETE WHERE project_id = {pid:String}",

--- a/platform/api/tests/features/audit/test_audit.py
+++ b/platform/api/tests/features/audit/test_audit.py
@@ -45,7 +45,12 @@ from hexgate_api.deps.identity import require_user
 from hexgate_api.deps.org import require_org_member
 from hexgate_api.deps.tokens import require_project
 from hexgate_api.main import app
-from hexgate_api.schemas import AnomalySeverity, AuditOutcome, DecisionEvent
+from hexgate_api.schemas import (
+    UINT32_MAX,
+    AnomalySeverity,
+    AuditOutcome,
+    DecisionEvent,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -138,6 +143,25 @@ def test_negative_run_counter_rejected() -> None:
     with pytest.raises(ValidationError) as exc:
         DecisionEvent(**_event(run_tool_calls=-1))
     assert "run_tool_calls" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "run_tool_calls",
+        "run_llm_calls",
+        "run_denials",
+        "run_total_tokens",
+        "run_elapsed_ms",
+    ],
+)
+def test_over_range_run_counter_rejected(field: str) -> None:
+    """The columns are UInt32: an over-range counter (e.g. elapsed emitted in
+    ns) must fail validation here, not at insert time — a permanent ClickHouse
+    error the batch caller would retry forever."""
+    with pytest.raises(ValidationError) as exc:
+        DecisionEvent(**_event(**{field: UINT32_MAX + 1}))
+    assert field in str(exc.value)
 
 
 # ---------------------------------------------------------------------------

--- a/platform/api/tests/features/llm_invocations/test_llm_invocation.py
+++ b/platform/api/tests/features/llm_invocations/test_llm_invocation.py
@@ -7,7 +7,11 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from clickhouse_connect.driver.exceptions import DataError, OperationalError
+from clickhouse_connect.driver.exceptions import (
+    DataError,
+    OperationalError,
+    ProgrammingError,
+)
 from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
@@ -164,6 +168,19 @@ def test_when_model_exceeds_max_length_then_validation_error_is_raised() -> None
     assert "model" in str(exc.value)
 
 
+def test_when_run_id_is_omitted_then_it_defaults_to_none() -> None:
+    """None (not the zero UUID) is the wire default — the zero-UUID
+    substitution happens at insert time, not on the wire model."""
+    e = LlmInvocationEvent(**_llm_event())
+    assert e.run_id is None
+
+
+def test_when_run_id_is_malformed_then_validation_error_is_raised() -> None:
+    with pytest.raises(ValidationError) as exc:
+        LlmInvocationEvent(**_llm_event(run_id="not-a-uuid"))
+    assert "run_id" in str(exc.value)
+
+
 # ---------------------------------------------------------------------------
 # Endpoint behaviour — auth + ClickHouse stubbed
 # ---------------------------------------------------------------------------
@@ -219,10 +236,11 @@ def test_ingest_llm_invocation_happy_path(
 
     fake_clickhouse.insert.assert_called_once()
     args, kwargs = fake_clickhouse.insert.call_args
-    assert args[0] == "llm_invocation"
+    assert args[0] == llm_invocations.LLM_INVOCATION_TABLE
     rows = args[1]
     assert len(rows) == 1
-    assert len(rows[0]) == 13
+    # Derived, not hardcoded: a length mismatch misaligns values silently.
+    assert len(rows[0]) == len(llm_invocations._LLM_INVOCATION_COLUMNS)
     # Indices match _LLM_INVOCATION_COLUMNS in service.py.
     assert rows[0][2] == "proj_test"  # project_id (bearer)
     assert rows[0][4] == _STUB_AGENT_VERSION_ID  # agent_version_id (platform)
@@ -230,6 +248,31 @@ def test_ingest_llm_invocation_happy_path(
     assert kwargs["settings"]["async_insert"] == 1
     # Durable: block until flush so insert failures surface synchronously.
     assert kwargs["settings"]["wait_for_async_insert"] == 1
+
+
+def _inserted(fake_clickhouse: MagicMock, column: str):
+    """The value stored in ``column`` by the last insert."""
+    rows = fake_clickhouse.insert.call_args.args[1]
+    return rows[0][llm_invocations._LLM_INVOCATION_COLUMNS.index(column)]
+
+
+def test_run_id_defaults_to_the_zero_uuid_when_omitted(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    """The column is UUID, not Nullable(UUID) — an absent run_id must not
+    reach ClickHouse as None."""
+    r = client.post("/v1/audit/llm-invocations", json=_llm_event())
+    assert r.status_code == 202
+    assert _inserted(fake_clickhouse, "run_id") == llm_invocations.ZERO_RUN_ID
+
+
+def test_run_id_round_trips_when_present(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    run_id = str(uuid.uuid4())
+    r = client.post("/v1/audit/llm-invocations", json=_llm_event(run_id=run_id))
+    assert r.status_code == 202
+    assert str(_inserted(fake_clickhouse, "run_id")) == run_id
 
 
 def test_when_occurred_at_is_in_the_future_then_400_is_returned(
@@ -280,6 +323,21 @@ def test_when_clickhouse_rejects_the_row_then_422_is_returned(
     assert r.status_code == 422
     assert "retry-after" not in {k.lower() for k in r.headers}
     assert "rejected" in r.json()["detail"]
+
+
+def test_when_schema_is_behind_the_build_then_503_is_returned(
+    client: TestClient, fake_clickhouse: MagicMock
+) -> None:
+    """ProgrammingError (the driver rejects our column names before sending)
+    is a schema-behind-this-build condition, not a bad row — retryable once
+    the migration lands, so 503 not 422. Regression guard: ProgrammingError
+    IS a ClickHouseError, so without its own except branch this fell through
+    to the generic one below and returned a non-retryable 422."""
+    fake_clickhouse.insert.side_effect = ProgrammingError("Unknown column 'run_id'")
+    r = client.post("/v1/audit/llm-invocations", json=_llm_event())
+    assert r.status_code == 503
+    assert r.headers.get("retry-after") == "5"
+    assert "unavailable" in r.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -560,12 +618,14 @@ def test_real_clickhouse_round_trip() -> None:
     try:
         rows = clickhouse_client.query(
             "SELECT event_id, project_id, model, input_tokens, output_tokens, "
-            "received_at, agent_version_id FROM llm_invocation "
+            "received_at, agent_version_id, run_id FROM llm_invocation "
             "WHERE project_id = {pid:String}",
             parameters={"pid": project_id},
         ).result_rows
         assert len(rows) == 1
-        ev_id, pid, model, input_tokens, output_tokens, received_at, av_id = rows[0]
+        ev_id, pid, model, input_tokens, output_tokens, received_at, av_id, run_id = (
+            rows[0]
+        )
         assert str(ev_id) == str(event_id)
         assert pid == project_id
         assert model == "gpt-4o-2024-08-06"
@@ -573,6 +633,8 @@ def test_real_clickhouse_round_trip() -> None:
         assert output_tokens == 45
         assert received_at is not None  # server-stamped via column default
         assert av_id == "9f1e3c5a-test"
+        # No run_id sent — the migrated column reads back the zero UUID, not NULL.
+        assert str(run_id) == "00000000-0000-0000-0000-000000000000"
     finally:
         clickhouse_client.command(
             "ALTER TABLE llm_invocation DELETE WHERE project_id = {pid:String}",

--- a/platform/clickhouse/init/schema.sql
+++ b/platform/clickhouse/init/schema.sql
@@ -37,7 +37,19 @@ CREATE TABLE IF NOT EXISTS hexgate_audit.policy_decision
     -- same shape whatever wrote it. No DEFAULT: these columns have existed
     -- since the first CREATE, so nothing needs a read-time rescue.
     user_roles          Array(LowCardinality(String)) COMMENT 'Distinct roles evaluated for this call, caller order; advisory + client-assertable',
-    deciding_role       LowCardinality(String) DEFAULT '' COMMENT 'Role whose policy granted/gated the call; empty when every role denied'
+    deciding_role       LowCardinality(String) DEFAULT '' COMMENT 'Role whose policy granted/gated the call; empty when every role denied',
+
+    -- Run attribution (advisory + client-assertable, same tier as user_id /
+    -- user_roles). Zero UUID / zero counters means "not attributed to a run
+    -- scope by the SDK that sent this row" — a truthful default until the
+    -- SDK starts stamping the run_ns namespace read once per decision
+    -- (hexgate/security/enforcer.py). See plans/run-state/run-state-schema.md §7.
+    run_id              UUID     DEFAULT toUUID('00000000-0000-0000-0000-000000000000') COMMENT 'RunFacts.id; zero when the decision was made outside a run scope or by an SDK that does not yet send it',
+    run_tool_calls      UInt32   DEFAULT 0 COMMENT 'run.tool_calls at decision time',
+    run_llm_calls       UInt32   DEFAULT 0 COMMENT 'run.llm_calls at decision time',
+    run_denials         UInt32   DEFAULT 0 COMMENT 'run.denials at decision time',
+    run_total_tokens    UInt32   DEFAULT 0 COMMENT 'run.total_tokens at decision time',
+    run_elapsed_ms      UInt32   DEFAULT 0 COMMENT 'run.elapsed_seconds * 1000 at decision time'
 )
 -- ReplacingMergeTree: SDK retries (same event_id) collapse on background
 -- merges — eventual dedup; exact counts use FINAL or count(DISTINCT event_id).
@@ -95,7 +107,9 @@ CREATE TABLE IF NOT EXISTS hexgate_audit.llm_invocation
     output_tokens       UInt32,
     latency_ms          UInt32 DEFAULT 0,
     status              LowCardinality(String) DEFAULT 'success',
-    error_code          LowCardinality(String) DEFAULT ''
+    error_code          LowCardinality(String) DEFAULT '',
+
+    run_id              UUID DEFAULT toUUID('00000000-0000-0000-0000-000000000000') COMMENT 'RunFacts.id of the run this LLM call belongs to; zero when outside a run scope or from an SDK that does not yet send it'
 )
 ENGINE = ReplacingMergeTree(received_at)
 PARTITION BY toYYYYMM(received_at)

--- a/platform/clickhouse/migrations/0002_add_run_columns.sql
+++ b/platform/clickhouse/migrations/0002_add_run_columns.sql
@@ -1,0 +1,44 @@
+-- Applied BY HAND, not by a runner. init/ only executes on an empty volume, so
+-- every environment that already has policy_decision / llm_invocation needs
+-- this run against it via `make clickhouse-cli` (paste the statements below).
+--
+-- ORDERING: apply this BEFORE deploying the API that references these
+-- columns. Skipping it takes down ingest for both event types, the same way
+-- 0001 describes:
+--   * policy_decision — insert_decision names the six run_* columns in
+--     column_names, ClickHouse rejects the row (ProgrammingError), the API
+--     returns 503 (see features/audit/router.py's ProgrammingError branch),
+--     and the SDK sender retries until the schema catches up.
+--   * llm_invocation — same shape, and until this migration's companion fix
+--     to features/llm_invocations/router.py, a ProgrammingError there fell
+--     through to a non-retryable 422 instead; this migration and that fix
+--     ship together.
+-- Both ALTERs are additive and back-compatible — a running old API never
+-- references the new columns — so they can be applied arbitrarily early.
+--
+-- Metadata-only on MergeTree: no part rewrite, no downtime, idempotent.
+-- Pre-existing rows read back as the zero UUID / zero counters, which is
+-- truthful: no SDK before this migration ever attributed a decision to a
+-- run, so "not attributed" is the correct historical value, not a
+-- placeholder.
+--
+-- ADD COLUMN without AFTER appends physically, matching schema.sql's order —
+-- see that file's comment on why order matching matters.
+
+ALTER TABLE hexgate_audit.policy_decision
+    ADD COLUMN IF NOT EXISTS run_id UUID DEFAULT toUUID('00000000-0000-0000-0000-000000000000')
+    COMMENT 'RunFacts.id; zero when the decision was made outside a run scope or by an SDK that does not yet send it',
+    ADD COLUMN IF NOT EXISTS run_tool_calls UInt32 DEFAULT 0
+    COMMENT 'run.tool_calls at decision time',
+    ADD COLUMN IF NOT EXISTS run_llm_calls UInt32 DEFAULT 0
+    COMMENT 'run.llm_calls at decision time',
+    ADD COLUMN IF NOT EXISTS run_denials UInt32 DEFAULT 0
+    COMMENT 'run.denials at decision time',
+    ADD COLUMN IF NOT EXISTS run_total_tokens UInt32 DEFAULT 0
+    COMMENT 'run.total_tokens at decision time',
+    ADD COLUMN IF NOT EXISTS run_elapsed_ms UInt32 DEFAULT 0
+    COMMENT 'run.elapsed_seconds * 1000 at decision time';
+
+ALTER TABLE hexgate_audit.llm_invocation
+    ADD COLUMN IF NOT EXISTS run_id UUID DEFAULT toUUID('00000000-0000-0000-0000-000000000000')
+    COMMENT 'RunFacts.id of the run this LLM call belongs to; zero when outside a run scope or from an SDK that does not yet send it';


### PR DESCRIPTION
> 📘 Reviewer's mental model (concepts, examples, no file-level detail):
> [How run_id ties a decision to its run — PR #153](https://app.notion.com/p/3cdfb45dbae28137a5c5de0a5d75e05e)

## What

Gives the audit log a place to put the `run.*` tally #129 built and #150 made
enforceable. Both live entirely inside the SDK process — the tally is gone the
moment it exits. This PR adds `run_id` plus a snapshot of the run counters to
every `policy_decision` row (and `run_id` alone to `llm_invocation`, so a model
call joins back to the run it belongs to):

```sql
run_id            UUID     DEFAULT toUUID('00000000-0000-0000-0000-000000000000')
run_tool_calls    UInt32   DEFAULT 0
run_llm_calls     UInt32   DEFAULT 0
run_denials       UInt32   DEFAULT 0
run_total_tokens  UInt32   DEFAULT 0
run_elapsed_ms    UInt32   DEFAULT 0
```

Today `policy_decision` is a stream of isolated rows — nothing says "these 20
decisions were one invocation." That blocks a per-run timeline in the
dashboard, blocks giving a customer a real distribution of tool-calls-per-run
to calibrate their own `run.tool_calls < K` cap against, and makes "why was
this call denied" a single row with no context.

**Platform-only, no SDK change.** Every row still reads the zero UUID / zero
counters until the SDK is taught to stamp the `run_ns` snapshot the enforcer
already builds once per decision (`security/enforcer.py`, since #150) onto the
outgoing payload — that's the next PR in the stack. Shipping the schema first
means the columns exist everywhere before any SDK build starts sending real
values, so API and SDK never need a coordinated deploy.

## Changes

**Schema**
- `platform/clickhouse/init/schema.sql`: the six columns on `policy_decision`,
  `run_id` on `llm_invocation`. Additive, `DEFAULT`-ed, appended (no `AFTER`) to
  match `_DECISION_COLUMNS`' "order matches schema.sql" convention.
- `platform/clickhouse/migrations/0002_add_run_columns.sql`: hand-applied ALTER
  for both tables, same header discipline as `0001` (must be applied **before**
  deploying this API build).

**Wire model + ingest**
- `schemas.py`: `DecisionEvent` gains `run_id: UUID | None` + the five counters
  (`Field(default=0, ge=0)`); `LlmInvocationEvent` gains `run_id`. `None` is the
  wire default — the zero-UUID substitution happens at insert time, not on the
  model, so the model reflects what the caller actually sent.
- `core/clickhouse.py`: `ZERO_RUN_ID` sentinel — the columns are `UUID`, not
  `Nullable(UUID)`, matching every other advisory column in this schema.
- `features/audit/service.py`, `features/llm_invocations/service.py`: both
  `_*_row` builders substitute `event.run_id or ZERO_RUN_ID`.

**Fixed while wiring `llm_invocations`**
- `features/llm_invocations/router.py`: added the missing `ProgrammingError` →
  503 branch (was falling through to a permanent-looking 422). `run_id` is the
  first column ever added to `llm_invocation` since its original `CREATE
  TABLE`, so "schema behind this build" became a reachable deploy-ordering
  state for the first time — mirrors the decision endpoint's existing handling.

## Notes for review

- **This branch was rebased after opening.** The base of the stack
  (`gp/feat/run_facts_policy_run`) picked up a large upstream refactor that
  generalized the audit schema-guard into shared `SchemaOutOfDate` /
  `verify_written_columns` / `verify_all` machinery in `core/clickhouse.py`,
  plus batch-insert support (`BatchItem`, `insert_batch`) for the
  span-enricher job. That collided with this PR's changes to the same three
  files. Resolution: adopted the new shared machinery as-is (it's strictly
  better than this PR's original per-file `verify_schema` loop) and merged
  `ZERO_RUN_ID` + the `run_id`/counter columns on top of it — no functional
  change to what this PR set out to do.
- No new columns in `_LIST_COLUMNS` or any dashboard response schema — a
  per-run timeline view is unblocked by this PR, not shipped by it.
- `Decision`/audit-payload wiring on the SDK side (`hexgate/security/enforcer.py`,
  `hexgate/audit.py`) is deliberately out of scope — next PR in the stack.

## Tests

New/extended coverage in `tests/features/audit/test_audit.py` and
`tests/features/llm_invocations/test_llm_invocation.py`: wire-model defaults +
validation, insert round-trip (zero-UUID default and explicit-value paths),
`verify_schema` schema-drift coverage, the `ProgrammingError` regression test,
and both real-ClickHouse integration round-trips extended to assert the new
columns.

`make fmt-check` clean, `ruff check .` clean, 527 unit + 6 integration tests
passing (`make clickhouse-up` for the integration run).
