### PR TITLE
test(sdk): pin run scope coverage for the streamed launch helper

### DIFF
--- a/tests/runtime/test_run_scope_coverage.py
+++ b/tests/runtime/test_run_scope_coverage.py
@@ -52,7 +52,20 @@ SCOPE_SITES: list[tuple[str, str, str, str]] = [
     ),
     ("hexgate.adapters.openai.runner", "HexgateRunner", "run", "run"),
     ("hexgate.adapters.openai.runner", "HexgateRunner", "run_sync", "run_sync"),
-    ("hexgate.adapters.openai.runner", "HexgateRunner", "run_streamed", "run_streamed"),
+    # Both streaming entry points delegate the wrap + scope to _launch_streamed
+    # after refreshing the binding and ban gate in their own (sync/async) way.
+    (
+        "hexgate.adapters.openai.runner",
+        "HexgateRunner",
+        "run_streamed",
+        "_launch_streamed",
+    ),
+    (
+        "hexgate.adapters.openai.runner",
+        "HexgateRunner",
+        "arun_streamed",
+        "_launch_streamed",
+    ),
     ("hexgate.adapters.pydantic_ai.agent", "HexgatePydanticAgent", "run", "_abind"),
     ("hexgate.adapters.pydantic_ai.agent", "HexgatePydanticAgent", "run_sync", "_bind"),
     (
@@ -149,12 +162,22 @@ def test_scope_opens_after_the_ban_check() -> None:
     assert source.index("_check_ban_async") < source.index("_abind")
 
 
+@pytest.mark.parametrize("method", ["run_streamed", "arun_streamed"])
+def test_streamed_boundaries_launch_after_the_ban_check(method: str) -> None:
+    """The streaming boundaries own only the refresh + ban gate; the scope lives
+    in ``_launch_streamed``, so each must actually hand off to it — and only
+    once a banned run has been refused."""
+    source = _source_of("hexgate.adapters.openai.runner", "HexgateRunner", method)
+    assert "_launch_streamed(" in source
+    assert source.index("ban_gate.check") < source.index("_launch_streamed(")
+
+
 def test_run_streamed_rejoins_rather_than_mints() -> None:
     """``run_streamed`` hands tools to a background task that snapshots the
     contextvars, so the consumer-side iterator must re-bind the same object —
     minting would split one invocation across two run ids."""
     source = _source_of(
-        "hexgate.adapters.openai.runner", "HexgateRunner", "run_streamed"
+        "hexgate.adapters.openai.runner", "HexgateRunner", "_launch_streamed"
     )
     assert _OPENS_SCOPE in source
     assert _JOINS_SCOPE in source


### PR DESCRIPTION
## What is Changing

`tests/runtime/test_run_scope_coverage.py` now pins the OpenAI adapter's streaming boundaries to `_launch_streamed`:

- `run_streamed` and the new `arun_streamed` are both listed in `SCOPE_SITES` with `_launch_streamed` as their scope site, following the file's existing convention for boundaries that delegate the scope to a helper.
- `test_run_streamed_rejoins_rather_than_mints` reads `_launch_streamed`, where the `run_scope(...)` / `Runner.run_streamed(...)` / `use_run_facts(...)` ordering actually lives.
- A new parametrized test pins that each streaming entry point calls `_launch_streamed(...)`, and only after the `ban_gate.check*` gate.

No runtime code changes.

## Why is this change necessary?

#149 refactored `HexgateRunner.run_streamed` into a shared `_launch_streamed` helper and added `arun_streamed`. The coverage test from #129 still expected the scope inline in `run_streamed` and did not know about `arun_streamed`, so three tests failed on `main`:

- `test_every_adapter_boundary_is_covered[openai.runner-HexgateRunner]` (derived boundary set included `arun_streamed`, pinned list did not)
- `test_scope_is_opened_for_every_boundary[runner.HexgateRunner.run_streamed]`
- `test_run_streamed_rejoins_rather_than_mints`

## Tests

```
uv run pytest tests/runtime/test_run_scope_coverage.py -q
27 passed
```

`make check-all` green on all four surfaces (SDK lint/format/coverage, platform-api ruff + 618 passed, dashboard typecheck/prettier/vitest 205 passed, collector gofmt/vet/test/build/validate).

`make platform-api-test-integration`: 7 passed against local ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)