### PR TITLE
feat(sdk): compose import graph (position=scope imports)

### DIFF
--- a/hexgate/cli/policy/main.py
+++ b/hexgate/cli/policy/main.py
@@ -606,18 +606,26 @@ def _main_resolve(args: argparse.Namespace) -> int:
     # --file (compose grammar) and --dir (policies/ tree) are the two front-ends;
     # both produce the same ProjectLinkResult, so the print path below is shared.
     if args.file is not None:
-        from hexgate.security.compose import parse_entry, resolve_entry
+        from hexgate.security.compose import file_loader, parse_entry, resolve_entry
 
+        file_path = Path(args.file)
         try:
-            text = Path(args.file).read_text(encoding="utf-8")
+            text = file_path.read_text(encoding="utf-8")
         except OSError as exc:
             print(f"load error: {exc}", file=sys.stderr)
             return 1
         # Parse once: resolve_entry reuses the Entry, and the agent hint below reads
         # its declared agents. resolve_entry surfaces every failure as LinkError.
+        # `import:` refs resolve relative to the entry file's directory (sandboxed).
         try:
             entry = parse_entry(text, source=args.file)
-            result = resolve_entry(entry, agent=args.agent, source=args.file)
+            result = resolve_entry(
+                entry,
+                agent=args.agent,
+                source=args.file,
+                loader=file_loader(file_path.parent),
+                entry_path=file_path.name,
+            )
         except LinkError as exc:
             print(f"link error: {exc}", file=sys.stderr)
             return 1

--- a/hexgate/security/compose/__init__.py
+++ b/hexgate/security/compose/__init__.py
@@ -11,6 +11,18 @@ from __future__ import annotations
 
 from hexgate.security.compose.grammar import Entry
 from hexgate.security.compose.parse import parse_entry
-from hexgate.security.compose.resolve import resolve_entry, resolve_file, resolve_text
+from hexgate.security.compose.resolve import (
+    file_loader,
+    resolve_entry,
+    resolve_file,
+    resolve_text,
+)
 
-__all__ = ["Entry", "parse_entry", "resolve_entry", "resolve_file", "resolve_text"]
+__all__ = [
+    "Entry",
+    "file_loader",
+    "parse_entry",
+    "resolve_entry",
+    "resolve_file",
+    "resolve_text",
+]

--- a/hexgate/security/compose/grammar.py
+++ b/hexgate/security/compose/grammar.py
@@ -22,7 +22,14 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_validator,
+    model_validator,
+)
 
 from hexgate.security.models import AgentVia
 
@@ -55,7 +62,9 @@ def _as_list(v: object) -> object:
 class _ConstraintsMixin(BaseModel):
     """Shared ``constraint``/``constraints`` ergonomics for every spec."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    # No populate_by_name: only the YAML aliases are accepted (e.g. `as:`, not the
+    # `via` field name), so a field-name spelling is rejected by extra="forbid".
+    model_config = ConfigDict(extra="forbid")
 
     constraints: list[str] = Field(default_factory=list)
 
@@ -117,14 +126,29 @@ class BoundaryBlock(BaseModel):
 
 
 class _GrantScope(BaseModel):
-    """The grant blocks legal at any scope (role body, agent body, top level)."""
+    """The grant blocks legal at any scope (role body, agent body, top level),
+    plus an ``import:`` list — position is scope, so a fragment imported here
+    applies at exactly this depth."""
 
+    # No populate_by_name: only the `import` alias is accepted, so the `imports`
+    # field-name spelling is rejected by extra="forbid" (no silent second spelling).
     model_config = ConfigDict(extra="forbid")
 
     boundary: BoundaryBlock | None = None
     tools: dict[str, GrantSpec] = Field(default_factory=dict)
     reach: dict[str, ReachSpec] = Field(default_factory=dict)
     mcp: dict[str, GrantSpec] = Field(default_factory=dict)
+    imports: list[str] = Field(default_factory=list, alias="import")
+
+    # Resolved leaf fragments spliced at this scope — populated by the import
+    # resolver, never authored. PrivateAttr so it is not YAML-settable, not
+    # validated, and not serialized. Elements are leaf ``_GrantScope``s (a
+    # ``RoleBlock`` export, or a whole-file ``Entry`` with no agents).
+    _imported: list["_GrantScope"] = PrivateAttr(default_factory=list)
+    # Source file this scope came from, for provenance on lowered ModuleContents.
+    # Local scopes keep the entry file; the resolver stamps each imported fragment
+    # with the file it was loaded from.
+    _source: str = PrivateAttr(default="policy.yaml")
 
     @model_validator(mode="after")
     def _no_tools_mcp_collision(self) -> "_GrantScope":
@@ -165,11 +189,11 @@ class Entry(_GrantScope):
     """
 
     version: int = 1
-    imports: list[str] = Field(default_factory=list, alias="import")
     exports: dict[str, RoleBlock] = Field(default_factory=dict, alias="export")
     agents: dict[str, AgentBlock] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    # Only the `export` alias is accepted (not the `exports` field name).
+    model_config = ConfigDict(extra="forbid")
 
     @field_validator("agents")
     @classmethod

--- a/hexgate/security/compose/imports.py
+++ b/hexgate/security/compose/imports.py
@@ -1,0 +1,195 @@
+"""Resolve the compose import graph — splice imported leaf fragments per scope.
+
+``import:`` is *position = scope*: a fragment imported in a role body applies to
+that cell, in an agent body to that agent, at the top level to everything. The
+resolver walks the scopes relevant to the agent being resolved, loads each
+referenced fragment via a ``loader``, and flattens the transitive closure of leaf
+fragments onto that scope's ``_imported``. The linker then unions those fragments
+with the local blocks like any other capability — imports *compose*, never
+replace, and the fold is commutative so import order never matters.
+
+Paths resolve **relative to the importing file's directory** and are sandboxed to
+the project tree (no absolute paths, no ``..`` escape). Only the scopes the target
+agent actually resolves are walked, so an unrelated agent's broken import can't
+abort resolving a valid one. Files are parsed once per resolution (cached).
+
+Scope for this increment: an imported target must be **leaf-only**
+(``tools`` / ``reach`` / ``mcp`` / ``boundary``); importing a file that declares
+``agents:`` / ``roles:`` is a later increment, as are globs. A cycle in the import
+graph is a :class:`LinkError`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import PurePosixPath
+
+from hexgate.security.compose.grammar import Entry, _GrantScope
+from hexgate.security.compose.parse import parse_entry
+from hexgate.security.modules import DEFAULT_AGENT, LinkError
+
+# project-relative posix path → the file's text. Injected so imports resolve
+# against a real directory for ``resolve_file`` and in-memory for tests.
+Loader = Callable[[str], str]
+
+
+class _Ctx:
+    """Per-resolution shared state: the loader, the entry's own path (to detect a
+    self-reference), and a parse cache so each file is read/parsed once."""
+
+    def __init__(self, loader: Loader | None, entry_path: str | None) -> None:
+        self.loader = loader
+        self.entry_path = entry_path
+        self.parsed: dict[str, Entry] = {}
+
+
+def resolve_imports(
+    entry: Entry,
+    *,
+    agent: str,
+    loader: Loader | None,
+    source: str,
+    entry_path: str | None = None,
+) -> None:
+    """Populate ``_imported`` for the scopes the given ``agent`` resolves.
+
+    Only the top level plus (for a named agent) that agent's body and its roles
+    are walked — never other agents — so per-agent resolution is isolated. Files
+    are parsed once and their flattened fragment lists memoized across the walk;
+    ``entry_path`` (the entry's own project-relative path, when known) lets a
+    fragment that imports the entry back be reported as a cycle.
+    """
+    ctx = _Ctx(loader, entry_path)
+    root = PurePosixPath()
+    _resolve_scope(entry, source=source, cur_dir=root, ctx=ctx)
+    agent_block = entry.agents.get(agent) if agent != DEFAULT_AGENT else None
+    if agent_block is not None:
+        _resolve_scope(agent_block, source=source, cur_dir=root, ctx=ctx)
+        for role in agent_block.roles.values():
+            _resolve_scope(role, source=source, cur_dir=root, ctx=ctx)
+
+
+def _resolve_scope(
+    scope: _GrantScope, *, source: str, cur_dir: PurePosixPath, ctx: _Ctx
+) -> None:
+    scope._source = source  # local grants carry the entry file for provenance
+    # `seen` de-dups by RESOLVED key across this scope's whole import closure, so a
+    # fragment reached via two refs (a diamond, or `x.yaml` vs `./x.yaml`) is
+    # contributed once; it also short-circuits the re-walk of a shared subtree.
+    seen: set[str] = set()
+    fragments: list[_GrantScope] = []
+    for ref in scope.imports:
+        fragments.extend(
+            _load(ref, source=source, cur_dir=cur_dir, stack=(), ctx=ctx, seen=seen)
+        )
+    scope._imported = fragments
+
+
+def _split_ref(ref: str) -> tuple[str, str | None]:
+    """``"caps.yaml#refunds"`` → ``("caps.yaml", "refunds")``; no ``#`` → name None."""
+    path, _, name = ref.partition("#")
+    return path, (name or None)
+
+
+def _resolve_path(
+    cur_dir: PurePosixPath, ref_path: str, *, source: str
+) -> PurePosixPath:
+    """Join ``ref_path`` onto ``cur_dir`` (the importing file's dir) and normalize,
+    rejecting an absolute path or one that escapes the project root via ``..``."""
+    candidate = PurePosixPath(ref_path)
+    if candidate.is_absolute():
+        raise LinkError(f"{source}: absolute import path not allowed: {ref_path!r}")
+    parts: list[str] = []
+    for part in (cur_dir / candidate).parts:
+        if part == "..":
+            if not parts:
+                raise LinkError(
+                    f"{source}: import escapes the project directory: {ref_path!r}"
+                )
+            parts.pop()
+        elif part != ".":
+            parts.append(part)
+    return PurePosixPath(*parts)
+
+
+def _load(
+    ref: str,
+    *,
+    source: str,
+    cur_dir: PurePosixPath,
+    stack: tuple[str, ...],
+    ctx: _Ctx,
+    seen: set[str],
+) -> list[_GrantScope]:
+    """Load one import ref → the flat transitive list of leaf fragments it pulls in."""
+    if ctx.loader is None:
+        raise LinkError(
+            f"{source}: 'import:' needs a base path to resolve {ref!r} — resolve "
+            f"via a file (resolve_file) or pass a loader"
+        )
+    path_str, name = _split_ref(ref)
+    target = _resolve_path(cur_dir, path_str, source=source)
+    target_str = str(target)
+    key = f"{target_str}#{name or ''}"
+    if key in stack:  # a true cycle: the ref is its own ancestor
+        raise LinkError(f"{source}: import cycle: {' -> '.join((*stack, key))}")
+    if target_str == ctx.entry_path:
+        raise LinkError(
+            f"{source}: import cycle: {ref!r} imports the entry file itself"
+        )
+    if key in seen:  # already contributed in this scope's closure (a diamond edge)
+        return []
+    seen.add(key)
+
+    imported = ctx.parsed.get(target_str)
+    if imported is None:
+        try:
+            text = ctx.loader(target_str)
+        except OSError as exc:
+            raise LinkError(f"{source}: cannot import {ref!r}: {exc}") from exc
+        imported = parse_entry(text, source=target_str)
+        ctx.parsed[target_str] = imported
+
+    if imported.agents:
+        raise LinkError(
+            f"{target_str}: an imported file must be leaf-only "
+            f"(tools/reach/mcp/boundary); it declares agents:/roles:, which "
+            f"imports do not support yet"
+        )
+
+    if name is not None:
+        fragment: _GrantScope | None = imported.exports.get(name)
+        if fragment is None:
+            known = sorted(imported.exports) or "none"
+            raise LinkError(
+                f"{target_str}: no export named {name!r} (exports: {known})"
+            )
+    else:
+        # Whole-file import: the file's top-level leaf blocks (its exports are for
+        # other importers; an Entry with no agents is itself a leaf scope).
+        fragment = imported
+
+    if fragment.boundary is not None:
+        raise LinkError(
+            f"{target_str}: an imported fragment may only grant (tools/reach/mcp); "
+            f"a boundary/ceiling must be authored in the importing file — an "
+            f"imported ceiling would intersect and can silently deny every grant"
+        )
+
+    fragment._source = target_str
+    # Flatten transitively; a fragment resolves ITS imports relative to its own
+    # file's directory, cycle-guarded by the ref key and de-duped via ``seen``.
+    out: list[_GrantScope] = [fragment]
+    child_dir = target.parent
+    for sub in fragment.imports:
+        out.extend(
+            _load(
+                sub,
+                source=target_str,
+                cur_dir=child_dir,
+                stack=(*stack, key),
+                ctx=ctx,
+                seen=seen,
+            )
+        )
+    return out

--- a/hexgate/security/compose/lower.py
+++ b/hexgate/security/compose/lower.py
@@ -79,43 +79,50 @@ def _boundary_policy(block: BoundaryBlock | None) -> AgentPolicy | None:
     )
 
 
-def _cap(name: str, policy: AgentPolicy) -> ModuleContent:
+def _cap(name: str, policy: AgentPolicy, source: str) -> ModuleContent:
     return ModuleContent(
         name=name,
         kind="capability",
         policy=policy,
-        source=f"policy.yaml#{name}",
+        source=f"{source}#{name}",
         content_hash=_content_hash(name, policy),
     )
 
 
-def _boundary(name: str, policy: AgentPolicy) -> ModuleContent:
+def _boundary(name: str, policy: AgentPolicy, source: str) -> ModuleContent:
     return ModuleContent(
         name=name,
         kind="boundary",
         policy=policy,
-        source=f"policy.yaml#{name}",
+        source=f"{source}#{name}",
         content_hash=_content_hash(name, policy),
     )
 
 
 def _cell(
-    scopes: list[tuple[str, _GrantScope]],
-    boundaries_src: list[tuple[str, BoundaryBlock | None]],
-    agent: str,
-    role: str,
+    scopes: list[tuple[str, _GrantScope]], agent: str, role: str
 ) -> tuple[list[ModuleContent], list[ModuleContent]]:
-    """Build the ``(boundaries, capabilities)`` ModuleContent lists for one cell."""
+    """Build the ``(boundaries, capabilities)`` ModuleContent lists for one cell.
+
+    Each scope contributes its own blocks *and* its imported leaf fragments
+    (``scope._imported``); grants union and boundaries intersect in the fold, so
+    an imported fragment is just an extra contribution — never a merge/overwrite.
+    """
     caps: list[ModuleContent] = []
-    for label, scope in scopes:
-        policy = _grants_policy(scope)
-        if policy is not None:
-            caps.append(_cap(f"{label}@{agent}/{role}", policy))
     boundaries: list[ModuleContent] = []
-    for label, block in boundaries_src:
-        policy = _boundary_policy(block)
-        if policy is not None:
-            boundaries.append(_boundary(f"boundary:{label}@{agent}/{role}", policy))
+    for label, scope in scopes:
+        for idx, frag in enumerate((scope, *scope._imported)):
+            tag = (
+                f"{label}@{agent}/{role}"
+                if idx == 0
+                else f"{label}#imp{idx}@{agent}/{role}"
+            )
+            grants = _grants_policy(frag)
+            if grants is not None:
+                caps.append(_cap(tag, grants, frag._source))
+            ceiling = _boundary_policy(frag.boundary)
+            if ceiling is not None:
+                boundaries.append(_boundary(f"boundary:{tag}", ceiling, frag._source))
     return boundaries, caps
 
 
@@ -127,6 +134,9 @@ def lower(entry: Entry, agent: str = DEFAULT_AGENT) -> dict[str, tuple[list, lis
     role declared under it, folding the top-level, agent-level, and role-level
     scopes together. The generic/unnamed agent (``"*"``) has only the ``default``
     role from the top-level blocks (roles live under a named agent).
+
+    Imports must already be resolved onto each scope's ``_imported`` (see
+    :func:`hexgate.security.compose.imports.resolve_imports`).
     """
     agent_block: AgentBlock | None = (
         entry.agents.get(agent) if agent != DEFAULT_AGENT else None
@@ -135,18 +145,14 @@ def lower(entry: Entry, agent: str = DEFAULT_AGENT) -> dict[str, tuple[list, lis
     # Scopes that apply regardless of role: top-level always; the agent body when
     # a named agent is being resolved.
     base_scopes: list[tuple[str, _GrantScope]] = [("top", entry)]
-    base_boundaries: list[tuple[str, BoundaryBlock | None]] = [("top", entry.boundary)]
     if agent_block is not None:
         base_scopes.append((f"agent:{agent}", agent_block))
-        base_boundaries.append((f"agent:{agent}", agent_block.boundary))
 
     # The default role: base scopes only (no role-specific block).
     out: dict[str, tuple[list, list]] = {
-        DEFAULT_ROLE: _cell(base_scopes, base_boundaries, agent, DEFAULT_ROLE)
+        DEFAULT_ROLE: _cell(base_scopes, agent, DEFAULT_ROLE)
     }
     # Each named role: base scopes + that role's block.
     for role, role_block in (agent_block.roles if agent_block else {}).items():
-        scopes = [*base_scopes, (f"role:{role}", role_block)]
-        boundaries_src = [*base_boundaries, (f"role:{role}", role_block.boundary)]
-        out[role] = _cell(scopes, boundaries_src, agent, role)
+        out[role] = _cell([*base_scopes, (f"role:{role}", role_block)], agent, role)
     return out

--- a/hexgate/security/compose/resolve.py
+++ b/hexgate/security/compose/resolve.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from hexgate.security.compose.grammar import Entry
+from hexgate.security.compose.imports import Loader, resolve_imports
 from hexgate.security.compose.lower import lower
 from hexgate.security.compose.parse import parse_entry
 from hexgate.security.constraints import ConstraintParseError
@@ -29,19 +30,48 @@ from hexgate.security.modules import (
 from hexgate.security.policy_set import DEFAULT_ROLE_NAME, PolicySet, PolicySetError
 
 
+def file_loader(base_dir: str | Path) -> Loader:
+    """A filesystem loader rooted at ``base_dir``, sandboxed to that tree.
+
+    The resolver's lexical guard already rejects ``..``/absolute refs; this also
+    resolves real paths (following symlinks) and rejects a target that escapes
+    ``base_dir`` — e.g. a symlink inside the project pointing outside it.
+    """
+    base = Path(base_dir).resolve()
+
+    def load(rel_path: str) -> str:
+        target = (base / rel_path).resolve()
+        if not target.is_relative_to(base):
+            raise LinkError(
+                f"import escapes the project directory: {rel_path!r} → {target}"
+            )
+        return target.read_text(encoding="utf-8")
+
+    return load
+
+
 def resolve_entry(
-    entry: Entry, *, agent: str = DEFAULT_AGENT, source: str = "policy.yaml"
+    entry: Entry,
+    *,
+    agent: str = DEFAULT_AGENT,
+    source: str = "policy.yaml",
+    loader: Loader | None = None,
+    entry_path: str | None = None,
 ) -> ProjectLinkResult:
     """Resolve an already-parsed :class:`Entry` for one executing ``agent``.
 
     Split from :func:`resolve_text` so a caller that already parsed (the CLI, to
-    read the declared agents for a hint) resolves without parsing twice.
+    read the declared agents for a hint) resolves without parsing twice. ``loader``
+    resolves ``import:`` refs; a policy that imports without one errors.
+    ``entry_path`` is the entry's own project-relative path, so a fragment that
+    imports the entry back is caught as a cycle.
     """
-    if entry.imports or entry.exports:
-        raise LinkError(
-            f"{source}: 'import:'/'export:' are not supported yet — the import "
-            f"graph lands in the next increment; inline the fragments for now"
-        )
+    # Splice imported leaf fragments onto each scope's ``_imported`` first — only
+    # the scopes this agent resolves, so an unrelated agent's bad import can't
+    # abort us. Raises a source-named LinkError on a bad ref, cycle, or missing loader.
+    resolve_imports(
+        entry, agent=agent, loader=loader, source=source, entry_path=entry_path
+    )
 
     # lower()/link build the SDK models, whose own validators (a bad constraint,
     # a reserved agent.* tool key, an empty `as:`) raise pydantic/constraint
@@ -63,13 +93,38 @@ def resolve_entry(
 
 
 def resolve_text(
-    text: str, *, agent: str = DEFAULT_AGENT, source: str = "policy.yaml"
+    text: str,
+    *,
+    agent: str = DEFAULT_AGENT,
+    source: str = "policy.yaml",
+    loader: Loader | None = None,
+    entry_path: str | None = None,
 ) -> ProjectLinkResult:
-    """Resolve one policy document's text for one executing ``agent``."""
-    return resolve_entry(parse_entry(text, source=source), agent=agent, source=source)
+    """Resolve one policy document's text for one executing ``agent``.
+
+    ``loader`` (import-ref path → text) resolves ``import:``; omit it for a
+    self-contained policy, or pass one to resolve imports in memory (tests).
+    """
+    return resolve_entry(
+        parse_entry(text, source=source),
+        agent=agent,
+        source=source,
+        loader=loader,
+        entry_path=entry_path,
+    )
 
 
 def resolve_file(path: str | Path, *, agent: str = DEFAULT_AGENT) -> ProjectLinkResult:
-    """Resolve the ``policy.yaml`` at ``path`` for one executing ``agent``."""
+    """Resolve the ``policy.yaml`` at ``path`` for one executing ``agent``.
+
+    ``import:`` refs resolve relative to the entry file's directory, sandboxed to
+    that tree.
+    """
     p = Path(path)
-    return resolve_text(p.read_text(encoding="utf-8"), agent=agent, source=str(p))
+    return resolve_text(
+        p.read_text(encoding="utf-8"),
+        agent=agent,
+        source=str(p),
+        loader=file_loader(p.parent),
+        entry_path=p.name,
+    )

--- a/tests/cli/test_policy.py
+++ b/tests/cli/test_policy.py
@@ -130,6 +130,30 @@ def test_resolve_file_unknown_agent_warns(
     assert "bott" in err and "not defined" in err
 
 
+def test_resolve_file_resolves_imports_relative_to_the_file(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    # `resolve --file` must resolve import: refs against the entry file's dir.
+    (tmp_path / "caps.yaml").write_text(
+        "export:\n  refunds:\n    tools: { refund_order: { mode: allow } }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "policy.yaml").write_text(
+        "import: [ caps.yaml#refunds ]\n", encoding="utf-8"
+    )
+    rc = _main_resolve(
+        _ns(
+            dir=".",
+            file=str(tmp_path / "policy.yaml"),
+            agent="*",
+            role=None,
+            output=None,
+        )
+    )
+    assert rc == 0
+    assert "refund_order" in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # validate
 # ---------------------------------------------------------------------------

--- a/tests/security/compose/test_compose.py
+++ b/tests/security/compose/test_compose.py
@@ -223,17 +223,278 @@ def test_reach_denied_when_boundary_omits_it_even_if_granted():
     assert tools["agent.tool:evil_bot"]["mode"] == "deny"
 
 
-# --- import deferred -----------------------------------------------------
+# --- imports -------------------------------------------------------------
 
 
-def test_import_not_supported_yet():
-    with pytest.raises(LinkError, match="import"):
-        resolve_text("import: [ other.yaml ]\ntools: { a: { mode: allow } }")
+def _loader(files: dict[str, str]):
+    """An in-memory loader: project-relative path -> file text (missing → OSError)."""
+
+    def load(path: str) -> str:
+        if path not in files:
+            raise FileNotFoundError(path)
+        return files[path]
+
+    return load
 
 
-def test_export_not_supported_yet():
-    with pytest.raises(LinkError, match="export"):
-        resolve_text("export: { frag: { tools: { a: {} } } }")
+def test_import_without_loader_errors():
+    with pytest.raises(LinkError, match="base path"):
+        resolve_text("import: [ other.yaml ]")
+
+
+def test_export_block_is_accepted_and_inert_for_own_resolution():
+    # A file may declare exports (for other importers); resolving it directly is
+    # fine and its exports don't affect its own effective policy.
+    res = resolve_text(
+        "tools: { a: { mode: allow } }\nexport: { frag: { tools: { b: {} } } }"
+    )
+    assert set(_eff(res)["default"]["tools"]) == {"a"}
+
+
+def test_import_whole_file_at_top_applies_to_all():
+    loader = _loader({"base.yaml": "tools: { read_ticket: { mode: allow } }\n"})
+    res = resolve_text("import: [ base.yaml ]", loader=loader)
+    assert "read_ticket" in _eff(res)["default"]["tools"]
+
+
+def test_import_named_export_is_scoped_by_position():
+    # A fragment imported in a role body applies only to that cell (position=scope).
+    loader = _loader(
+        {"caps.yaml": "export:\n  refunds:\n    tools: { refund: { mode: allow } }\n"}
+    )
+    doc = """
+    agents:
+      bot:
+        roles:
+          support:
+            import: [ caps.yaml#refunds ]
+          billing: {}
+    """
+    eff = _eff(resolve_text(doc, agent="bot", loader=loader))
+    assert "refund" in eff["support"]["tools"]
+    assert "refund" not in eff["billing"]["tools"]  # not imported here
+    assert "refund" not in eff["default"]["tools"]
+
+
+def test_import_is_transitive():
+    loader = _loader(
+        {
+            "a.yaml": "import: [ b.yaml ]\ntools: { from_a: { mode: allow } }\n",
+            "b.yaml": "tools: { from_b: { mode: allow } }\n",
+        }
+    )
+    tools = _eff(resolve_text("import: [ a.yaml ]", loader=loader))["default"]["tools"]
+    assert {"from_a", "from_b"} <= set(tools)
+
+
+def test_import_cycle_is_a_linkerror():
+    loader = _loader(
+        {"a.yaml": "import: [ b.yaml ]\n", "b.yaml": "import: [ a.yaml ]\n"}
+    )
+    with pytest.raises(LinkError, match="cycle"):
+        resolve_text("import: [ a.yaml ]", loader=loader)
+
+
+def test_import_missing_export_is_a_linkerror():
+    loader = _loader({"caps.yaml": "export: { other: { tools: {} } }\n"})
+    with pytest.raises(LinkError, match="no export named"):
+        resolve_text("import: [ caps.yaml#refunds ]", loader=loader)
+
+
+def test_import_of_structural_file_rejected():
+    # An imported file must be leaf-only; importing one that declares agents:/roles:
+    # is a later increment.
+    loader = _loader(
+        {"full.yaml": "agents: { bot: { tools: { a: { mode: allow } } } }\n"}
+    )
+    with pytest.raises(LinkError, match="leaf-only"):
+        resolve_text("import: [ full.yaml ]", loader=loader)
+
+
+def test_import_matches_inlining_golden():
+    # Importing a fragment resolves identically to inlining the same grants.
+    loader = _loader(
+        {"caps.yaml": "export:\n  c:\n    tools: { refund: { mode: allow } }\n"}
+    )
+    imported = resolve_text("import: [ caps.yaml#c ]", loader=loader)
+    inlined = resolve_text("tools: { refund: { mode: allow } }")
+    assert json.dumps(_eff(imported), sort_keys=True) == json.dumps(
+        _eff(inlined), sort_keys=True
+    )
+
+
+def test_resolve_file_imports_relative_to_entry_dir(tmp_path: Path):
+    (tmp_path / "caps.yaml").write_text(
+        "export:\n  refunds:\n    tools: { refund: { mode: allow } }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "policy.yaml").write_text(
+        "import: [ caps.yaml#refunds ]\n", encoding="utf-8"
+    )
+    res = resolve_file(tmp_path / "policy.yaml")
+    assert "refund" in _eff(res)["default"]["tools"]
+
+
+def test_transitive_import_resolves_relative_to_importing_file(tmp_path: Path):
+    # A nested file's own import resolves against ITS dir, not the entry's:
+    # shared/caps.yaml imports "helper.yaml" meaning shared/helper.yaml.
+    (tmp_path / "shared").mkdir()
+    (tmp_path / "shared" / "helper.yaml").write_text(
+        "tools: { helped: { mode: allow } }\n", encoding="utf-8"
+    )
+    (tmp_path / "shared" / "caps.yaml").write_text(
+        "import: [ helper.yaml ]\ntools: { capped: { mode: allow } }\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "policy.yaml").write_text(
+        "import: [ shared/caps.yaml ]\n", encoding="utf-8"
+    )
+    tools = _eff(resolve_file(tmp_path / "policy.yaml"))["default"]["tools"]
+    assert {"helped", "capped"} <= set(tools)
+
+
+def test_absolute_import_path_rejected():
+    with pytest.raises(LinkError, match="absolute import"):
+        resolve_text("import: [ /etc/passwd ]", loader=_loader({}))
+
+
+def test_escaping_import_path_rejected():
+    with pytest.raises(LinkError, match="escapes the project"):
+        resolve_text("import: [ ../secret.yaml ]", loader=_loader({}))
+
+
+def test_missing_import_file_is_a_linkerror():
+    with pytest.raises(LinkError, match="cannot import"):
+        resolve_text("import: [ nope.yaml ]", loader=_loader({}))
+
+
+def test_per_agent_import_isolation():
+    # 'other' has a broken import, but resolving the valid 'bot' must succeed —
+    # only the target agent's scopes are walked.
+    loader = _loader({"caps.yaml": "tools: { a: { mode: allow } }\n"})
+    doc = """
+    agents:
+      bot:
+        roles:
+          support: { import: [ caps.yaml ] }
+      other:
+        roles:
+          x: { import: [ missing.yaml ] }
+    """
+    eff = _eff(resolve_text(doc, agent="bot", loader=loader))
+    assert "a" in eff["support"]["tools"]
+
+
+def test_plural_import_key_rejected():
+    # `imports:` (the field name) is not the `import:` alias — reject it.
+    with pytest.raises(LinkError):
+        parse_entry("imports: [ caps.yaml ]")
+
+
+def test_via_field_name_rejected():
+    # `via:` is the field name; the alias is `as:` — reject the field-name spelling.
+    with pytest.raises(LinkError):
+        parse_entry("reach: { bot: { via: [tool] } }")
+
+
+def test_imported_file_parsed_once_across_scopes():
+    calls = {"n": 0}
+
+    def counting_loader(path: str) -> str:
+        calls["n"] += 1
+        return "tools: { a: { mode: allow } }\n"
+
+    doc = """
+    import: [ caps.yaml ]
+    agents:
+      bot:
+        import: [ caps.yaml ]
+        roles:
+          support: { import: [ caps.yaml ] }
+    """
+    resolve_text(doc, agent="bot", loader=counting_loader)
+    assert calls["n"] == 1  # cached — one read despite three import sites
+
+
+def test_imported_grant_provenance_names_the_source_file():
+    # An imported grant's ModuleContent source names the file it came from, not
+    # the entry — so signing/audit/debug attribute it correctly.
+    loader = _loader(
+        {"caps.yaml": "export:\n  c:\n    tools: { refund: { mode: allow } }\n"}
+    )
+    res = resolve_text("import: [ caps.yaml#c ]", loader=loader)
+    provs = res.by_role["default"].trace.contributors["refund"]
+    assert any("caps.yaml" in p.source for p in provs)
+
+
+def test_imported_fragment_with_boundary_rejected():
+    # Imports grant only; an imported ceiling would intersect and can silently
+    # deny every grant, so a boundary in an import is rejected.
+    loader = _loader({"ceil.yaml": "boundary: { tools: { x: {} } }\n"})
+    with pytest.raises(LinkError, match="may only grant"):
+        resolve_text("import: [ ceil.yaml ]", loader=loader)
+
+
+def test_duplicate_import_refs_are_deduped():
+    loader = _loader({"caps.yaml": "tools: { a: { mode: allow } }\n"})
+    res = resolve_text("import: [ caps.yaml, caps.yaml ]", loader=loader)
+    provs = res.by_role["default"].trace.contributors["a"]
+    assert len(provs) == 1  # one contribution despite the repeated ref
+
+
+def test_symlink_escaping_project_is_rejected(tmp_path: Path):
+    import os
+
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (tmp_path / "secret.yaml").write_text(
+        "tools: { leaked: { mode: allow } }\n", encoding="utf-8"
+    )
+    try:
+        os.symlink(tmp_path / "secret.yaml", proj / "link.yaml")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported here")
+    (proj / "policy.yaml").write_text("import: [ link.yaml ]\n", encoding="utf-8")
+    with pytest.raises(LinkError, match="escapes the project"):
+        resolve_file(proj / "policy.yaml")
+
+
+def test_import_of_the_entry_file_is_a_cycle(tmp_path: Path):
+    (tmp_path / "a.yaml").write_text("import: [ policy.yaml ]\n", encoding="utf-8")
+    (tmp_path / "policy.yaml").write_text("import: [ a.yaml ]\n", encoding="utf-8")
+    with pytest.raises(LinkError, match="cycle"):
+        resolve_file(tmp_path / "policy.yaml")
+
+
+def test_diamond_import_contributes_shared_fragment_once():
+    # x → a, b; a → c, b → c. c is reached via two paths but contributes once.
+    loader = _loader(
+        {
+            "x.yaml": "import: [ a.yaml, b.yaml ]\n",
+            "a.yaml": "import: [ c.yaml ]\n",
+            "b.yaml": "import: [ c.yaml ]\n",
+            "c.yaml": "tools: { shared: { mode: allow } }\n",
+        }
+    )
+    res = resolve_text("import: [ x.yaml ]", loader=loader)
+    provs = res.by_role["default"].trace.contributors["shared"]
+    assert len(provs) == 1
+
+
+def test_same_target_via_different_ref_strings_deduped():
+    # `caps.yaml` and `./caps.yaml` resolve to the same file → one contribution.
+    loader = _loader({"caps.yaml": "tools: { a: { mode: allow } }\n"})
+    res = resolve_text("import: [ caps.yaml, ./caps.yaml ]", loader=loader)
+    assert len(res.by_role["default"].trace.contributors["a"]) == 1
+
+
+def test_local_grant_provenance_names_the_entry_file(tmp_path: Path):
+    # A file's own (non-imported) grants carry the entry file as source, not a
+    # hardcoded "policy.yaml".
+    p = tmp_path / "main.yaml"
+    p.write_text("tools: { a: { mode: allow } }\n", encoding="utf-8")
+    provs = resolve_file(p).by_role["default"].trace.contributors["a"]
+    assert all(str(p) in pr.source for pr in provs)
 
 
 # --- validation errors surface as source-named LinkError --------------------


### PR DESCRIPTION
Adds `import:` to the compose front-end — PR-2 of the policy-authoring stack, on top of #175. A policy can import a leaf capability fragment at any scope; the resolver splices it onto that scope and the linker unions it like any other capability. Imports **compose, never replace**, and the fold is commutative so order never matters.

**Stacked on #175** — this targets the `lhq/feat/policy-authoring` branch, so the diff here is just the import graph. It retargets to `main` automatically when #175 merges.

## What it does
- **`import:` at any scope** (top / agent body / role body) — *position is scope*: a fragment imported in a role applies to that cell, in an agent body to that agent, at the top level to everything.
- **Forms:** `caps.yaml` (whole-file leaf blocks) and `caps.yaml#refunds` (a named `export:`), resolved **transitively** and **relative to the importing file's directory**, sandboxed to the project tree (no `..` / absolute / symlink escape).
- **Safety:** cycles (including importing the entry file back) → `LinkError`; imports are **grant-only** (a `boundary` in an import is rejected — an imported ceiling would intersect and could silently deny every grant); imported files must be **leaf-only** (no `agents:`/`roles:` yet). Per-agent resolution is isolated — an unrelated agent's broken import can't abort a valid one. Provenance names the real source file.

## Try it
```sh
mkdir demo && cd demo
printf 'export:\n  refunds:\n    tools: { refund_order: { mode: allow } }\n' > caps.yaml
printf 'import: [ caps.yaml#refunds ]\ntools: { read_ticket: { mode: allow } }\n' > policy.yaml
hexgate policy resolve --file policy.yaml   # refund_order + read_ticket resolve
```

## Important files
- `hexgate/security/compose/imports.py` — the resolver (new): loader, path sandbox, cycle/`seen` de-dup, leaf/grant-only checks
- `hexgate/security/compose/{grammar,lower,resolve}.py` — `import:` on every scope; splice into the fold; shared `file_loader`
- `hexgate/cli/policy/main.py` — `resolve --file` resolves imports relative to the file
- `tests/security/compose/test_compose.py` — position=scope, transitive, cycles, sandbox, diamond de-dup, provenance, …

## Notes
- **Deferred to a follow-up:** globs (`dir/*`, needs a listing loader) and structural imports (an import carrying `agents:`/`roles:`).
- Imported ≡ inlined (golden test). 1211 SDK security + CLI tests pass; ruff clean. Three review rounds (7 → 7 → 2 findings), all addressed.
