### PR TITLE
refactor(dashboard): move workspace switcher into a collapsible sidebar

### DIFF
--- a/platform/dashboard/src/components/AppShell.test.tsx
+++ b/platform/dashboard/src/components/AppShell.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * Tests for the sidebar app-shell.
+ *
+ * Four surfaces worth pinning:
+ *   1. The workspace nav renders its links, and collapsing the sidebar
+ *      hides the labels (icon-only mode).
+ *   2. The collapse toggle works from both the button and Cmd/Ctrl-B.
+ *   3. The account chip shows the signed-in user and signs out.
+ *   4. The bootstrap effect auto-picks a first org + project, and heals
+ *      a stale (removed-org / deleted-project) selection.
+ *
+ * The dropdown/label plumbing inside OrgProjectSwitcher has its own
+ * test — here we only assert the shell's own behaviour.
+ */
+
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppShell } from "@/components/AppShell";
+import { useActive } from "@/lib/active";
+import { useUi } from "@/lib/ui";
+import { renderWithProviders } from "@/test/render";
+
+const USER = { id: "user-1", email: "dev@example.com", is_verified: true };
+const ORG_A = {
+  id: "org-a",
+  slug: "org-a",
+  name: "Org Alpha",
+  created_at: "2026-01-01T00:00:00Z",
+  role: "owner" as const,
+};
+const ORG_B = {
+  id: "org-b",
+  slug: "org-b",
+  name: "Org Beta",
+  created_at: "2026-01-02T00:00:00Z",
+  role: "member" as const,
+};
+const PROJ_A1 = { id: "proj-a1", name: "alpha-one", org_id: "org-a" };
+const PROJ_A2 = { id: "proj-a2", name: "alpha-two", org_id: "org-a" };
+
+/** Stub fetch with canned JSON keyed by path; 404 for anything else so
+ * a missed route surfaces as an obvious failure rather than a hang. */
+function stubFetch(routes: Record<string, unknown>): void {
+  vi.spyOn(window, "fetch").mockImplementation(
+    async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+      const path = url.split("?")[0];
+      if (path in routes) {
+        return new Response(JSON.stringify(routes[path]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  );
+}
+
+/** A fully-wired workspace: a signed-in user, two orgs, two projects
+ * under org-a. Individual tests seed the active selection they want. */
+function stubWorkspace(): void {
+  stubFetch({
+    "/v1/users/me": USER,
+    "/v1/orgs": [ORG_A, ORG_B],
+    "/v1/orgs/org-a/projects": [PROJ_A1, PROJ_A2],
+    "/v1/orgs/org-b/projects": [],
+    "/v1/auth/cookie/logout": {},
+    "/v1/auth/google/authorize": {},
+  });
+}
+
+describe("AppShell", () => {
+  beforeEach(() => {
+    useUi.setState({ sidebarCollapsed: false });
+    act(() => {
+      useActive.setState({
+        activeOrgId: ORG_A.id,
+        activeProjectId: PROJ_A1.id,
+      });
+    });
+    stubWorkspace();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("renders the workspace nav links", async () => {
+    renderWithProviders(<AppShell />);
+    await waitFor(() => {
+      expect(screen.getByText("Agents")).toBeInTheDocument();
+    });
+    for (const label of [
+      "Policies",
+      "Graph",
+      "Playground",
+      "Audit",
+      "API keys",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("collapsing the sidebar hides the nav labels", async () => {
+    renderWithProviders(<AppShell />);
+    await waitFor(() => expect(screen.getByText("Agents")).toBeInTheDocument());
+
+    await userEvent
+      .setup()
+      .click(screen.getByRole("button", { name: "Collapse sidebar" }));
+
+    expect(useUi.getState().sidebarCollapsed).toBe(true);
+    // Labels drop out in icon-only mode; the toggle flips to "Expand".
+    expect(screen.queryByText("Agents")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Expand sidebar" }),
+    ).toBeInTheDocument();
+  });
+
+  it("Cmd/Ctrl-B toggles the sidebar", async () => {
+    renderWithProviders(<AppShell />);
+    await waitFor(() => expect(screen.getByText("Agents")).toBeInTheDocument());
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "b", metaKey: true });
+    });
+    expect(useUi.getState().sidebarCollapsed).toBe(true);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "B", ctrlKey: true });
+    });
+    expect(useUi.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it("shows the signed-in user and signs out", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<AppShell />);
+
+    // Username (email local-part) shows in the account chip.
+    await waitFor(() => expect(screen.getByText("dev")).toBeInTheDocument());
+
+    await user.click(screen.getByText("dev"));
+    await user.click(await screen.findByText("Log out"));
+
+    await waitFor(() => {
+      expect(window.fetch).toHaveBeenCalledWith(
+        "/v1/auth/cookie/logout",
+        expect.anything(),
+      );
+    });
+  });
+
+  it("bootstraps a first org and project when nothing is active", async () => {
+    act(() => {
+      useActive.setState({ activeOrgId: null, activeProjectId: null });
+    });
+    renderWithProviders(<AppShell />);
+
+    await waitFor(() => {
+      expect(useActive.getState().activeOrgId).toBe(ORG_A.id);
+    });
+    await waitFor(() => {
+      expect(useActive.getState().activeProjectId).toBe(PROJ_A1.id);
+    });
+  });
+
+  it("heals a stale active org that the user no longer belongs to", async () => {
+    act(() => {
+      useActive.setState({ activeOrgId: "ghost-org", activeProjectId: null });
+    });
+    renderWithProviders(<AppShell />);
+
+    await waitFor(() => {
+      expect(useActive.getState().activeOrgId).toBe(ORG_A.id);
+    });
+  });
+
+  it("heals a stale active project that no longer exists", async () => {
+    act(() => {
+      useActive.setState({
+        activeOrgId: ORG_A.id,
+        activeProjectId: "ghost-project",
+      });
+    });
+    renderWithProviders(<AppShell />);
+
+    await waitFor(() => {
+      expect(useActive.getState().activeProjectId).toBe(PROJ_A1.id);
+    });
+  });
+});

--- a/platform/dashboard/src/components/AppShell.test.tsx
+++ b/platform/dashboard/src/components/AppShell.test.tsx
@@ -135,6 +135,36 @@ describe("AppShell", () => {
     expect(useUi.getState().sidebarCollapsed).toBe(false);
   });
 
+  it("ignores Cmd/Ctrl-B while typing in an editable target", async () => {
+    renderWithProviders(<AppShell />);
+    await waitFor(() => expect(screen.getByText("Agents")).toBeInTheDocument());
+
+    // A press originating in an input (or the CodeMirror editor, which binds
+    // Ctrl-B to move-left) must not toggle the sidebar.
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    const before = useUi.getState().sidebarCollapsed;
+    act(() => {
+      fireEvent.keyDown(input, { key: "b", metaKey: true });
+    });
+    expect(useUi.getState().sidebarCollapsed).toBe(before);
+    input.remove();
+  });
+
+  it("ignores a repeated or over-modified Cmd/Ctrl-B", async () => {
+    renderWithProviders(<AppShell />);
+    await waitFor(() => expect(screen.getByText("Agents")).toBeInTheDocument());
+    const before = useUi.getState().sidebarCollapsed;
+
+    act(() => {
+      fireEvent.keyDown(window, { key: "b", metaKey: true, repeat: true });
+    });
+    act(() => {
+      fireEvent.keyDown(window, { key: "b", ctrlKey: true, altKey: true });
+    });
+    expect(useUi.getState().sidebarCollapsed).toBe(before); // neither toggled
+  });
+
   it("shows the signed-in user and signs out", async () => {
     const user = userEvent.setup();
     renderWithProviders(<AppShell />);

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -9,6 +9,7 @@ import {
   LogOut,
   MessageSquareCode,
   Network,
+  PanelLeft,
   ScrollText,
   Settings2,
   ShieldCheck,
@@ -16,6 +17,14 @@ import {
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { OrgProjectSwitcher } from "@/components/OrgProjectSwitcher";
 import { PreviewBanner } from "@/components/PreviewBanner";
 import { VerifyEmailBanner } from "@/components/VerifyEmailBanner";
@@ -23,6 +32,7 @@ import { useActive } from "@/lib/active";
 import { useLogout, useUser } from "@/lib/auth";
 import { useOrgs } from "@/lib/orgs";
 import { useProjects } from "@/lib/projects";
+import { useUi } from "@/lib/ui";
 import { cn } from "@/lib/utils";
 
 /**
@@ -104,6 +114,7 @@ function NavItem({
   end,
   badge,
   status,
+  collapsed,
 }: {
   to: string;
   label: string;
@@ -111,14 +122,17 @@ function NavItem({
   end?: boolean;
   badge?: string;
   status?: string;
+  collapsed?: boolean;
 }) {
   return (
     <NavLink
       to={to}
       end={end}
+      title={collapsed ? label : undefined}
       className={({ isActive }) =>
         cn(
-          "flex h-9 items-center justify-between rounded-md px-3 text-sm transition-colors",
+          "flex h-9 items-center rounded-md text-sm transition-colors",
+          collapsed ? "justify-center px-0" : "justify-between px-2",
           isActive
             ? "bg-primary/15 text-primary font-medium"
             : "text-muted-foreground hover:bg-accent hover:text-foreground",
@@ -126,13 +140,13 @@ function NavItem({
       }
     >
       <span className="flex items-center gap-2.5">
-        <Icon className="size-4" />
-        {label}
+        <Icon className="size-4 shrink-0" />
+        {!collapsed && label}
       </span>
-      {badge && (
+      {!collapsed && badge && (
         <span className="text-[11px] text-muted-foreground">{badge}</span>
       )}
-      {status && (
+      {!collapsed && status && (
         <span className="rounded-full bg-allow/15 px-1.5 py-0.5 text-[10px] font-medium text-allow">
           {status}
         </span>
@@ -146,49 +160,72 @@ export function AppShell() {
   // shows something usable instead of "Pick an organization" empty
   // state. Idempotent — won't overwrite an existing valid selection.
   useActiveBootstrap();
+  const { sidebarCollapsed, toggleSidebar } = useUi();
+
+  // Cmd/Ctrl-B toggles the sidebar (standard editor shortcut). toggleSidebar is
+  // a stable zustand action, so this binds once.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {
+        e.preventDefault();
+        toggleSidebar();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [toggleSidebar]);
 
   return (
     <div className="flex h-screen bg-background text-foreground">
-      <aside className="flex w-[220px] flex-col border-r border-border bg-card">
-        <div className="flex h-14 items-center gap-2 px-4 border-b border-border">
-          <img src="/icon.svg" alt="" className="size-7" />
-          <span className="text-sm font-semibold">Hexgate</span>
+      <aside
+        className={cn(
+          // No hard right border — the card-vs-background shade separates the
+          // sidebar from the content (VSCode "shades, not rules"). The whole
+          // shell lives in the sidebar (switcher on top, account on the
+          // bottom) so the content column reclaims the old header's height.
+          "flex flex-col bg-card transition-[width] duration-200",
+          sidebarCollapsed ? "w-14" : "w-[240px]",
+        )}
+      >
+        {/* Top: project/org switcher (two lines) + the collapse toggle,
+            top-aligned so it sits level with the project line. */}
+        <div
+          className={cn(
+            "flex items-start gap-1 overflow-hidden py-2",
+            sidebarCollapsed ? "justify-center px-0" : "px-2",
+          )}
+        >
+          {!sidebarCollapsed && (
+            <div className="min-w-0 flex-1">
+              <OrgProjectSwitcher />
+            </div>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 shrink-0 text-muted-foreground"
+            title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+            aria-label={
+              sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"
+            }
+            onClick={toggleSidebar}
+          >
+            <PanelLeft className="size-4" />
+          </Button>
         </div>
 
-        <nav className="flex-1 overflow-y-auto p-3 scrollbar-thin">
-          <div className="mb-4">
-            <div className="px-3 pb-2 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-              Workspace
-            </div>
-            <div className="flex flex-col gap-0.5">
-              {workspaceLinks.map((l) => (
-                <NavItem key={l.to} {...l} />
-              ))}
-            </div>
+        <nav className="flex-1 overflow-y-auto px-2 py-2 scrollbar-thin">
+          <div className="flex flex-col gap-0.5">
+            {workspaceLinks.map((l) => (
+              <NavItem key={l.to} {...l} collapsed={sidebarCollapsed} />
+            ))}
           </div>
         </nav>
 
-        <div className="border-t border-border p-3 text-[11px] text-muted-foreground space-y-1">
-          <div className="flex items-center gap-1.5">
-            <span className="relative flex size-1.5">
-              <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-primary opacity-50" />
-              <span className="relative inline-flex size-1.5 rounded-full bg-primary" />
-            </span>
-            Serving bundle <span className="font-mono text-foreground">v1</span>
-          </div>
-          <div>Pushed just now</div>
-          <div>local · 1 region</div>
-        </div>
+        <AccountChip collapsed={sidebarCollapsed} />
       </aside>
 
       <div className="flex flex-1 flex-col">
-        <header className="flex h-14 items-center justify-between border-b border-border px-6">
-          <div className="flex items-center gap-3">
-            <OrgProjectSwitcher />
-          </div>
-          <UserMenu />
-        </header>
-
         <PreviewBanner />
         <VerifyEmailBanner />
 
@@ -200,40 +237,77 @@ export function AppShell() {
   );
 }
 
-/** Top-right corner: shows the signed-in user's initial + a sign-out
- * button. Phase 5 will replace this with a proper dropdown menu (and
- * an org switcher next to it); for now a flat layout is enough. */
-function UserMenu() {
+/**
+ * Bottom-of-sidebar account chip — the signed-in user, opening a menu
+ * upward with settings shortcuts and sign-out (OpenAI-style). The project
+ * and org now live in the top switcher, so this is purely the user's
+ * identity. When the sidebar is collapsed it shrinks to just the avatar.
+ */
+function AccountChip({ collapsed }: { collapsed: boolean }) {
   const { user } = useUser();
   const logout = useLogout();
   const navigate = useNavigate();
 
   if (!user) return null;
 
-  const initial = user.email.slice(0, 1).toUpperCase();
+  const username = user.email.split("@")[0] || user.email;
+  const initial = (user.email.slice(0, 1) || "?").toUpperCase();
 
   return (
-    <div className="flex items-center gap-3 text-muted-foreground">
-      <div className="flex items-center gap-2">
-        <span className="size-8 rounded-full bg-primary/20 text-primary grid place-items-center text-xs font-medium">
-          {initial}
-        </span>
-        <span className="hidden text-xs text-foreground sm:inline">
-          {user.email}
-        </span>
-      </div>
-      <Button
-        variant="ghost"
-        size="icon"
-        title="Sign out"
-        disabled={logout.isPending}
-        onClick={async () => {
-          await logout.mutateAsync().catch(() => undefined);
-          navigate("/sign-in", { replace: true });
-        }}
-      >
-        <LogOut className="h-4 w-4" />
-      </Button>
+    <div className="p-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            title={collapsed ? user.email : undefined}
+            className={cn(
+              "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-accent",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              collapsed && "justify-center",
+            )}
+          >
+            <span className="grid size-7 shrink-0 place-items-center rounded-full bg-primary/20 text-xs font-medium text-primary">
+              {initial}
+            </span>
+            {!collapsed && (
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium">
+                  {username}
+                </span>
+                <span className="block truncate text-xs text-muted-foreground">
+                  {user.email}
+                </span>
+              </span>
+            )}
+          </button>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent align="start" side="top" className="min-w-[240px]">
+          <DropdownMenuLabel className="truncate text-xs font-normal text-muted-foreground">
+            {user.email}
+          </DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => navigate("/settings")}>
+            <Settings2 className="size-4" />
+            <span>Settings</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => navigate("/orgs")}>
+            <Building2 className="size-4" />
+            <span>Organizations</span>
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            disabled={logout.isPending}
+            onSelect={async () => {
+              await logout.mutateAsync().catch(() => undefined);
+              navigate("/sign-in", { replace: true });
+            }}
+          >
+            <LogOut className="size-4" />
+            <span>Log out</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }

--- a/platform/dashboard/src/components/AppShell.tsx
+++ b/platform/dashboard/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate, NavLink, Outlet } from "react-router-dom";
 import {
   Ban,
@@ -26,6 +26,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { OrgProjectSwitcher } from "@/components/OrgProjectSwitcher";
+import { CreateOrgDialog } from "@/components/CreateOrgDialog";
+import { CreateProjectDialog } from "@/components/CreateProjectDialog";
 import { PreviewBanner } from "@/components/PreviewBanner";
 import { VerifyEmailBanner } from "@/components/VerifyEmailBanner";
 import { useActive } from "@/lib/active";
@@ -162,14 +164,29 @@ export function AppShell() {
   useActiveBootstrap();
   const { sidebarCollapsed, toggleSidebar } = useUi();
 
+  // The workspace create-dialogs live here, not in OrgProjectSwitcher, so
+  // collapsing the sidebar (which unmounts the switcher trigger) can't unmount
+  // an open dialog and drop the user's half-typed form.
+  const [createOrgOpen, setCreateOrgOpen] = useState(false);
+  const [createProjectOpen, setCreateProjectOpen] = useState(false);
+
   // Cmd/Ctrl-B toggles the sidebar (standard editor shortcut). toggleSidebar is
-  // a stable zustand action, so this binds once.
+  // a stable zustand action, so this binds once. Guard the match: ignore key
+  // repeat and extra modifiers, and — crucially — presses inside an editable
+  // target (an input, or the CodeMirror policy editor, which binds Ctrl-B to
+  // move-cursor-left) so the shortcut never hijacks typing.
   useEffect(() => {
+    const isEditable = (t: EventTarget | null): boolean =>
+      t instanceof HTMLElement &&
+      (t.isContentEditable ||
+        ["INPUT", "TEXTAREA", "SELECT"].includes(t.tagName) ||
+        t.closest(".cm-editor") !== null);
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "b") {
-        e.preventDefault();
-        toggleSidebar();
-      }
+      if (e.repeat || e.altKey || e.shiftKey) return;
+      if (!(e.metaKey || e.ctrlKey) || e.key.toLowerCase() !== "b") return;
+      if (isEditable(e.target)) return;
+      e.preventDefault();
+      toggleSidebar();
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -197,7 +214,10 @@ export function AppShell() {
         >
           {!sidebarCollapsed && (
             <div className="min-w-0 flex-1">
-              <OrgProjectSwitcher />
+              <OrgProjectSwitcher
+                onNewOrg={() => setCreateOrgOpen(true)}
+                onNewProject={() => setCreateProjectOpen(true)}
+              />
             </div>
           )}
           <Button
@@ -233,6 +253,14 @@ export function AppShell() {
           <Outlet />
         </main>
       </div>
+
+      {/* Workspace dialogs live at the shell level so their lifecycle is
+          independent of the sidebar's collapse state. */}
+      <CreateOrgDialog open={createOrgOpen} onOpenChange={setCreateOrgOpen} />
+      <CreateProjectDialog
+        open={createProjectOpen}
+        onOpenChange={setCreateProjectOpen}
+      />
     </div>
   );
 }

--- a/platform/dashboard/src/components/OrgProjectSwitcher.test.tsx
+++ b/platform/dashboard/src/components/OrgProjectSwitcher.test.tsx
@@ -70,7 +70,9 @@ describe("OrgProjectSwitcher", () => {
   });
 
   it("shows the active org name in the trigger", async () => {
-    renderWithProviders(<OrgProjectSwitcher />);
+    renderWithProviders(
+      <OrgProjectSwitcher onNewOrg={vi.fn()} onNewProject={vi.fn()} />,
+    );
     await waitFor(() => {
       expect(screen.getByText("Org Alpha")).toBeInTheDocument();
     });
@@ -86,7 +88,9 @@ describe("OrgProjectSwitcher", () => {
     });
 
     const user = userEvent.setup();
-    renderWithProviders(<OrgProjectSwitcher />);
+    renderWithProviders(
+      <OrgProjectSwitcher onNewOrg={vi.fn()} onNewProject={vi.fn()} />,
+    );
 
     // Open the dropdown.
     await waitFor(() => {
@@ -104,23 +108,56 @@ describe("OrgProjectSwitcher", () => {
     expect(useActive.getState().activeProjectId).toBeNull();
   });
 
-  it('"New organization" opens the create dialog', async () => {
+  it('"New organization" signals the parent to open the dialog', async () => {
+    // The dialog now lives in AppShell (so a sidebar collapse can't unmount it);
+    // the switcher only fires the intent callback.
+    const onNewOrg = vi.fn();
     const user = userEvent.setup();
-    renderWithProviders(<OrgProjectSwitcher />);
+    renderWithProviders(
+      <OrgProjectSwitcher onNewOrg={onNewOrg} onNewProject={vi.fn()} />,
+    );
 
     await waitFor(() => {
       expect(screen.getByText("Org Alpha")).toBeInTheDocument();
     });
     await user.click(screen.getAllByText("Org Alpha")[0]!);
+    await user.click(await screen.findByText("New organization"));
 
-    const newOrgItem = await screen.findByText("New organization");
-    await user.click(newOrgItem);
+    expect(onNewOrg).toHaveBeenCalled();
+  });
 
-    // CreateOrgDialog renders both a title and a submit button with
-    // the text "Create organization" — assert on something unique to
-    // the dialog body to avoid the multi-match getByText error.
-    expect(
-      await screen.findByText(/Teams in Hexgate live inside/i),
-    ).toBeInTheDocument();
+  it("reads Loading… (not No project) while projects are still loading", async () => {
+    // An org switch clears the active project and refetches projects; orgs are
+    // cached, so only the projects query is in flight. The primary line must not
+    // flash "No project" during that window — and the org context stays.
+    act(() => {
+      useActive.setState({ activeOrgId: ORG_A.id, activeProjectId: "p-x" });
+    });
+    vi.spyOn(window, "fetch").mockImplementation(
+      async (input: RequestInfo | URL) => {
+        const path = (
+          typeof input === "string" ? input : input.toString()
+        ).split("?")[0];
+        if (path === "/v1/orgs") {
+          return new Response(JSON.stringify([ORG_A, ORG_B]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+        // Projects never resolve → the query stays in its loading state.
+        return new Promise<Response>(() => {});
+      },
+    );
+    renderWithProviders(
+      <OrgProjectSwitcher onNewOrg={vi.fn()} onNewProject={vi.fn()} />,
+    );
+
+    // Wait for the window under test: orgs resolved (org name shows) while the
+    // projects query is still loading.
+    await waitFor(() =>
+      expect(screen.getByText("Org Alpha")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Loading…")).toBeInTheDocument(); // primary line
+    expect(screen.queryByText("No project")).not.toBeInTheDocument();
   });
 });

--- a/platform/dashboard/src/components/OrgProjectSwitcher.tsx
+++ b/platform/dashboard/src/components/OrgProjectSwitcher.tsx
@@ -1,11 +1,5 @@
 import { useState } from "react";
-import {
-  Building2,
-  Check,
-  ChevronsUpDown,
-  FolderPlus,
-  Plus,
-} from "lucide-react";
+import { Check, ChevronsUpDown, FolderPlus, Plus } from "lucide-react";
 
 import { CreateOrgDialog } from "@/components/CreateOrgDialog";
 import { CreateProjectDialog } from "@/components/CreateProjectDialog";
@@ -23,10 +17,14 @@ import { useProjects, type ProjectRead } from "@/lib/projects";
 import { cn } from "@/lib/utils";
 
 /**
- * The pill that lives in the AppShell header. Reads the active org +
+ * The workspace switcher at the top of the sidebar. Reads the active org +
  * project from the store, lists all the user's orgs (with their
  * projects nested) in a single dropdown. "+ New project" /
  * "+ New organization" footer actions open the corresponding dialogs.
+ *
+ * Renders as a two-line block — project name on top, org name beneath — so
+ * the project reads as the primary context (OpenAI-style) even though one
+ * dropdown still switches both.
  *
  * Two state pieces:
  *   - which orgs/projects exist (from React Query)
@@ -48,6 +46,7 @@ export function OrgProjectSwitcher() {
   const projects: ProjectRead[] = projectsQuery.data ?? [];
   const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? null;
   const activeProject = projects.find((p) => p.id === activeProjectId) ?? null;
+  const label = switcherLabel(activeOrg, activeProject, orgsQuery.isLoading);
 
   return (
     <>
@@ -56,18 +55,22 @@ export function OrgProjectSwitcher() {
           <button
             type="button"
             className={cn(
-              "inline-flex items-center gap-2 rounded-md border border-border bg-card px-2.5 py-1 text-xs",
-              "transition-colors hover:border-primary hover:bg-primary/5",
+              "flex w-full flex-col gap-0.5 rounded-md px-2 py-1 text-left",
+              "transition-colors hover:bg-accent",
               "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
             )}
           >
-            <Building2 className="h-3.5 w-3.5 text-primary" />
-            <SwitcherLabel
-              activeOrg={activeOrg}
-              activeProject={activeProject}
-              loading={orgsQuery.isLoading}
-            />
-            <ChevronsUpDown className="h-3 w-3 text-muted-foreground" />
+            <span className="flex w-full items-center gap-1">
+              <span className="truncate text-sm font-medium text-foreground">
+                {label.project}
+              </span>
+              <ChevronsUpDown className="ml-auto size-3 shrink-0 text-muted-foreground" />
+            </span>
+            {label.org && (
+              <span className="truncate text-xs text-muted-foreground">
+                {label.org}
+              </span>
+            )}
           </button>
         </DropdownMenuTrigger>
 
@@ -154,37 +157,16 @@ export function OrgProjectSwitcher() {
   );
 }
 
-interface SwitcherLabelProps {
-  activeOrg: OrgWithRole | null;
-  activeProject: ProjectRead | null;
-  loading: boolean;
-}
-
-function SwitcherLabel({
-  activeOrg,
-  activeProject,
-  loading,
-}: SwitcherLabelProps) {
-  if (loading) {
-    return <span className="text-muted-foreground">Loading…</span>;
-  }
-  if (!activeOrg) {
-    return <span className="text-muted-foreground">Pick an organization</span>;
-  }
-  return (
-    <span className="flex items-center gap-1.5">
-      <span className="text-foreground">{activeOrg.name}</span>
-      {activeProject && (
-        <>
-          <span className="text-muted-foreground">/</span>
-          <span className="font-mono text-foreground">
-            {activeProject.name}
-          </span>
-        </>
-      )}
-      {!activeProject && (
-        <span className="text-muted-foreground">· no project</span>
-      )}
-    </span>
-  );
+/** Project (primary line) + org (secondary line) for the two-line trigger. */
+function switcherLabel(
+  activeOrg: OrgWithRole | null,
+  activeProject: ProjectRead | null,
+  loading: boolean,
+): { project: string; org: string } {
+  if (loading) return { project: "Loading…", org: "" };
+  if (!activeOrg) return { project: "Pick an organization", org: "" };
+  return {
+    project: activeProject?.name ?? "No project",
+    org: activeOrg.name,
+  };
 }

--- a/platform/dashboard/src/components/OrgProjectSwitcher.tsx
+++ b/platform/dashboard/src/components/OrgProjectSwitcher.tsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
 import { Check, ChevronsUpDown, FolderPlus, Plus } from "lucide-react";
 
-import { CreateOrgDialog } from "@/components/CreateOrgDialog";
-import { CreateProjectDialog } from "@/components/CreateProjectDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -31,129 +28,133 @@ import { cn } from "@/lib/utils";
  *   - which is active (from the zustand store)
  *
  * Bootstrap (auto-pick first org + project when nothing's active) is
- * handled by the parent AppShell so this component stays pure.
+ * handled by the parent AppShell so this component stays pure. The create
+ * dialogs are owned by AppShell too (so collapsing the sidebar can't unmount
+ * an open one); this only signals intent via `onNewOrg` / `onNewProject`.
  */
-export function OrgProjectSwitcher() {
+export function OrgProjectSwitcher({
+  onNewOrg,
+  onNewProject,
+}: {
+  onNewOrg: () => void;
+  onNewProject: () => void;
+}) {
   const { activeOrgId, activeProjectId, setActiveOrg, setActiveProject } =
     useActive();
   const orgsQuery = useOrgs();
   const projectsQuery = useProjects(activeOrgId);
 
-  const [createOrgOpen, setCreateOrgOpen] = useState(false);
-  const [createProjectOpen, setCreateProjectOpen] = useState(false);
-
   const orgs: OrgWithRole[] = orgsQuery.data ?? [];
   const projects: ProjectRead[] = projectsQuery.data ?? [];
   const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? null;
   const activeProject = projects.find((p) => p.id === activeProjectId) ?? null;
-  const label = switcherLabel(activeOrg, activeProject, orgsQuery.isLoading);
+  // Show "Loading…" (not "No project") while EITHER query is in flight — projects
+  // is a separate query, so after an org switch (which clears the active project)
+  // orgs is cached but projects is still loading.
+  const label = switcherLabel(
+    activeOrg,
+    activeProject,
+    orgsQuery.isLoading || (activeOrgId !== null && projectsQuery.isLoading),
+  );
 
   return (
-    <>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              "flex w-full flex-col gap-0.5 rounded-md px-2 py-1 text-left",
-              "transition-colors hover:bg-accent",
-              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            )}
-          >
-            <span className="flex w-full items-center gap-1">
-              <span className="truncate text-sm font-medium text-foreground">
-                {label.project}
-              </span>
-              <ChevronsUpDown className="ml-auto size-3 shrink-0 text-muted-foreground" />
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex w-full flex-col gap-0.5 rounded-md px-2 py-1 text-left",
+            "transition-colors hover:bg-accent",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          <span className="flex w-full items-center gap-1">
+            <span className="truncate text-sm font-medium text-foreground">
+              {label.project}
             </span>
-            {label.org && (
-              <span className="truncate text-xs text-muted-foreground">
-                {label.org}
+            <ChevronsUpDown className="ml-auto size-3 shrink-0 text-muted-foreground" />
+          </span>
+          {label.org && (
+            <span className="truncate text-xs text-muted-foreground">
+              {label.org}
+            </span>
+          )}
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" className="min-w-[260px]">
+        <DropdownMenuLabel>Organizations</DropdownMenuLabel>
+        {orgs.length === 0 ? (
+          <div className="px-2 py-3 text-xs text-muted-foreground">
+            Loading…
+          </div>
+        ) : (
+          orgs.map((org) => (
+            <DropdownMenuItem
+              key={org.id}
+              onSelect={() => setActiveOrg(org.id)}
+              className="flex items-center gap-2"
+            >
+              <span className="flex-1 truncate font-medium">{org.name}</span>
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                {org.role}
               </span>
-            )}
-          </button>
-        </DropdownMenuTrigger>
+              {org.id === activeOrgId && (
+                <Check className="h-3.5 w-3.5 text-primary" />
+              )}
+            </DropdownMenuItem>
+          ))
+        )}
 
-        <DropdownMenuContent align="start" className="min-w-[260px]">
-          <DropdownMenuLabel>Organizations</DropdownMenuLabel>
-          {orgs.length === 0 ? (
-            <div className="px-2 py-3 text-xs text-muted-foreground">
-              Loading…
-            </div>
-          ) : (
-            orgs.map((org) => (
-              <DropdownMenuItem
-                key={org.id}
-                onSelect={() => setActiveOrg(org.id)}
-                className="flex items-center gap-2"
-              >
-                <span className="flex-1 truncate font-medium">{org.name}</span>
-                <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-                  {org.role}
-                </span>
-                {org.id === activeOrgId && (
-                  <Check className="h-3.5 w-3.5 text-primary" />
-                )}
-              </DropdownMenuItem>
-            ))
-          )}
+        <DropdownMenuSeparator />
 
-          <DropdownMenuSeparator />
+        <DropdownMenuLabel>
+          Projects{activeOrg ? ` in ${activeOrg.name}` : ""}
+        </DropdownMenuLabel>
+        {activeOrgId === null ? (
+          <div className="px-2 py-3 text-xs text-muted-foreground">
+            Pick an organization first.
+          </div>
+        ) : projectsQuery.isLoading ? (
+          <div className="px-2 py-3 text-xs text-muted-foreground">
+            Loading…
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="px-2 py-3 text-xs text-muted-foreground">
+            No projects yet.
+          </div>
+        ) : (
+          projects.map((project) => (
+            <DropdownMenuItem
+              key={project.id}
+              onSelect={() => setActiveProject(project.id)}
+              className="flex items-center gap-2"
+            >
+              <span className="flex-1 truncate font-mono text-xs">
+                {project.name}
+              </span>
+              {project.id === activeProjectId && (
+                <Check className="h-3.5 w-3.5 text-primary" />
+              )}
+            </DropdownMenuItem>
+          ))
+        )}
 
-          <DropdownMenuLabel>
-            Projects{activeOrg ? ` in ${activeOrg.name}` : ""}
-          </DropdownMenuLabel>
-          {activeOrgId === null ? (
-            <div className="px-2 py-3 text-xs text-muted-foreground">
-              Pick an organization first.
-            </div>
-          ) : projectsQuery.isLoading ? (
-            <div className="px-2 py-3 text-xs text-muted-foreground">
-              Loading…
-            </div>
-          ) : projects.length === 0 ? (
-            <div className="px-2 py-3 text-xs text-muted-foreground">
-              No projects yet.
-            </div>
-          ) : (
-            projects.map((project) => (
-              <DropdownMenuItem
-                key={project.id}
-                onSelect={() => setActiveProject(project.id)}
-                className="flex items-center gap-2"
-              >
-                <span className="flex-1 truncate font-mono text-xs">
-                  {project.name}
-                </span>
-                {project.id === activeProjectId && (
-                  <Check className="h-3.5 w-3.5 text-primary" />
-                )}
-              </DropdownMenuItem>
-            ))
-          )}
+        <DropdownMenuSeparator />
 
-          <DropdownMenuSeparator />
-
-          <DropdownMenuItem
-            onSelect={() => setCreateProjectOpen(true)}
-            disabled={!activeOrgId}
-          >
-            <FolderPlus className="h-3.5 w-3.5" />
-            <span>New project</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => setCreateOrgOpen(true)}>
-            <Plus className="h-3.5 w-3.5" />
-            <span>New organization</span>
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-
-      <CreateOrgDialog open={createOrgOpen} onOpenChange={setCreateOrgOpen} />
-      <CreateProjectDialog
-        open={createProjectOpen}
-        onOpenChange={setCreateProjectOpen}
-      />
-    </>
+        <DropdownMenuItem
+          onSelect={() => onNewProject()}
+          disabled={!activeOrgId}
+        >
+          <FolderPlus className="h-3.5 w-3.5" />
+          <span>New project</span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onNewOrg()}>
+          <Plus className="h-3.5 w-3.5" />
+          <span>New organization</span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -163,7 +164,9 @@ function switcherLabel(
   activeProject: ProjectRead | null,
   loading: boolean,
 ): { project: string; org: string } {
-  if (loading) return { project: "Loading…", org: "" };
+  // Keep the org name visible while projects load, so an org switch doesn't
+  // blank the context — only the project line reads "Loading…".
+  if (loading) return { project: "Loading…", org: activeOrg?.name ?? "" };
   if (!activeOrg) return { project: "Pick an organization", org: "" };
   return {
     project: activeProject?.name ?? "No project",

--- a/platform/dashboard/src/lib/ui.test.ts
+++ b/platform/dashboard/src/lib/ui.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Unit tests for the persisted UI-preference store.
+ *
+ * Two things worth pinning: the toggle actually flips the flag, and the
+ * value round-trips through localStorage under the expected key so a
+ * collapse survives a reload.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { useUi } from "@/lib/ui";
+
+describe("useUi", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    useUi.setState({ sidebarCollapsed: false });
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("starts expanded", () => {
+    expect(useUi.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it("toggleSidebar flips the flag both ways", () => {
+    useUi.getState().toggleSidebar();
+    expect(useUi.getState().sidebarCollapsed).toBe(true);
+    useUi.getState().toggleSidebar();
+    expect(useUi.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it("persists the collapsed state to localStorage", () => {
+    useUi.getState().toggleSidebar();
+    const raw = window.localStorage.getItem("hexgate-ui");
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw!).state.sidebarCollapsed).toBe(true);
+  });
+});

--- a/platform/dashboard/src/lib/ui.ts
+++ b/platform/dashboard/src/lib/ui.ts
@@ -1,0 +1,27 @@
+/**
+ * Small persisted UI-preference store (separate from `active`, which holds the
+ * org/project scope). Currently just the workspace-sidebar collapsed state, so
+ * a collapse survives a reload.
+ */
+
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+interface UiState {
+  sidebarCollapsed: boolean;
+  toggleSidebar: () => void;
+}
+
+export const useUi = create<UiState>()(
+  persist(
+    (set) => ({
+      sidebarCollapsed: false,
+      toggleSidebar: () =>
+        set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+    }),
+    {
+      name: "hexgate-ui",
+      storage: createJSONStorage(() => localStorage),
+    },
+  ),
+);


### PR DESCRIPTION
Extracts the app-shell / navigation plumbing that was bundled into the policy-module editor PR (#132) so it can merge on its own, independent of the policy-authoring rewrite that supersedes the rest of that branch.

## What it does
- **AppShell** — restructures the nav into a collapsible sidebar, moves the org/project switcher into it, and adds a user dropdown (settings / orgs / sign-out).
- **OrgProjectSwitcher** — redesigns the trigger into a two-line block (project name primary, org beneath), OpenAI-style, while one dropdown still switches both.
- **lib/ui** — a small persisted zustand store so the sidebar's collapsed state survives a reload.

## Try it
- Collapse/expand the sidebar — the state persists across a reload.
- Switch org/project from the sidebar trigger.

## Important files
- `platform/dashboard/src/components/AppShell.tsx`
- `platform/dashboard/src/components/OrgProjectSwitcher.tsx`
- `platform/dashboard/src/lib/ui.ts` (new)

## Notes
- Lifted from `lhq/feat/policy-editor` (#132), **minus** the `/policy-modules` nav item + route and the `PolicyFolder` id change — those belong to the policy-module work, not this refactor. No policy/tier coupling remains.
- `tsc`, `eslint`, and `prettier --check` all pass.
