### PR TITLE
feat(sdk): compose policy.yaml grammar front-end

### DIFF
--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -33,6 +33,7 @@ from hexgate.security.testing import run_namespace
 from hexgate.security import (
     AgentPolicy,
     DecisionOutcome,
+    DEFAULT_AGENT,
     DEFAULT_ROLE_NAME,
     OpaNotFoundError,
     PolicySetError,
@@ -261,10 +262,28 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:
             "exactly what the engines will enforce."
         ),
     )
-    p_resolve.add_argument(
+    resolve_src = p_resolve.add_mutually_exclusive_group()
+    resolve_src.add_argument(
         "--dir",
         default=".",
         help="Repo root containing a policies/ tree (default: current dir).",
+    )
+    resolve_src.add_argument(
+        "--file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Resolve a single-file policy.yaml (the compose grammar) instead of a "
+            "policies/ tree. Mutually exclusive with --dir."
+        ),
+    )
+    p_resolve.add_argument(
+        "--agent",
+        default=DEFAULT_AGENT,
+        help=(
+            f'The executing agent to resolve for (default: the generic "{DEFAULT_AGENT}" '
+            "agent). Selects an agent's column in either layout."
+        ),
     )
     p_resolve.add_argument(
         "--role",
@@ -584,25 +603,67 @@ def _main_resolve(args: argparse.Namespace) -> int:
         resolve_for_project,
     )
 
-    try:
-        boundaries, capabilities = load_local_modules(args.dir)
-        roles = load_roles(args.dir)
-    except (ValueError, OSError) as exc:
-        print(f"load error: {exc}", file=sys.stderr)
-        return 1
-    if not boundaries and not capabilities:
-        print(
-            f"no modules found under {args.dir}/policies/"
-            " (expected policies/boundaries/ and/or policies/capabilities/)",
-            file=sys.stderr,
-        )
-        return 1
+    # --file (compose grammar) and --dir (policies/ tree) are the two front-ends;
+    # both produce the same ProjectLinkResult, so the print path below is shared.
+    if args.file is not None:
+        from hexgate.security.compose import parse_entry, resolve_entry
 
-    try:
-        result = resolve_for_project(boundaries, capabilities, roles)
-    except (LinkError, PolicySetError, ConstraintParseError, ValidationError) as exc:
-        print(f"link error: {exc}", file=sys.stderr)
-        return 1
+        try:
+            text = Path(args.file).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"load error: {exc}", file=sys.stderr)
+            return 1
+        # Parse once: resolve_entry reuses the Entry, and the agent hint below reads
+        # its declared agents. resolve_entry surfaces every failure as LinkError.
+        try:
+            entry = parse_entry(text, source=args.file)
+            result = resolve_entry(entry, agent=args.agent, source=args.file)
+        except LinkError as exc:
+            print(f"link error: {exc}", file=sys.stderr)
+            return 1
+        # Roles live under a named agent. Nudge if the generic "*" view hides named
+        # agents; warn if a named --agent isn't defined (a typo resolves to the
+        # generic baseline rather than erroring — matching resolve_for_project).
+        declared = sorted(entry.agents)
+        if args.agent == DEFAULT_AGENT and declared:
+            print(
+                f"note: resolved the generic '*' agent; this policy also defines "
+                f"agents {declared} — pass --agent NAME to resolve one.",
+                file=sys.stderr,
+            )
+        elif args.agent != DEFAULT_AGENT and args.agent not in declared:
+            print(
+                f"warning: agent {args.agent!r} is not defined in this policy "
+                f"(defined: {declared or 'none'}); resolved the generic baseline.",
+                file=sys.stderr,
+            )
+    else:
+        try:
+            boundaries, capabilities = load_local_modules(args.dir)
+            roles = load_roles(args.dir)
+        except (ValueError, OSError) as exc:
+            print(f"load error: {exc}", file=sys.stderr)
+            return 1
+        if not boundaries and not capabilities:
+            print(
+                f"no modules found under {args.dir}/policies/"
+                " (expected policies/boundaries/ and/or policies/capabilities/)",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            result = resolve_for_project(
+                boundaries, capabilities, roles, agent=args.agent
+            )
+        except (
+            LinkError,
+            PolicySetError,
+            ConstraintParseError,
+            ValidationError,
+        ) as exc:
+            print(f"link error: {exc}", file=sys.stderr)
+            return 1
 
     if args.role is not None and args.role not in result.by_role:
         print(

--- a/hexgate/security/analyzer.py
+++ b/hexgate/security/analyzer.py
@@ -269,7 +269,11 @@ def _dead_grants(
     effective = result.effective[DEFAULT_ROLE_NAME]
     out: list[PolicyLint] = []
     for cap in capabilities:
-        for tool, tp in cap.policy.tools.items():
+        # effective_tools: composed agent-level grants (admission/reach lowered to
+        # agent.* keys) are linted like ordinary tools. A shadowed agent key stays
+        # in the resolved policy as an explicit deny (not GRANT_MODES), so it is
+        # correctly reported dead here.
+        for tool, tp in cap.policy.effective_tools.items():
             if tp.mode not in GRANT_MODES:
                 continue
             eff = effective.tools.get(tool)
@@ -304,7 +308,7 @@ def _redundant_grants(capabilities: list[ModuleContent]) -> list[PolicyLint]:
     out: list[PolicyLint] = []
     seen: dict[tuple[str, str, tuple[str, ...]], ModuleContent] = {}
     for cap in capabilities:
-        for tool, tp in cap.policy.tools.items():
+        for tool, tp in cap.policy.effective_tools.items():
             if tp.mode not in GRANT_MODES:
                 continue
             key = (tool, tp.mode, tuple(sorted(tp.constraints)))
@@ -338,7 +342,7 @@ def _constraint_erased(capabilities: list[ModuleContent]) -> list[PolicyLint]:
     """
     grants: dict[str, list[tuple[ModuleContent, Any]]] = {}
     for cap in capabilities:
-        for tool, tp in cap.policy.tools.items():
+        for tool, tp in cap.policy.effective_tools.items():
             if tp.mode in GRANT_MODES:
                 grants.setdefault(tool, []).append((cap, tp))
 

--- a/hexgate/security/compose/__init__.py
+++ b/hexgate/security/compose/__init__.py
@@ -1,0 +1,16 @@
+"""The ``policy.yaml`` authoring front-end.
+
+Parses the position-wildcard grammar (one entry file + imports) and lowers it to
+the ``ModuleContent`` lists the existing linker fold consumes — so the entire
+fold → rego → wasm → signing path is reused unchanged. See
+:mod:`hexgate.security.compose.grammar` for the shape and
+:func:`hexgate.security.compose.resolve.resolve_file` for the entry point.
+"""
+
+from __future__ import annotations
+
+from hexgate.security.compose.grammar import Entry
+from hexgate.security.compose.parse import parse_entry
+from hexgate.security.compose.resolve import resolve_entry, resolve_file, resolve_text
+
+__all__ = ["Entry", "parse_entry", "resolve_entry", "resolve_file", "resolve_text"]

--- a/hexgate/security/compose/grammar.py
+++ b/hexgate/security/compose/grammar.py
@@ -1,0 +1,189 @@
+"""The ``policy.yaml`` authoring grammar (position-wildcard shape).
+
+These pydantic models are the *authoring* surface — a single entry file plus
+imports — distinct from the SDK's resolved :class:`~hexgate.security.models.AgentPolicy`.
+:mod:`hexgate.security.compose.lower` turns a parsed :class:`Entry` into the
+``ModuleContent`` lists the existing linker fold consumes; nothing here touches
+the engine.
+
+Shape (scope by depth — a block keyword is a sibling of the ``agents``/``roles``
+name-map, never a key inside it):
+
+    version, import, export          # top-level only
+    boundary / tools / reach / mcp   # at any scope → applies to that scope
+    agents: { <name>: agent-body }   # top level only; body may add roles:
+    roles:  { <name>: role-body }    # agent-body only
+
+A ``tools`` block at the top level means all agents + all roles; in an agent body,
+that agent + all its roles; in a role body, that one cell.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from hexgate.security.models import AgentVia
+
+# Keywords that are structural, so an agent or role may not be *named* one — a
+# `roles: { tools: … }` would be unreadable even though the parser could tell it
+# from the block. Enforced on every name-map.
+RESERVED_NAMES = frozenset(
+    {
+        "version",
+        "import",
+        "export",
+        "boundary",
+        "tools",
+        "reach",
+        "mcp",
+        "agents",
+        "roles",
+    }
+)
+
+GrantMode = Literal["allow", "approval_required"]
+CeilingMode = Literal["allow", "approval_required", "deny"]
+
+
+def _as_list(v: object) -> object:
+    """Accept ``constraint: "x"`` as sugar for ``constraints: ["x"]``."""
+    return [v] if isinstance(v, str) else v
+
+
+class _ConstraintsMixin(BaseModel):
+    """Shared ``constraint``/``constraints`` ergonomics for every spec."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    constraints: list[str] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _fold_singular_constraint(cls, data: object) -> object:
+        if isinstance(data, dict) and "constraint" in data:
+            data = dict(data)
+            single = data.pop("constraint")
+            if "constraints" in data:
+                raise ValueError(
+                    "specify either 'constraint' (one) or 'constraints' (a list), "
+                    "not both"
+                )
+            data["constraints"] = _as_list(single)
+        return data
+
+
+class GrantSpec(_ConstraintsMixin):
+    """A ``tools``/``mcp`` grant. Grants only ever allow or gate on approval."""
+
+    mode: GrantMode = "allow"
+
+
+class ReachSpec(_ConstraintsMixin):
+    """A ``reach`` edge to a named target agent, per transfer mode (``as``)."""
+
+    mode: GrantMode = "allow"
+    # ``as`` is a Python keyword; expose it as the YAML key via an alias.
+    via: list[AgentVia] = Field(default_factory=lambda: ["tool", "handoff"], alias="as")
+
+    @field_validator("via", mode="before")
+    @classmethod
+    def _one_or_many(cls, v: object) -> object:
+        return [v] if isinstance(v, str) else v
+
+
+class CeilingSpec(_ConstraintsMixin):
+    """A ``boundary`` entry — a ceiling. Caps only: it permits up to a constraint
+    (``allow``/``approval_required``) or subtracts (``deny``); it never grants."""
+
+    mode: CeilingMode = "allow"
+
+
+class BoundaryBlock(BaseModel):
+    """A ceiling block. ``default_policy`` is fail-closed deny by construction, so
+    a tool (or reach edge) it does not list is denied — the closed-world posture.
+
+    ``reach`` here is the ceiling's *allow-list* of permitted reach edges (each an
+    optional cap): agent keys are closed-world, so a reach not listed in the
+    boundary is denied even if a capability grants it. To permit reaching a
+    target, the boundary must list it.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    tools: dict[str, CeilingSpec] = Field(default_factory=dict)
+    reach: dict[str, ReachSpec] = Field(default_factory=dict)
+
+
+class _GrantScope(BaseModel):
+    """The grant blocks legal at any scope (role body, agent body, top level)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    boundary: BoundaryBlock | None = None
+    tools: dict[str, GrantSpec] = Field(default_factory=dict)
+    reach: dict[str, ReachSpec] = Field(default_factory=dict)
+    mcp: dict[str, GrantSpec] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _no_tools_mcp_collision(self) -> "_GrantScope":
+        # mcp is sugar for tools (same key namespace), so a name in both blocks in
+        # one scope would silently clobber — reject it at parse, source-named.
+        clash = sorted(set(self.tools) & set(self.mcp))
+        if clash:
+            raise ValueError(
+                f"tool name(s) {clash} declared in both 'tools' and 'mcp' in the "
+                f"same scope; mcp is sugar for tools — declare each once"
+            )
+        return self
+
+
+class RoleBlock(_GrantScope):
+    """A ``(agent, role)`` leaf — grants + an optional per-role ceiling."""
+
+
+class AgentBlock(_GrantScope):
+    """One agent's body: its all-roles grants/ceiling + a ``roles`` name-map."""
+
+    roles: dict[str, RoleBlock] = Field(default_factory=dict)
+
+    @field_validator("roles")
+    @classmethod
+    def _no_reserved_role_names(
+        cls, value: dict[str, RoleBlock]
+    ) -> dict[str, RoleBlock]:
+        _reject_reserved(value, "role")
+        return value
+
+
+class Entry(_GrantScope):
+    """The entry ``policy.yaml`` — the import-graph root.
+
+    Carries the top-level (all-agents, all-roles) grant blocks plus the ``agents``
+    name-map, and the file-level ``version`` / ``import`` / ``export``.
+    """
+
+    version: int = 1
+    imports: list[str] = Field(default_factory=list, alias="import")
+    exports: dict[str, RoleBlock] = Field(default_factory=dict, alias="export")
+    agents: dict[str, AgentBlock] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    @field_validator("agents")
+    @classmethod
+    def _no_reserved_agent_names(
+        cls, value: dict[str, AgentBlock]
+    ) -> dict[str, AgentBlock]:
+        _reject_reserved(value, "agent")
+        return value
+
+
+def _reject_reserved(names: dict[str, object], kind: str) -> None:
+    clash = sorted(set(names) & RESERVED_NAMES)
+    if clash:
+        raise ValueError(
+            f"{kind} name(s) {clash} are reserved keywords; an {kind} may not be "
+            f"named one of {sorted(RESERVED_NAMES)}"
+        )

--- a/hexgate/security/compose/lower.py
+++ b/hexgate/security/compose/lower.py
@@ -1,0 +1,152 @@
+"""Lower a parsed :class:`Entry` into the ``ModuleContent`` lists the linker fold
+consumes — one ``(boundaries, capabilities)`` pair per resolved role.
+
+This is the whole point of the front-end: the new grammar is *assembly above the
+fold*. Each grant block becomes a capability ``ModuleContent``; each ``boundary``
+becomes a boundary ``ModuleContent``; the linker unions the grants and intersects
+the ceilings exactly as it does for the tier-folder layout, so the engine, rego,
+and signing paths never change.
+
+Scope by depth (per the grammar): the top-level blocks apply to every agent and
+role; an agent body's blocks to that agent's roles; a role body's blocks to that
+one cell. Roles live under a named agent, so the generic/unnamed agent (``"*"``)
+resolves a single ``default`` role from the top-level blocks alone.
+"""
+
+from __future__ import annotations
+
+from hexgate.security.compose.grammar import (
+    AgentBlock,
+    BoundaryBlock,
+    Entry,
+    _GrantScope,
+)
+from hexgate.security.module_loader import _canonical_hash
+from hexgate.security.models import AgentPolicy, AgentTargetPolicy, BaseToolPolicy
+from hexgate.security.modules import DEFAULT_AGENT, ModuleContent
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME
+
+# The single role every project has: the generic agent, and any named agent with
+# no `roles:` map, resolve to it. Reuse the SDK's constant so the two can't drift.
+DEFAULT_ROLE = DEFAULT_ROLE_NAME
+
+
+def _content_hash(name: str, policy: AgentPolicy) -> str:
+    """Stable identity for a synthetic fragment — reuses the loader's canonical
+    hash so compose and file-loaded modules serialize identically (and non-JSON
+    YAML scalars are handled via its ``default=str``, not re-raised here)."""
+    return _canonical_hash({"name": name, "policy": policy.model_dump(mode="json")})
+
+
+def _grants_policy(scope: _GrantScope) -> AgentPolicy | None:
+    """An :class:`AgentPolicy` carrying a scope's ``tools``/``mcp``/``reach`` grants
+    (never a boundary). ``None`` when the scope grants nothing."""
+    # mcp is readability sugar — an MCP tool is a tool; it composes identically
+    # (same key namespace). A name in both blocks is rejected at parse (the
+    # grammar's _no_tools_mcp_collision), so here they simply merge.
+    tools: dict[str, BaseToolPolicy] = {}
+    for name, spec in scope.tools.items():
+        tools[name] = BaseToolPolicy(mode=spec.mode, constraints=spec.constraints)
+    for name, spec in scope.mcp.items():
+        tools[name] = BaseToolPolicy(mode=spec.mode, constraints=spec.constraints)
+    agents: dict[str, AgentTargetPolicy] = {}
+    for target, spec in scope.reach.items():
+        agents[target] = AgentTargetPolicy(
+            via=spec.via, mode=spec.mode, constraints=spec.constraints
+        )
+    if not tools and not agents:
+        return None
+    return AgentPolicy(tools=tools, agents=agents)
+
+
+def _boundary_policy(block: BoundaryBlock | None) -> AgentPolicy | None:
+    """An :class:`AgentPolicy` ceiling (``default_policy: deny``) for a boundary
+    block. ``None`` when there is no boundary at this scope."""
+    if block is None:
+        return None
+    tools = {
+        name: BaseToolPolicy(mode=spec.mode, constraints=spec.constraints)
+        for name, spec in block.tools.items()
+    }
+    agents = {
+        target: AgentTargetPolicy(
+            via=spec.via, mode=spec.mode, constraints=spec.constraints
+        )
+        for target, spec in block.reach.items()
+    }
+    return AgentPolicy(
+        default_policy=BaseToolPolicy(mode="deny"), tools=tools, agents=agents
+    )
+
+
+def _cap(name: str, policy: AgentPolicy) -> ModuleContent:
+    return ModuleContent(
+        name=name,
+        kind="capability",
+        policy=policy,
+        source=f"policy.yaml#{name}",
+        content_hash=_content_hash(name, policy),
+    )
+
+
+def _boundary(name: str, policy: AgentPolicy) -> ModuleContent:
+    return ModuleContent(
+        name=name,
+        kind="boundary",
+        policy=policy,
+        source=f"policy.yaml#{name}",
+        content_hash=_content_hash(name, policy),
+    )
+
+
+def _cell(
+    scopes: list[tuple[str, _GrantScope]],
+    boundaries_src: list[tuple[str, BoundaryBlock | None]],
+    agent: str,
+    role: str,
+) -> tuple[list[ModuleContent], list[ModuleContent]]:
+    """Build the ``(boundaries, capabilities)`` ModuleContent lists for one cell."""
+    caps: list[ModuleContent] = []
+    for label, scope in scopes:
+        policy = _grants_policy(scope)
+        if policy is not None:
+            caps.append(_cap(f"{label}@{agent}/{role}", policy))
+    boundaries: list[ModuleContent] = []
+    for label, block in boundaries_src:
+        policy = _boundary_policy(block)
+        if policy is not None:
+            boundaries.append(_boundary(f"boundary:{label}@{agent}/{role}", policy))
+    return boundaries, caps
+
+
+def lower(entry: Entry, agent: str = DEFAULT_AGENT) -> dict[str, tuple[list, list]]:
+    """Lower ``entry`` for one executing ``agent`` → ``{role: (boundaries, caps)}``.
+
+    Every result carries a ``default`` role (resolved from the base scopes alone),
+    matching the SDK's always-present default; a named agent also resolves each
+    role declared under it, folding the top-level, agent-level, and role-level
+    scopes together. The generic/unnamed agent (``"*"``) has only the ``default``
+    role from the top-level blocks (roles live under a named agent).
+    """
+    agent_block: AgentBlock | None = (
+        entry.agents.get(agent) if agent != DEFAULT_AGENT else None
+    )
+
+    # Scopes that apply regardless of role: top-level always; the agent body when
+    # a named agent is being resolved.
+    base_scopes: list[tuple[str, _GrantScope]] = [("top", entry)]
+    base_boundaries: list[tuple[str, BoundaryBlock | None]] = [("top", entry.boundary)]
+    if agent_block is not None:
+        base_scopes.append((f"agent:{agent}", agent_block))
+        base_boundaries.append((f"agent:{agent}", agent_block.boundary))
+
+    # The default role: base scopes only (no role-specific block).
+    out: dict[str, tuple[list, list]] = {
+        DEFAULT_ROLE: _cell(base_scopes, base_boundaries, agent, DEFAULT_ROLE)
+    }
+    # Each named role: base scopes + that role's block.
+    for role, role_block in (agent_block.roles if agent_block else {}).items():
+        scopes = [*base_scopes, (f"role:{role}", role_block)]
+        boundaries_src = [*base_boundaries, (f"role:{role}", role_block.boundary)]
+        out[role] = _cell(scopes, boundaries_src, agent, role)
+    return out

--- a/hexgate/security/compose/parse.py
+++ b/hexgate/security/compose/parse.py
@@ -1,0 +1,36 @@
+"""Parse a ``policy.yaml`` document into a grammar :class:`Entry`.
+
+A thin seam over YAML + pydantic: it exists so parse failures surface as a
+:class:`~hexgate.security.modules.LinkError` (the error family the resolver and
+the platform already catch) with the source file named, rather than a raw
+``yaml``/``pydantic`` exception.
+"""
+
+from __future__ import annotations
+
+import yaml
+from pydantic import ValidationError
+
+from hexgate.security.compose.grammar import Entry
+from hexgate.security.modules import LinkError
+
+
+def parse_entry(text: str, *, source: str = "policy.yaml") -> Entry:
+    """Parse one policy document's text into an :class:`Entry`."""
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise LinkError(f"{source}: invalid YAML — {exc}") from exc
+    # An empty / comment-only / explicitly-null document is an empty (fail-closed
+    # deny-all) policy. Any other non-mapping (a list, bool, number) is malformed
+    # — error rather than silently coercing a falsy value to an empty policy.
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise LinkError(
+            f"{source}: a policy document must be a mapping, got {type(raw).__name__}"
+        )
+    try:
+        return Entry.model_validate(raw)
+    except ValidationError as exc:
+        raise LinkError(f"{source}: {exc}") from exc

--- a/hexgate/security/compose/resolve.py
+++ b/hexgate/security/compose/resolve.py
@@ -1,0 +1,75 @@
+"""Resolve a ``policy.yaml`` into a role-keyed :class:`ProjectLinkResult`.
+
+The orchestration seam: parse the entry file, lower it per ``(agent, role)``, and
+fold each cell through the existing :func:`~hexgate.security.linker.link_policy_set`
+— assembling the same ``ProjectLinkResult`` shape :func:`resolve_for_project`
+produces, so ``effective_policy_by_role`` and the rego/wasm/signing path consume
+it unchanged. Folding per cell (rather than calling ``resolve_for_project``) is
+what lets a per-agent / per-role ``boundary`` apply only to its own cell.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from hexgate.security.compose.grammar import Entry
+from hexgate.security.compose.lower import lower
+from hexgate.security.compose.parse import parse_entry
+from hexgate.security.constraints import ConstraintParseError
+from hexgate.security.linker import link_policy_set
+from hexgate.security.models import AgentPolicy
+from hexgate.security.modules import (
+    DEFAULT_AGENT,
+    LinkError,
+    LinkResult,
+    ProjectLinkResult,
+)
+from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySet, PolicySetError
+
+
+def resolve_entry(
+    entry: Entry, *, agent: str = DEFAULT_AGENT, source: str = "policy.yaml"
+) -> ProjectLinkResult:
+    """Resolve an already-parsed :class:`Entry` for one executing ``agent``.
+
+    Split from :func:`resolve_text` so a caller that already parsed (the CLI, to
+    read the declared agents for a hint) resolves without parsing twice.
+    """
+    if entry.imports or entry.exports:
+        raise LinkError(
+            f"{source}: 'import:'/'export:' are not supported yet — the import "
+            f"graph lands in the next increment; inline the fragments for now"
+        )
+
+    # lower()/link build the SDK models, whose own validators (a bad constraint,
+    # a reserved agent.* tool key, an empty `as:`) raise pydantic/constraint
+    # errors. Surface them as a source-named LinkError, honouring the contract
+    # that parse/resolve failures come back as LinkError with the file named.
+    try:
+        per_role = lower(entry, agent)
+        by_role: dict[str, LinkResult] = {}
+        effective: dict[str, AgentPolicy] = {}
+        for role, (boundaries, caps) in per_role.items():
+            result = link_policy_set(boundaries, caps)
+            by_role[role] = result
+            effective[role] = result.effective[DEFAULT_ROLE_NAME]
+        return ProjectLinkResult(policy_set=PolicySet(effective), by_role=by_role)
+    except LinkError:
+        raise  # already carries module provenance
+    except (ValidationError, ConstraintParseError, PolicySetError) as exc:
+        raise LinkError(f"{source}: {exc}") from exc
+
+
+def resolve_text(
+    text: str, *, agent: str = DEFAULT_AGENT, source: str = "policy.yaml"
+) -> ProjectLinkResult:
+    """Resolve one policy document's text for one executing ``agent``."""
+    return resolve_entry(parse_entry(text, source=source), agent=agent, source=source)
+
+
+def resolve_file(path: str | Path, *, agent: str = DEFAULT_AGENT) -> ProjectLinkResult:
+    """Resolve the ``policy.yaml`` at ``path`` for one executing ``agent``."""
+    p = Path(path)
+    return resolve_text(p.read_text(encoding="utf-8"), agent=agent, source=str(p))

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -25,6 +25,7 @@ from hexgate.security.analyzer import PolicyLint
 from hexgate.cli.policy.main import (
     _main_build,
     _main_keygen,
+    _main_resolve,
     _main_show_rego,
     _main_test,
     _main_validate,
@@ -75,6 +76,58 @@ def policy_file(tmp_path: Path) -> Path:
 def _ns(**kwargs) -> argparse.Namespace:
     """Convenience for building an argparse.Namespace with sane defaults."""
     return argparse.Namespace(**kwargs)
+
+
+def test_resolve_file_uses_the_compose_grammar(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # `policy resolve --file` resolves a single-file compose policy.yaml through
+    # the compose front-end and prints the effective policy (refund capped by the
+    # boundary ceiling; a tool the ceiling omits is shadowed away).
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        'boundary:\n  tools: { refund: { constraint: "args.amount <= 100" } }\n'
+        "tools: { refund: { mode: allow }, ghost: { mode: allow } }\n",
+        encoding="utf-8",
+    )
+    rc = _main_resolve(_ns(dir=".", file=str(p), agent="*", role=None, output=None))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "refund" in out
+    assert "args.amount <= 100" in out  # boundary ceiling folded in
+    assert "ghost" not in out  # not in the ceiling → shadowed away
+
+
+def test_resolve_file_generic_agent_hints_at_named_agents(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # Resolving the generic "*" for a policy that names agents should nudge the
+    # user toward --agent, since roles live under a named agent.
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        "agents:\n  bot:\n    roles:\n      support: { tools: { a: { mode: allow } } }\n",
+        encoding="utf-8",
+    )
+    rc = _main_resolve(_ns(dir=".", file=str(p), agent="*", role=None, output=None))
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "--agent" in err and "bot" in err
+
+
+def test_resolve_file_unknown_agent_warns(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # A typo'd --agent resolves to the generic baseline (matching the SDK), but the
+    # CLI warns loudly so the user notices the agent isn't defined.
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        "agents:\n  bot:\n    roles:\n      support: { tools: { a: { mode: allow } } }\n",
+        encoding="utf-8",
+    )
+    rc = _main_resolve(_ns(dir=".", file=str(p), agent="bott", role=None, output=None))
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "bott" in err and "not defined" in err
 
 
 # ---------------------------------------------------------------------------

--- a/tests/security/compose/test_compose.py
+++ b/tests/security/compose/test_compose.py
@@ -8,6 +8,7 @@ equivalent tier-folder project resolve to byte-identical effective policy.
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -18,7 +19,7 @@ from hexgate.security import (
     ModuleContent,
     resolve_for_project,
 )
-from hexgate.security.compose import parse_entry, resolve_text
+from hexgate.security.compose import parse_entry, resolve_file, resolve_text
 from hexgate.security.linker import effective_policy_by_role
 
 
@@ -52,6 +53,23 @@ def test_parse_worked_example():
 def test_reserved_agent_name_rejected():
     with pytest.raises(LinkError, match="reserved"):
         parse_entry("agents: { tools: {} }")
+
+
+def test_reserved_role_name_rejected():
+    with pytest.raises(LinkError, match="reserved"):
+        parse_entry("agents: { bot: { roles: { boundary: {} } } }")
+
+
+def test_invalid_yaml_is_a_linkerror():
+    with pytest.raises(LinkError, match="invalid YAML"):
+        parse_entry("tools: { x: { : }")  # malformed mapping
+
+
+def test_empty_via_rejected():
+    # `as: []` is an empty transfer-mode list; AgentTargetPolicy rejects it, and
+    # resolve surfaces that as a source-named LinkError.
+    with pytest.raises(LinkError):
+        resolve_text("reach: { billing_bot: { as: [] } }")
 
 
 def test_unknown_top_level_key_rejected():
@@ -138,6 +156,52 @@ def test_reach_allowed_when_boundary_permits_it():
     # ceiling AND grant, both present
     assert any("2000" in c for c in reach["constraints"])
     assert any("1000" in c for c in reach["constraints"])
+
+
+def test_reach_multi_via_lowers_to_both_keys():
+    # `as: [tool, handoff]` lowers to both agent.tool: and agent.handoff: keys,
+    # each permitted by a boundary that lists the same two vias.
+    doc = """
+    boundary:
+      reach: { billing_bot: { as: [tool, handoff] } }
+    agents:
+      bot:
+        roles:
+          support:
+            reach: { billing_bot: { as: [tool, handoff] } }
+    """
+    tools = _eff(resolve_text(doc, agent="bot"))["support"]["tools"]
+    assert tools["agent.tool:billing_bot"]["mode"] == "allow"
+    assert tools["agent.handoff:billing_bot"]["mode"] == "allow"
+
+
+def test_mcp_block_lowers_to_a_tool():
+    # mcp is sugar for tools — a mcp grant resolves to an ordinary tool key.
+    doc = "mcp: { knowledge: { mode: approval_required } }"
+    tools = _eff(resolve_text(doc))["default"]["tools"]
+    assert tools["knowledge"]["mode"] == "approval_required"
+
+
+def test_per_agent_boundary_caps_a_role_grant():
+    # A boundary declared in an agent body is a ceiling for that agent only; it
+    # intersects the grant (AND) like any ceiling.
+    doc = """
+    agents:
+      bot:
+        boundary: { tools: { refund: { constraint: "args.amount <= 100" } } }
+        roles:
+          support: { tools: { refund: { mode: allow } } }
+    """
+    refund = _eff(resolve_text(doc, agent="bot"))["support"]["tools"]["refund"]
+    assert refund["mode"] == "allow"
+    assert any("args.amount <= 100" in c for c in refund["constraints"])
+
+
+def test_resolve_file_from_path(tmp_path: Path):
+    p = tmp_path / "policy.yaml"
+    p.write_text("tools: { a: { mode: allow } }\n", encoding="utf-8")
+    res = resolve_file(p)
+    assert _eff(res)["default"]["tools"]["a"]["mode"] == "allow"
 
 
 def test_reach_denied_when_boundary_omits_it_even_if_granted():

--- a/tests/security/compose/test_compose.py
+++ b/tests/security/compose/test_compose.py
@@ -1,0 +1,276 @@
+"""Tests for the ``policy.yaml`` compose front-end.
+
+The front-end lowers the position-wildcard grammar to the linker's ModuleContent
+lists, so the headline test is **golden parity**: a compose policy and the
+equivalent tier-folder project resolve to byte-identical effective policy.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hexgate.security import (
+    AgentPolicy,
+    BaseToolPolicy,
+    LinkError,
+    ModuleContent,
+    resolve_for_project,
+)
+from hexgate.security.compose import parse_entry, resolve_text
+from hexgate.security.linker import effective_policy_by_role
+
+
+def _eff(res):
+    return effective_policy_by_role(res)
+
+
+# --- parse ---------------------------------------------------------------
+
+
+def test_parse_worked_example():
+    entry = parse_entry(
+        """
+        version: 1
+        boundary:
+          tools: { refund_order: { constraint: "args.amount <= 5000" } }
+        tools: { read_ticket: { mode: allow } }
+        agents:
+          triage_bot:
+            roles:
+              support:
+                reach: { billing_bot: { as: tool, constraint: "args.amount <= 1000" } }
+        """
+    )
+    assert list(entry.tools) == ["read_ticket"]
+    reach = entry.agents["triage_bot"].roles["support"].reach["billing_bot"]
+    assert reach.via == ["tool"]
+    assert reach.constraints == ["args.amount <= 1000"]  # singular folded to list
+
+
+def test_reserved_agent_name_rejected():
+    with pytest.raises(LinkError, match="reserved"):
+        parse_entry("agents: { tools: {} }")
+
+
+def test_unknown_top_level_key_rejected():
+    with pytest.raises(LinkError):
+        parse_entry("tolls: { x: {} }")  # typo → extra=forbid
+
+
+def test_non_mapping_document_rejected():
+    with pytest.raises(LinkError, match="mapping"):
+        parse_entry("- just\n- a\n- list")
+
+
+def test_falsy_non_mapping_documents_rejected():
+    # A falsy non-mapping (empty list, bool, number) must error like any other
+    # non-mapping, not silently coerce to an empty policy.
+    for doc in ("[]", "false", "42"):
+        with pytest.raises(LinkError, match="mapping"):
+            parse_entry(doc)
+
+
+def test_empty_or_null_document_is_an_empty_deny_all_policy():
+    # A comment-only / explicitly-null file is a valid empty (fail-closed) policy.
+    res = resolve_text("null")
+    assert sorted(_eff(res)) == ["default"]
+    assert _eff(res)["default"]["tools"] == {}
+
+
+# --- resolve: roles + scope ---------------------------------------------
+
+
+def test_default_role_always_present():
+    res = resolve_text("tools: { a: { mode: allow } }")
+    assert sorted(_eff(res)) == ["default"]
+
+
+def test_named_agent_resolves_its_roles_plus_default():
+    doc = """
+    agents:
+      bot:
+        roles:
+          support: { tools: { a: { mode: allow } } }
+          billing: { tools: { b: { mode: allow } } }
+    """
+    assert sorted(_eff(resolve_text(doc, agent="bot"))) == [
+        "billing",
+        "default",
+        "support",
+    ]
+
+
+def test_scope_by_depth_agent_and_role_grants_fold_together():
+    doc = """
+    tools: { top: { mode: allow } }
+    agents:
+      bot:
+        tools: { agentwide: { mode: allow } }
+        roles:
+          support: { tools: { rolescoped: { mode: allow } } }
+    """
+    support = _eff(resolve_text(doc, agent="bot"))["support"]["tools"]
+    assert set(support) == {"top", "agentwide", "rolescoped"}
+    # the default role gets the base scopes only (no role-scoped grant)
+    default = _eff(resolve_text(doc, agent="bot"))["default"]["tools"]
+    assert set(default) == {"top", "agentwide"}
+
+
+# --- reach (composes via #124) ------------------------------------------
+
+
+def test_reach_allowed_when_boundary_permits_it():
+    doc = """
+    boundary:
+      reach: { billing_bot: { as: tool, constraint: "args.amount <= 2000" } }
+    agents:
+      bot:
+        roles:
+          support:
+            reach: { billing_bot: { as: tool, constraint: "args.amount <= 1000" } }
+    """
+    reach = _eff(resolve_text(doc, agent="bot"))["support"]["tools"][
+        "agent.tool:billing_bot"
+    ]
+    assert reach["mode"] == "allow"
+    # ceiling AND grant, both present
+    assert any("2000" in c for c in reach["constraints"])
+    assert any("1000" in c for c in reach["constraints"])
+
+
+def test_reach_denied_when_boundary_omits_it_even_if_granted():
+    # closed-world / confused-deputy guard: a reach the ceiling never lists is
+    # denied even though a capability grants it.
+    doc = """
+    boundary:
+      reach: { billing_bot: { as: tool } }
+    agents:
+      bot:
+        roles:
+          support:
+            reach:
+              billing_bot: { as: tool }
+              evil_bot: { as: tool }
+    """
+    tools = _eff(resolve_text(doc, agent="bot"))["support"]["tools"]
+    assert tools["agent.tool:billing_bot"]["mode"] == "allow"
+    assert tools["agent.tool:evil_bot"]["mode"] == "deny"
+
+
+# --- import deferred -----------------------------------------------------
+
+
+def test_import_not_supported_yet():
+    with pytest.raises(LinkError, match="import"):
+        resolve_text("import: [ other.yaml ]\ntools: { a: { mode: allow } }")
+
+
+def test_export_not_supported_yet():
+    with pytest.raises(LinkError, match="export"):
+        resolve_text("export: { frag: { tools: { a: {} } } }")
+
+
+# --- validation errors surface as source-named LinkError --------------------
+
+
+def test_bad_constraint_is_a_source_named_linkerror():
+    # A malformed constraint fails when lower() builds the SDK tool policy; it must
+    # come back as a LinkError naming the source, not a raw pydantic error.
+    with pytest.raises(LinkError, match="policy.yaml"):
+        resolve_text('tools: { x: { constraint: "args.amount <<< 5" } }')
+
+
+def test_reserved_agent_tool_key_is_a_linkerror():
+    # agent.run in a tools block trips #124's reserved-name guard in lower(); the
+    # resolve wrapper turns that into a LinkError rather than a ValidationError.
+    with pytest.raises(LinkError):
+        resolve_text('tools: { "agent.run": { mode: allow } }')
+
+
+def test_tools_mcp_same_key_rejected():
+    with pytest.raises(LinkError, match="both 'tools' and 'mcp'"):
+        resolve_text("tools: { x: { mode: allow } }\nmcp: { x: { mode: allow } }")
+
+
+def test_constraint_and_constraints_both_rejected():
+    # Giving both forms is ambiguous and would silently drop one (widening access),
+    # so it is a parse error rather than a quiet merge.
+    with pytest.raises(LinkError, match="not both"):
+        resolve_text(
+            'tools: { x: { constraint: "args.a <= 1", constraints: ["args.b <= 2"] } }'
+        )
+
+
+# --- golden parity vs the tier-folder layout -----------------------------
+
+
+def _mod(name, kind, tools, *, default_mode="allow"):
+    return ModuleContent(
+        name=name,
+        kind=kind,
+        policy=AgentPolicy(
+            default_policy=BaseToolPolicy(mode=default_mode), tools=tools
+        ),
+        source=f"{name}.yaml",
+        content_hash=f"hash-{name}",
+    )
+
+
+def test_golden_parity_all_compose_ceiling_boundary():
+    # A compose policy and the equivalent tier-folder project (one ceiling
+    # boundary + one capability, no roles → the single default role) must resolve
+    # to byte-identical effective policy — proving the fold path is reused.
+    compose = resolve_text(
+        """
+        boundary:
+          tools:
+            refund_order: { constraint: "args.amount <= 1000" }
+            view_orders: {}
+        tools:
+          view_orders: { mode: allow }
+          refund_order: { mode: allow, constraint: 'args.currency == "USD"' }
+        """
+    )
+    ceiling = _mod(
+        "b",
+        "boundary",
+        {
+            "refund_order": BaseToolPolicy(
+                mode="allow", constraints=["args.amount <= 1000"]
+            ),
+            "view_orders": BaseToolPolicy(mode="allow"),
+        },
+        default_mode="deny",
+    )
+    cap = _mod(
+        "c",
+        "capability",
+        {
+            "view_orders": BaseToolPolicy(mode="allow"),
+            "refund_order": BaseToolPolicy(
+                mode="allow", constraints=['args.currency == "USD"']
+            ),
+        },
+    )
+    tier = resolve_for_project([ceiling], [cap], None)
+    assert json.dumps(_eff(compose), sort_keys=True) == json.dumps(
+        _eff(tier), sort_keys=True
+    )
+
+
+def test_capability_deny_style_rules_still_rejected_via_boundary_semantics():
+    # Grants may only allow/approve; the grammar has no deny in tools/reach, so a
+    # "deny" is expressed as a boundary omission (closed-world). A tool granted
+    # nowhere and not in the boundary is simply absent from the effective policy.
+    res = resolve_text(
+        """
+        boundary:
+          tools: { a: {} }
+        tools: { a: { mode: allow }, b: { mode: allow } }
+        """
+    )
+    tools = _eff(res)["default"]["tools"]
+    assert tools["a"]["mode"] == "allow"
+    assert "b" not in tools  # b not in the ceiling → shadowed away

--- a/tests/security/test_analyzer.py
+++ b/tests/security/test_analyzer.py
@@ -98,6 +98,30 @@ def test_dead_grant_when_a_boundary_hard_denies_the_tool():
     assert "denies" in dead[0].message
 
 
+def test_dead_reach_grant_flagged_like_a_tool_grant():
+    # Agent-level blocks compose through the linker (#124), so a reach grant a
+    # ceiling never permits is a dead grant — the lint passes read effective_tools,
+    # so the lowered agent.tool: key is covered like any tool.
+    ceiling = ModuleContent(
+        name="org",
+        kind="boundary",
+        policy=AgentPolicy(
+            default_policy=BaseToolPolicy(mode="deny")
+        ),  # lists no reach
+        source="org.yaml",
+        content_hash="hash-org",
+    )
+    cap = ModuleContent(
+        name="c",
+        kind="capability",
+        policy=AgentPolicy(agents={"evil_bot": {"via": ["tool"], "mode": "allow"}}),
+        source="c.yaml",
+        content_hash="hash-c",
+    )
+    dead = [lint for lint in check([ceiling], [cap]) if lint.code == "dead-grant"]
+    assert [lint.tool for lint in dead] == ["agent.tool:evil_bot"]
+
+
 # --- redundant-grant ---
 
 


### PR DESCRIPTION
Adds the `policy.yaml` authoring front-end — the first SDK PR of the policy-authoring revamp. It parses the position-wildcard grammar and lowers it onto the **existing** linker fold (which already composes agent keys via #124), so the rego → wasm → signing path is reused unchanged, not reimplemented.

## What it does
- **`hexgate/security/compose/`** — a single-file `policy.yaml` grammar: `agents → roles → (tools | reach | mcp | boundary)`, with **scope-by-depth** wildcards — a block at the top level applies to all agents/roles, in an agent body to that agent's roles, in a role body to that one cell. Reach lowers to `agents:` blocks, `mcp` is readability sugar for tools, `boundary` is a closed-world ceiling.
- Resolves **per `(agent, role)`** through `link_policy_set`, assembling the same `ProjectLinkResult` that `resolve_for_project` returns — which is what lets a per-agent / per-role `boundary` apply only to its own cell.
- **CLI:** `hexgate policy resolve --file policy.yaml [--agent X] [--role Y]` (mutually exclusive with `--dir`; `--agent` now selects an agent column in either layout).
- **Analyzer fix:** the dead / redundant / constraint-erased lint passes now read `effective_tools`, so composed reach/admission grants are linted like ordinary tools — a gap #124 left when it made agent keys compose.

## Try it
```sh
cat > policy.yaml <<'YAML'
boundary:
  tools: { refund_order: { constraint: "args.amount <= 1000" } }
tools:
  refund_order: { mode: allow, constraint: 'args.currency == "USD"' }
YAML
hexgate policy resolve --file policy.yaml
```
The effective `refund_order` shows the boundary ceiling **and** the grant constraint AND-ed together; a tool the ceiling omits is shadowed away.

## Important files
- `hexgate/security/compose/{grammar,parse,lower,resolve}.py` — parse → lower → resolve
- `hexgate/cli/policy/main.py` — `resolve --file` / `--agent`
- `hexgate/security/analyzer.py` — lint passes read `effective_tools`
- `tests/security/compose/test_compose.py` — golden-parity + reach + error paths

## Notes
- **Golden parity:** a compose policy and the equivalent `policies/` tree resolve to byte-identical effective policy — proof the fold is reused, not forked.
- **Closed-world reach:** a reach the boundary doesn't list is denied even if a capability grants it (the confused-deputy guard).
- **Errors are source-named:** bad constraints, reserved `agent.*` tool keys, empty `as:`, `tools`/`mcp` key collisions, and non-mapping documents all surface as a `LinkError` naming the file.
- **Deferred to the next SDK PR** (parsed, but rejected with a clear error for now): the import graph — `import:` / `export:`, position-as-scope, cycle detection, globs. `boundary` is a ceiling only (no floor) and roles are per-named-agent, both per the ratified grammar.
- Builds on #124 (agent keys compose through the linker); no engine / rego / signing change. 1179 SDK security + CLI tests pass.
