### PR TITLE
feat(sdk): run facts on the audit payload, and policy-level constraints

### DIFF
--- a/docs/policy/constraints.mdx
+++ b/docs/policy/constraints.mdx
@@ -317,6 +317,17 @@ constraints:
   role-wide fence would be fail-open.
 </Note>
 
+### Upgrading
+
+Top-level `constraints:` is new. Single-file policies ignore keys they don't
+recognise, so before this release the block parsed and was silently dropped —
+after it, the same YAML is enforced against every tool the role can reach. If
+you wrote one speculatively, it starts denying on upgrade, and the policy's
+compiled `source_hash` changes with it. Grep your policies for a top-level
+`constraints:` before you roll forward — `hexgate policy show-rego` prints the
+compiled rules if you want to diff exactly what moved. (Composed module policies
+are unaffected: they rejected the key outright, then and now.)
+
 ## Named constants
 
 Define reusable values once in a `consts:` block and reference them as

--- a/docs/policy/constraints.mdx
+++ b/docs/policy/constraints.mdx
@@ -209,11 +209,77 @@ deliberate: an unwired boundary should not brick the agent. The cases:
   `asyncio.gather`, `asyncio.to_thread` and LangChain's own executor all carry
   the run correctly; only a hand-rolled `threading.Thread` loses it.
 
+### What a denied model is told
+
+On a `run.*` denial the model sees the constraint text — `run.tool_calls < 20`
+— so it learns the threshold and that it was crossed. It is never told the
+current counter value, and the run's id and counters are not in the payload the
+model receives. Budget *pressure* is deliberately not surfaced to the agent.
+
 One more, if you consume streams: two `astream()` generators consumed
 round-robin **in the same task** will cross-contaminate, because Python has no
 per-generator context. Consume one at a time, or put each in its own task. (This
 already affects caller identity via `HexgateContext`, so it isn't new to
 `run.*`.)
+
+## Where a constraint can live
+
+Three places, widening in reach:
+
+| Location | Applies to |
+|---|---|
+| `tools.<name>.constraints` | that one tool |
+| `default_policy.constraints` | tools **not** listed under `tools:` |
+| `constraints:` (top level) | **every** tool the role can reach |
+
+`default_policy.constraints` is the common trap. It is the *catch-all* policy,
+not a floor: once a tool is listed under `tools:`, the default no longer applies
+to it, so a run cap written there silently misses every tool you named.
+
+```yaml
+constraints:
+  - run.tool_calls < 20        # applies to read_file AND refund_order
+
+default_policy:
+  mode: deny
+
+tools:
+  read_file:
+    mode: allow
+  refund_order:
+    mode: allow
+    constraints:
+      - args.amount <= 500     # plus this one, on refund_order only
+```
+
+Policy-level constraints can only **narrow**. A tool with `mode: deny` is denied
+before constraints are consulted, so nothing here can grant access.
+
+### Inheritance unions them
+
+Every other field overrides through `inherits:` — a child's `tools` entry
+replaces its parent's. Policy-level constraints are the exception: they
+**accumulate**, so a child cannot drop a fence a mixin declared.
+
+```yaml
+# policies/read_only.yaml
+is_mixin: true
+constraints:
+  - run.tool_calls < 50
+
+# policies/billing.yaml
+inherits: [read_only]
+constraints:
+  - run.elapsed_seconds < 120
+# → both apply. Duplicates across a diamond are collapsed.
+```
+
+<Note>
+  Policy-level constraints belong in a single-file policy. Composed module
+  policies (`policies/boundaries/`, `policies/capabilities/`) reject them at
+  load: the fold composes per-tool rules only, and silently dropping a
+  role-wide fence would be fail-open.
+</Note>
 
 ## Named constants
 

--- a/docs/policy/constraints.mdx
+++ b/docs/policy/constraints.mdx
@@ -230,7 +230,7 @@ Three places, widening in reach:
 |---|---|
 | `tools.<name>.constraints` | that one tool |
 | `default_policy.constraints` | tools **not** listed under `tools:` |
-| `constraints:` (top level) | **every** tool the role can reach |
+| `constraints:` (top level) | **every** tool the role can reach, `agent.run` included |
 
 `default_policy.constraints` is the common trap. It is the *catch-all* policy,
 not a floor: once a tool is listed under `tools:`, the default no longer applies
@@ -254,6 +254,42 @@ tools:
 
 Policy-level constraints can only **narrow**. A tool with `mode: deny` is denied
 before constraints are consulted, so nothing here can grant access.
+
+### `args.*` at policy level reaches admission
+
+"Every tool the role can reach" includes `agent.run`, the synthetic key an
+`admission:` block lowers to. The admission check passes one argument —
+`args.agent`, the agent's name — so an `args.*` constraint written with tools in
+mind reads a missing field there, and **a missing ref fails closed**: the agent
+is refused before it starts.
+
+<Warning>
+**This policy denies its own agent at ingress.**
+
+```yaml
+constraints:
+  - args.amount <= 500     # no `amount` on agent.run → admission denied
+
+admission:
+  mode: allow
+
+tools:
+  refund_order: { mode: allow }
+```
+
+Not an admission quirk — the same constraint denies *any* tool that doesn't take
+an `amount`. Policy level is the place for predicates every reachable key can
+answer: `run.*`, `ctx.*`, `role`. Keep `args.*` on the tool that defines the
+argument.
+</Warning>
+
+When you do want one argument fenced role-wide, exempt the admission key by name
+— `tool` is a fact like any other, and the grammar has `or`:
+
+```yaml
+constraints:
+  - tool == "agent.run" or args.amount <= 500
+```
 
 ### Inheritance unions them
 

--- a/docs/policy/constraints.mdx
+++ b/docs/policy/constraints.mdx
@@ -230,7 +230,7 @@ Three places, widening in reach:
 |---|---|
 | `tools.<name>.constraints` | that one tool |
 | `default_policy.constraints` | tools **not** listed under `tools:` |
-| `constraints:` (top level) | **every** tool the role can reach, `agent.run` included |
+| `constraints:` (top level) | **every** tool the role can reach, the synthetic `agent.*` keys included |
 
 `default_policy.constraints` is the common trap. It is the *catch-all* policy,
 not a floor: once a tool is listed under `tools:`, the default no longer applies
@@ -255,13 +255,15 @@ tools:
 Policy-level constraints can only **narrow**. A tool with `mode: deny` is denied
 before constraints are consulted, so nothing here can grant access.
 
-### `args.*` at policy level reaches admission
+### `args.*` at policy level reaches admission and reach
 
-"Every tool the role can reach" includes `agent.run`, the synthetic key an
-`admission:` block lowers to. The admission check passes one argument —
-`args.agent`, the agent's name — so an `args.*` constraint written with tools in
-mind reads a missing field there, and **a missing ref fails closed**: the agent
-is refused before it starts.
+"Every tool the role can reach" includes the synthetic keys `admission:` and
+`agents:` lower to — `agent.run`, plus `agent.handoff:<target>` and
+`agent.tool:<target>`. Those gates pass only their own arguments (`args.agent`
+for admission; `args.agent` / `args.target` / `args.via` for reach), so an
+`args.*` constraint written with tools in mind reads a missing field there, and
+**a missing ref fails closed**: the agent is refused before it starts, and every
+handoff and agent-as-tool call is denied.
 
 <Warning>
 **This policy denies its own agent at ingress.**
@@ -269,9 +271,13 @@ is refused before it starts.
 ```yaml
 constraints:
   - args.amount <= 500     # no `amount` on agent.run → admission denied
+                           # ...nor on agent.handoff:billing → handoff denied
 
 admission:
   mode: allow
+
+agents:
+  billing: { via: [handoff], mode: allow }
 
 tools:
   refund_order: { mode: allow }
@@ -283,13 +289,16 @@ answer: `run.*`, `ctx.*`, `role`. Keep `args.*` on the tool that defines the
 argument.
 </Warning>
 
-When you do want one argument fenced role-wide, exempt the admission key by name
-— `tool` is a fact like any other, and the grammar has `or`:
+When you do want one argument fenced role-wide, exempt the whole reserved
+namespace — `tool` is a fact like any other, and the grammar has `or`:
 
 ```yaml
 constraints:
-  - tool == "agent.run" or args.amount <= 500
+  - startswith(tool, "agent.") or args.amount <= 500
 ```
+
+Use the prefix, not `tool == "agent.run"`: naming the admission key alone still
+leaves `agent.handoff:<target>` and `agent.tool:<target>` denied.
 
 ### Inheritance unions them
 

--- a/docs/policy/yaml-shape.mdx
+++ b/docs/policy/yaml-shape.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Policy YAML shape"
-description: "version, default_policy, tools, modes, constraints."
+description: "version, constraints, default_policy, tools, modes."
 ---
 
 Enforcement is **deny-by-default**: the policy file lists what's allowed. Each
@@ -8,6 +8,11 @@ tool gets a mode and an optional list of [constraints](/policy/constraints).
 
 ```yaml
 version: 1
+
+# Applies to every tool below. default_policy.constraints would only reach
+# tools NOT listed under `tools:` — see "Where a constraint can live".
+constraints:
+  - run.tool_calls < 20
 
 default_policy:
   mode: deny

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -179,8 +179,9 @@ class AuditEvent:
         JSON strings (the caps are defined in serialized-JSON bytes, so the
         capped quantity stays the measured one); the two list fields as native
         string arrays. Absent optional fields are left out rather than sent as
-        ``None`` — OTel attributes can't carry null. The role fields
-        deliberately pass through untouched — see the comment on them below."""
+        ``None`` — OTel attributes can't carry null. The role fields and the
+        ``run.*`` fields deliberately pass through untouched — see the comments
+        on them below."""
         d = self.decision
         attrs: dict[str, Any] = {
             semconv.EVENT_ID: str(self.event_id),
@@ -200,6 +201,13 @@ class AuditEvent:
             semconv.VIOLATIONS: _bounded_violations(d.violations),
             semconv.USER_ID: self.user_id,
             semconv.SESSION_ID: self.session_id,
+            # Neither redacted nor capped: five bounded counters and a UUID
+            # produced by the SDK's own accumulator, not by caller data — the
+            # same reasoning as the role fields above. Spread from one method
+            # so the wire names live in a single place
+            # (RunAttribution.as_span_attributes), reviewable against
+            # DecisionEvent as a unit. Note RUN_ID is absent, never "", there.
+            **d.run.as_span_attributes(),
         }
         if d.arguments is not None:
             attrs[semconv.ARGUMENTS] = json.dumps(

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -201,12 +201,8 @@ class AuditEvent:
             semconv.VIOLATIONS: _bounded_violations(d.violations),
             semconv.USER_ID: self.user_id,
             semconv.SESSION_ID: self.session_id,
-            # Neither redacted nor capped: five bounded counters and a UUID
-            # produced by the SDK's own accumulator, not by caller data — the
-            # same reasoning as the role fields above. Spread from one method
-            # so the wire names live in a single place
-            # (RunAttribution.as_span_attributes), reviewable against
-            # DecisionEvent as a unit. Note RUN_ID is absent, never "", there.
+            # Neither redacted nor capped — SDK counters, not caller data.
+            # Spread so the wire names live in one place.
             **d.run.as_span_attributes(),
         }
         if d.arguments is not None:

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -542,6 +542,8 @@ def _iter_raw_constraints(payload: dict) -> "list[tuple[str, str, str]]":
 
     Handles both document shapes: inline-roles (``payload["roles"]``) and the
     flat single-policy form (tools at the top level → the ``default`` role).
+    Constraints with no tool of their own are labelled ``<policy>``
+    (policy-level, applying to every tool) or ``<default>`` (the catch-all).
     Defensive against partially-malformed payloads — non-dict tools/specs are
     skipped so the schema validator downstream reports them.
     """
@@ -562,9 +564,11 @@ def _iter_raw_constraints(payload: dict) -> "list[tuple[str, str, str]]":
     for role, spec in specs:
         if not isinstance(spec, dict):
             continue
-        # The role's catch-all policy also carries constraints — report a bad
-        # expression there under "<default>" instead of letting the schema
-        # load raise a raw, unlocalized ValidationError.
+        # The role's policy-level constraints and its catch-all both carry
+        # expressions with no tool of their own — report a bad one under a
+        # named bucket instead of letting the schema load raise a raw,
+        # unlocalized ValidationError.
+        _emit(role, "<policy>", spec)
         _emit(role, "<default>", spec.get("default_policy"))
         tools = spec.get("tools")
         if isinstance(tools, dict):

--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -543,7 +543,7 @@ def _iter_raw_constraints(payload: dict) -> "list[tuple[str, str, str]]":
     Handles both document shapes: inline-roles (``payload["roles"]``) and the
     flat single-policy form (tools at the top level → the ``default`` role).
     Constraints with no tool of their own are labelled ``<policy>``
-    (policy-level, applying to every tool) or ``<default>`` (the catch-all).
+    (policy-level) or ``<default>`` (the catch-all).
     Defensive against partially-malformed payloads — non-dict tools/specs are
     skipped so the schema validator downstream reports them.
     """
@@ -564,10 +564,9 @@ def _iter_raw_constraints(payload: dict) -> "list[tuple[str, str, str]]":
     for role, spec in specs:
         if not isinstance(spec, dict):
             continue
-        # The role's policy-level constraints and its catch-all both carry
-        # expressions with no tool of their own — report a bad one under a
-        # named bucket instead of letting the schema load raise a raw,
-        # unlocalized ValidationError.
+        # Policy-level and catch-all constraints have no tool of their own —
+        # report a bad one under a named bucket instead of letting the schema
+        # load raise a raw, unlocalized ValidationError.
         _emit(role, "<policy>", spec)
         _emit(role, "<default>", spec.get("default_policy"))
         tools = spec.get("tools")

--- a/hexgate/guards/runner.py
+++ b/hexgate/guards/runner.py
@@ -174,11 +174,9 @@ def _halt_to_decision(halt: Halt, call: ToolCall) -> Decision:
     ``guard_denied`` so it is distinguishable from a real policy denial to both
     the model and any trail consumer.
 
-    The run facts are read here rather than threaded down from ``decide()``: a
-    pre-guard halt fires before any decision snapshot exists, and a post-guard
-    halt fires after the call was counted, so the counters have legitimately
-    moved. Both readings are truthful at the moment they are taken, which is
-    what the audit row claims.
+    Run facts are read here, not threaded down from ``decide()``: a pre-guard
+    halt fires before any snapshot exists, and a post-guard halt fires after
+    the call was counted.
     """
     # A guard halt has no policy-deciding role (the guard decided, not a role),
     # so deciding_role stays None; user_roles carries the caller's roles.
@@ -189,9 +187,8 @@ def _halt_to_decision(halt: Halt, call: ToolCall) -> Decision:
         tool_name=call.tool_name,
         user_roles=user_roles,
         arguments=dict(call.args),
-        # Same run as the tool call decided a moment earlier, so a halt and the
-        # decision it interrupts share a run_id — otherwise a per-run timeline
-        # loses exactly the row explaining why the run stopped.
+        # Shares a run_id with the decision it interrupts, so a per-run
+        # timeline keeps the row explaining why the run stopped.
         run=RunAttribution.from_namespace(get_run_facts().as_namespace(call.tool_name)),
     )
     if halt.outcome is DecisionOutcome.DENY:

--- a/hexgate/guards/runner.py
+++ b/hexgate/guards/runner.py
@@ -39,7 +39,12 @@ from hexgate.guards.types import (
 )
 from hexgate.runtime.context import get_current_context
 from hexgate.runtime.run_facts import get_run_facts
-from hexgate.security.decision import Decision, DecisionOutcome, Verdict
+from hexgate.security.decision import (
+    Decision,
+    DecisionOutcome,
+    RunAttribution,
+    Verdict,
+)
 
 if TYPE_CHECKING:
     from hexgate.approvals import ApprovalHandler
@@ -168,6 +173,12 @@ def _halt_to_decision(halt: Halt, call: ToolCall) -> Decision:
     still cannot see the input the guard objected to. A DENY halt is marked
     ``guard_denied`` so it is distinguishable from a real policy denial to both
     the model and any trail consumer.
+
+    The run facts are read here rather than threaded down from ``decide()``: a
+    pre-guard halt fires before any decision snapshot exists, and a post-guard
+    halt fires after the call was counted, so the counters have legitimately
+    moved. Both readings are truthful at the moment they are taken, which is
+    what the audit row claims.
     """
     # A guard halt has no policy-deciding role (the guard decided, not a role),
     # so deciding_role stays None; user_roles carries the caller's roles.
@@ -178,6 +189,10 @@ def _halt_to_decision(halt: Halt, call: ToolCall) -> Decision:
         tool_name=call.tool_name,
         user_roles=user_roles,
         arguments=dict(call.args),
+        # Same run as the tool call decided a moment earlier, so a halt and the
+        # decision it interrupts share a run_id — otherwise a per-run timeline
+        # loses exactly the row explaining why the run stopped.
+        run=RunAttribution.from_namespace(get_run_facts().as_namespace(call.tool_name)),
     )
     if halt.outcome is DecisionOutcome.DENY:
         decision = replace(decision, error_type="guard_denied")

--- a/hexgate/security/__init__.py
+++ b/hexgate/security/__init__.py
@@ -71,6 +71,7 @@ from hexgate.security.decision import (
     Decision,
     DecisionOutcome,
     PolicyEngine,
+    RunAttribution,
     Verdict,
     combine_role_verdicts,
 )
@@ -233,6 +234,7 @@ __all__ = [
     "PolicyMode",
     "PolicySet",
     "RegoVerdict",
+    "RunAttribution",
     "PolicySetError",
     "SignedBundle",
     "ToolPolicy",

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -385,6 +385,14 @@ def _drift(
       * capability drift is a dead grant -> warning.
       * a boundary deny's arg typo inverts (``not(<missing> ...)`` folds to allow)
         -> fail-open -> error; other arg drift -> warning.
+
+    Policy-level ``constraints`` are deliberately not walked: they have no tool
+    to check ``args.*`` against, and checking them against every tool would
+    make an ``args.*`` policy-level constraint unwritable — a new restriction
+    unrelated to arg drift. Such a constraint is a smell (it denies every tool
+    lacking that argument) but it fails *closed*, so the first test run finds
+    it. Module composition rejects the field outright anyway (see
+    ``linker._MODULE_COMPOSABLE_FIELDS``), so this pipeline never sees one.
     """
     tool_props: dict[str, set[str]] = {
         t.name: set(t.input_schema.properties) for t in manifest.tools

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -386,13 +386,9 @@ def _drift(
       * a boundary deny's arg typo inverts (``not(<missing> ...)`` folds to allow)
         -> fail-open -> error; other arg drift -> warning.
 
-    Policy-level ``constraints`` are deliberately not walked: they have no tool
-    to check ``args.*`` against, and checking them against every tool would
-    make an ``args.*`` policy-level constraint unwritable — a new restriction
-    unrelated to arg drift. Such a constraint is a smell (it denies every tool
-    lacking that argument) but it fails *closed*, so the first test run finds
-    it. Module composition rejects the field outright anyway (see
-    ``linker._MODULE_COMPOSABLE_FIELDS``), so this pipeline never sees one.
+    Policy-level ``constraints`` are not walked: they have no tool to check
+    ``args.*`` against, and ``link()`` rejects the field in a module anyway, so
+    this pipeline never sees one.
     """
     tool_props: dict[str, set[str]] = {
         t.name: set(t.input_schema.properties) for t in manifest.tools

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -200,6 +200,23 @@ _ERROR_TYPE_BY_OUTCOME: dict[DecisionOutcome, str] = {
 # ``run.elapsed_seconds`` is a float; the platform column is UInt32 ms.
 _MILLISECONDS_PER_SECOND = 1000
 
+# The range the platform's ``DecisionEvent`` validates every run counter against
+# (``ge=0, le=UINT32_MAX``, backing a UInt32 ClickHouse column). Duplicated
+# rather than imported: the SDK does not depend on the platform package.
+_COUNTER_MIN = 0
+_COUNTER_MAX = 2**32 - 1
+
+
+def _as_counter(value: Any) -> int:
+    """Coerce one ``run.*`` value into the platform's UInt32 counter range.
+
+    Clamped, not passed through: counters are monotone within a run, so an
+    out-of-range value does not cost one row — the validator rejects every
+    later decision for that run too, and the DLQ takes the rest of the trail
+    with it. A clamped counter misreports; a rejected span loses the record.
+    """
+    return min(max(int(value), _COUNTER_MIN), _COUNTER_MAX)
+
 
 @dataclass(frozen=True, slots=True)
 class RunAttribution:
@@ -220,17 +237,18 @@ class RunAttribution:
     def from_namespace(cls, run: Mapping[str, Any] | None) -> "RunAttribution":
         """Project the ``run.*`` namespace onto the five persisted counters.
 
-        A subset: the other paths have no column yet.
+        A subset: the other paths have no column yet. Every counter is clamped
+        to the wire's range (see :func:`_as_counter`).
         """
         if not run:
             return DETACHED_RUN
         return cls(
             run_id=str(run.get("id", "")),
-            tool_calls=int(run.get("tool_calls", 0)),
-            llm_calls=int(run.get("llm_calls", 0)),
-            denials=int(run.get("denials", 0)),
-            total_tokens=int(run.get("total_tokens", 0)),
-            elapsed_ms=int(
+            tool_calls=_as_counter(run.get("tool_calls", 0)),
+            llm_calls=_as_counter(run.get("llm_calls", 0)),
+            denials=_as_counter(run.get("denials", 0)),
+            total_tokens=_as_counter(run.get("total_tokens", 0)),
+            elapsed_ms=_as_counter(
                 float(run.get("elapsed_seconds", 0.0)) * _MILLISECONDS_PER_SECOND
             ),
         )

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Final, Protocol, runtime_checkable
+
+from hexgate.tracing import semconv
 
 
 class DecisionOutcome(str, Enum):
@@ -195,6 +197,84 @@ _ERROR_TYPE_BY_OUTCOME: dict[DecisionOutcome, str] = {
 }
 
 
+# ``run.elapsed_seconds`` is a float; the platform column is UInt32
+# milliseconds (platform/clickhouse/init/schema.sql, policy_decision), typed so
+# a distribution query buckets predictably. Convert once, here.
+_MILLISECONDS_PER_SECOND = 1000
+
+
+@dataclass(frozen=True, slots=True)
+class RunAttribution:
+    """The run a decision belongs to, in the shape the audit wire wants.
+
+    Built from :meth:`~hexgate.runtime.run_facts.RunFacts.as_namespace`, which
+    :meth:`~hexgate.security.enforcer.PolicyEnforcer.decide` reads once per
+    decision so the record and the verdict cannot disagree about the same run.
+    Bounded integers and a UUID string — not caller data, so it is neither
+    redacted nor capped on its way out (see ``audit.AuditEvent.span_attributes``).
+
+    ``run_id`` is ``""`` for a decision made outside a run scope, matching
+    ``run_facts.DETACHED.id``. That is an in-process signal only: the wire
+    field is ``UUID | None``, so :meth:`as_span_attributes` omits it.
+    """
+
+    run_id: str = ""
+    tool_calls: int = 0
+    llm_calls: int = 0
+    denials: int = 0
+    total_tokens: int = 0
+    elapsed_ms: int = 0
+
+    @classmethod
+    def from_namespace(cls, run: Mapping[str, Any] | None) -> "RunAttribution":
+        """Project the ``run.*`` namespace onto the five persisted counters.
+
+        A subset by design: the namespace also carries ``agent``,
+        ``approvals``, ``errors``, ``calls_of_this_tool``, ``tools_used`` and
+        the token split, none of which has a column yet. Adding one later is a
+        DEFAULT-ed column plus a line here.
+        """
+        if not run:
+            return DETACHED_RUN
+        return cls(
+            run_id=str(run.get("id", "")),
+            tool_calls=int(run.get("tool_calls", 0)),
+            llm_calls=int(run.get("llm_calls", 0)),
+            denials=int(run.get("denials", 0)),
+            total_tokens=int(run.get("total_tokens", 0)),
+            elapsed_ms=int(
+                float(run.get("elapsed_seconds", 0.0)) * _MILLISECONDS_PER_SECOND
+            ),
+        )
+
+    def as_span_attributes(self) -> dict[str, Any]:
+        """Span attributes for the platform's ``DecisionEvent``.
+
+        ``RUN_ID`` is omitted, never sent as ``""``: OTLP attributes cannot
+        carry null, and the platform types ``run_id`` as ``UUID | None`` and
+        rejects an empty string with a 422 — so a decision made outside a run
+        scope would lose its whole audit record, not just its attribution. An
+        absent attribute is what the enricher decodes back to ``None``.
+        """
+        attrs: dict[str, Any] = {
+            semconv.RUN_TOOL_CALLS: self.tool_calls,
+            semconv.RUN_LLM_CALLS: self.llm_calls,
+            semconv.RUN_DENIALS: self.denials,
+            semconv.RUN_TOTAL_TOKENS: self.total_tokens,
+            semconv.RUN_ELAPSED_MS: self.elapsed_ms,
+        }
+        if self.run_id:
+            attrs[semconv.RUN_ID] = self.run_id
+        return attrs
+
+
+# Shared zero value: a decision with no run scope behind it. Safe as a
+# module-level singleton because the class is frozen — unlike
+# ``run_facts.DETACHED``, which needs a write-dropping flag to play the same
+# role for a mutable accumulator.
+DETACHED_RUN: Final[RunAttribution] = RunAttribution()
+
+
 @dataclass(frozen=True, slots=True)
 class Decision:
     """One policy decision for a proposed tool invocation."""
@@ -220,6 +300,13 @@ class Decision:
     # deliberately still absent from ``as_error_payload`` — the model must
     # never see it.
     attributes: dict[str, Any] | None = None
+    # The run this decision belongs to. Persisted by the audit sender
+    # untouched — bounded integers and a UUID, not caller data — and
+    # deliberately absent from ``as_error_payload`` for the same reason
+    # ``attributes`` is: the model must not learn how close it is to its
+    # budget. Surfacing budget pressure to the agent is its own design
+    # decision, not something to ship by accident here.
+    run: RunAttribution = DETACHED_RUN
 
     @classmethod
     def from_verdict(
@@ -232,9 +319,15 @@ class Decision:
         deciding_role: str | None = None,
         arguments: dict[str, Any] | None = None,
         attributes: dict[str, Any] | None = None,
+        run: RunAttribution = DETACHED_RUN,
     ) -> "Decision":
         """Lift an engine :class:`Verdict` into a host-facing decision, stamping
-        on the context the engine doesn't know."""
+        on the context the engine doesn't know.
+
+        ``run`` defaults to :data:`DETACHED_RUN` rather than being required: a
+        decision built with no run context is a legitimate state (a direct
+        ``decide()``, a bypassed entry point), and defaulting keeps every
+        existing caller valid."""
         return cls(
             outcome=verdict.outcome,
             agent_name=agent_name,
@@ -247,6 +340,7 @@ class Decision:
             violations=verdict.violations,
             arguments=arguments,
             attributes=attributes,
+            run=run,
         )
 
     @property

--- a/hexgate/security/decision.py
+++ b/hexgate/security/decision.py
@@ -197,9 +197,7 @@ _ERROR_TYPE_BY_OUTCOME: dict[DecisionOutcome, str] = {
 }
 
 
-# ``run.elapsed_seconds`` is a float; the platform column is UInt32
-# milliseconds (platform/clickhouse/init/schema.sql, policy_decision), typed so
-# a distribution query buckets predictably. Convert once, here.
+# ``run.elapsed_seconds`` is a float; the platform column is UInt32 ms.
 _MILLISECONDS_PER_SECOND = 1000
 
 
@@ -207,15 +205,8 @@ _MILLISECONDS_PER_SECOND = 1000
 class RunAttribution:
     """The run a decision belongs to, in the shape the audit wire wants.
 
-    Built from :meth:`~hexgate.runtime.run_facts.RunFacts.as_namespace`, which
-    :meth:`~hexgate.security.enforcer.PolicyEnforcer.decide` reads once per
-    decision so the record and the verdict cannot disagree about the same run.
-    Bounded integers and a UUID string — not caller data, so it is neither
-    redacted nor capped on its way out (see ``audit.AuditEvent.span_attributes``).
-
-    ``run_id`` is ``""`` for a decision made outside a run scope, matching
-    ``run_facts.DETACHED.id``. That is an in-process signal only: the wire
-    field is ``UUID | None``, so :meth:`as_span_attributes` omits it.
+    ``run_id`` is ``""`` outside a run scope, matching ``run_facts.DETACHED``.
+    An in-process signal only — the wire field is ``UUID | None``.
     """
 
     run_id: str = ""
@@ -229,10 +220,7 @@ class RunAttribution:
     def from_namespace(cls, run: Mapping[str, Any] | None) -> "RunAttribution":
         """Project the ``run.*`` namespace onto the five persisted counters.
 
-        A subset by design: the namespace also carries ``agent``,
-        ``approvals``, ``errors``, ``calls_of_this_tool``, ``tools_used`` and
-        the token split, none of which has a column yet. Adding one later is a
-        DEFAULT-ed column plus a line here.
+        A subset: the other paths have no column yet.
         """
         if not run:
             return DETACHED_RUN
@@ -250,11 +238,8 @@ class RunAttribution:
     def as_span_attributes(self) -> dict[str, Any]:
         """Span attributes for the platform's ``DecisionEvent``.
 
-        ``RUN_ID`` is omitted, never sent as ``""``: OTLP attributes cannot
-        carry null, and the platform types ``run_id`` as ``UUID | None`` and
-        rejects an empty string with a 422 — so a decision made outside a run
-        scope would lose its whole audit record, not just its attribution. An
-        absent attribute is what the enricher decodes back to ``None``.
+        ``RUN_ID`` is omitted, never ``""``: OTLP cannot carry null and the
+        platform rejects an empty string, losing the whole record.
         """
         attrs: dict[str, Any] = {
             semconv.RUN_TOOL_CALLS: self.tool_calls,
@@ -268,10 +253,7 @@ class RunAttribution:
         return attrs
 
 
-# Shared zero value: a decision with no run scope behind it. Safe as a
-# module-level singleton because the class is frozen — unlike
-# ``run_facts.DETACHED``, which needs a write-dropping flag to play the same
-# role for a mutable accumulator.
+# A decision with no run scope behind it. Safe to share: the class is frozen.
 DETACHED_RUN: Final[RunAttribution] = RunAttribution()
 
 
@@ -300,12 +282,9 @@ class Decision:
     # deliberately still absent from ``as_error_payload`` — the model must
     # never see it.
     attributes: dict[str, Any] | None = None
-    # The run this decision belongs to. Persisted by the audit sender
-    # untouched — bounded integers and a UUID, not caller data — and
-    # deliberately absent from ``as_error_payload`` for the same reason
-    # ``attributes`` is: the model must not learn how close it is to its
-    # budget. Surfacing budget pressure to the agent is its own design
-    # decision, not something to ship by accident here.
+    # The run this decision belongs to. Persisted untouched (bounded ints and a
+    # UUID, not caller data); absent from ``as_error_payload`` like
+    # ``attributes`` — the model must not learn how close it is to its budget.
     run: RunAttribution = DETACHED_RUN
 
     @classmethod
@@ -322,12 +301,7 @@ class Decision:
         run: RunAttribution = DETACHED_RUN,
     ) -> "Decision":
         """Lift an engine :class:`Verdict` into a host-facing decision, stamping
-        on the context the engine doesn't know.
-
-        ``run`` defaults to :data:`DETACHED_RUN` rather than being required: a
-        decision built with no run context is a legitimate state (a direct
-        ``decide()``, a bypassed entry point), and defaulting keeps every
-        existing caller valid."""
+        on the context the engine doesn't know."""
         return cls(
             outcome=verdict.outcome,
             agent_name=agent_name,

--- a/hexgate/security/enforcer.py
+++ b/hexgate/security/enforcer.py
@@ -159,9 +159,8 @@ class PolicyEnforcer:
             deciding_role=deciding_role,
             arguments=args_snapshot,
             attributes=attrs_snapshot,
-            # Projected from the same snapshot the verdict was evaluated
-            # against, never a second read: the audit record and the decision
-            # must not describe different counter values for one call.
+            # The same snapshot the verdict saw, never a second read: the
+            # record and the decision must not disagree about the run.
             run=RunAttribution.from_namespace(run_snapshot),
         )
 

--- a/hexgate/security/enforcer.py
+++ b/hexgate/security/enforcer.py
@@ -22,7 +22,12 @@ from hexgate.audit import AuditEvent, configure
 from hexgate.runtime.context import get_current_context
 from hexgate.runtime.roles import resolve_role_set
 from hexgate.runtime.run_facts import get_run_facts
-from hexgate.security.decision import Decision, PolicyEngine, combine_role_verdicts
+from hexgate.security.decision import (
+    Decision,
+    PolicyEngine,
+    RunAttribution,
+    combine_role_verdicts,
+)
 from hexgate.tracing._senders import AuditSender
 
 if TYPE_CHECKING:
@@ -154,6 +159,10 @@ class PolicyEnforcer:
             deciding_role=deciding_role,
             arguments=args_snapshot,
             attributes=attrs_snapshot,
+            # Projected from the same snapshot the verdict was evaluated
+            # against, never a second read: the audit record and the decision
+            # must not describe different counter values for one call.
+            run=RunAttribution.from_namespace(run_snapshot),
         )
 
         self.record(

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -14,9 +14,8 @@ PolicyMode = Literal["allow", "deny", "approval_required"]
 
 def _parse_all(constraints: list[str]) -> list[str]:
     """Parse every constraint at load — a malformed expression is a config
-    error, surfaced here at ``model_validate`` time rather than lazily at the
-    first matching tool call. Keeps ``models.py`` (document schema) and
-    ``constraints.py`` (expression grammar) jointly the enforced spec."""
+    error, surfaced at ``model_validate`` time rather than at the first
+    matching tool call."""
     for constraint in constraints:
         parse_constraint(constraint)
     return constraints
@@ -130,11 +129,10 @@ class AgentPolicy(BaseModel):
     won't pick it as the effective policy for any HexgateContext scope; it can only
     be referenced via ``inherits``.
 
-    ``constraints`` are policy-level: they apply to every tool this role can
-    reach, not just the ones falling through to ``default_policy``. The place
-    for a run-wide circuit breaker (``run.tool_calls < 20``). Unlike every
-    other field here they **union** across ``inherits`` rather than override,
-    because a child silently dropping a parent's fence would be fail-open.
+    ``constraints`` apply to every tool this role can reach, not just those
+    falling through to ``default_policy`` — the place for a run-wide circuit
+    breaker. Alone among these fields they **union** across ``inherits``:
+    a child dropping a parent's fence would be fail-open.
 
     ``consts`` names reusable values referenced from constraints as
     ``consts.<name>`` (e.g. ``args.amount <= consts.max_refund``). Merged
@@ -165,15 +163,10 @@ class AgentPolicy(BaseModel):
     inherits: list[str] = Field(default_factory=list)
     is_mixin: bool = False
     default_policy: BaseToolPolicy = Field(default_factory=BaseToolPolicy)
-    # Applied to *every* tool this role can reach, on top of the tool's own
-    # constraints and evaluated before them. Distinct from
-    # ``default_policy.constraints``, which only reaches tools that fall
-    # through to the default — so a run-wide cap on a role that lists ten tools
-    # would otherwise have to be repeated ten times.
-    #
-    # Can only narrow: a tool with ``mode: deny`` short-circuits before
-    # constraints on both engines, so this never resurrects a denied tool.
-    # Unions (not overrides) across ``inherits`` — see ``_resolve_inheritance``.
+    # Applied to *every* tool this role can reach, before the tool's own.
+    # Unlike ``default_policy.constraints``, which only reaches tools that fall
+    # through to the default. Can only narrow: ``mode: deny`` short-circuits
+    # before constraints on both engines.
     constraints: list[str] = Field(default_factory=list)
     tools: dict[str, ToolPolicy] = Field(default_factory=dict)
     consts: dict[str, Any] = Field(default_factory=dict)

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -12,6 +12,16 @@ from hexgate.security.constraints import parse_constraint
 PolicyMode = Literal["allow", "deny", "approval_required"]
 
 
+def _parse_all(constraints: list[str]) -> list[str]:
+    """Parse every constraint at load — a malformed expression is a config
+    error, surfaced here at ``model_validate`` time rather than lazily at the
+    first matching tool call. Keeps ``models.py`` (document schema) and
+    ``constraints.py`` (expression grammar) jointly the enforced spec."""
+    for constraint in constraints:
+        parse_constraint(constraint)
+    return constraints
+
+
 class BaseToolPolicy(BaseModel):
     """Define the access mode and per-call constraints for a single tool.
 
@@ -29,13 +39,7 @@ class BaseToolPolicy(BaseModel):
     @field_validator("constraints")
     @classmethod
     def _validate_constraint_grammar(cls, value: list[str]) -> list[str]:
-        """Parse every constraint at load — a malformed expression is a config
-        error, surfaced here at ``model_validate`` time rather than lazily at
-        the first matching tool call. Keeps ``models.py`` (document schema) and
-        ``constraints.py`` (expression grammar) jointly the enforced spec."""
-        for constraint in value:
-            parse_constraint(constraint)
-        return value
+        return _parse_all(value)
 
 
 class FileScope(BaseModel):
@@ -126,6 +130,12 @@ class AgentPolicy(BaseModel):
     won't pick it as the effective policy for any HexgateContext scope; it can only
     be referenced via ``inherits``.
 
+    ``constraints`` are policy-level: they apply to every tool this role can
+    reach, not just the ones falling through to ``default_policy``. The place
+    for a run-wide circuit breaker (``run.tool_calls < 20``). Unlike every
+    other field here they **union** across ``inherits`` rather than override,
+    because a child silently dropping a parent's fence would be fail-open.
+
     ``consts`` names reusable values referenced from constraints as
     ``consts.<name>`` (e.g. ``args.amount <= consts.max_refund``). Merged
     through ``inherits`` like ``tools`` — put shared constants in a mixin.
@@ -155,10 +165,25 @@ class AgentPolicy(BaseModel):
     inherits: list[str] = Field(default_factory=list)
     is_mixin: bool = False
     default_policy: BaseToolPolicy = Field(default_factory=BaseToolPolicy)
+    # Applied to *every* tool this role can reach, on top of the tool's own
+    # constraints and evaluated before them. Distinct from
+    # ``default_policy.constraints``, which only reaches tools that fall
+    # through to the default — so a run-wide cap on a role that lists ten tools
+    # would otherwise have to be repeated ten times.
+    #
+    # Can only narrow: a tool with ``mode: deny`` short-circuits before
+    # constraints on both engines, so this never resurrects a denied tool.
+    # Unions (not overrides) across ``inherits`` — see ``_resolve_inheritance``.
+    constraints: list[str] = Field(default_factory=list)
     tools: dict[str, ToolPolicy] = Field(default_factory=dict)
     consts: dict[str, Any] = Field(default_factory=dict)
     admission: BaseToolPolicy | None = None
     agents: dict[str, AgentTargetPolicy] = Field(default_factory=dict)
+
+    @field_validator("constraints")
+    @classmethod
+    def _validate_constraint_grammar(cls, value: list[str]) -> list[str]:
+        return _parse_all(value)
 
     @field_validator("tools")
     @classmethod

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -78,10 +78,10 @@ def evaluate_tool_call(
 ) -> Verdict:
     """Return a :class:`Verdict` for a proposed tool call (pydantic engine).
 
-    Evaluates the tool's ``constraints`` list against the invocation's
-    arguments (see :mod:`hexgate.security.constraints` for the grammar).
-    Every constraint must pass for the call to authorize — fail-closed by
-    design. A path denial carries a machine-readable ``hint`` so the host
+    Evaluates the policy's own ``constraints`` (which apply to every tool)
+    followed by the tool's, against the invocation's arguments (see
+    :mod:`hexgate.security.constraints` for the grammar). Every constraint must
+    pass for the call to authorize — fail-closed by design. A path denial carries a machine-readable ``hint`` so the host
     can tell the model what scope it stayed within.
 
     Returns rather than raises; :func:`authorize_tool_call` wraps this for
@@ -99,7 +99,14 @@ def evaluate_tool_call(
 
     try:
         check_constraints(
-            tool_policy.constraints,
+            # Policy-level first: a run-budget denial reads better in a deny
+            # reason than an argument one ("run budget exhausted" before
+            # "amount too high"), and check_constraints reports the first
+            # failure. Order is all this choice affects — every constraint
+            # must pass either way. Reached only after the deny
+            # short-circuit above, so a policy-level constraint can narrow a
+            # grant but never resurrect a denied tool.
+            [*policy.constraints, *tool_policy.constraints],
             arguments,
             tool_name,
             role=role,

--- a/hexgate/security/policy.py
+++ b/hexgate/security/policy.py
@@ -99,13 +99,8 @@ def evaluate_tool_call(
 
     try:
         check_constraints(
-            # Policy-level first: a run-budget denial reads better in a deny
-            # reason than an argument one ("run budget exhausted" before
-            # "amount too high"), and check_constraints reports the first
-            # failure. Order is all this choice affects — every constraint
-            # must pass either way. Reached only after the deny
-            # short-circuit above, so a policy-level constraint can narrow a
-            # grant but never resurrect a denied tool.
+            # Policy-level first, so a run-budget denial is the one reported.
+            # Order is all it affects — every constraint must pass either way.
             [*policy.constraints, *tool_policy.constraints],
             arguments,
             tool_name,

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -23,8 +23,7 @@ Inheritance semantics: left-to-right merge — ``inherits: [A, B]`` resolves
 to ``merge(A, merge(B, self))``, where ``merge`` deep-merges the ``tools``
 maps (child entries override parent entries by tool name) and replaces
 scalar fields (``default_policy``) with the child's value when set.
-Policy-level ``constraints`` are the exception: they union across the chain,
-so a child cannot drop a fence a mixin declared.
+Policy-level ``constraints`` are the exception: they union across the chain.
 
 Mixin policies (``is_mixin: true``) can only be referenced via ``inherits``
 — they're never picked as the effective policy for any context scope.
@@ -185,11 +184,8 @@ def _raw_constraints(
 ) -> Iterator[str]:
     """Every constraint string a role evaluates, policy-level first.
 
-    Mirrors the order in :func:`~hexgate.security.policy.evaluate_tool_call`,
-    so the first reference a validator rejects is the first one a call would
-    have hit. ``tools`` is a parameter because the two validators walk
-    different tool views — const refs cover the lowered ``agent.*`` keys in
-    ``effective_tools``, run refs only the authored ``tools``.
+    ``tools`` is a parameter because the two validators walk different views:
+    const refs cover the lowered ``agent.*`` keys, run refs only authored ones.
     """
     yield from policy.constraints
     for tool_policy in (*tools, policy.default_policy):
@@ -458,13 +454,10 @@ def _resolve_inheritance(
     with explicit precedence: ``self`` wins, then later parents, then
     earlier parents.
 
-    ``constraints`` is the one exception: policy-level constraints **union**
-    across the chain instead of overriding. A parent's constraint is a fence
-    the child inherits, so letting ``inherits: [read_only]`` replace the
-    mixin's run cap would silently remove it — fail-open on a security
-    restriction. Union can only narrow, which is the fail-closed direction.
-    Deduplicated, first-seen order, so diamond inheritance does not evaluate
-    the same predicate twice.
+    ``constraints`` is the one exception: it **unions** across the chain, since
+    letting a child replace a mixin's cap would silently remove it. Union can
+    only narrow. Deduplicated in first-seen order, so a diamond does not
+    evaluate the same predicate twice.
     """
     if name in chain:
         raise PolicySetError(f"cyclic inheritance: {' -> '.join(chain + [name])}")
@@ -504,9 +497,7 @@ def _resolve_inheritance(
     merged_tools.update(own.tools)
     merged_agents.update(own.agents)
     merged_consts.update(own.consts)
-    # Union, not override — the one field here that accumulates. See the
-    # docstring: a child replacing a parent's policy-level constraint would
-    # silently drop a fence, and dropping a restriction is fail-open.
+    # Union, not override — the one field here that accumulates (see docstring).
     _extend_unique(merged_constraints, own.constraints)
     if "default_policy" in own.model_fields_set:
         merged_default = own.default_policy

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -23,6 +23,8 @@ Inheritance semantics: left-to-right merge — ``inherits: [A, B]`` resolves
 to ``merge(A, merge(B, self))``, where ``merge`` deep-merges the ``tools``
 maps (child entries override parent entries by tool name) and replaces
 scalar fields (``default_policy``) with the child's value when set.
+Policy-level ``constraints`` are the exception: they union across the chain,
+so a child cannot drop a fence a mixin declared.
 
 Mixin policies (``is_mixin: true``) can only be referenced via ``inherits``
 — they're never picked as the effective policy for any context scope.
@@ -30,7 +32,7 @@ Mixin policies (``is_mixin: true``) can only be referenced via ``inherits``
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Iterable, Iterator, Mapping
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from typing import Any
@@ -178,6 +180,22 @@ class PolicySet:
         return f"PolicySet(roles={self.roles!r})"
 
 
+def _raw_constraints(
+    policy: AgentPolicy, *, tools: Iterable[BaseToolPolicy]
+) -> Iterator[str]:
+    """Every constraint string a role evaluates, policy-level first.
+
+    Mirrors the order in :func:`~hexgate.security.policy.evaluate_tool_call`,
+    so the first reference a validator rejects is the first one a call would
+    have hit. ``tools`` is a parameter because the two validators walk
+    different tool views — const refs cover the lowered ``agent.*`` keys in
+    ``effective_tools``, run refs only the authored ``tools``.
+    """
+    yield from policy.constraints
+    for tool_policy in (*tools, policy.default_policy):
+        yield from tool_policy.constraints
+
+
 def _validate_const_refs(policies: Mapping[str, AgentPolicy]) -> None:
     """Reject a ``consts.<name>`` reference to a constant not defined for its role.
 
@@ -189,14 +207,13 @@ def _validate_const_refs(policies: Mapping[str, AgentPolicy]) -> None:
     """
     for role, policy in policies.items():
         available = set(policy.consts)
-        for tool_policy in (*policy.effective_tools.values(), policy.default_policy):
-            for raw in tool_policy.constraints:
-                for name in iter_const_refs(parse_constraint(raw)):
-                    if name not in available:
-                        raise PolicySetError(
-                            f"role {role!r}: constraint {raw!r} references "
-                            f"undefined constant consts.{name}"
-                        )
+        for raw in _raw_constraints(policy, tools=policy.effective_tools.values()):
+            for name in iter_const_refs(parse_constraint(raw)):
+                if name not in available:
+                    raise PolicySetError(
+                        f"role {role!r}: constraint {raw!r} references "
+                        f"undefined constant consts.{name}"
+                    )
 
 
 def _sdk_version() -> str:
@@ -233,11 +250,10 @@ def _validate_run_refs(
     before any list-valued path is registered.
     """
     for role, policy in policies.items():
-        for tool_policy in (*policy.tools.values(), policy.default_policy):
-            for raw in tool_policy.constraints:
-                node = parse_constraint(raw)
-                _reject_unknown_run_paths(node, role, raw, scalar_paths | list_paths)
-                _reject_list_paths_in_scalar_position(node, role, raw, list_paths)
+        for raw in _raw_constraints(policy, tools=policy.tools.values()):
+            node = parse_constraint(raw)
+            _reject_unknown_run_paths(node, role, raw, scalar_paths | list_paths)
+            _reject_list_paths_in_scalar_position(node, role, raw, list_paths)
 
 
 def _reject_unknown_run_paths(
@@ -441,6 +457,14 @@ def _resolve_inheritance(
     then this role's own fields overlay last. Equivalent to Python's MRO
     with explicit precedence: ``self`` wins, then later parents, then
     earlier parents.
+
+    ``constraints`` is the one exception: policy-level constraints **union**
+    across the chain instead of overriding. A parent's constraint is a fence
+    the child inherits, so letting ``inherits: [read_only]`` replace the
+    mixin's run cap would silently remove it — fail-open on a security
+    restriction. Union can only narrow, which is the fail-closed direction.
+    Deduplicated, first-seen order, so diamond inheritance does not evaluate
+    the same predicate twice.
     """
     if name in chain:
         raise PolicySetError(f"cyclic inheritance: {' -> '.join(chain + [name])}")
@@ -454,6 +478,7 @@ def _resolve_inheritance(
     merged_tools: dict[str, ToolPolicy] = {}
     merged_agents: dict[str, AgentTargetPolicy] = {}
     merged_consts: dict[str, object] = {}
+    merged_constraints: list[str] = []
     merged_default: BaseToolPolicy = own.default_policy
     merged_admission: BaseToolPolicy | None = own.admission
 
@@ -466,6 +491,7 @@ def _resolve_inheritance(
         merged_tools.update(parent.tools)
         merged_agents.update(parent.agents)
         merged_consts.update(parent.consts)
+        _extend_unique(merged_constraints, parent.constraints)
         merged_default = parent.default_policy
         if parent.admission is not None:
             merged_admission = parent.admission
@@ -478,6 +504,10 @@ def _resolve_inheritance(
     merged_tools.update(own.tools)
     merged_agents.update(own.agents)
     merged_consts.update(own.consts)
+    # Union, not override — the one field here that accumulates. See the
+    # docstring: a child replacing a parent's policy-level constraint would
+    # silently drop a fence, and dropping a restriction is fail-open.
+    _extend_unique(merged_constraints, own.constraints)
     if "default_policy" in own.model_fields_set:
         merged_default = own.default_policy
     if "admission" in own.model_fields_set:
@@ -488,8 +518,16 @@ def _resolve_inheritance(
         inherits=own.inherits,
         is_mixin=own.is_mixin,
         default_policy=merged_default,
+        constraints=merged_constraints,
         tools=merged_tools,
         consts=merged_consts,
         admission=merged_admission,
         agents=merged_agents,
     )
+
+
+def _extend_unique(target: list[str], values: Iterable[str]) -> None:
+    """Append values not already present, preserving first-seen order."""
+    for value in values:
+        if value not in target:
+            target.append(value)

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -285,6 +285,9 @@ def _rules_for_role(
     """
     effective = policy.effective_tools
     listed = sorted(effective)
+    # Applied to every rule this role emits, mirroring the pydantic engine,
+    # where they are prepended to whatever get_tool_policy resolved.
+    policy_constraints = list(policy.constraints)
     out: list[str] = []
     for tool_name in listed:
         tool_guard = [f'    input.tool == "{_escape_string(tool_name)}"']
@@ -296,9 +299,19 @@ def _rules_for_role(
                 effective[tool_name],
                 tool_name,
                 helpers,
+                policy_constraints=policy_constraints,
             )
         )
-    out.extend(_default_rules(role, role_guard, policy.default_policy, listed, helpers))
+    out.extend(
+        _default_rules(
+            role,
+            role_guard,
+            policy.default_policy,
+            listed,
+            helpers,
+            policy_constraints=policy_constraints,
+        )
+    )
     return out
 
 
@@ -308,6 +321,8 @@ def _default_rules(
     default_policy: BaseToolPolicy,
     listed: list[str],
     helpers: dict[str, list[str]],
+    *,
+    policy_constraints: list[str],
 ) -> list[str]:
     """Catch-all rules for ``default_policy`` — any tool not explicitly listed.
 
@@ -331,7 +346,13 @@ def _default_rules(
         members = ", ".join(json.dumps(name) for name in listed)
         tool_guard.append(f"    not input.tool in {{{members}}}")
     return _gated_rules(
-        role, role_guard, tool_guard, default_policy, "<default>", helpers
+        role,
+        role_guard,
+        tool_guard,
+        default_policy,
+        "<default>",
+        helpers,
+        policy_constraints=policy_constraints,
     )
 
 
@@ -342,12 +363,20 @@ def _gated_rules(
     tool_policy: BaseToolPolicy,
     label: str,
     helpers: dict[str, list[str]],
+    *,
+    policy_constraints: list[str],
 ) -> list[str]:
     """Render the positive + per-constraint violation rules for one policy.
 
     ``role_guard`` / ``tool_guard`` are the body line(s) selecting which
     caller(s) and tool(s) the rule applies to. ``label`` names the tool (or
     ``<default>``) for constraint parse errors.
+
+    ``policy_constraints`` are the role's policy-level constraints, applied to
+    every tool. Required and keyword-only on purpose: there are two call
+    sites and a missed one is engine drift (the pydantic engine applies them
+    unconditionally), which is silent — a required parameter turns it into a
+    TypeError the first Rego test triggers.
 
     ``deny`` mode emits nothing — absence of a rule IS the deny.
     """
@@ -369,8 +398,12 @@ def _gated_rules(
     head = "allow" if tool_policy.mode == "allow" else "requires_approval"
 
     # Parse all constraints up-front — surfaces bad grammar at compile time.
+    # Policy-level first, matching evaluate_tool_call's order. An empty
+    # policy-level list makes this exactly ``tool_policy.constraints``, so the
+    # rendered module is byte-identical to one compiled before this field
+    # existed — every project's source_hash stays put on upgrade.
     parsed: list[tuple[str, Node]] = []
-    for raw_constraint in tool_policy.constraints:
+    for raw_constraint in (*policy_constraints, *tool_policy.constraints):
         try:
             parsed.append((raw_constraint, parse_constraint(raw_constraint)))
         except Exception as exc:

--- a/hexgate/security/rego.py
+++ b/hexgate/security/rego.py
@@ -285,8 +285,7 @@ def _rules_for_role(
     """
     effective = policy.effective_tools
     listed = sorted(effective)
-    # Applied to every rule this role emits, mirroring the pydantic engine,
-    # where they are prepended to whatever get_tool_policy resolved.
+    # Applied to every rule this role emits, mirroring the pydantic engine.
     policy_constraints = list(policy.constraints)
     out: list[str] = []
     for tool_name in listed:
@@ -373,10 +372,8 @@ def _gated_rules(
     ``<default>``) for constraint parse errors.
 
     ``policy_constraints`` are the role's policy-level constraints, applied to
-    every tool. Required and keyword-only on purpose: there are two call
-    sites and a missed one is engine drift (the pydantic engine applies them
-    unconditionally), which is silent — a required parameter turns it into a
-    TypeError the first Rego test triggers.
+    every tool. Required and keyword-only: there are two call sites, and a
+    missed one is silent engine drift rather than a crash.
 
     ``deny`` mode emits nothing — absence of a rule IS the deny.
     """
@@ -398,10 +395,8 @@ def _gated_rules(
     head = "allow" if tool_policy.mode == "allow" else "requires_approval"
 
     # Parse all constraints up-front — surfaces bad grammar at compile time.
-    # Policy-level first, matching evaluate_tool_call's order. An empty
-    # policy-level list makes this exactly ``tool_policy.constraints``, so the
-    # rendered module is byte-identical to one compiled before this field
-    # existed — every project's source_hash stays put on upgrade.
+    # Policy-level first, matching evaluate_tool_call. An empty list renders
+    # byte-identically to before the field existed, so no source_hash moves.
     parsed: list[tuple[str, Node]] = []
     for raw_constraint in (*policy_constraints, *tool_policy.constraints):
         try:

--- a/hexgate/tracing/semconv.py
+++ b/hexgate/tracing/semconv.py
@@ -60,6 +60,17 @@ HINT = "sec_ai.hint"
 ARGUMENTS = "sec_ai.arguments"
 ATTRIBUTES = "sec_ai.attributes"
 
+# --- Run attribution (SCOPE_AUDIT, plus RUN_ID on SCOPE_USAGE) -----------------
+# Omitted entirely when the emitter has no run to attribute: OTLP attributes
+# cannot carry null, and the platform's run_id is ``UUID | None`` — an empty
+# string is a 422. An absent attribute decodes to None; "" would not.
+RUN_ID = "sec_ai.run_id"
+RUN_TOOL_CALLS = "sec_ai.run_tool_calls"
+RUN_LLM_CALLS = "sec_ai.run_llm_calls"
+RUN_DENIALS = "sec_ai.run_denials"
+RUN_TOTAL_TOKENS = "sec_ai.run_total_tokens"
+RUN_ELAPSED_MS = "sec_ai.run_elapsed_ms"
+
 # --- LLM usage spans (SCOPE_USAGE) ----------------------------------------------
 # Official OTel GenAI semconv names — never coin new gen_ai.* names ourselves.
 GEN_AI_REQUEST_MODEL = "gen_ai.request.model"

--- a/hexgate/tracing/usage.py
+++ b/hexgate/tracing/usage.py
@@ -32,13 +32,19 @@ class LlmUsageEvent:
     session_id: str = ""
     user_id: str = ""
     error_code: str | None = None  # optional error code if status is "error"
+    # The run this model request belongs to, so llm_invocation rows join to the
+    # policy_decision rows of the same invocation. ``""`` outside a run scope,
+    # matching ``run_facts.DETACHED.id``; a plain field rather than the six-way
+    # RunAttribution because llm_invocation carries one run column, and the
+    # counters mid-request are not what a token total should be read from.
+    run_id: str = ""
     event_id: UUID = field(default_factory=uuid4)
     occurred_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
     def span_attributes(self) -> dict[str, Any]:
         """Flat span attributes: official ``gen_ai.*`` names for model and
         token counts, ``sec_ai.*`` for everything Hexgate-specific."""
-        return {
+        attrs: dict[str, Any] = {
             semconv.EVENT_ID: str(self.event_id),
             semconv.AGENT_NAME: self.agent_name,
             semconv.SESSION_ID: self.session_id,
@@ -50,6 +56,13 @@ class LlmUsageEvent:
             semconv.STATUS: self.status,
             semconv.ERROR_CODE: self.error_code or "",
         }
+        # Absent, never "": the platform types run_id as ``UUID | None`` and
+        # rejects an empty string with a 422, which the sender drops rather
+        # than retries — losing the whole usage record, not just its
+        # attribution.
+        if self.run_id:
+            attrs[semconv.RUN_ID] = self.run_id
+        return attrs
 
 
 def emit_llm_usage(
@@ -80,7 +93,10 @@ def emit_llm_usage(
     try:
         # Before the sender check: a token cap must work with no platform
         # attached, or run.total_tokens stays a permanent 0 in local mode.
-        get_run_facts().record_llm_usage(input_tokens, output_tokens)
+        # Bound once, so the tokens recorded and the run they are attributed to
+        # are structurally the same run rather than incidentally so.
+        facts = get_run_facts()
+        facts.record_llm_usage(input_tokens, output_tokens)
 
         sender = configure_usage_sender(api_key)
         if sender is None:
@@ -99,6 +115,7 @@ def emit_llm_usage(
                 else "",
                 user_id=context.user_id if context is not None else "",
                 error_code=error_code,
+                run_id=facts.id,
             )
         )
     except Exception:

--- a/hexgate/tracing/usage.py
+++ b/hexgate/tracing/usage.py
@@ -32,11 +32,9 @@ class LlmUsageEvent:
     session_id: str = ""
     user_id: str = ""
     error_code: str | None = None  # optional error code if status is "error"
-    # The run this model request belongs to, so llm_invocation rows join to the
-    # policy_decision rows of the same invocation. ``""`` outside a run scope,
-    # matching ``run_facts.DETACHED.id``; a plain field rather than the six-way
-    # RunAttribution because llm_invocation carries one run column, and the
-    # counters mid-request are not what a token total should be read from.
+    # Joins this row to the policy_decision rows of the same invocation. ``""``
+    # outside a run scope. A plain field, not a RunAttribution: llm_invocation
+    # carries one run column.
     run_id: str = ""
     event_id: UUID = field(default_factory=uuid4)
     occurred_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
@@ -56,10 +54,8 @@ class LlmUsageEvent:
             semconv.STATUS: self.status,
             semconv.ERROR_CODE: self.error_code or "",
         }
-        # Absent, never "": the platform types run_id as ``UUID | None`` and
-        # rejects an empty string with a 422, which the sender drops rather
-        # than retries — losing the whole usage record, not just its
-        # attribution.
+        # Absent, never "": the platform rejects an empty string, losing the
+        # whole usage record rather than just its attribution.
         if self.run_id:
             attrs[semconv.RUN_ID] = self.run_id
         return attrs
@@ -93,8 +89,7 @@ def emit_llm_usage(
     try:
         # Before the sender check: a token cap must work with no platform
         # attached, or run.total_tokens stays a permanent 0 in local mode.
-        # Bound once, so the tokens recorded and the run they are attributed to
-        # are structurally the same run rather than incidentally so.
+        # Bound once, so the tokens and the run_id come from the same object.
         facts = get_run_facts()
         facts.record_llm_usage(input_tokens, output_tokens)
 

--- a/platform/api/hexgate_api/jobs/enricher/mapping.py
+++ b/platform/api/hexgate_api/jobs/enricher/mapping.py
@@ -107,7 +107,36 @@ def _decision_fields(attrs: dict[str, Any], scope: str) -> dict[str, Any]:
                 attrs.get(semconv.ATTRIBUTES), key=semconv.ATTRIBUTES, scope=scope
             )
         ),
+        **_run_fields(attrs, scope),
     }
+
+
+# Counter attribute → DecisionEvent field. run_id is handled apart: it is the
+# one nullable field of the group, and the only one a foreign emitter is likely
+# to omit wholesale.
+_RUN_COUNTERS = {
+    semconv.RUN_TOOL_CALLS: "run_tool_calls",
+    semconv.RUN_LLM_CALLS: "run_llm_calls",
+    semconv.RUN_DENIALS: "run_denials",
+    semconv.RUN_TOTAL_TOKENS: "run_total_tokens",
+    semconv.RUN_ELAPSED_MS: "run_elapsed_ms",
+}
+
+
+def _run_fields(attrs: dict[str, Any], scope: str) -> dict[str, Any]:
+    """Run attribution, absent-tolerant: a span from an emitter that predates
+    the run namespace maps to the model's zero defaults rather than a rejection.
+
+    ``run_id`` stays ``None`` when the attribute is missing — the SDK omits it
+    outside a run scope, and the platform substitutes the zero UUID at insert.
+    """
+    fields: dict[str, Any] = {
+        field: as_int(attrs[key], key=key, scope=scope)
+        for key, field in _RUN_COUNTERS.items()
+        if key in attrs
+    }
+    fields["run_id"] = as_str(attrs.get(semconv.RUN_ID)) or None
+    return fields
 
 
 def _usage_fields(attrs: dict[str, Any], span: Span, scope: str) -> dict[str, Any]:
@@ -131,6 +160,8 @@ def _usage_fields(attrs: dict[str, Any], span: Span, scope: str) -> dict[str, An
         ),
         "latency_ms": as_int(latency, key=semconv.LATENCY_MS, scope=scope),
         "error_code": as_str(attrs.get(semconv.ERROR_CODE)),
+        # Same nullable contract as the decision scope: absent, never "".
+        "run_id": as_str(attrs.get(semconv.RUN_ID)) or None,
     }
     status = attrs.get(semconv.STATUS)
     if status is not None:  # absent → the model's "success" default

--- a/platform/api/tests/jobs/enricher/test_mapping.py
+++ b/platform/api/tests/jobs/enricher/test_mapping.py
@@ -185,15 +185,11 @@ def test_when_run_attributes_are_absent_then_counters_default_to_zero() -> None:
 
 
 def test_sdk_decision_span_validates_in_and_out_of_a_run_scope() -> None:
-    """The cross-package contract, asserted against the real SDK emitter.
+    """The cross-package contract, asserted against the real SDK emitter — the
+    only place both halves of the wire shape meet.
 
-    The SDK's own suite can only check its idea of the wire shape; this is the
-    only place both halves meet. An attribute name the enricher does not read
-    is silently dropped, so a rename on either side has to fail here.
-
-    Out of a run scope the SDK omits ``RUN_ID`` entirely — OTLP cannot carry
-    null and ``DecisionEvent.run_id`` is ``UUID | None``, so an empty string
-    would fail validation and DLQ the whole record rather than its attribution.
+    Out of a run scope the SDK omits ``RUN_ID``: OTLP cannot carry null, and an
+    empty string would DLQ the whole record rather than its attribution.
     """
     from hexgate.audit import AuditEvent
     from hexgate.security.decision import Decision, DecisionOutcome, RunAttribution

--- a/platform/api/tests/jobs/enricher/test_mapping.py
+++ b/platform/api/tests/jobs/enricher/test_mapping.py
@@ -231,6 +231,39 @@ def test_sdk_decision_span_validates_in_and_out_of_a_run_scope() -> None:
     assert out_of_run.run_tool_calls == 0
 
 
+def test_sdk_clamps_an_overflowing_run_counter_into_a_span_this_side_accepts() -> None:
+    """The other half of the counter contract.
+
+    Counters are monotone within a run, so an unclamped overflow would not cost
+    one row: every later decision for that run would fail the same validator and
+    DLQ, taking the tail of the trail with it. The SDK clamps at projection so
+    the run stays observable; ``le=UINT32_MAX`` here stays the backstop for a
+    foreign emitter.
+    """
+    from hexgate.audit import AuditEvent
+    from hexgate.security.decision import Decision, DecisionOutcome, RunAttribution
+
+    attrs = AuditEvent(
+        decision=Decision(
+            outcome=DecisionOutcome.ALLOW,
+            agent_name="example_agent",
+            tool_name="read_file",
+            run=RunAttribution.from_namespace(
+                {
+                    "id": str(uuid.uuid4()),
+                    "total_tokens": UINT32_MAX + 1,
+                    "elapsed_seconds": 1e9,
+                }
+            ),
+        )
+    ).span_attributes()
+
+    event = map_span(semconv.SCOPE_AUDIT, make_span(attrs), {})
+
+    assert event.run_total_tokens == UINT32_MAX
+    assert event.run_elapsed_ms == UINT32_MAX
+
+
 def test_sdk_usage_span_validates_in_and_out_of_a_run_scope() -> None:
     """Same contract for llm_invocation.run_id, which joins usage rows to the
     policy_decision rows of the same invocation."""

--- a/platform/api/tests/jobs/enricher/test_mapping.py
+++ b/platform/api/tests/jobs/enricher/test_mapping.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import time
+import uuid
 from datetime import datetime, timezone
 
 import pytest
@@ -146,3 +147,115 @@ def test_when_agent_name_is_absent_then_resource_service_name_is_used() -> None:
         semconv.SCOPE_AUDIT, make_span(attrs), {"service.name": "svc-agent"}
     )
     assert event.agent_name == "svc-agent"
+
+
+# --- run attribution: the SDK↔platform contract -----------------------------
+
+
+def test_map_span_carries_run_attribution() -> None:
+    run_id = str(uuid.uuid4())
+    attrs = decision_attrs(
+        **{
+            semconv.RUN_ID: run_id,
+            semconv.RUN_TOOL_CALLS: 3,
+            semconv.RUN_LLM_CALLS: 2,
+            semconv.RUN_DENIALS: 1,
+            semconv.RUN_TOTAL_TOKENS: 1200,
+            semconv.RUN_ELAPSED_MS: 4500,
+        }
+    )
+
+    event = map_span(semconv.SCOPE_AUDIT, make_span(attrs), {})
+
+    assert str(event.run_id) == run_id
+    assert event.run_tool_calls == 3
+    assert event.run_llm_calls == 2
+    assert event.run_denials == 1
+    assert event.run_total_tokens == 1200
+    assert event.run_elapsed_ms == 4500
+
+
+def test_when_run_attributes_are_absent_then_counters_default_to_zero() -> None:
+    """A span from an emitter that predates the run namespace still maps."""
+    event = map_span(semconv.SCOPE_AUDIT, make_span(decision_attrs()), {})
+
+    assert event.run_id is None
+    assert event.run_tool_calls == 0
+    assert event.run_elapsed_ms == 0
+
+
+def test_sdk_decision_span_validates_in_and_out_of_a_run_scope() -> None:
+    """The cross-package contract, asserted against the real SDK emitter.
+
+    The SDK's own suite can only check its idea of the wire shape; this is the
+    only place both halves meet. An attribute name the enricher does not read
+    is silently dropped, so a rename on either side has to fail here.
+
+    Out of a run scope the SDK omits ``RUN_ID`` entirely — OTLP cannot carry
+    null and ``DecisionEvent.run_id`` is ``UUID | None``, so an empty string
+    would fail validation and DLQ the whole record rather than its attribution.
+    """
+    from hexgate.audit import AuditEvent
+    from hexgate.security.decision import Decision, DecisionOutcome, RunAttribution
+
+    run_id = str(uuid.uuid4())
+    attributed = AuditEvent(
+        decision=Decision(
+            outcome=DecisionOutcome.DENY,
+            agent_name="example_agent",
+            tool_name="read_file",
+            run=RunAttribution(
+                run_id=run_id,
+                tool_calls=3,
+                llm_calls=2,
+                denials=1,
+                total_tokens=1200,
+                elapsed_ms=4500,
+            ),
+        )
+    ).span_attributes()
+    detached = AuditEvent(
+        decision=Decision(
+            outcome=DecisionOutcome.ALLOW,
+            agent_name="example_agent",
+            tool_name="read_file",
+        )
+    ).span_attributes()
+
+    in_run = map_span(semconv.SCOPE_AUDIT, make_span(attributed), {})
+    out_of_run = map_span(semconv.SCOPE_AUDIT, make_span(detached), {})
+
+    assert str(in_run.run_id) == run_id
+    assert in_run.run_tool_calls == 3
+    assert in_run.run_llm_calls == 2
+    assert in_run.run_denials == 1
+    assert in_run.run_total_tokens == 1200
+    assert in_run.run_elapsed_ms == 4500
+    assert out_of_run.run_id is None
+    assert out_of_run.run_tool_calls == 0
+
+
+def test_sdk_usage_span_validates_in_and_out_of_a_run_scope() -> None:
+    """Same contract for llm_invocation.run_id, which joins usage rows to the
+    policy_decision rows of the same invocation."""
+    from hexgate.tracing.usage import LlmUsageEvent
+
+    def _event(**overrides: object) -> LlmUsageEvent:
+        base = dict(
+            agent_name="a",
+            model="gpt-4o",
+            input_tokens=1,
+            output_tokens=1,
+            latency_ms=1,
+            status="success",
+        )
+        return LlmUsageEvent(**{**base, **overrides})
+
+    run_id = str(uuid.uuid4())
+    attributed = map_span(
+        semconv.SCOPE_USAGE, make_span(_event(run_id=run_id).span_attributes()), {}
+    )
+    detached = map_span(semconv.SCOPE_USAGE, make_span(_event().span_attributes()), {})
+
+    assert str(attributed.run_id) == run_id
+    assert detached.run_id is None

--- a/tests/audit/test_event.py
+++ b/tests/audit/test_event.py
@@ -391,14 +391,11 @@ def test_span_attributes_carry_run_attribution() -> None:
 
 
 def test_span_attributes_omit_run_id_never_send_an_empty_string() -> None:
-    """The regression guard for the whole feature's worst failure mode.
+    """The regression guard for this feature's worst failure mode.
 
-    ``DecisionEvent.run_id`` is ``UUID | None`` on the platform. Pydantic does
-    not coerce "" to a UUID, and a span the enricher cannot validate goes to
-    the DLQ — so an empty string would lose the entire audit record for every
-    decision made outside a run scope, which is precisely the population an
-    auditor most wants to see. OTLP attributes cannot carry null either, so the
-    absent attribute is the only way to say "no run".
+    "" is not a UUID, so the enricher DLQs the span — losing the entire record
+    for every decision made outside a run scope. OTLP cannot carry null, so
+    absence is the only way to say "no run".
     """
     wire = AuditEvent(decision=_decision()).span_attributes()
 
@@ -408,8 +405,7 @@ def test_span_attributes_omit_run_id_never_send_an_empty_string() -> None:
 
 
 def test_span_attributes_do_not_redact_or_truncate_run_fields() -> None:
-    """Bounded integers and a UUID from the SDK's own accumulator — not caller
-    data, so they pass through like the role fields do."""
+    """SDK counters, not caller data — they pass through like the role fields."""
     wire = AuditEvent(
         decision=_decision(run=_run(tool_calls=10**6, total_tokens=10**7))
     ).span_attributes()
@@ -419,13 +415,11 @@ def test_span_attributes_do_not_redact_or_truncate_run_fields() -> None:
 
 
 def test_span_attribute_key_set_is_the_wire_contract() -> None:
-    """Mirrors what the enricher decodes into DecisionEvent
-    (platform/api/hexgate_api/jobs/enricher/mapping.py).
+    """Mirrors what the enricher decodes, asserted as a set rather than field
+    by field.
 
-    Asserted as a set, not field by field: an attribute the enricher does not
-    know is silently dropped rather than rejected. A field added to Decision
-    without a mapping, or renamed on either side, has to fail here or it fails
-    nowhere.
+    An attribute the enricher does not read is dropped silently. A field added
+    without a mapping has to fail here or fail nowhere.
     """
     wire = AuditEvent(
         decision=_decision(run=_run(), arguments={"path": "x"}, attributes={"a": 1})
@@ -455,8 +449,7 @@ def test_span_attribute_key_set_is_the_wire_contract() -> None:
 
 
 def test_run_fields_are_otlp_attribute_values() -> None:
-    """The span emitter passes these straight to the OTel SDK, which drops any
-    attribute whose value is not a primitive — silently, inside the export."""
+    """The OTel SDK silently drops any attribute that is not a primitive."""
     wire = AuditEvent(decision=_decision(run=_run())).span_attributes()
 
     run_keys = {

--- a/tests/audit/test_event.py
+++ b/tests/audit/test_event.py
@@ -15,7 +15,7 @@ from hexgate.audit import (
     AuditEvent,
 )
 from hexgate.runtime import MAX_EVALUATED_ROLES
-from hexgate.security.decision import Decision, DecisionOutcome
+from hexgate.security.decision import Decision, DecisionOutcome, RunAttribution
 from hexgate.tracing import semconv
 
 
@@ -362,3 +362,109 @@ def test_a_full_role_set_goes_out_whole() -> None:
 
     assert wire[semconv.USER_ROLES] == list(roles)
     assert wire[semconv.DECIDING_ROLE] == roles[-1]
+
+
+# --- run attribution --------------------------------------------------------
+
+
+def _run(**overrides) -> RunAttribution:
+    base = dict(
+        run_id="9c2f1d3e-0000-4000-8000-000000000001",
+        tool_calls=3,
+        llm_calls=2,
+        denials=1,
+        total_tokens=1200,
+        elapsed_ms=4500,
+    )
+    return RunAttribution(**{**base, **overrides})
+
+
+def test_span_attributes_carry_run_attribution() -> None:
+    wire = AuditEvent(decision=_decision(run=_run())).span_attributes()
+
+    assert wire[semconv.RUN_ID] == "9c2f1d3e-0000-4000-8000-000000000001"
+    assert wire[semconv.RUN_TOOL_CALLS] == 3
+    assert wire[semconv.RUN_LLM_CALLS] == 2
+    assert wire[semconv.RUN_DENIALS] == 1
+    assert wire[semconv.RUN_TOTAL_TOKENS] == 1200
+    assert wire[semconv.RUN_ELAPSED_MS] == 4500
+
+
+def test_span_attributes_omit_run_id_never_send_an_empty_string() -> None:
+    """The regression guard for the whole feature's worst failure mode.
+
+    ``DecisionEvent.run_id`` is ``UUID | None`` on the platform. Pydantic does
+    not coerce "" to a UUID, and a span the enricher cannot validate goes to
+    the DLQ — so an empty string would lose the entire audit record for every
+    decision made outside a run scope, which is precisely the population an
+    auditor most wants to see. OTLP attributes cannot carry null either, so the
+    absent attribute is the only way to say "no run".
+    """
+    wire = AuditEvent(decision=_decision()).span_attributes()
+
+    assert semconv.RUN_ID not in wire
+    assert wire[semconv.RUN_TOOL_CALLS] == 0
+    assert wire[semconv.RUN_ELAPSED_MS] == 0
+
+
+def test_span_attributes_do_not_redact_or_truncate_run_fields() -> None:
+    """Bounded integers and a UUID from the SDK's own accumulator — not caller
+    data, so they pass through like the role fields do."""
+    wire = AuditEvent(
+        decision=_decision(run=_run(tool_calls=10**6, total_tokens=10**7))
+    ).span_attributes()
+
+    assert wire[semconv.RUN_TOOL_CALLS] == 10**6
+    assert wire[semconv.RUN_TOTAL_TOKENS] == 10**7
+
+
+def test_span_attribute_key_set_is_the_wire_contract() -> None:
+    """Mirrors what the enricher decodes into DecisionEvent
+    (platform/api/hexgate_api/jobs/enricher/mapping.py).
+
+    Asserted as a set, not field by field: an attribute the enricher does not
+    know is silently dropped rather than rejected. A field added to Decision
+    without a mapping, or renamed on either side, has to fail here or it fails
+    nowhere.
+    """
+    wire = AuditEvent(
+        decision=_decision(run=_run(), arguments={"path": "x"}, attributes={"a": 1})
+    ).span_attributes()
+
+    assert set(wire) == {
+        semconv.EVENT_ID,
+        semconv.AGENT_NAME,
+        semconv.TOOL_NAME,
+        semconv.OUTCOME,
+        semconv.USER_ROLES,
+        semconv.DECIDING_ROLE,
+        semconv.ERROR_TYPE,
+        semconv.REASON,
+        semconv.VIOLATIONS,
+        semconv.ARGUMENTS,
+        semconv.ATTRIBUTES,
+        semconv.USER_ID,
+        semconv.SESSION_ID,
+        semconv.RUN_ID,
+        semconv.RUN_TOOL_CALLS,
+        semconv.RUN_LLM_CALLS,
+        semconv.RUN_DENIALS,
+        semconv.RUN_TOTAL_TOKENS,
+        semconv.RUN_ELAPSED_MS,
+    }
+
+
+def test_run_fields_are_otlp_attribute_values() -> None:
+    """The span emitter passes these straight to the OTel SDK, which drops any
+    attribute whose value is not a primitive — silently, inside the export."""
+    wire = AuditEvent(decision=_decision(run=_run())).span_attributes()
+
+    run_keys = {
+        semconv.RUN_ID,
+        semconv.RUN_TOOL_CALLS,
+        semconv.RUN_LLM_CALLS,
+        semconv.RUN_DENIALS,
+        semconv.RUN_TOTAL_TOKENS,
+        semconv.RUN_ELAPSED_MS,
+    }
+    assert all(isinstance(wire[key], (str, int)) for key in run_keys)

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -191,6 +191,24 @@ def test_validate_reports_constraint_error_in_default_policy(
     assert "no recognised operator" in err
 
 
+def test_validate_reports_constraint_error_at_the_policy_level(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A policy-level constraint has no tool of its own, so it is reported
+    under ``<policy>`` — same friendly localization as ``<default>``, instead
+    of a raw schema ValidationError."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        "version: 1\nroles:\n  default:\n    constraints:\n      - args.amount ~~ 50\n",
+        encoding="utf-8",
+    )
+    rc = _main_validate(_ns(source=str(bad)))
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "default → <policy>" in err
+    assert "no recognised operator" in err
+
+
 def test_validate_catches_undefined_const_like_build(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -195,8 +195,7 @@ def test_validate_reports_constraint_error_at_the_policy_level(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A policy-level constraint has no tool of its own, so it is reported
-    under ``<policy>`` — same friendly localization as ``<default>``, instead
-    of a raw schema ValidationError."""
+    under ``<policy>`` rather than as a raw schema ValidationError."""
     bad = tmp_path / "bad.yaml"
     bad.write_text(
         "version: 1\nroles:\n  default:\n    constraints:\n      - args.amount ~~ 50\n",

--- a/tests/guards/test_runner.py
+++ b/tests/guards/test_runner.py
@@ -22,6 +22,7 @@ from hexgate.guards.types import (
     ToolOutcome,
     ToolPipeline,
 )
+from hexgate.runtime.run_facts import run_scope
 from hexgate.security.decision import DecisionOutcome
 from tests.guards.helpers import FakeEnforcer, RecordingInvoke, langchain_error
 
@@ -687,3 +688,70 @@ async def test_post_halt_records_both_the_allow_and_the_guard_denial() -> None:
     markers = [d.error_type for d in enf.recorded]
     assert DecisionOutcome.ALLOW in outcomes  # the tool genuinely ran
     assert "guard_denied" in markers  # and the halt is also on the trail
+
+
+# ---------------------------------------------------------------------------
+# Guard halts carry the run they happened in
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pre_halt_carries_the_enclosing_run_id() -> None:
+    """A halt and the call it interrupts must share a run_id.
+
+    ``_record_halt`` exists so a guard-blocked call leaves the same trail a
+    policy denial does. Stamping the run only in ``PolicyEnforcer.decide``
+    would break that: a per-run timeline would show the run's tool calls but
+    not the guard that stopped it — the one row that explains the ending.
+    """
+    enf, inv = FakeEnforcer(), RecordingInvoke()
+    pipe = _pipe(pre=[lambda call: Halt(reason="blocked")])
+
+    with run_scope("agent") as facts:
+        await _run(enf, pipe, {"x": 1}, invoke=inv)
+
+    assert enf.recorded[0].run.run_id == facts.id
+
+
+@pytest.mark.asyncio
+async def test_post_halt_counts_the_tool_that_already_ran() -> None:
+    """A post-guard halt withholds the result; the side effect happened, so the
+    call stays counted. Both recorded decisions belong to the same run."""
+    enf, inv = FakeEnforcer(), RecordingInvoke("val")
+    pipe = _pipe(post=[lambda call, out: Halt(reason="withheld")])
+
+    with run_scope("agent") as facts:
+        await _run(enf, pipe, {"x": 1}, invoke=inv)
+
+    halt = next(d for d in enf.recorded if d.error_type == "guard_denied")
+    assert halt.run.run_id == facts.id
+    assert halt.run.tool_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_halt_outside_a_run_scope_is_detached() -> None:
+    enf, inv = FakeEnforcer(), RecordingInvoke()
+    pipe = _pipe(pre=[lambda call: Halt(reason="blocked")])
+
+    await _run(enf, pipe, {"x": 1}, invoke=inv)
+
+    assert enf.recorded[0].run.run_id == ""
+
+
+def test_sync_halt_carries_the_enclosing_run_id() -> None:
+    """The sync path mirrors the async one; both build the same Decision."""
+    enf, inv = FakeEnforcer(), RecordingInvoke()
+    pipe = _pipe(pre=[lambda call: Halt(reason="blocked")])
+
+    with run_scope("agent") as facts:
+        run_guarded_sync(
+            "echo",
+            {"x": 1},
+            enforcer=enf,
+            pipeline=pipe,
+            approval_handler=None,
+            invoke=inv.sync,
+            render_error=langchain_error,
+        )
+
+    assert enf.recorded[0].run.run_id == facts.id

--- a/tests/guards/test_runner.py
+++ b/tests/guards/test_runner.py
@@ -697,13 +697,8 @@ async def test_post_halt_records_both_the_allow_and_the_guard_denial() -> None:
 
 @pytest.mark.asyncio
 async def test_pre_halt_carries_the_enclosing_run_id() -> None:
-    """A halt and the call it interrupts must share a run_id.
-
-    ``_record_halt`` exists so a guard-blocked call leaves the same trail a
-    policy denial does. Stamping the run only in ``PolicyEnforcer.decide``
-    would break that: a per-run timeline would show the run's tool calls but
-    not the guard that stopped it — the one row that explains the ending.
-    """
+    """A halt and the call it interrupts must share a run_id, or a per-run
+    timeline shows the tool calls but not the guard that stopped them."""
     enf, inv = FakeEnforcer(), RecordingInvoke()
     pipe = _pipe(pre=[lambda call: Halt(reason="blocked")])
 
@@ -715,8 +710,8 @@ async def test_pre_halt_carries_the_enclosing_run_id() -> None:
 
 @pytest.mark.asyncio
 async def test_post_halt_counts_the_tool_that_already_ran() -> None:
-    """A post-guard halt withholds the result; the side effect happened, so the
-    call stays counted. Both recorded decisions belong to the same run."""
+    """A post-guard halt withholds the result, but the side effect happened —
+    so the call stays counted."""
     enf, inv = FakeEnforcer(), RecordingInvoke("val")
     pipe = _pipe(post=[lambda call, out: Halt(reason="withheld")])
 
@@ -739,7 +734,7 @@ async def test_halt_outside_a_run_scope_is_detached() -> None:
 
 
 def test_sync_halt_carries_the_enclosing_run_id() -> None:
-    """The sync path mirrors the async one; both build the same Decision."""
+    """The sync path builds the same Decision as the async one."""
     enf, inv = FakeEnforcer(), RecordingInvoke()
     pipe = _pipe(pre=[lambda call: Halt(reason="blocked")])
 

--- a/tests/security/test_decision.py
+++ b/tests/security/test_decision.py
@@ -462,8 +462,13 @@ def test_combine_rejects_an_empty_role_list() -> None:
 
 # --- RunAttribution ---------------------------------------------------------
 #
-# The one place that knows the wire field names, the seconds→ms conversion, and
-# the ``""`` → ``None`` rule for run_id.
+# The one place that knows the wire field names, the seconds→ms conversion, the
+# ``""`` → ``None`` rule for run_id, and the counter clamp.
+
+# Spelled out rather than imported from either side: this is the contract the
+# SDK and the platform's ``DecisionEvent`` must agree on, so a drift on either
+# fails here.
+_WIRE_COUNTER_MAX = 2**32 - 1
 
 
 def _facts_with(tool_calls: int = 0, denials: int = 0, tokens: int = 0) -> RunFacts:
@@ -514,6 +519,42 @@ def test_run_attribution_of_detached_facts_reads_zeros_and_no_id() -> None:
         0,
         0,
     )
+
+
+def test_run_attribution_clamps_a_counter_over_the_wire_maximum() -> None:
+    """The platform validates each counter ``le=UINT32_MAX``. Counters are
+    monotone, so sending one over the top would not lose a single row — every
+    later decision for that run would be rejected too, DLQ-ing the tail of the
+    trail. A clamped counter keeps the run observable."""
+    run = RunAttribution.from_namespace(
+        {"id": "r", "total_tokens": _WIRE_COUNTER_MAX + 1}
+    )
+
+    assert run.total_tokens == _WIRE_COUNTER_MAX
+
+
+def test_run_attribution_clamps_elapsed_ms_over_the_wire_maximum() -> None:
+    """The arm a real run can reach: ~49.7 days of wall clock, not 4.29e9 tokens."""
+    run = RunAttribution.from_namespace({"id": "r", "elapsed_seconds": 1e9})
+
+    assert run.elapsed_ms == _WIRE_COUNTER_MAX
+
+
+def test_run_attribution_floors_a_negative_counter_at_zero() -> None:
+    """``ge=0`` is the other half of the platform's validation. Real facts are
+    monotonic-clock derived, but a caller-supplied namespace is not."""
+    run = RunAttribution.from_namespace({"id": "r", "elapsed_seconds": -5.0})
+
+    assert run.elapsed_ms == 0
+
+
+def test_run_attribution_leaves_an_in_range_counter_exact() -> None:
+    """Clamping is a ceiling, not a rounding — ordinary counters pass through."""
+    run = RunAttribution.from_namespace(
+        {"id": "r", "tool_calls": 12, "total_tokens": _WIRE_COUNTER_MAX}
+    )
+
+    assert (run.tool_calls, run.total_tokens) == (12, _WIRE_COUNTER_MAX)
 
 
 def test_run_attribution_omits_run_id_never_sends_an_empty_string() -> None:

--- a/tests/security/test_decision.py
+++ b/tests/security/test_decision.py
@@ -462,9 +462,8 @@ def test_combine_rejects_an_empty_role_list() -> None:
 
 # --- RunAttribution ---------------------------------------------------------
 #
-# The projection from the ``run.*`` namespace onto the six audit columns. It is
-# the only place that knows the wire field names, the seconds→milliseconds
-# conversion, and the ``""`` → ``None`` rule for run_id.
+# The one place that knows the wire field names, the seconds→ms conversion, and
+# the ``""`` → ``None`` rule for run_id.
 
 
 def _facts_with(tool_calls: int = 0, denials: int = 0, tokens: int = 0) -> RunFacts:
@@ -491,7 +490,7 @@ def test_run_attribution_projects_the_namespace() -> None:
 
 
 def test_run_attribution_converts_elapsed_seconds_to_truncated_milliseconds() -> None:
-    """The platform column is UInt32 milliseconds; the namespace is a float."""
+    """The column is UInt32 ms; the namespace is a float."""
     run = RunAttribution.from_namespace({"id": "r", "elapsed_seconds": 1.2345})
 
     assert run.elapsed_ms == 1234
@@ -503,7 +502,7 @@ def test_run_attribution_of_no_namespace_is_the_detached_singleton() -> None:
 
 
 def test_run_attribution_of_detached_facts_reads_zeros_and_no_id() -> None:
-    """A detached run is a value, not an absence — zeros and an empty id."""
+    """A detached run is a value, not an absence."""
     from hexgate.runtime.run_facts import DETACHED
 
     run = RunAttribution.from_namespace(DETACHED.as_namespace("read_file"))
@@ -518,17 +517,14 @@ def test_run_attribution_of_detached_facts_reads_zeros_and_no_id() -> None:
 
 
 def test_run_attribution_omits_run_id_never_sends_an_empty_string() -> None:
-    """The platform types run_id as ``UUID | None`` and rejects "". A rejected
-    span is DLQ'd, so an empty string would lose the whole audit record — not
-    just the attribution — for every decision made outside a run scope. OTLP
-    attributes cannot carry null, so absence is how "no run" travels."""
+    """The platform rejects "", so an empty string loses the whole record for
+    every decision made outside a run scope."""
     assert semconv.RUN_ID not in DETACHED_RUN.as_span_attributes()
 
 
 def test_run_attribution_attribute_names_match_the_wire_contract() -> None:
-    """Mirrors what the enricher decodes into DecisionEvent
-    (platform/api/hexgate_api/jobs/enricher/mapping.py). A rename on either
-    side is a silently ignored attribute rather than a rejection."""
+    """Mirrors what the enricher decodes. A rename on either side is a silently
+    ignored attribute rather than a rejection."""
     assert set(RunAttribution(run_id="run-9").as_span_attributes()) == {
         semconv.RUN_ID,
         semconv.RUN_TOOL_CALLS,
@@ -559,11 +555,8 @@ def test_from_verdict_carries_the_run_through() -> None:
 def test_error_payload_withholds_the_run_from_the_model() -> None:
     """A deliberate information-flow boundary, not an oversight.
 
-    The model may learn *that* a constraint tripped (the reason names it, so
-    ``run.tool_calls < 20`` reaches it verbatim), but never the counter's
-    current value — how close it is to its budget. Surfacing budget pressure to
-    an agent is its own design decision; shipping it accidentally here would
-    foreclose making it deliberately.
+    The model may learn *that* a constraint tripped — the reason names it —
+    but never the counter's value, i.e. how close it is to its budget.
     """
     decision = Decision(
         outcome=DecisionOutcome.DENY,

--- a/tests/security/test_decision.py
+++ b/tests/security/test_decision.py
@@ -12,12 +12,16 @@ from collections.abc import Callable
 import pytest
 
 from hexgate.security.decision import (
+    DETACHED_RUN,
     Decision,
     DecisionOutcome,
+    RunAttribution,
     Verdict,
     combine_role_verdicts,
 )
 from hexgate.runtime.roles import MAX_EVALUATED_ROLES
+from hexgate.runtime.run_facts import RunFacts
+from hexgate.tracing import semconv
 
 
 def _deny_decision() -> Decision:
@@ -454,3 +458,124 @@ def test_combine_rejects_an_empty_role_list() -> None:
 
     with pytest.raises(ValueError, match="at least one role"):
         combine_role_verdicts([], evaluate)
+
+
+# --- RunAttribution ---------------------------------------------------------
+#
+# The projection from the ``run.*`` namespace onto the six audit columns. It is
+# the only place that knows the wire field names, the seconds→milliseconds
+# conversion, and the ``""`` → ``None`` rule for run_id.
+
+
+def _facts_with(tool_calls: int = 0, denials: int = 0, tokens: int = 0) -> RunFacts:
+    facts = RunFacts(id="run-1", agent="agent-1")
+    for _ in range(tool_calls):
+        facts.record_execution("read_file")
+    for _ in range(denials):
+        facts.record_denial()
+    if tokens:
+        facts.record_llm_usage(tokens, 0)
+    return facts
+
+
+def test_run_attribution_projects_the_namespace() -> None:
+    facts = _facts_with(tool_calls=2, denials=1, tokens=7)
+
+    run = RunAttribution.from_namespace(facts.as_namespace("read_file"))
+
+    assert run.run_id == "run-1"
+    assert run.tool_calls == 2
+    assert run.denials == 1
+    assert run.llm_calls == 1
+    assert run.total_tokens == 7
+
+
+def test_run_attribution_converts_elapsed_seconds_to_truncated_milliseconds() -> None:
+    """The platform column is UInt32 milliseconds; the namespace is a float."""
+    run = RunAttribution.from_namespace({"id": "r", "elapsed_seconds": 1.2345})
+
+    assert run.elapsed_ms == 1234
+
+
+def test_run_attribution_of_no_namespace_is_the_detached_singleton() -> None:
+    assert RunAttribution.from_namespace(None) is DETACHED_RUN
+    assert RunAttribution.from_namespace({}) is DETACHED_RUN
+
+
+def test_run_attribution_of_detached_facts_reads_zeros_and_no_id() -> None:
+    """A detached run is a value, not an absence — zeros and an empty id."""
+    from hexgate.runtime.run_facts import DETACHED
+
+    run = RunAttribution.from_namespace(DETACHED.as_namespace("read_file"))
+
+    assert run.run_id == ""
+    assert (run.tool_calls, run.denials, run.total_tokens, run.elapsed_ms) == (
+        0,
+        0,
+        0,
+        0,
+    )
+
+
+def test_run_attribution_omits_run_id_never_sends_an_empty_string() -> None:
+    """The platform types run_id as ``UUID | None`` and rejects "". A rejected
+    span is DLQ'd, so an empty string would lose the whole audit record — not
+    just the attribution — for every decision made outside a run scope. OTLP
+    attributes cannot carry null, so absence is how "no run" travels."""
+    assert semconv.RUN_ID not in DETACHED_RUN.as_span_attributes()
+
+
+def test_run_attribution_attribute_names_match_the_wire_contract() -> None:
+    """Mirrors what the enricher decodes into DecisionEvent
+    (platform/api/hexgate_api/jobs/enricher/mapping.py). A rename on either
+    side is a silently ignored attribute rather than a rejection."""
+    assert set(RunAttribution(run_id="run-9").as_span_attributes()) == {
+        semconv.RUN_ID,
+        semconv.RUN_TOOL_CALLS,
+        semconv.RUN_LLM_CALLS,
+        semconv.RUN_DENIALS,
+        semconv.RUN_TOTAL_TOKENS,
+        semconv.RUN_ELAPSED_MS,
+    }
+
+
+def test_decision_defaults_to_the_detached_run() -> None:
+    assert _deny_decision().run is DETACHED_RUN
+
+
+def test_from_verdict_carries_the_run_through() -> None:
+    run = RunAttribution(run_id="run-9", tool_calls=3)
+
+    decision = Decision.from_verdict(
+        Verdict(outcome=DecisionOutcome.ALLOW),
+        agent_name="a",
+        tool_name="t",
+        run=run,
+    )
+
+    assert decision.run is run
+
+
+def test_error_payload_withholds_the_run_from_the_model() -> None:
+    """A deliberate information-flow boundary, not an oversight.
+
+    The model may learn *that* a constraint tripped (the reason names it, so
+    ``run.tool_calls < 20`` reaches it verbatim), but never the counter's
+    current value — how close it is to its budget. Surfacing budget pressure to
+    an agent is its own design decision; shipping it accidentally here would
+    foreclose making it deliberately.
+    """
+    decision = Decision(
+        outcome=DecisionOutcome.DENY,
+        agent_name="a",
+        tool_name="read_file",
+        reason="constraint failed — run.tool_calls < 20",
+        run=RunAttribution(run_id="run-secret", tool_calls=19, total_tokens=4321),
+    )
+
+    payload = decision.as_error_payload()
+
+    assert not [key for key in payload if key.startswith("run")]
+    rendered = repr(payload) + decision.as_error_message()
+    assert "run-secret" not in rendered
+    assert "4321" not in rendered

--- a/tests/security/test_enforcer_audit.py
+++ b/tests/security/test_enforcer_audit.py
@@ -210,13 +210,13 @@ def test_decide_outside_a_run_scope_is_detached() -> None:
     enforcer.decide("read_file", {})
 
     # Value-equal, not the singleton: DETACHED still projects a populated
-    # all-zero namespace, so from_namespace builds a fresh equal instance.
+    # all-zero namespace.
     assert sender.events[0].decision.run == DETACHED_RUN
     assert semconv.RUN_ID not in sender.events[0].span_attributes()
 
 
 def test_two_invocations_stamp_two_distinct_run_ids() -> None:
-    """Catches a scope opened once at construction instead of per invocation."""
+    """Catches a scope opened once at construction, not per invocation."""
     sender = _CapturingSender()
     enforcer = PolicyEnforcer(_StubEngine(), agent_name="r", audit_sender=sender)
 
@@ -229,12 +229,8 @@ def test_two_invocations_stamp_two_distinct_run_ids() -> None:
 
 
 def test_stamped_counters_are_the_ones_the_verdict_saw() -> None:
-    """One read per decide(), shared by the fold and the record.
-
-    A second get_run_facts() read for the audit stamp would let the row claim a
-    counter value no role ever evaluated against — the record and the decision
-    disagreeing about the same call.
-    """
+    """One read per decide(), shared by the fold and the record: a second read
+    would let the row claim a value no role evaluated against."""
     sender = _CapturingSender()
     seen: list[Mapping[str, Any] | None] = []
 

--- a/tests/security/test_enforcer_audit.py
+++ b/tests/security/test_enforcer_audit.py
@@ -10,7 +10,8 @@ import pytest
 from hexgate.audit import AuditEvent
 from hexgate.tracing import _senders, semconv
 from hexgate.runtime.context import HexgateContext
-from hexgate.security.decision import DecisionOutcome, Verdict
+from hexgate.runtime.run_facts import run_scope
+from hexgate.security.decision import DETACHED_RUN, DecisionOutcome, Verdict
 from hexgate.security.enforcer import PolicyEnforcer
 
 
@@ -186,3 +187,67 @@ async def test_audited_deny_records_no_deciding_role() -> None:
     wire = sender.events[0].span_attributes()
     assert wire[semconv.DECIDING_ROLE] == ""
     assert wire[semconv.USER_ROLES] == ["support", "billing"]
+
+
+# --- run attribution --------------------------------------------------------
+
+
+def test_decide_stamps_the_enclosing_run_on_the_audit_event() -> None:
+    sender = _CapturingSender()
+    enforcer = PolicyEnforcer(_StubEngine(), agent_name="r", audit_sender=sender)
+
+    with run_scope("r") as facts:
+        enforcer.decide("read_file", {})
+
+    assert sender.events[0].decision.run.run_id == facts.id
+    assert sender.events[0].span_attributes()[semconv.RUN_ID] == facts.id
+
+
+def test_decide_outside_a_run_scope_is_detached() -> None:
+    sender = _CapturingSender()
+    enforcer = PolicyEnforcer(_StubEngine(), agent_name="r", audit_sender=sender)
+
+    enforcer.decide("read_file", {})
+
+    # Value-equal, not the singleton: DETACHED still projects a populated
+    # all-zero namespace, so from_namespace builds a fresh equal instance.
+    assert sender.events[0].decision.run == DETACHED_RUN
+    assert semconv.RUN_ID not in sender.events[0].span_attributes()
+
+
+def test_two_invocations_stamp_two_distinct_run_ids() -> None:
+    """Catches a scope opened once at construction instead of per invocation."""
+    sender = _CapturingSender()
+    enforcer = PolicyEnforcer(_StubEngine(), agent_name="r", audit_sender=sender)
+
+    for _ in range(2):
+        with run_scope("r"):
+            enforcer.decide("read_file", {})
+
+    first, second = (event.decision.run.run_id for event in sender.events)
+    assert first and second and first != second
+
+
+def test_stamped_counters_are_the_ones_the_verdict_saw() -> None:
+    """One read per decide(), shared by the fold and the record.
+
+    A second get_run_facts() read for the audit stamp would let the row claim a
+    counter value no role ever evaluated against — the record and the decision
+    disagreeing about the same call.
+    """
+    sender = _CapturingSender()
+    seen: list[Mapping[str, Any] | None] = []
+
+    class _RecordingEngine(_StubEngine):
+        def evaluate(self, *, run: Mapping[str, Any] | None = None, **kwargs: Any):
+            seen.append(run)
+            return super().evaluate(run=run, **kwargs)
+
+    enforcer = PolicyEnforcer(_RecordingEngine(), agent_name="r", audit_sender=sender)
+
+    with run_scope("r") as facts:
+        facts.record_execution("read_file")
+        facts.record_execution("read_file")
+        enforcer.decide("read_file", {})
+
+    assert seen[0]["tool_calls"] == sender.events[0].decision.run.tool_calls == 2

--- a/tests/security/test_engine_parity.py
+++ b/tests/security/test_engine_parity.py
@@ -1043,3 +1043,82 @@ def test_policy_level_constraint_reaches_admission_parity(
     policy: dict, tool: str, args: dict, expect: str
 ) -> None:
     _assert_parity(policy, None, tool, args, expect)
+
+
+# ---------------------------------------------------------------------------
+# Policy-level constraints meet declared reach
+#
+# The same fail-closed interaction as admission above, on the reach keys
+# ``agents:`` lowers to (``agent.handoff:<target>`` / ``agent.tool:<target>``,
+# added by the reach/admission runtime seams). The reach gate passes only
+# ``{agent, target, via}``, so a tool-shaped ``args.*`` predicate reads a
+# missing ref there too. Pinned separately because exempting ``agent.run`` by
+# name — the escape hatch the admission case documents — does *not* cover
+# these; a prefix test over the whole reserved namespace does.
+# ---------------------------------------------------------------------------
+
+_REACH_POLICY = {
+    "version": 1,
+    "roles": {
+        "default": {
+            "constraints": ["args.amount <= 500"],
+            "admission": {"mode": "allow"},
+            "agents": {"billing": {"via": ["handoff", "tool"], "mode": "allow"}},
+            "tools": {"refund": {"mode": "allow"}},
+        },
+    },
+}
+
+_REACH_NAMED_POLICY = {
+    "version": 1,
+    "roles": {
+        "default": {
+            "constraints": ['tool == "agent.run" or args.amount <= 500'],
+            "admission": {"mode": "allow"},
+            "agents": {"billing": {"via": ["handoff", "tool"], "mode": "allow"}},
+            "tools": {"refund": {"mode": "allow"}},
+        },
+    },
+}
+
+_REACH_SCOPED_POLICY = {
+    "version": 1,
+    "roles": {
+        "default": {
+            "constraints": ['startswith(tool, "agent.") or args.amount <= 500'],
+            "admission": {"mode": "allow"},
+            "agents": {"billing": {"via": ["handoff", "tool"], "mode": "allow"}},
+            "tools": {"refund": {"mode": "allow"}},
+        },
+    },
+}
+
+_HANDOFF_ARGS = {"agent": "svc", "target": "billing", "via": "handoff"}
+_TOOL_REACH_ARGS = {"agent": "svc", "target": "billing", "via": "tool"}
+
+
+@pytest.mark.parametrize(
+    ("policy", "tool", "args", "expect"),
+    [
+        # The trap, on both reach modes: neither gate carries an `amount`.
+        (_REACH_POLICY, "agent.handoff:billing", _HANDOFF_ARGS, "deny"),
+        (_REACH_POLICY, "agent.tool:billing", _TOOL_REACH_ARGS, "deny"),
+        (_REACH_POLICY, "refund", {"amount": 10}, "allow"),
+        # Exempting agent.run by name frees admission but leaves both reach
+        # keys denied — the reason the prefix form is the documented fix.
+        (_REACH_NAMED_POLICY, "agent.run", {"agent": "svc"}, "allow"),
+        (_REACH_NAMED_POLICY, "agent.handoff:billing", _HANDOFF_ARGS, "deny"),
+        (_REACH_NAMED_POLICY, "agent.tool:billing", _TOOL_REACH_ARGS, "deny"),
+        # The prefix form covers the whole reserved namespace at once.
+        (_REACH_SCOPED_POLICY, "agent.run", {"agent": "svc"}, "allow"),
+        (_REACH_SCOPED_POLICY, "agent.handoff:billing", _HANDOFF_ARGS, "allow"),
+        (_REACH_SCOPED_POLICY, "agent.tool:billing", _TOOL_REACH_ARGS, "allow"),
+        # ...and still fences the tools it was written for.
+        (_REACH_SCOPED_POLICY, "refund", {"amount": 10}, "allow"),
+        (_REACH_SCOPED_POLICY, "refund", {"amount": 999}, "deny"),
+    ],
+)
+def test_policy_level_constraint_reaches_reach_keys_parity(
+    policy: dict, tool: str, args: dict, expect: str
+) -> None:
+    _assert_parity(policy, None, tool, args, expect)

--- a/tests/security/test_engine_parity.py
+++ b/tests/security/test_engine_parity.py
@@ -932,11 +932,9 @@ def test_run_none_namespace_fails_closed_both_engines() -> None:
 # ---------------------------------------------------------------------------
 # Policy-level constraints — applied to every tool, on both engines
 #
-# The drift risk is structural: the pydantic engine prepends them to whatever
-# get_tool_policy resolved, which is one code path for every tool key. The Rego
-# compiler emits a rule *per* tool key from three separate call sites, and the
-# easiest one to forget is the synthetic agent.run admission rule, whose policy
-# comes from a fallback constant rather than the document.
+# The drift risk is structural: pydantic has one code path for every tool key,
+# while the Rego compiler emits a rule per key from three call sites. The
+# easiest to forget is agent.run, whose policy comes from a fallback constant.
 # ---------------------------------------------------------------------------
 
 _POLICY_LEVEL_POLICY = {
@@ -986,6 +984,6 @@ _POLICY_LEVEL_POLICY = {
 def test_policy_level_constraint_parity(
     tool: str, args: dict, run: dict, expect: str
 ) -> None:
-    """The constraint is inherited from a mixin, so this also covers the union
-    merge reaching the Rego compiler through the resolved PolicySet."""
+    """Inherited from a mixin, so this also covers the union merge reaching the
+    Rego compiler through the resolved PolicySet."""
     _assert_parity(_POLICY_LEVEL_POLICY, None, tool, args, expect, run=run)

--- a/tests/security/test_engine_parity.py
+++ b/tests/security/test_engine_parity.py
@@ -927,3 +927,65 @@ def test_run_fact_parity(tool: str, run: dict, expect: str) -> None:
 
 def test_run_none_namespace_fails_closed_both_engines() -> None:
     _assert_parity(_RUN_POLICY, "default", "identity", {}, "deny", run=None)
+
+
+# ---------------------------------------------------------------------------
+# Policy-level constraints — applied to every tool, on both engines
+#
+# The drift risk is structural: the pydantic engine prepends them to whatever
+# get_tool_policy resolved, which is one code path for every tool key. The Rego
+# compiler emits a rule *per* tool key from three separate call sites, and the
+# easiest one to forget is the synthetic agent.run admission rule, whose policy
+# comes from a fallback constant rather than the document.
+# ---------------------------------------------------------------------------
+
+_POLICY_LEVEL_POLICY = {
+    "roles": {
+        "read_only": {
+            "is_mixin": True,
+            "constraints": ["run.tool_calls < 3"],
+        },
+        "default": {
+            "inherits": ["read_only"],
+            "default_policy": {"mode": "allow"},
+            "tools": {
+                "listed": {"mode": "allow"},
+                "capped": {"mode": "allow", "constraints": ["args.amount <= 50"]},
+                "forbidden": {"mode": "deny"},
+            },
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    ("tool", "args", "run", "expect"),
+    [
+        # A listed tool, under and over the policy-level cap.
+        ("listed", {}, {"tool_calls": 1}, "allow"),
+        ("listed", {}, {"tool_calls": 5}, "deny"),
+        # A tool falling through to default_policy.
+        ("unlisted", {}, {"tool_calls": 1}, "allow"),
+        ("unlisted", {}, {"tool_calls": 5}, "deny"),
+        # Admission is closed-world on both engines: unlisted denies whether or
+        # not the policy-level cap is satisfied.
+        ("agent.run", {}, {"tool_calls": 1}, "deny"),
+        ("agent.run", {}, {"tool_calls": 5}, "deny"),
+        # Both lists apply, in either failing direction.
+        ("capped", {"amount": 10}, {"tool_calls": 1}, "allow"),
+        ("capped", {"amount": 999}, {"tool_calls": 1}, "deny"),
+        ("capped", {"amount": 10}, {"tool_calls": 5}, "deny"),
+        # Can only narrow: a satisfied policy-level constraint never
+        # resurrects a denied tool or an unlisted reach key.
+        ("forbidden", {}, {"tool_calls": 0}, "deny"),
+        ("agent.handoff:other", {}, {"tool_calls": 0}, "deny"),
+        # Missing namespace fails closed on both.
+        ("listed", {}, {}, "deny"),
+    ],
+)
+def test_policy_level_constraint_parity(
+    tool: str, args: dict, run: dict, expect: str
+) -> None:
+    """The constraint is inherited from a mixin, so this also covers the union
+    merge reaching the Rego compiler through the resolved PolicySet."""
+    _assert_parity(_POLICY_LEVEL_POLICY, None, tool, args, expect, run=run)

--- a/tests/security/test_engine_parity.py
+++ b/tests/security/test_engine_parity.py
@@ -987,3 +987,59 @@ def test_policy_level_constraint_parity(
     """Inherited from a mixin, so this also covers the union merge reaching the
     Rego compiler through the resolved PolicySet."""
     _assert_parity(_POLICY_LEVEL_POLICY, None, tool, args, expect, run=run)
+
+
+# ---------------------------------------------------------------------------
+# Policy-level constraints meet declared admission
+#
+# ``agent.run`` is an effective tool like any other once ``admission:`` is
+# declared, so a policy-level constraint gates the agent at ingress. The gate
+# passes only ``{"agent": <name>}``, so an ``args.*`` predicate written for
+# tools reads a missing ref and fails closed — the agent is refused before it
+# starts. Documented in constraints.mdx ("Policy-level `args.*` reaches
+# admission"), pinned here on both engines because the fix for it is an
+# authoring escape hatch, not a code path.
+# ---------------------------------------------------------------------------
+
+_ADMITTED_POLICY = {
+    "version": 1,
+    "roles": {
+        "default": {
+            "constraints": ["args.amount <= 500"],
+            "admission": {"mode": "allow"},
+            "tools": {"refund": {"mode": "allow"}},
+        },
+    },
+}
+
+_ADMITTED_SCOPED_POLICY = {
+    "version": 1,
+    "roles": {
+        "default": {
+            "constraints": ['tool == "agent.run" or args.amount <= 500'],
+            "admission": {"mode": "allow"},
+            "tools": {"refund": {"mode": "allow"}},
+        },
+    },
+}
+
+
+@pytest.mark.parametrize(
+    ("policy", "tool", "args", "expect"),
+    [
+        # The trap: admission carries no `amount`, so the tool-shaped cap
+        # locks the agent out at ingress on both engines.
+        (_ADMITTED_POLICY, "agent.run", {"agent": "billing"}, "deny"),
+        # Not admission-specific — any tool missing the argument is denied.
+        (_ADMITTED_POLICY, "refund", {}, "deny"),
+        (_ADMITTED_POLICY, "refund", {"amount": 10}, "allow"),
+        # The documented escape hatch: exempt the admission key by name.
+        (_ADMITTED_SCOPED_POLICY, "agent.run", {"agent": "billing"}, "allow"),
+        (_ADMITTED_SCOPED_POLICY, "refund", {"amount": 10}, "allow"),
+        (_ADMITTED_SCOPED_POLICY, "refund", {"amount": 999}, "deny"),
+    ],
+)
+def test_policy_level_constraint_reaches_admission_parity(
+    policy: dict, tool: str, args: dict, expect: str
+) -> None:
+    _assert_parity(policy, None, tool, args, expect)

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -395,6 +395,24 @@ def test_capability_agents_deny_is_a_link_error() -> None:
         link([], [cap])
 
 
+def test_link_rejects_policy_level_constraints_in_module() -> None:
+    """The fold composes ``.tools`` only, so a role-wide fence authored in a
+    module would be silently dropped — fail-open. ``_MODULE_COMPOSABLE_FIELDS``
+    rejects it automatically, which is the point of the allowlist: a field
+    added to AgentPolicy fails closed until composition learns it. Pinned here
+    so nobody adds ``constraints`` to that set without teaching ``link()`` to
+    fold it (and deciding which layer may set a role-wide fence)."""
+    mod = ModuleContent(
+        name="d",
+        kind="boundary",
+        policy=AgentPolicy(constraints=["run.tool_calls < 5"]),
+        source="d.yaml",
+        content_hash="hash-d",
+    )
+    with pytest.raises(LinkError, match=r"\['constraints'\]"):
+        link([mod], [])
+
+
 # --- provenance + policy-set wiring ---
 
 

--- a/tests/security/test_linker.py
+++ b/tests/security/test_linker.py
@@ -396,12 +396,10 @@ def test_capability_agents_deny_is_a_link_error() -> None:
 
 
 def test_link_rejects_policy_level_constraints_in_module() -> None:
-    """The fold composes ``.tools`` only, so a role-wide fence authored in a
-    module would be silently dropped — fail-open. ``_MODULE_COMPOSABLE_FIELDS``
-    rejects it automatically, which is the point of the allowlist: a field
-    added to AgentPolicy fails closed until composition learns it. Pinned here
-    so nobody adds ``constraints`` to that set without teaching ``link()`` to
-    fold it (and deciding which layer may set a role-wide fence)."""
+    """The fold composes ``.tools`` only, so a role-wide fence in a module would
+    be silently dropped. ``_MODULE_COMPOSABLE_FIELDS`` rejects it for free;
+    pinned so nobody adds it to that set without teaching ``link()`` to fold
+    it."""
     mod = ModuleContent(
         name="d",
         kind="boundary",

--- a/tests/security/test_models.py
+++ b/tests/security/test_models.py
@@ -71,15 +71,14 @@ def test_valid_full_policy_document() -> None:
 
 
 def test_policy_level_constraints_are_grammar_checked_at_load() -> None:
-    """The same rule as a tool's list, via the shared ``_parse_all`` helper —
-    duplicating the check would let the two drift."""
+    """Same rule as a tool's list, via the shared ``_parse_all`` helper."""
     with pytest.raises(ValidationError):
         AgentPolicy(constraints=["args.amount =< 500"])
 
 
 def test_policy_level_constraints_default_to_empty_and_unset() -> None:
-    """``model_fields_set`` is what ``linker._reject_unsupported_module_fields``
-    keys on, so an unset field must not register as authored."""
+    """``linker._reject_unsupported_module_fields`` keys on
+    ``model_fields_set``, so an unset field must not register as authored."""
     policy = AgentPolicy()
 
     assert policy.constraints == []
@@ -87,8 +86,8 @@ def test_policy_level_constraints_default_to_empty_and_unset() -> None:
 
 
 def test_policy_level_constraints_are_not_folded_into_effective_tools() -> None:
-    """``effective_tools`` is what ``get_tool_policy`` returns; folding a
-    role-wide list into a tool's own would make that return value a lie."""
+    """``get_tool_policy`` returns ``effective_tools``; folding a role-wide list
+    into a tool's own would make that return value a lie."""
     policy = AgentPolicy(
         constraints=["run.tool_calls < 3"],
         tools={"read_file": BaseToolPolicy(mode="allow")},

--- a/tests/security/test_models.py
+++ b/tests/security/test_models.py
@@ -65,3 +65,33 @@ def test_valid_full_policy_document() -> None:
         }
     )
     assert policy.tools["refund_order"].constraints[0] == "args.amount <= 500"
+
+
+# --- policy-level constraints ----------------------------------------------
+
+
+def test_policy_level_constraints_are_grammar_checked_at_load() -> None:
+    """The same rule as a tool's list, via the shared ``_parse_all`` helper —
+    duplicating the check would let the two drift."""
+    with pytest.raises(ValidationError):
+        AgentPolicy(constraints=["args.amount =< 500"])
+
+
+def test_policy_level_constraints_default_to_empty_and_unset() -> None:
+    """``model_fields_set`` is what ``linker._reject_unsupported_module_fields``
+    keys on, so an unset field must not register as authored."""
+    policy = AgentPolicy()
+
+    assert policy.constraints == []
+    assert "constraints" not in policy.model_fields_set
+
+
+def test_policy_level_constraints_are_not_folded_into_effective_tools() -> None:
+    """``effective_tools`` is what ``get_tool_policy`` returns; folding a
+    role-wide list into a tool's own would make that return value a lie."""
+    policy = AgentPolicy(
+        constraints=["run.tool_calls < 3"],
+        tools={"read_file": BaseToolPolicy(mode="allow")},
+    )
+
+    assert policy.effective_tools["read_file"].constraints == []

--- a/tests/security/test_policy_level_constraints.py
+++ b/tests/security/test_policy_level_constraints.py
@@ -1,14 +1,8 @@
 """Policy-level ``constraints:`` — the list that applies to every tool.
 
-``default_policy.constraints`` only reaches tools that fall *through* to the
-default, so a run-wide circuit breaker on a role that lists ten tools would
-have to be repeated ten times. This field is written once and applies
-everywhere, which makes three properties load-bearing and each is pinned here:
-
-  * it reaches every tool key, including the synthetic ``agent.run``;
-  * it can only *narrow* — a denied tool stays denied, never resurrected;
-  * it unions across ``inherits`` instead of overriding, so a child cannot
-    silently drop a mixin's fence.
+Three properties are load-bearing, one section each: it reaches every tool key
+including the synthetic ``agent.run``; it can only *narrow*; and it unions
+across ``inherits`` rather than overriding.
 """
 
 from __future__ import annotations
@@ -66,8 +60,7 @@ def test_deny_reason_names_the_policy_level_constraint() -> None:
 
 
 def test_evaluated_before_the_tools_own_constraints() -> None:
-    """Order decides only which violation is reported first; a run-budget
-    denial reads better than an argument one."""
+    """Order decides only which violation is reported first."""
     policy = _policy(
         tools={"refund": {"mode": "allow", "constraints": ["args.amount <= 50"]}}
     )
@@ -97,14 +90,12 @@ def test_the_tools_own_constraints_still_apply() -> None:
 
 
 def test_never_resurrects_a_denied_tool() -> None:
-    """``mode: deny`` short-circuits before constraints, so a satisfied
-    policy-level constraint cannot turn a deny into an allow."""
+    """``mode: deny`` short-circuits before constraints."""
     assert _outcome(_policy(), "delete_all", tool_calls=0) == "deny"
 
 
 def test_never_resurrects_an_unlisted_reach_key() -> None:
-    """Reach keys are closed-world: a permissive default (and now a satisfied
-    policy-level constraint) must not grant an unlisted handoff."""
+    """Reach keys are closed-world — nothing here may grant an unlisted one."""
     assert _outcome(_policy(), "agent.handoff:billing", tool_calls=0) == "deny"
 
 
@@ -124,8 +115,8 @@ def _resolved(policy_map: dict[str, dict], role: str) -> AgentPolicy:
 
 
 def test_unions_across_inherits_rather_than_overriding() -> None:
-    """Trap 2. Override would let ``inherits: [read_only]`` silently *remove*
-    the mixin's cap — fail-open on a security restriction."""
+    """Override would let ``inherits: [read_only]`` silently remove the mixin's
+    cap — fail-open on a security restriction."""
     resolved = _resolved(
         {
             "read_only": {"is_mixin": True, "constraints": ["run.tool_calls < 50"]},
@@ -142,12 +133,9 @@ def test_unions_across_inherits_rather_than_overriding() -> None:
 
 
 def test_an_inherited_constraint_actually_denies() -> None:
-    """Trap 1, asserted by *evaluating* rather than by inspecting the field.
-
-    ``_resolve_inheritance`` builds its return value by naming fields, so a
-    field left out is dropped for every role using ``inherits:`` — and a
-    dropped constraint is fail-open. A field-equality assertion alone would
-    also pass against a merge that built the list but never applied it.
+    """``_resolve_inheritance`` names its fields, so one left out is dropped for
+    every role using ``inherits:`` — fail-open. Asserted by *evaluating*: a
+    field check alone would pass a merge that built the list but never used it.
     """
     resolved = _resolved(
         {
@@ -169,8 +157,7 @@ def test_an_inherited_constraint_actually_denies() -> None:
 
 
 def test_deduplicated_on_a_diamond() -> None:
-    """A predicate inherited by two paths is evaluated once, and named once in
-    a deny reason."""
+    """A predicate inherited by two paths is evaluated once."""
     resolved = _resolved(
         {
             "base": {"is_mixin": True, "constraints": ["run.tool_calls < 50"]},
@@ -188,8 +175,7 @@ def test_deduplicated_on_a_diamond() -> None:
 
 
 def test_a_role_without_inherits_is_untouched() -> None:
-    """The no-inherits early return skips the merge entirely, so it is a
-    separate path from the union above."""
+    """The no-inherits early return skips the merge — a separate path."""
     resolved = _resolved(
         {"default": {"constraints": ["run.tool_calls < 3"]}}, "default"
     )

--- a/tests/security/test_policy_level_constraints.py
+++ b/tests/security/test_policy_level_constraints.py
@@ -1,0 +1,233 @@
+"""Policy-level ``constraints:`` — the list that applies to every tool.
+
+``default_policy.constraints`` only reaches tools that fall *through* to the
+default, so a run-wide circuit breaker on a role that lists ten tools would
+have to be repeated ten times. This field is written once and applies
+everywhere, which makes three properties load-bearing and each is pinned here:
+
+  * it reaches every tool key, including the synthetic ``agent.run``;
+  * it can only *narrow* — a denied tool stays denied, never resurrected;
+  * it unions across ``inherits`` instead of overriding, so a child cannot
+    silently drop a mixin's fence.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hexgate.security.models import AgentPolicy
+from hexgate.security.policy import evaluate_tool_call
+from hexgate.security.policy_set import PolicySetError, load_policy_map
+
+
+def _policy(**overrides) -> AgentPolicy:
+    base = {
+        "constraints": ["run.tool_calls < 3"],
+        "default_policy": {"mode": "allow"},
+        "tools": {
+            "read_file": {"mode": "allow"},
+            "delete_all": {"mode": "deny"},
+        },
+    }
+    return AgentPolicy.model_validate({**base, **overrides})
+
+
+def _outcome(policy: AgentPolicy, tool: str, tool_calls: int) -> str:
+    return evaluate_tool_call(
+        policy, tool, {}, run={"tool_calls": tool_calls}
+    ).outcome.value
+
+
+# --- reach ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool", ["read_file", "not_listed_anywhere"])
+def test_applies_to_every_reachable_tool(tool: str) -> None:
+    """A listed tool and a tool falling through to ``default_policy`` — the
+    two _gated_rules call sites, and the fall-through one is the easy miss."""
+    policy = _policy()
+
+    assert _outcome(policy, tool, tool_calls=1) == "allow"
+    assert _outcome(policy, tool, tool_calls=5) == "deny"
+
+
+def test_cannot_admit_an_unlisted_agent_run() -> None:
+    """Agent keys are closed-world: a satisfied policy-level constraint cannot
+    resurrect admission the document never granted."""
+    policy = _policy()
+
+    assert _outcome(policy, "agent.run", tool_calls=1) == "deny"
+
+
+def test_deny_reason_names_the_policy_level_constraint() -> None:
+    verdict = evaluate_tool_call(_policy(), "read_file", {}, run={"tool_calls": 5})
+
+    assert "run.tool_calls < 3" in verdict.reason
+
+
+def test_evaluated_before_the_tools_own_constraints() -> None:
+    """Order decides only which violation is reported first; a run-budget
+    denial reads better than an argument one."""
+    policy = _policy(
+        tools={"refund": {"mode": "allow", "constraints": ["args.amount <= 50"]}}
+    )
+
+    verdict = evaluate_tool_call(
+        policy, "refund", {"amount": 999}, run={"tool_calls": 5}
+    )
+
+    assert "run.tool_calls < 3" in verdict.reason
+    assert "args.amount" not in verdict.reason
+
+
+def test_the_tools_own_constraints_still_apply() -> None:
+    policy = _policy(
+        tools={"refund": {"mode": "allow", "constraints": ["args.amount <= 50"]}}
+    )
+
+    verdict = evaluate_tool_call(
+        policy, "refund", {"amount": 999}, run={"tool_calls": 1}
+    )
+
+    assert verdict.outcome.value == "deny"
+    assert "args.amount <= 50" in verdict.reason
+
+
+# --- can only narrow --------------------------------------------------------
+
+
+def test_never_resurrects_a_denied_tool() -> None:
+    """``mode: deny`` short-circuits before constraints, so a satisfied
+    policy-level constraint cannot turn a deny into an allow."""
+    assert _outcome(_policy(), "delete_all", tool_calls=0) == "deny"
+
+
+def test_never_resurrects_an_unlisted_reach_key() -> None:
+    """Reach keys are closed-world: a permissive default (and now a satisfied
+    policy-level constraint) must not grant an unlisted handoff."""
+    assert _outcome(_policy(), "agent.handoff:billing", tool_calls=0) == "deny"
+
+
+def test_an_empty_list_changes_nothing() -> None:
+    policy = _policy(constraints=[])
+
+    assert _outcome(policy, "read_file", tool_calls=999) == "allow"
+
+
+# --- inheritance ------------------------------------------------------------
+
+
+def _resolved(policy_map: dict[str, dict], role: str) -> AgentPolicy:
+    return load_policy_map(
+        {name: AgentPolicy.model_validate(spec) for name, spec in policy_map.items()}
+    ).policy_for(role)
+
+
+def test_unions_across_inherits_rather_than_overriding() -> None:
+    """Trap 2. Override would let ``inherits: [read_only]`` silently *remove*
+    the mixin's cap — fail-open on a security restriction."""
+    resolved = _resolved(
+        {
+            "read_only": {"is_mixin": True, "constraints": ["run.tool_calls < 50"]},
+            "default": {
+                "inherits": ["read_only"],
+                "constraints": ["run.elapsed_seconds < 120"],
+                "default_policy": {"mode": "allow"},
+            },
+        },
+        "default",
+    )
+
+    assert resolved.constraints == ["run.tool_calls < 50", "run.elapsed_seconds < 120"]
+
+
+def test_an_inherited_constraint_actually_denies() -> None:
+    """Trap 1, asserted by *evaluating* rather than by inspecting the field.
+
+    ``_resolve_inheritance`` builds its return value by naming fields, so a
+    field left out is dropped for every role using ``inherits:`` — and a
+    dropped constraint is fail-open. A field-equality assertion alone would
+    also pass against a merge that built the list but never applied it.
+    """
+    resolved = _resolved(
+        {
+            "read_only": {"is_mixin": True, "constraints": ["run.tool_calls < 3"]},
+            "default": {
+                "inherits": ["read_only"],
+                "default_policy": {"mode": "allow"},
+            },
+        },
+        "default",
+    )
+
+    assert (
+        evaluate_tool_call(
+            resolved, "anything", {}, run={"tool_calls": 5}
+        ).outcome.value
+        == "deny"
+    )
+
+
+def test_deduplicated_on_a_diamond() -> None:
+    """A predicate inherited by two paths is evaluated once, and named once in
+    a deny reason."""
+    resolved = _resolved(
+        {
+            "base": {"is_mixin": True, "constraints": ["run.tool_calls < 50"]},
+            "audited": {"is_mixin": True, "inherits": ["base"]},
+            "read_only": {"is_mixin": True, "inherits": ["base"]},
+            "default": {
+                "inherits": ["audited", "read_only"],
+                "default_policy": {"mode": "allow"},
+            },
+        },
+        "default",
+    )
+
+    assert resolved.constraints == ["run.tool_calls < 50"]
+
+
+def test_a_role_without_inherits_is_untouched() -> None:
+    """The no-inherits early return skips the merge entirely, so it is a
+    separate path from the union above."""
+    resolved = _resolved(
+        {"default": {"constraints": ["run.tool_calls < 3"]}}, "default"
+    )
+
+    assert resolved.constraints == ["run.tool_calls < 3"]
+
+
+# --- load-time validation ---------------------------------------------------
+
+
+def test_grammar_error_surfaces_at_model_validate() -> None:
+    with pytest.raises(Exception, match="constraint|parse"):
+        AgentPolicy.model_validate({"constraints": ["args.amount <<< 3"]})
+
+
+def test_undefined_const_reference_rejected_at_policy_set_construction() -> None:
+    with pytest.raises(PolicySetError, match="undefined constant consts.cap"):
+        load_policy_map(
+            {
+                "default": AgentPolicy.model_validate(
+                    {"constraints": ["run.tool_calls < consts.cap"]}
+                )
+            }
+        )
+
+
+def test_const_reference_resolves_when_defined() -> None:
+    policy = load_policy_map(
+        {
+            "default": AgentPolicy.model_validate(
+                {
+                    "consts": {"cap": 3},
+                    "constraints": ["run.tool_calls < consts.cap"],
+                    "default_policy": {"mode": "allow"},
+                }
+            )
+        }
+    ).policy_for("default")
+
+    assert _outcome(policy, "anything", tool_calls=1) == "allow"
+    assert _outcome(policy, "anything", tool_calls=5) == "deny"

--- a/tests/security/test_rego_compile.py
+++ b/tests/security/test_rego_compile.py
@@ -1030,8 +1030,7 @@ _POLICY_LEVEL_PAYLOAD = {
 
 def test_policy_level_constraint_lands_in_every_rule() -> None:
     """Both _gated_rules call sites: the per-tool loop and the default_policy
-    catch-all. Missing either is silent engine drift — the pydantic engine
-    prepends the policy-level constraints unconditionally."""
+    catch-all. Missing either is silent engine drift."""
     rego = compile_to_rego(_POLICY_LEVEL_PAYLOAD)
 
     listed, catch_all = (block for block in rego.split("allow if {")[1:])
@@ -1042,9 +1041,8 @@ def test_policy_level_constraint_lands_in_every_rule() -> None:
 
 
 def test_policy_level_constraint_emits_a_violation_rule_per_tool() -> None:
-    """Each violation rule carries its own tool guard, so one policy-level
-    constraint on N rule heads emits N membership rules — inherent, and the
-    deny reason names the raw constraint string either way."""
+    """Each violation rule carries its own tool guard, so one constraint on N
+    rule heads emits N membership rules."""
     rego = compile_to_rego(_POLICY_LEVEL_PAYLOAD)
 
     assert rego.count("violations contains `run.tool_calls < 3`") == 2
@@ -1068,9 +1066,8 @@ def test_policy_level_constraints_precede_the_tools_own() -> None:
 
 
 def test_an_empty_policy_level_list_renders_byte_identically() -> None:
-    """The bundle-hash guard, stated directly rather than only via the golden
-    file: every project recompiling and changing source_hash on upgrade is a
-    support conversation nobody needs."""
+    """The bundle-hash guard: otherwise every project's source_hash moves on
+    upgrade."""
     without = {"roles": {"default": {"tools": {"t": {"mode": "allow"}}}}}
     with_empty = {
         "roles": {"default": {"constraints": [], "tools": {"t": {"mode": "allow"}}}}

--- a/tests/security/test_rego_compile.py
+++ b/tests/security/test_rego_compile.py
@@ -1011,3 +1011,71 @@ def test_run_ordered_constraint_emits_type_guard() -> None:
     rego = _run_rego("run.elapsed_seconds < 300")
     assert "is_number(input.run.elapsed_seconds)" in rego
     assert "input.run.elapsed_seconds < 300" in rego
+
+
+# ---------------------------------------------------------------------------
+# Policy-level constraints — one conjunct in every rule the role emits
+# ---------------------------------------------------------------------------
+
+_POLICY_LEVEL_PAYLOAD = {
+    "roles": {
+        "default": {
+            "constraints": ["run.tool_calls < 3"],
+            "default_policy": {"mode": "allow"},
+            "tools": {"read_file": {"mode": "allow"}},
+        }
+    },
+}
+
+
+def test_policy_level_constraint_lands_in_every_rule() -> None:
+    """Both _gated_rules call sites: the per-tool loop and the default_policy
+    catch-all. Missing either is silent engine drift — the pydantic engine
+    prepends the policy-level constraints unconditionally."""
+    rego = compile_to_rego(_POLICY_LEVEL_PAYLOAD)
+
+    listed, catch_all = (block for block in rego.split("allow if {")[1:])
+    assert 'input.tool == "read_file"' in listed
+    assert "not input.tool in" in catch_all
+    for block in (listed, catch_all):
+        assert "input.run.tool_calls < 3" in block
+
+
+def test_policy_level_constraint_emits_a_violation_rule_per_tool() -> None:
+    """Each violation rule carries its own tool guard, so one policy-level
+    constraint on N rule heads emits N membership rules — inherent, and the
+    deny reason names the raw constraint string either way."""
+    rego = compile_to_rego(_POLICY_LEVEL_PAYLOAD)
+
+    assert rego.count("violations contains `run.tool_calls < 3`") == 2
+
+
+def test_policy_level_constraints_precede_the_tools_own() -> None:
+    payload = {
+        "roles": {
+            "default": {
+                "constraints": ["run.tool_calls < 3"],
+                "tools": {
+                    "refund": {"mode": "allow", "constraints": ["args.amount <= 50"]}
+                },
+            }
+        }
+    }
+
+    body = compile_to_rego(payload).split("allow if {")[1]
+
+    assert body.index("input.run.tool_calls") < body.index("input.args.amount")
+
+
+def test_an_empty_policy_level_list_renders_byte_identically() -> None:
+    """The bundle-hash guard, stated directly rather than only via the golden
+    file: every project recompiling and changing source_hash on upgrade is a
+    support conversation nobody needs."""
+    without = {"roles": {"default": {"tools": {"t": {"mode": "allow"}}}}}
+    with_empty = {
+        "roles": {"default": {"constraints": [], "tools": {"t": {"mode": "allow"}}}}
+    }
+
+    assert compile_to_rego(without, source_hash="H") == compile_to_rego(
+        with_empty, source_hash="H"
+    )

--- a/tests/security/test_run_refs_validation.py
+++ b/tests/security/test_run_refs_validation.py
@@ -172,9 +172,7 @@ def test_policy_set_construction_accepts_a_registered_run_path() -> None:
 
 # --- policy-level constraints ----------------------------------------------
 #
-# Policy-level constraints are where a run cap is most likely to be written —
-# that is what the field is for — so the linter has to reach them or its whole
-# rationale is undone at exactly the wrong spot.
+# Where a run cap is most likely to be written, so the linter has to reach it.
 
 
 def _policy_level(*constraints: str) -> AgentPolicy:
@@ -201,8 +199,7 @@ def test_known_path_accepted_at_the_policy_level() -> None:
 
 
 def test_inherited_policy_level_constraint_is_validated() -> None:
-    """The validators run on the *resolved* map, so a bad reference cannot hide
-    in a mixin the child never restates."""
+    """Validation runs on the resolved map, so a bad ref cannot hide in a mixin."""
     from hexgate.security.policy_set import load_policy_map
 
     with pytest.raises(PolicySetError, match="unknown run.\\* path 'tool_call'"):

--- a/tests/security/test_run_refs_validation.py
+++ b/tests/security/test_run_refs_validation.py
@@ -168,3 +168,49 @@ def test_policy_set_construction_rejects_an_unknown_run_path() -> None:
 
 def test_policy_set_construction_accepts_a_registered_run_path() -> None:
     PolicySet({DEFAULT_ROLE_NAME: _policy('run.agent == "billing"')})
+
+
+# --- policy-level constraints ----------------------------------------------
+#
+# Policy-level constraints are where a run cap is most likely to be written —
+# that is what the field is for — so the linter has to reach them or its whole
+# rationale is undone at exactly the wrong spot.
+
+
+def _policy_level(*constraints: str) -> AgentPolicy:
+    return AgentPolicy.model_validate({"constraints": list(constraints)})
+
+
+def test_unknown_path_rejected_at_the_policy_level() -> None:
+    with pytest.raises(PolicySetError, match="unknown run.\\* path 'tool_call'"):
+        _validate(policy=_policy_level("run.tool_call < 5"))
+
+
+def test_too_deep_path_rejected_at_the_policy_level() -> None:
+    with pytest.raises(PolicySetError, match="exactly two segments"):
+        _validate(policy=_policy_level('run.id.value == "x"'))
+
+
+def test_list_path_in_scalar_position_rejected_at_the_policy_level() -> None:
+    with pytest.raises(PolicySetError, match="silently passes"):
+        _validate(policy=_policy_level('run.tools_used not in ["shell"]'))
+
+
+def test_known_path_accepted_at_the_policy_level() -> None:
+    _validate(policy=_policy_level("run.tool_calls < 20"))
+
+
+def test_inherited_policy_level_constraint_is_validated() -> None:
+    """The validators run on the *resolved* map, so a bad reference cannot hide
+    in a mixin the child never restates."""
+    from hexgate.security.policy_set import load_policy_map
+
+    with pytest.raises(PolicySetError, match="unknown run.\\* path 'tool_call'"):
+        load_policy_map(
+            {
+                "base": AgentPolicy.model_validate(
+                    {"is_mixin": True, "constraints": ["run.tool_call < 5"]}
+                ),
+                "default": AgentPolicy.model_validate({"inherits": ["base"]}),
+            }
+        )

--- a/tests/tracing/test_usage_emit.py
+++ b/tests/tracing/test_usage_emit.py
@@ -208,8 +208,8 @@ def test_token_cap_trails_the_turn_that_exceeded_it() -> None:
 
 
 def test_emit_stamps_the_enclosing_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
-    """llm_invocation rows must join to the policy_decision rows of the same
-    invocation, so the run has to reach the event, not just the counters."""
+    """llm_invocation rows join to the policy_decision rows of the same run, so
+    the run_id has to reach the event, not just the counters."""
     sender = _FakeSender()
     monkeypatch.setattr(
         usage_mod, "configure_usage_sender", lambda api_key=None: sender
@@ -239,8 +239,7 @@ def test_emit_outside_a_run_scope_sends_no_run_id(
 def test_emit_attributes_tokens_and_the_run_id_to_the_same_facts(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """One get_run_facts() read: the tokens recorded and the run they are
-    attributed to are the same object, structurally rather than incidentally."""
+    """One get_run_facts() read, so the tokens and the run_id share an object."""
     sender = _FakeSender()
     monkeypatch.setattr(
         usage_mod, "configure_usage_sender", lambda api_key=None: sender

--- a/tests/tracing/test_usage_emit.py
+++ b/tests/tracing/test_usage_emit.py
@@ -11,8 +11,10 @@ from typing import Any
 import pytest
 
 from hexgate.runtime import HexgateContext
+from hexgate.runtime.run_facts import run_scope
 from hexgate.tracing import usage as usage_mod
 from hexgate.tracing.usage import emit_llm_usage
+from hexgate.tracing import semconv
 
 
 class _FakeSender:
@@ -203,3 +205,49 @@ def test_token_cap_trails_the_turn_that_exceeded_it() -> None:
         emit_llm_usage("a", "gpt-4o", 400, 0)
         # ...so the overshoot is only visible to the *next* decision.
         assert not enforcer.decide("t", {}).allowed
+
+
+def test_emit_stamps_the_enclosing_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """llm_invocation rows must join to the policy_decision rows of the same
+    invocation, so the run has to reach the event, not just the counters."""
+    sender = _FakeSender()
+    monkeypatch.setattr(
+        usage_mod, "configure_usage_sender", lambda api_key=None: sender
+    )
+
+    with run_scope("agent") as facts:
+        emit_llm_usage("agent", "gpt-4o", 10, 5)
+
+    assert sender.events[0].run_id == facts.id
+    assert sender.events[0].span_attributes()[semconv.RUN_ID] == facts.id
+
+
+def test_emit_outside_a_run_scope_sends_no_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sender = _FakeSender()
+    monkeypatch.setattr(
+        usage_mod, "configure_usage_sender", lambda api_key=None: sender
+    )
+
+    emit_llm_usage("agent", "gpt-4o", 10, 5)
+
+    assert sender.events[0].run_id == ""
+    assert semconv.RUN_ID not in sender.events[0].span_attributes()
+
+
+def test_emit_attributes_tokens_and_the_run_id_to_the_same_facts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One get_run_facts() read: the tokens recorded and the run they are
+    attributed to are the same object, structurally rather than incidentally."""
+    sender = _FakeSender()
+    monkeypatch.setattr(
+        usage_mod, "configure_usage_sender", lambda api_key=None: sender
+    )
+
+    with run_scope("agent") as facts:
+        emit_llm_usage("agent", "gpt-4o", 10, 5)
+
+    assert facts.as_namespace("t")["total_tokens"] == 15
+    assert sender.events[0].run_id == facts.id

--- a/tests/tracing/test_usage_event.py
+++ b/tests/tracing/test_usage_event.py
@@ -87,3 +87,17 @@ def test_occurred_at_defaults_to_an_aware_utc_datetime() -> None:
     ev = _event()
     assert ev.occurred_at.utcoffset() is not None
     assert ev.occurred_at.utcoffset().total_seconds() == 0
+
+
+def test_span_attributes_omit_run_id_never_send_an_empty_string() -> None:
+    """``LlmInvocationEvent.run_id`` is ``UUID | None`` on the platform: an
+    empty string fails validation and sends the span to the DLQ — losing the
+    usage record for every model call made outside a run scope. OTLP cannot
+    carry null, so the absent attribute is how "no run" travels."""
+    assert semconv.RUN_ID not in _event().span_attributes()
+
+
+def test_span_attributes_carry_the_run_id_when_inside_a_run() -> None:
+    wire = _event(run_id="9c2f1d3e-0000-4000-8000-000000000001").span_attributes()
+
+    assert wire[semconv.RUN_ID] == "9c2f1d3e-0000-4000-8000-000000000001"

--- a/tests/tracing/test_usage_event.py
+++ b/tests/tracing/test_usage_event.py
@@ -90,10 +90,8 @@ def test_occurred_at_defaults_to_an_aware_utc_datetime() -> None:
 
 
 def test_span_attributes_omit_run_id_never_send_an_empty_string() -> None:
-    """``LlmInvocationEvent.run_id`` is ``UUID | None`` on the platform: an
-    empty string fails validation and sends the span to the DLQ — losing the
-    usage record for every model call made outside a run scope. OTLP cannot
-    carry null, so the absent attribute is how "no run" travels."""
+    """An empty string is not a UUID: the enricher DLQs the span, losing the
+    record for every model call made outside a run scope."""
     assert semconv.RUN_ID not in _event().span_attributes()
 
 


### PR DESCRIPTION

PR A–C made `run.*` a live, enforced policy namespace and gave ClickHouse the columns to store it. This PR makes the SDK actually *send* those columns, and makes a run-wide cap writable once instead of once per tool.

## Commits

**1. `feat(sdk, platform-api): attach run facts to the decision audit payload`**

`run_id` + five counters now reach the audit wire. New `RunAttribution` value object on `Decision` owns the whole namespace→wire mapping: the `run.*` key names, the seconds→milliseconds conversion, and the `"" → None` rule. Stamped at both `Decision` construction sites — `PolicyEnforcer.decide` (reusing the snapshot the verdict was evaluated against, so the record and the decision cannot disagree) and `_halt_to_decision` for guard halts. `LlmUsageEvent` carries `run_id` too, so `llm_invocation` rows join to the same run.

Deliberately **not** added to `as_error_payload` / `as_error_message`: the model may learn *that* a constraint tripped, never how close it is to its budget. Pinned by a negative test.

**2. `feat(sdk): policy-level constraints applied to every tool`**

New top-level `constraints:` on `AgentPolicy`, applied to every tool the role can reach, on both engines. `default_policy.constraints` only covers tools that fall *through* to the default, so a run cap on a role listing ten tools had to be repeated ten times.

- Unions across `inherits` instead of overriding — the only field here that does. Override would let `inherits: [read_only]` silently drop the mixin's cap, which is fail-open on a security restriction. Deduplicated, first-seen order.
- Can only narrow: `mode: deny` short-circuits before constraints on both engines, so nothing here resurrects a denied tool or an unlisted reach key.
- Both load-time validators (`consts.*` and `run.*`) reach the new list, so a typo is still rejected at `PolicySet` construction rather than denying silently at runtime.

**3. `fix(cli): localize a grammar error in a policy-level constraint`**

`hexgate policy check` reports it under `<policy>` instead of a raw pydantic `ValidationError`.

**4–5. Docs + comment trim.** `constraints.mdx` gains a "where a constraint can live" section (the three locations, the inheritance union, the module-composition restriction) and a note on what a denied model is told.

## Three things the plan missed, found while grounding

1. **`run_id: ""` on the wire would have dropped whole audit rows.** The platform types it `UUID | None`; pydantic won't coerce `""`, FastAPI returns 422, and the sender discards any 4xx without retrying. Every decision made outside a run scope would have lost its entire record — not just its attribution. The `"" → None` conversion lives in one place and has a cross-package test on both sides of the wire.
2. **Guard halts are a second `Decision` construction site.** Stamping only in `decide()` would leave a halt inside a live run writing the zero UUID — losing exactly the row that explains why the run stopped.
3. **`_gated_rules` has three call sites, not two.** The third is the synthetic `agent.run` admission rule, whose policy comes from a fallback constant rather than the document. Missing it would allow on WASM what pydantic denies. The new parameter is required and keyword-only so a fourth call site can't be added silently; a parity case covers `agent.run` specifically.

## Testing

`make check-all` green — 2307 SDK + 530 platform tests. `opa` was on PATH, so the cross-engine parity suite ran for real rather than skipping.

Commit 1 was verified releasable on its own (commits 2–5 stashed, both suites green against that tree alone). The golden Rego snapshot is unchanged, so no existing project's `source_hash` moves on upgrade.

## Deploy ordering

Needs PR C **deployed** (migration + API), not just merged. Against an un-migrated ClickHouse ingest returns 503 and the sender retries; against a migrated DB with an old API the new fields are silently ignored — lossy, not fatal.
