### PR TITLE
feat(sdk): add hexgate.messages wire contract and content caps

### DIFF
--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -140,19 +140,24 @@ def _truncate_json(payload: dict[str, Any], *, cap: int) -> dict[str, Any]:
     same object ``as_error_payload`` hands the host. The copy is shallow —
     enough to stop a rebind, not a nested in-place mutation."""
     payload_json = json.dumps(payload, default=str)
-    if len(payload_json.encode("utf-8")) <= cap:
+    raw = payload_json.encode("utf-8")
+    if len(raw) <= cap:
         return dict(payload)
-    preview_bytes = cap - _TRUNCATION_WRAPPER_HEADROOM_BYTES
+    # Floored at 1: a cap at or below the wrapper headroom would otherwise make
+    # this negative, which slices from the *end* of the payload and never
+    # shrinks (``-1 // 2 == -1``), so the loop would not terminate.
+    preview_bytes = max(cap - _TRUNCATION_WRAPPER_HEADROOM_BYTES, 1)
     while True:
         wrapper = {
             "_truncated": True,
-            "original_bytes": len(payload_json.encode("utf-8")),
-            "preview": payload_json.encode("utf-8")[:preview_bytes].decode(
-                "utf-8", errors="ignore"
-            ),
+            "original_bytes": len(raw),
+            "preview": raw[:preview_bytes].decode("utf-8", errors="ignore"),
         }
         if len(json.dumps(wrapper).encode("utf-8")) <= cap:
             return wrapper
+        if preview_bytes == 1:
+            # Not even one byte of preview fits: ship the marker alone.
+            return {"_truncated": True, "original_bytes": len(raw)}
         preview_bytes //= 2
 
 
@@ -192,40 +197,34 @@ def _truncate_head_tail(text: str, *, max_bytes: int) -> str:
     return head + _HEAD_TAIL_MARKER.format(omitted=omitted) + tail
 
 
-def _largest_string_leaf(
-    node: Any, path: tuple[Any, ...] = ()
-) -> tuple[tuple[Any, ...] | None, int]:
-    """``(path, utf8_size)`` of the biggest string value under ``node`` — dict
-    values and list items, never dict keys — or ``(None, 0)`` if there is none."""
+def _largest_string_leaf_bytes(node: Any) -> int:
+    """UTF-8 size of the biggest string value under ``node`` — dict values and
+    list items, never dict keys — or ``0`` if there is none."""
     if isinstance(node, str):
-        return path, _utf8_len(node)
-    best: tuple[tuple[Any, ...] | None, int] = (None, 0)
+        return _utf8_len(node)
     if isinstance(node, dict):
-        children = node.items()
+        children: Any = node.values()
     elif isinstance(node, (list, tuple)):
-        children = enumerate(node)
+        children = node
     else:
-        return best
-    for key, child in children:
-        found = _largest_string_leaf(child, (*path, key))
-        if found[1] > best[1]:
-            best = found
-    return best
+        return 0
+    return max((_largest_string_leaf_bytes(child) for child in children), default=0)
 
 
-def _get_at(node: Any, path: tuple[Any, ...]) -> Any:
-    for key in path:
-        node = node[key]
+def _cap_leaves(node: Any, *, limit: int) -> Any:
+    """Rebuild ``node`` with every string leaf shrunk head+tail to ``limit``
+    UTF-8 bytes. Leaves already under ``limit`` are kept whole.
+
+    A fresh structure, so the input is never mutated; tuples come back as
+    lists, which is what ``json.dumps`` would have written for them anyway and
+    what makes the result assignable at all."""
+    if isinstance(node, str):
+        return _truncate_head_tail(node, max_bytes=limit)
+    if isinstance(node, dict):
+        return {key: _cap_leaves(child, limit=limit) for key, child in node.items()}
+    if isinstance(node, (list, tuple)):
+        return [_cap_leaves(child, limit=limit) for child in node]
     return node
-
-
-def _set_at(node: Any, path: tuple[Any, ...], value: Any) -> Any:
-    if not path:
-        return value
-    for key in path[:-1]:
-        node = node[key]
-    node[path[-1]] = value
-    return None
 
 
 def _cap_json_head_tail(value: Any, *, cap: int) -> tuple[Any, bool]:
@@ -239,33 +238,39 @@ def _cap_json_head_tail(value: Any, *, cap: int) -> tuple[Any, bool]:
     the platform (``json.dumps(default=str)``), so what is capped here is
     what the enricher measures.
 
+    Every leaf gets the *same* byte allowance, found by binary search on the
+    serialized size: the largest allowance that fits. A per-leaf budget derived
+    from the overage instead would be wrong twice over — the overage is measured
+    on the escaped JSON while a leaf is measured in UTF-8, so escape-heavy
+    content (CJK at 6 JSON bytes a character, or anything with many quotes and
+    newlines) would over-cut to nothing; and charging one leaf for the whole
+    document's overage makes the outcome depend on which message happens to be
+    biggest. One allowance for all of them is order-independent and leaves no
+    cap unspent.
+
     Last resort: when the JSON structure alone exceeds ``cap`` (hundreds of
     tiny messages), no string cut can help, so the ``_truncate_json`` preview
     wrapper ships instead — inside a one-item list when the input was a list,
     so the attribute keeps its container type."""
-    work = copy.deepcopy(value)
-    over = _utf8_len(json.dumps(work, default=str)) - cap
-    if over <= 0:
-        return work, False
-    while over > 0:
-        path, size = _largest_string_leaf(work)
-        if path is None or size <= _HEAD_TAIL_FLOOR_BYTES:
-            if isinstance(work, list):
-                return [_truncate_json({"messages": work}, cap=cap - 2)], True
-            payload = work if isinstance(work, dict) else {"value": work}
-            return _truncate_json(payload, cap=cap), True
-        leaf = work if not path else _get_at(work, path)
-        # Cutting ``over`` raw bytes removes at least ``over`` JSON bytes (an
-        # escaped character encodes to no fewer bytes than its UTF-8), so one
-        # pass usually lands under the cap; the loop re-measures regardless.
-        target = max(size - over, _HEAD_TAIL_FLOOR_BYTES)
-        cut = _truncate_head_tail(leaf, max_bytes=target)
-        if not path:
-            work = cut
+    if _utf8_len(json.dumps(value, default=str)) <= cap:
+        return copy.deepcopy(value), False
+    # Cheapest allowance first: if the floor does not fit, nothing does, and
+    # the search below would spend a serialization per step to prove it.
+    floored = _cap_leaves(value, limit=_HEAD_TAIL_FLOOR_BYTES)
+    if _utf8_len(json.dumps(floored, default=str)) > cap:
+        if isinstance(value, list):
+            return [_truncate_json({"messages": list(value)}, cap=cap - 2)], True
+        payload = value if isinstance(value, dict) else {"value": value}
+        return _truncate_json(payload, cap=cap), True
+    best, low, high = floored, _HEAD_TAIL_FLOOR_BYTES, _largest_string_leaf_bytes(value)
+    while low < high:
+        allowance = (low + high + 1) // 2
+        candidate = _cap_leaves(value, limit=allowance)
+        if _utf8_len(json.dumps(candidate, default=str)) <= cap:
+            best, low = candidate, allowance
         else:
-            _set_at(work, path, cut)
-        over = _utf8_len(json.dumps(work, default=str)) - cap
-    return work, True
+            high = allowance - 1
+    return best, True
 
 
 # Public aliases so server-side ingestion can import this pipeline instead of

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -7,7 +7,6 @@ Lifecycle: configure() per api_key, await shutdown() at process exit.
 
 from __future__ import annotations
 
-import copy
 import json
 import re
 from collections.abc import Sequence
@@ -65,9 +64,20 @@ MAX_VIOLATION_CHARS = 1024
 # The input cap is 256 KiB, not the 32 KiB first proposed: 32 KiB is ~7,000
 # tokens of ASCII, which 20 retrieved chunks already exceed, so the cap would
 # have fired on exactly the calls the log exists to explain. What bounds it is
-# the OTLP record size, not storage — and the message path's topic carries
-# ``max.message.bytes=8 MiB``, so a quarter-megabyte field costs nothing
-# operationally. Typical events stay a few KB; this is a ceiling, not a target.
+# the pipeline's record and request limits, not storage — and those limits are
+# NOT yet in place. As the deployed config stands, the Collector's kafka
+# exporter caps a record at the configkafka default (1 MB, no compression) and
+# batches 512 spans into one, ``hexgate.otlp.raw`` sets no
+# ``max.message.bytes``, and the OTLP receiver takes a 20 MiB request body —
+# so a batch of large message spans fails as a whole and takes the decision
+# spans batched alongside it down too, which is the blast radius these caps
+# exist to bound. Raising the topic, the exporter's producer limit, a
+# ``send_batch_max_size``, and the receiver body size is a prerequisite for
+# emitting this scope at all (its own PR, deployed not merely merged) — no
+# message cap, 32 KiB or 256 KiB, is safe before it. Nothing emits
+# ``hexgate.messages`` yet, so declaring the constant here is safe; wiring an
+# emitter before that config is deployed is not. Typical events stay a few KB;
+# this is a ceiling, not a target.
 MAX_INPUT_MESSAGES_BYTES = 256 * 1024
 MAX_OUTPUT_MESSAGES_BYTES = 8 * 1024
 MAX_SYSTEM_INSTRUCTIONS_BYTES = 8 * 1024
@@ -241,9 +251,10 @@ def _cap_json_head_tail(value: Any, *, cap: int) -> tuple[Any, bool]:
     Unlike ``_truncate_json`` — which swaps the whole dict for a preview
     wrapper — the result keeps the input's shape (roles, message boundaries,
     part types all survive), so a reader still sees *which* message lost its
-    middle. Pure: ``value`` is deep-copied, never mutated. Measurement mirrors
-    the platform (``json.dumps(default=str)``), so what is capped here is
-    what the enricher measures.
+    middle. Pure: every path rebuilds the containers rather than writing into
+    them, so ``value`` is never mutated. Measurement mirrors the platform
+    (``json.dumps(default=str)``), so what is capped here is what the enricher
+    measures.
 
     Every leaf gets the *same* byte allowance, found by binary search on the
     serialized size: the largest allowance that fits. A per-leaf budget derived
@@ -260,7 +271,13 @@ def _cap_json_head_tail(value: Any, *, cap: int) -> tuple[Any, bool]:
     wrapper ships instead — inside a one-item list when the input was a list,
     so the attribute keeps its container type."""
     if _utf8_len(json.dumps(value, default=str)) <= cap:
-        return copy.deepcopy(value), False
+        # ``limit=cap`` cuts nothing — a leaf cannot exceed a document that
+        # fits — so this is the copy, not a truncation. Rebuilding via
+        # ``_cap_leaves`` rather than ``copy.deepcopy`` keeps the fast path as
+        # tolerant as the slow one: a framework message object holding a lock
+        # or a socket is uncopyable, and deep-copying it raised where the
+        # truncation path went through.
+        return _cap_leaves(value, limit=cap), False
     # Cheapest allowance first: if the floor does not fit, nothing does, and
     # the search below would spend a serialization per step to prove it.
     floored = _cap_leaves(value, limit=_HEAD_TAIL_FLOOR_BYTES)

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -187,7 +187,7 @@ def _truncate_head_tail(text: str, *, max_bytes: int) -> str:
     head_n = budget // 2
     tail_n = budget - head_n
     head = raw[:head_n].decode("utf-8", errors="ignore")
-    tail = raw[len(raw) - tail_n :].decode("utf-8", errors="ignore")
+    tail = raw[-tail_n:].decode("utf-8", errors="ignore")
     omitted = len(raw) - _utf8_len(head) - _utf8_len(tail)
     return head + _HEAD_TAIL_MARKER.format(omitted=omitted) + tail
 

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -7,6 +7,7 @@ Lifecycle: configure() per api_key, await shutdown() at process exit.
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 from collections.abc import Sequence
@@ -51,6 +52,18 @@ MAX_HINT_BYTES = 4 * 1024
 # lose the audit record for a *denied* call — the outcome most worth keeping.
 MAX_VIOLATIONS = 64
 MAX_VIOLATION_CHARS = 1024
+
+# Caps for LLM message content (scope ``hexgate.messages``), measured on the
+# serialized JSON like the decision caps above and enforced twice: here before
+# export, and again by the platform's span-enricher. Larger than the decision
+# caps because a prompt is not a tool argument — 32 KiB is roughly a
+# 7,000-token message. Truncation is head+tail (``cap_json_head_tail``) rather
+# than the preview wrapper ``truncate_json`` uses: on a RAG call the retrieved
+# context sits in the middle of one message, and an auditor needs the question
+# at the start and the instruction at the end more than the chunks between.
+MAX_INPUT_MESSAGES_BYTES = 32 * 1024
+MAX_OUTPUT_MESSAGES_BYTES = 8 * 1024
+MAX_SYSTEM_INSTRUCTIONS_BYTES = 8 * 1024
 
 # Keys whose values are stripped from the audit copy of ``arguments`` before
 # transmission. Substring match: tool inputs are arbitrary caller data, so a
@@ -143,10 +156,124 @@ def _truncate_json(payload: dict[str, Any], *, cap: int) -> dict[str, Any]:
         preview_bytes //= 2
 
 
+# ASCII on purpose: ``json.dumps`` escapes non-ASCII to ``\\uXXXX`` (6 bytes a
+# character), so a marker with an ellipsis would cost more than it says.
+_HEAD_TAIL_MARKER = " ...[truncated {omitted} bytes]... "
+# Below this a string leaf is not worth cutting further: what is over the cap
+# is the JSON structure around it, not the text inside it.
+_HEAD_TAIL_FLOOR_BYTES = 64
+
+
+def _utf8_len(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def _truncate_head_tail(text: str, *, max_bytes: int) -> str:
+    """Shrink ``text`` to at most ``max_bytes`` of UTF-8, keeping its head and
+    its tail joined by a marker naming the omitted byte count.
+
+    Returned unchanged when it already fits. Cuts land on code-point
+    boundaries (``errors="ignore"`` drops a split character rather than
+    emitting a broken one). The marker's room is reserved for the widest count
+    it could carry, so the result never exceeds ``max_bytes``."""
+    raw = text.encode("utf-8")
+    if len(raw) <= max_bytes:
+        return text
+    reserve = _utf8_len(_HEAD_TAIL_MARKER.format(omitted=len(raw)))
+    budget = max_bytes - reserve
+    if budget < 2:
+        # No room for a marker and content both: keep whatever head fits.
+        return raw[:max_bytes].decode("utf-8", errors="ignore")
+    head_n = budget // 2
+    tail_n = budget - head_n
+    head = raw[:head_n].decode("utf-8", errors="ignore")
+    tail = raw[len(raw) - tail_n :].decode("utf-8", errors="ignore")
+    omitted = len(raw) - _utf8_len(head) - _utf8_len(tail)
+    return head + _HEAD_TAIL_MARKER.format(omitted=omitted) + tail
+
+
+def _largest_string_leaf(
+    node: Any, path: tuple[Any, ...] = ()
+) -> tuple[tuple[Any, ...] | None, int]:
+    """``(path, utf8_size)`` of the biggest string value under ``node`` — dict
+    values and list items, never dict keys — or ``(None, 0)`` if there is none."""
+    if isinstance(node, str):
+        return path, _utf8_len(node)
+    best: tuple[tuple[Any, ...] | None, int] = (None, 0)
+    if isinstance(node, dict):
+        children = node.items()
+    elif isinstance(node, (list, tuple)):
+        children = enumerate(node)
+    else:
+        return best
+    for key, child in children:
+        found = _largest_string_leaf(child, (*path, key))
+        if found[1] > best[1]:
+            best = found
+    return best
+
+
+def _get_at(node: Any, path: tuple[Any, ...]) -> Any:
+    for key in path:
+        node = node[key]
+    return node
+
+
+def _set_at(node: Any, path: tuple[Any, ...], value: Any) -> Any:
+    if not path:
+        return value
+    for key in path[:-1]:
+        node = node[key]
+    node[path[-1]] = value
+    return None
+
+
+def _cap_json_head_tail(value: Any, *, cap: int) -> tuple[Any, bool]:
+    """Shrink the string leaves of ``value`` head+tail, largest first, until
+    ``json.dumps(value)`` fits ``cap`` bytes. Returns ``(capped, truncated)``.
+
+    Unlike ``_truncate_json`` — which swaps the whole dict for a preview
+    wrapper — the result keeps the input's shape (roles, message boundaries,
+    part types all survive), so a reader still sees *which* message lost its
+    middle. Pure: ``value`` is deep-copied, never mutated. Measurement mirrors
+    the platform (``json.dumps(default=str)``), so what is capped here is
+    what the enricher measures.
+
+    Last resort: when the JSON structure alone exceeds ``cap`` (hundreds of
+    tiny messages), no string cut can help, so the ``_truncate_json`` preview
+    wrapper ships instead — inside a one-item list when the input was a list,
+    so the attribute keeps its container type."""
+    work = copy.deepcopy(value)
+    over = _utf8_len(json.dumps(work, default=str)) - cap
+    if over <= 0:
+        return work, False
+    while over > 0:
+        path, size = _largest_string_leaf(work)
+        if path is None or size <= _HEAD_TAIL_FLOOR_BYTES:
+            if isinstance(work, list):
+                return [_truncate_json({"messages": work}, cap=cap - 2)], True
+            payload = work if isinstance(work, dict) else {"value": work}
+            return _truncate_json(payload, cap=cap), True
+        leaf = work if not path else _get_at(work, path)
+        # Cutting ``over`` raw bytes removes at least ``over`` JSON bytes (an
+        # escaped character encodes to no fewer bytes than its UTF-8), so one
+        # pass usually lands under the cap; the loop re-measures regardless.
+        target = max(size - over, _HEAD_TAIL_FLOOR_BYTES)
+        cut = _truncate_head_tail(leaf, max_bytes=target)
+        if not path:
+            work = cut
+        else:
+            _set_at(work, path, cut)
+        over = _utf8_len(json.dumps(work, default=str)) - cap
+    return work, True
+
+
 # Public aliases so server-side ingestion can import this pipeline instead of
 # keeping its own copy.
 redact = _redact
 truncate_json = _truncate_json
+truncate_head_tail = _truncate_head_tail
+cap_json_head_tail = _cap_json_head_tail
 bounded_violations = _bounded_violations
 SENSITIVE_ARG_KEY_RE = _SENSITIVE_ARG_KEY_RE
 SENSITIVE_ATTR_KEY_RE = _SENSITIVE_ATTR_KEY_RE

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -56,12 +56,19 @@ MAX_VIOLATION_CHARS = 1024
 # Caps for LLM message content (scope ``hexgate.messages``), measured on the
 # serialized JSON like the decision caps above and enforced twice: here before
 # export, and again by the platform's span-enricher. Larger than the decision
-# caps because a prompt is not a tool argument — 32 KiB is roughly a
-# 7,000-token message. Truncation is head+tail (``cap_json_head_tail``) rather
-# than the preview wrapper ``truncate_json`` uses: on a RAG call the retrieved
-# context sits in the middle of one message, and an auditor needs the question
-# at the start and the instruction at the end more than the chunks between.
-MAX_INPUT_MESSAGES_BYTES = 32 * 1024
+# caps because a prompt is not a tool argument. Truncation is head+tail
+# (``cap_json_head_tail``) rather than the preview wrapper ``truncate_json``
+# uses: on a RAG call the retrieved context sits in the middle of one message,
+# and an auditor needs the question at the start and the instruction at the end
+# more than the chunks between.
+#
+# The input cap is 256 KiB, not the 32 KiB first proposed: 32 KiB is ~7,000
+# tokens of ASCII, which 20 retrieved chunks already exceed, so the cap would
+# have fired on exactly the calls the log exists to explain. What bounds it is
+# the OTLP record size, not storage — and the message path's topic carries
+# ``max.message.bytes=8 MiB``, so a quarter-megabyte field costs nothing
+# operationally. Typical events stay a few KB; this is a ceiling, not a target.
+MAX_INPUT_MESSAGES_BYTES = 256 * 1024
 MAX_OUTPUT_MESSAGES_BYTES = 8 * 1024
 MAX_SYSTEM_INSTRUCTIONS_BYTES = 8 * 1024
 

--- a/hexgate/tracing/semconv.py
+++ b/hexgate/tracing/semconv.py
@@ -10,7 +10,8 @@ must produce by them):
 
 - One event = one span. The instrumentation scope name selects the event
   type: ``SCOPE_AUDIT`` → DecisionEvent, ``SCOPE_USAGE`` → LlmInvocationEvent,
-  ``SCOPE_BANS`` → BanEnforcementEvent (platform schemas).
+  ``SCOPE_BANS`` → BanEnforcementEvent, ``SCOPE_MESSAGES`` → LlmMessageEvent
+  (platform schemas).
 - ``occurred_at`` travels as the span's ``start_time_unix_nano`` — the one
   field OTLP already types as a timestamp. No separate attribute: a duplicate
   would invite the two values disagreeing with no rule for which wins. These
@@ -33,6 +34,18 @@ must produce by them):
 - LLM usage reuses the official ``gen_ai.*`` names where they exist (model,
   token counts) and never invents new ``gen_ai.*`` names; everything
   Hexgate-specific lives under ``sec_ai.*``.
+- LLM message content (``SCOPE_MESSAGES``) is the official GenAI trio —
+  ``gen_ai.input.messages`` / ``gen_ai.output.messages`` /
+  ``gen_ai.system_instructions`` — each a JSON-string attribute (same rule as
+  the dict fields above: the platform caps are measured in serialized-JSON
+  bytes, and the SDK applies the same caps before export). One event per LLM
+  call carrying only the input messages *new to that call* plus its
+  completion, never a snapshot of the whole conversation. ``MESSAGE_SEQ``
+  counts events within one ``TURN_KEY`` (one framework message list — a
+  sub-agent or handoff has its own) so a reader can detect a missing row;
+  ``RESYNCED`` marks an event that restates the whole list because the
+  framework rewrote it rather than extending it. ``TRUNCATED`` is set by
+  the SDK when a cap cut any content field.
 """
 
 from __future__ import annotations
@@ -41,8 +54,9 @@ from __future__ import annotations
 SCOPE_AUDIT = "hexgate.audit"
 SCOPE_USAGE = "hexgate.usage"
 SCOPE_BANS = "hexgate.bans"
+SCOPE_MESSAGES = "hexgate.messages"
 
-# --- Envelope attributes (all three scopes) -----------------------------------
+# --- Envelope attributes (all four scopes) ------------------------------------
 EVENT_ID = "sec_ai.event_id"
 AGENT_NAME = "sec_ai.agent_name"
 SESSION_ID = "sec_ai.session_id"
@@ -73,3 +87,14 @@ ERROR_CODE = "sec_ai.error_code"
 # --- Ban enforcement spans (SCOPE_BANS) ------------------------------------------
 BAN_TYPE = "sec_ai.ban_type"
 BAN_ID = "sec_ai.ban_id"
+
+# --- LLM message spans (SCOPE_MESSAGES) -------------------------------------------
+# Official OTel GenAI semconv names for prompt/completion content — verbatim.
+GEN_AI_INPUT_MESSAGES = "gen_ai.input.messages"
+GEN_AI_OUTPUT_MESSAGES = "gen_ai.output.messages"
+GEN_AI_SYSTEM_INSTRUCTIONS = "gen_ai.system_instructions"
+# Hexgate-specific message fields (see the wire contract above).
+MESSAGE_SEQ = "sec_ai.message_seq"
+TURN_KEY = "sec_ai.turn_key"
+RESYNCED = "sec_ai.resynced"
+TRUNCATED = "sec_ai.truncated"

--- a/tests/audit/test_message_caps.py
+++ b/tests/audit/test_message_caps.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import copy
 import json
+import threading
 from typing import Any
 
 from hexgate.audit import (
@@ -141,6 +142,20 @@ def test_cap_json_head_tail_does_not_mutate_the_input() -> None:
     before = copy.deepcopy(messages)
     cap_json_head_tail(messages, cap=1_024)
     assert messages == before
+
+
+def test_when_a_message_holds_an_uncopyable_object_then_both_paths_survive() -> None:
+    """Framework message objects can carry a lock or a socket. The truncation
+    path rebuilds containers and tolerates them, so the under-cap path must
+    too — a deep copy here would raise on exactly the small inputs that need
+    no truncation at all."""
+    lock = threading.Lock()
+    for content in ("short", "x" * 400_000):
+        messages = [{"role": "user", "lock": lock, "content": content}]
+        out, _ = cap_json_head_tail(messages, cap=8 * 1024)
+        assert _json_size(out) <= 8 * 1024
+        # A copy, not the caller's own object.
+        assert out[0] is not messages[0]
 
 
 def test_when_structure_alone_exceeds_the_cap_then_a_preview_wrapper_ships() -> None:

--- a/tests/audit/test_message_caps.py
+++ b/tests/audit/test_message_caps.py
@@ -127,6 +127,13 @@ def test_when_two_leaves_are_both_large_then_both_are_cut_until_it_fits() -> Non
     assert truncated is True
     assert _json_size(out) <= 8 * 1024
     assert all("...[truncated " in m["parts"][0]["content"] for m in out)
+    # Equal leaves keep equal shares: the overage is not billed to whichever
+    # one the walk reached first, so neither collapses to the floor.
+    kept = [len(m["parts"][0]["content"]) for m in out]
+    assert min(kept) > 1_000
+    assert max(kept) - min(kept) <= 1
+    # And the allowance is spent, not abandoned.
+    assert _json_size(out) > (8 * 1024) // 2
 
 
 def test_cap_json_head_tail_does_not_mutate_the_input() -> None:
@@ -165,3 +172,41 @@ def test_when_content_is_non_ascii_then_the_json_measure_still_fits() -> None:
     assert _json_size(out) <= 4_096
     content = out[0]["parts"][0]["content"]
     assert content.startswith("日") and content.endswith("日")
+    # The escape cost is charged once, not twice: at 6 JSON bytes a character
+    # a 4 KiB cap buys ~680 of them, so anything near the 64-byte floor means
+    # a UTF-8 length was cut by a JSON-measured overage.
+    assert len(content) > 500
+    assert _json_size(out) > 4_096 // 2
+
+
+def test_when_content_is_escape_heavy_then_the_allowance_is_still_spent() -> None:
+    """A tool result that is itself JSON: every quote costs two JSON bytes."""
+    payload = json.dumps({f"key_{i}": f"value_{i}" for i in range(2_000)})
+    out, truncated = cap_json_head_tail([_message(payload)], cap=8 * 1024)
+    assert truncated is True
+    assert _json_size(out) <= 8 * 1024
+    assert _json_size(out) > (8 * 1024) // 2
+
+
+def test_when_a_message_list_holds_tuples_then_they_are_capped_as_lists() -> None:
+    """LangChain's ``[("system", ...), ("human", ...)]`` form: tuples are not
+    assignable, so a path-based cut would raise on the export path."""
+    out, truncated = cap_json_head_tail(
+        [("system", "s" * 100), ("human", "h" * 50_000)], cap=4_096
+    )
+    assert truncated is True
+    assert _json_size(out) <= 4_096
+    assert out[0] == ["system", "s" * 100]
+    assert out[1][0] == "human"
+    assert "...[truncated " in out[1][1]
+
+
+def test_when_the_cap_is_below_the_wrapper_headroom_then_it_still_returns() -> None:
+    """``cap_json_head_tail`` is public and the enricher imports it, so a small
+    cap must terminate rather than halve a negative preview budget forever."""
+    messages = [_message("ok", role="tool") for _ in range(200)]
+    for cap in (513, 512, 400, 64):
+        out, truncated = cap_json_head_tail(messages, cap=cap)
+        assert truncated is True
+        assert isinstance(out, list) and len(out) == 1
+        assert out[0]["_truncated"] is True

--- a/tests/audit/test_message_caps.py
+++ b/tests/audit/test_message_caps.py
@@ -32,7 +32,7 @@ def _message(content: str, role: str = "user") -> dict[str, Any]:
 
 
 def test_caps_are_the_design_values() -> None:
-    assert MAX_INPUT_MESSAGES_BYTES == 32 * 1024
+    assert MAX_INPUT_MESSAGES_BYTES == 256 * 1024
     assert MAX_OUTPUT_MESSAGES_BYTES == 8 * 1024
     assert MAX_SYSTEM_INSTRUCTIONS_BYTES == 8 * 1024
 
@@ -86,7 +86,7 @@ def test_when_the_cap_is_smaller_than_the_marker_then_only_a_head_survives() -> 
 
 
 def test_cap_json_head_tail_happy_path() -> None:
-    messages = [_message("Q" * 1_000 + "C" * 100_000 + "A" * 1_000)]
+    messages = [_message("Q" * 1_000 + "C" * 400_000 + "A" * 1_000)]
     out, truncated = cap_json_head_tail(messages, cap=MAX_INPUT_MESSAGES_BYTES)
     assert truncated is True
     assert _json_size(out) <= MAX_INPUT_MESSAGES_BYTES

--- a/tests/audit/test_message_caps.py
+++ b/tests/audit/test_message_caps.py
@@ -1,0 +1,167 @@
+"""Head+tail caps for LLM message content (hexgate.audit).
+
+These are the SDK-side caps for the ``hexgate.messages`` scope. The platform
+enricher imports the same functions, so what is asserted here about shape and
+size is what the stored row will have."""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import Any
+
+from hexgate.audit import (
+    MAX_INPUT_MESSAGES_BYTES,
+    MAX_OUTPUT_MESSAGES_BYTES,
+    MAX_SYSTEM_INSTRUCTIONS_BYTES,
+    cap_json_head_tail,
+    truncate_head_tail,
+)
+
+
+def _json_size(value: Any) -> int:
+    """The platform's measure: serialized-JSON bytes, ``default=str``."""
+    return len(json.dumps(value, default=str).encode("utf-8"))
+
+
+def _message(content: str, role: str = "user") -> dict[str, Any]:
+    return {"role": role, "parts": [{"type": "text", "content": content}]}
+
+
+# --- cap constants ------------------------------------------------------------
+
+
+def test_caps_are_the_design_values() -> None:
+    assert MAX_INPUT_MESSAGES_BYTES == 32 * 1024
+    assert MAX_OUTPUT_MESSAGES_BYTES == 8 * 1024
+    assert MAX_SYSTEM_INSTRUCTIONS_BYTES == 8 * 1024
+
+
+# --- truncate_head_tail -------------------------------------------------------
+
+
+def test_truncate_head_tail_happy_path() -> None:
+    text = "H" * 500 + "M" * 500 + "T" * 500
+    out = truncate_head_tail(text, max_bytes=200)
+    assert len(out.encode("utf-8")) <= 200
+    assert out.startswith("HHH")
+    assert out.endswith("TTT")
+    assert "M" not in out
+    kept = len(out.encode("utf-8")) - len(
+        out.split("...[truncated ")[1].split(" bytes]...")[0]
+    )
+    assert "...[truncated " in out and " bytes]... " in out
+    assert kept > 0
+
+
+def test_when_text_fits_then_it_is_returned_unchanged() -> None:
+    text = "short"
+    assert truncate_head_tail(text, max_bytes=100) is text
+
+
+def test_when_the_marker_names_omitted_bytes_then_the_count_is_exact() -> None:
+    text = "a" * 10_000
+    out = truncate_head_tail(text, max_bytes=1_000)
+    omitted = int(out.split("...[truncated ")[1].split(" bytes]...")[0])
+    kept_content = len(out.encode("utf-8")) - len(
+        f" ...[truncated {omitted} bytes]... ".encode("utf-8")
+    )
+    assert omitted + kept_content == 10_000
+
+
+def test_when_text_is_multibyte_then_cuts_land_on_code_points() -> None:
+    text = "é" * 2_000  # 2 bytes each
+    out = truncate_head_tail(text, max_bytes=301)  # odd budget forces a split
+    assert len(out.encode("utf-8")) <= 301
+    assert out.startswith("é") and out.endswith("é")
+    assert "�" not in out
+
+
+def test_when_the_cap_is_smaller_than_the_marker_then_only_a_head_survives() -> None:
+    out = truncate_head_tail("x" * 100, max_bytes=10)
+    assert out == "x" * 10
+
+
+# --- cap_json_head_tail -------------------------------------------------------
+
+
+def test_cap_json_head_tail_happy_path() -> None:
+    messages = [_message("Q" * 1_000 + "C" * 100_000 + "A" * 1_000)]
+    out, truncated = cap_json_head_tail(messages, cap=MAX_INPUT_MESSAGES_BYTES)
+    assert truncated is True
+    assert _json_size(out) <= MAX_INPUT_MESSAGES_BYTES
+    # Shape survives: still one user message with one text part.
+    assert out[0]["role"] == "user"
+    assert out[0]["parts"][0]["type"] == "text"
+    content = out[0]["parts"][0]["content"]
+    assert content.startswith("QQQ") and content.endswith("AAA")
+    assert "...[truncated " in content
+    # And it round-trips as JSON — head+tail was applied to the text, not to
+    # the serialized document.
+    assert json.loads(json.dumps(out)) == out
+
+
+def test_when_under_cap_then_a_copy_is_returned_untouched() -> None:
+    messages = [_message("hello")]
+    out, truncated = cap_json_head_tail(messages, cap=1_024)
+    assert truncated is False
+    assert out == messages
+    assert out is not messages
+    assert out[0] is not messages[0]
+
+
+def test_when_several_leaves_then_the_largest_is_cut_first() -> None:
+    small = _message("tool result: ok", role="tool")
+    big = _message("R" * 50_000, role="user")
+    out, truncated = cap_json_head_tail([small, big], cap=8 * 1024)
+    assert truncated is True
+    assert out[0] == small
+    assert "...[truncated " in out[1]["parts"][0]["content"]
+    assert _json_size(out) <= 8 * 1024
+
+
+def test_when_two_leaves_are_both_large_then_both_are_cut_until_it_fits() -> None:
+    out, truncated = cap_json_head_tail(
+        [_message("A" * 30_000), _message("B" * 30_000)], cap=8 * 1024
+    )
+    assert truncated is True
+    assert _json_size(out) <= 8 * 1024
+    assert all("...[truncated " in m["parts"][0]["content"] for m in out)
+
+
+def test_cap_json_head_tail_does_not_mutate_the_input() -> None:
+    messages = [_message("X" * 50_000)]
+    before = copy.deepcopy(messages)
+    cap_json_head_tail(messages, cap=1_024)
+    assert messages == before
+
+
+def test_when_structure_alone_exceeds_the_cap_then_a_preview_wrapper_ships() -> None:
+    """Hundreds of tiny messages: no string cut can help, so the existing
+    preview wrapper is the fallback — inside a list so the attribute keeps its
+    container type."""
+    messages = [_message("ok", role="tool") for _ in range(2_000)]
+    out, truncated = cap_json_head_tail(messages, cap=1_024)
+    assert truncated is True
+    assert _json_size(out) <= 1_024
+    assert isinstance(out, list) and len(out) == 1
+    assert out[0]["_truncated"] is True
+    assert out[0]["original_bytes"] > 1_024
+
+
+def test_when_value_is_a_bare_string_then_it_is_cut_head_tail() -> None:
+    out, truncated = cap_json_head_tail("s" * 10_000, cap=200)
+    assert truncated is True
+    assert isinstance(out, str)
+    assert _json_size(out) <= 200
+    assert out.startswith("sss") and out.endswith("sss")
+
+
+def test_when_content_is_non_ascii_then_the_json_measure_still_fits() -> None:
+    """``json.dumps`` escapes each CJK character to 6 bytes; the cap is on
+    that serialized form, not on the raw text."""
+    out, truncated = cap_json_head_tail([_message("日" * 20_000)], cap=4_096)
+    assert truncated is True
+    assert _json_size(out) <= 4_096
+    content = out[0]["parts"][0]["content"]
+    assert content.startswith("日") and content.endswith("日")

--- a/tests/tracing/test_semconv.py
+++ b/tests/tracing/test_semconv.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from hexgate.tracing import semconv
 
-_SCOPES = {"SCOPE_AUDIT", "SCOPE_USAGE", "SCOPE_BANS"}
+_SCOPES = {"SCOPE_AUDIT", "SCOPE_USAGE", "SCOPE_BANS", "SCOPE_MESSAGES"}
 _GEN_AI = {
     "GEN_AI_REQUEST_MODEL",
     "GEN_AI_USAGE_INPUT_TOKENS",
     "GEN_AI_USAGE_OUTPUT_TOKENS",
+    "GEN_AI_INPUT_MESSAGES",
+    "GEN_AI_OUTPUT_MESSAGES",
+    "GEN_AI_SYSTEM_INSTRUCTIONS",
 }
 
 
@@ -43,3 +46,14 @@ def test_when_gen_ai_names_are_read_then_they_match_the_official_semconv() -> No
     assert semconv.GEN_AI_REQUEST_MODEL == "gen_ai.request.model"
     assert semconv.GEN_AI_USAGE_INPUT_TOKENS == "gen_ai.usage.input_tokens"
     assert semconv.GEN_AI_USAGE_OUTPUT_TOKENS == "gen_ai.usage.output_tokens"
+    assert semconv.GEN_AI_INPUT_MESSAGES == "gen_ai.input.messages"
+    assert semconv.GEN_AI_OUTPUT_MESSAGES == "gen_ai.output.messages"
+    assert semconv.GEN_AI_SYSTEM_INSTRUCTIONS == "gen_ai.system_instructions"
+
+
+def test_when_the_message_scope_is_read_then_it_names_the_emitting_library() -> None:
+    """The scope selects the event type platform-side; the content attributes
+    stay OTel's so a foreign backend reads standard GenAI fields."""
+    assert semconv.SCOPE_MESSAGES == "hexgate.messages"
+    for name in ("MESSAGE_SEQ", "TURN_KEY", "RESYNCED", "TRUNCATED"):
+        assert getattr(semconv, name).startswith("sec_ai."), name


### PR DESCRIPTION
Wire contract only — no emitter, no platform change; nothing sends this scope yet.

## What is Changing

- **`hexgate/tracing/semconv.py`** — `SCOPE_MESSAGES = "hexgate.messages"`, the official GenAI content names `gen_ai.input.messages` / `gen_ai.output.messages` / `gen_ai.system_instructions` (verbatim, never coined), and the Hexgate-specific `sec_ai.message_seq` / `turn_key` / `resynced` / `truncated`. The module docstring gains the message rules: JSON-string content, one event per LLM call carrying only the messages new to that call, `message_seq` per `turn_key` for gap detection.
- **`hexgate/audit.py`** — `MAX_INPUT_MESSAGES_BYTES` (256 KiB), `MAX_OUTPUT_MESSAGES_BYTES` (8 KiB), `MAX_SYSTEM_INSTRUCTIONS_BYTES` (8 KiB) beside the decision caps, plus `truncate_head_tail()` and `cap_json_head_tail()`. The latter shrinks every string leaf head+tail to one shared byte allowance — the largest that makes the serialized JSON fit, found by binary search — so roles and message boundaries survive and only the middle of oversized text is lost. Falls back to the existing `truncate_json` preview wrapper when the JSON structure alone exceeds the cap. Pure; measures with `json.dumps(default=str)` like the platform.

## Why is this change necessary?

`semconv.py` is the one file both packages import, so the wire contract lands first and the platform and SDK lanes can then proceed in parallel.

**Why the caps and helpers live in the SDK.** The SDK applies the cap **before export** — the design's blast-radius argument (one oversized span must not take its batch down) only holds upstream of the batch — and the platform enricher will import the same functions as enforcement, exactly as `enforcement.py` imports `truncate_json` today.

**Why the input cap is 256 KiB and not the 32 KiB first proposed.** 32 KiB is ~7,000 tokens of ASCII (~5,400 CJK characters, since JSON escapes each to 6 bytes), which 20 retrieved chunks of 500 tokens already exceed — the cap would have fired on exactly the RAG calls the message log exists to explain. What bounds it is the OTLP record size rather than storage, and the message path's topic is raised to `max.message.bytes=8 MiB` anyway, so a quarter-megabyte field costs nothing operationally.

**Why one shared allowance rather than a per-leaf budget.** Deriving each leaf's target from the document's overage is wrong twice over: the overage is measured on escaped JSON while a leaf is measured in UTF-8, so escape-heavy content over-cuts to the floor (70k CJK characters kept 42 of a 32 KiB cap); and charging one leaf for the whole overage makes the outcome depend on which message happens to be biggest (two equal messages came out 64 / 8,004). A single allowance is order-independent and leaves no cap unspent.

## Tests

- `tests/tracing/test_semconv.py` — new scope and names in the prefix / collision / official-name invariants.
- `tests/audit/test_message_caps.py` — head+tail on ASCII and multibyte text, exact omitted-byte count, largest-leaf-first, both-leaves-cut with balance and utilization bounds, escape-heavy content, tuple-shaped message lists (LangChain's `[("system", …), ("human", …)]`), caps below the preview wrapper's headroom, no input mutation, structure-only overflow fallback, bare string, CJK under the JSON measure.
- Full SDK suite: 2389 passed, 13 skipped.

## Known gap

Inline base64 image parts are capped as ordinary string leaves, so a large `data:image/...` URL survives as a useless fragment eating most of the input budget. Tracked in #198 — image parts should be placeholder-substituted before the cap runs.

## Design

[LLM message logging design](https://app.notion.com/p/3d4fb45dbae28141a3c4d32338a0d496) · [implementation spec](https://app.notion.com/p/3d4fb45dbae28109b82fd38cb03b9d11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
