### PR TITLE
feat(platform-api): map hexgate.messages spans into LlmMessageEvent

### DIFF
--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -105,22 +105,62 @@ _SENSITIVE_ATTR_KEY_RE = re.compile(
 )
 _REDACTED = "[REDACTED]"
 
+# Keys whose string value may itself be serialized JSON that ``_redact`` must
+# look inside. In a ``gen_ai.*`` message a tool-call part carries the caller's
+# ``arguments``, and the raw OpenAI wire shape serializes them as a JSON
+# string, not an object — a string leaf, whose keys the substring match never
+# sees. Exact key names on purpose: parsing every string that happens to be
+# JSON would rewrite a user message whose content is JSON.
+TOOL_CALL_JSON_KEYS = frozenset({"arguments"})
 
-def _redact(value: Any, *, pattern: re.Pattern[str]) -> Any:
+
+def _redact(
+    value: Any,
+    *,
+    pattern: re.Pattern[str],
+    json_string_keys: frozenset[str] = frozenset(),
+) -> Any:
     """Return a copy of ``value`` with values under ``pattern``-matching keys replaced.
 
     Pure — never mutates the input, so the ``Decision`` the caller holds
-    keeps its full arguments; only the wire payload is redacted."""
+    keeps its full arguments; only the wire payload is redacted.
+
+    A string value under a key in ``json_string_keys`` that parses to a JSON
+    container is redacted inside and serialized back, so the field keeps the
+    shape the emitter chose while its nested keys still match."""
     if isinstance(value, dict):
         return {
             k: _REDACTED
             if isinstance(k, str) and pattern.search(k)
-            else _redact(v, pattern=pattern)
+            else _redact_json_string(
+                v, pattern=pattern, json_string_keys=json_string_keys
+            )
+            if k in json_string_keys and isinstance(v, str)
+            else _redact(v, pattern=pattern, json_string_keys=json_string_keys)
             for k, v in value.items()
         }
     if isinstance(value, (list, tuple)):
-        return [_redact(v, pattern=pattern) for v in value]
+        return [
+            _redact(v, pattern=pattern, json_string_keys=json_string_keys)
+            for v in value
+        ]
     return value
+
+
+def _redact_json_string(
+    text: str, *, pattern: re.Pattern[str], json_string_keys: frozenset[str]
+) -> str:
+    """``_redact`` applied inside a JSON-string leaf; non-JSON or scalar JSON
+    comes back untouched (nothing in it has a key to match)."""
+    try:
+        parsed = json.loads(text)
+    except ValueError:
+        return text
+    if not isinstance(parsed, (dict, list)):
+        return text
+    return json.dumps(
+        _redact(parsed, pattern=pattern, json_string_keys=json_string_keys)
+    )
 
 
 def _bounded_violations(violations: Sequence[str]) -> list[str]:

--- a/hexgate/tracing/semconv.py
+++ b/hexgate/tracing/semconv.py
@@ -74,7 +74,7 @@ HINT = "sec_ai.hint"
 ARGUMENTS = "sec_ai.arguments"
 ATTRIBUTES = "sec_ai.attributes"
 
-# --- Run attribution (SCOPE_AUDIT, plus RUN_ID on SCOPE_USAGE) -----------------
+# --- Run attribution (SCOPE_AUDIT; RUN_ID also on SCOPE_USAGE, SCOPE_MESSAGES) --
 # Omitted entirely when the emitter has no run to attribute: OTLP attributes
 # cannot carry null, and the platform's run_id is ``UUID | None`` — an empty
 # string is a 422. An absent attribute decodes to None; "" would not.

--- a/platform/api/hexgate_api/jobs/enricher/coerce.py
+++ b/platform/api/hexgate_api/jobs/enricher/coerce.py
@@ -115,3 +115,28 @@ def as_json_dict(value: Any, *, key: str, scope: str) -> dict[str, Any] | None:
         error_class="validation",
         scope=scope,
     )
+
+
+def as_json_value(value: Any, *, key: str, scope: str) -> Any:
+    """Like :func:`as_json_dict` for attributes whose JSON is not an object —
+    the ``gen_ai.*`` message fields are arrays. Any valid JSON is accepted;
+    an already-decoded array or kvlist is accepted with a log line."""
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        _log.warning("accepted decoded %s (expected a JSON string)", key)
+        return value
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except ValueError as exc:
+            raise SpanRejected(
+                f"{key} is not valid JSON: {exc}",
+                error_class="validation",
+                scope=scope,
+            ) from None
+    raise SpanRejected(
+        f"{key}={value!r} is not a JSON-string value",
+        error_class="validation",
+        scope=scope,
+    )

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -21,7 +21,12 @@ from typing import Any
 
 from opentelemetry.proto.trace.v1.trace_pb2 import Span
 
-from hexgate.audit import SENSITIVE_ARG_KEY_RE, redact, truncate_json
+from hexgate.audit import (
+    SENSITIVE_ARG_KEY_RE,
+    TOOL_CALL_JSON_KEYS,
+    redact,
+    truncate_json,
+)
 from hexgate.tracing import semconv
 from hexgate_api.jobs.enricher.decode import attrs_dict
 
@@ -87,7 +92,12 @@ def _redacted_attributes(span: Span) -> dict[str, Any]:
                 parsed = None
             attributes[key] = parsed if isinstance(parsed, containers) else _UNPARSEABLE
     return truncate_json(
-        redact(attributes, pattern=SENSITIVE_ARG_KEY_RE), cap=_ATTRIBUTES_CAP_BYTES
+        redact(
+            attributes,
+            pattern=SENSITIVE_ARG_KEY_RE,
+            json_string_keys=TOOL_CALL_JSON_KEYS,
+        ),
+        cap=_ATTRIBUTES_CAP_BYTES,
     )
 
 

--- a/platform/api/hexgate_api/jobs/enricher/dlq.py
+++ b/platform/api/hexgate_api/jobs/enricher/dlq.py
@@ -29,6 +29,20 @@ from hexgate_api.jobs.enricher.decode import attrs_dict
 # matches dict keys, so a still-serialized payload would pass through whole
 # with its secret-bearing keys unread.
 _JSON_DICT_KEYS = (semconv.ARGUMENTS, semconv.HINT, semconv.ATTRIBUTES)
+# The gen_ai.* message fields are JSON arrays of messages; a tool-call message
+# inside one carries the same caller arguments ``ARGUMENTS`` does, so they are
+# parsed and redacted the same way. ``redact`` recurses lists, so an array is
+# as redactable as an object — only a bare scalar has nothing to match.
+_JSON_LIST_KEYS = (
+    semconv.GEN_AI_INPUT_MESSAGES,
+    semconv.GEN_AI_OUTPUT_MESSAGES,
+    semconv.GEN_AI_SYSTEM_INSTRUCTIONS,
+)
+# Key → the container types its JSON may parse to and still be redactable.
+_JSON_KEYS: dict[str, tuple[type, ...]] = {
+    **{key: (dict,) for key in _JSON_DICT_KEYS},
+    **{key: (dict, list) for key in _JSON_LIST_KEYS},
+}
 _UNPARSEABLE = "[UNPARSEABLE]"
 
 # Both variable-size fields are capped well below the DLQ producer's
@@ -54,23 +68,24 @@ def _source(topic: str, partition: int, offset: int) -> dict[str, Any]:
 
 
 def _redacted_attributes(span: Span) -> dict[str, Any]:
-    """Span attributes safe for the DLQ: JSON-string dicts parsed, then redacted.
+    """Span attributes safe for the DLQ: JSON-string fields parsed, then redacted.
 
-    A dict field that doesn't parse *to a dict* can't be redacted (``redact``
-    matches keys, so a bare string or list has nothing to match), so it is
-    dropped rather than forwarded raw — the DLQ is for diagnosing the
-    rejection, and the source record (see ``_source``) still holds the
-    original bytes.
+    A field that doesn't parse to the container its contract names can't be
+    trusted to redact (``redact`` matches keys, so a bare string has nothing
+    to match, and a list where a dict was promised is not the shape the
+    emitter meant), so it is dropped rather than forwarded raw — the DLQ is
+    for diagnosing the rejection, and the source record (see ``_source``)
+    still holds the original bytes.
     """
     attributes = attrs_dict(span.attributes)
-    for key in _JSON_DICT_KEYS:
+    for key, containers in _JSON_KEYS.items():
         raw = attributes.get(key)
         if isinstance(raw, str):
             try:
                 parsed = json.loads(raw)
             except ValueError:
                 parsed = None
-            attributes[key] = parsed if isinstance(parsed, dict) else _UNPARSEABLE
+            attributes[key] = parsed if isinstance(parsed, containers) else _UNPARSEABLE
     return truncate_json(
         redact(attributes, pattern=SENSITIVE_ARG_KEY_RE), cap=_ATTRIBUTES_CAP_BYTES
     )
@@ -92,8 +107,9 @@ def span_envelope(
     Attributes are redacted (substring key match, the stricter of the two
     SDK patterns) before they land here: this topic has 30-day retention and
     no ACLs, so unredacted arguments must never reach it. The JSON-string
-    dict fields are parsed first so the key match reaches inside them, and
-    they stay dicts in the envelope.
+    fields — decision dicts and gen_ai.* message arrays alike — are parsed
+    first so the key match reaches inside them, and they stay parsed in the
+    envelope.
     """
     attributes = _redacted_attributes(span)
     payload = {

--- a/platform/api/hexgate_api/jobs/enricher/enforcement.py
+++ b/platform/api/hexgate_api/jobs/enricher/enforcement.py
@@ -8,19 +8,32 @@ gating mirror ``AuditEvent.as_payload``: arguments are redacted (substring
 key match) then capped at 8 KiB; hint is capped at 4 KiB but never redacted
 (policy config, not caller data); attributes are redacted (anchored key
 match) then capped at 4 KiB, with a falsy bag normalised to None.
+
+LLM message content (scope ``hexgate.messages``) follows the arguments rule
+— substring key redaction, since a tool-call message carries the same caller
+arguments a decision does — then a head+tail cap per field. The SDK applied
+the same caps before export; re-applying them here is what makes the stored
+row's size a platform guarantee rather than a client courtesy. Content is
+truncated, never rejected: an over-cap prompt is the one an auditor most
+needs to see.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from hexgate.audit import (
     MAX_ARGS_BYTES,
     MAX_ATTRIBUTES_BYTES,
     MAX_HINT_BYTES,
+    MAX_INPUT_MESSAGES_BYTES,
+    MAX_OUTPUT_MESSAGES_BYTES,
+    MAX_SYSTEM_INSTRUCTIONS_BYTES,
     SENSITIVE_ARG_KEY_RE,
     SENSITIVE_ATTR_KEY_RE,
     bounded_violations,
+    cap_json_head_tail,
     redact,
     truncate_json,
 )
@@ -51,3 +64,33 @@ def capped_attributes(value: dict[str, Any] | None) -> dict[str, Any] | None:
 
 def capped_violations(values: list[str]) -> list[str]:
     return bounded_violations(values)
+
+
+def _capped_content(value: Any, *, cap: int) -> tuple[str, bool]:
+    """Redact, cap head+tail, and serialize one ``gen_ai.*`` content field.
+
+    Returns the JSON text the row stores and whether this side cut it — the
+    caller ORs that into the SDK's ``truncated`` flag. Serialization matches
+    the cap's own measure (``json.dumps``, ``default=str``), so the text is
+    never longer than what was found to fit.
+    """
+    capped, truncated = cap_json_head_tail(
+        redact(value, pattern=SENSITIVE_ARG_KEY_RE), cap=cap
+    )
+    return json.dumps(capped, default=str), truncated
+
+
+def capped_input_messages(value: Any) -> tuple[str, bool]:
+    return _capped_content(value, cap=MAX_INPUT_MESSAGES_BYTES)
+
+
+def capped_output_messages(value: Any) -> tuple[str, bool]:
+    return _capped_content(value, cap=MAX_OUTPUT_MESSAGES_BYTES)
+
+
+def capped_system_instructions(value: Any | None) -> tuple[str, bool]:
+    # Only the first event of a turn_key carries instructions; the column
+    # defaults to "" for the rest.
+    if value is None:
+        return "", False
+    return _capped_content(value, cap=MAX_SYSTEM_INSTRUCTIONS_BYTES)

--- a/platform/api/hexgate_api/jobs/enricher/enforcement.py
+++ b/platform/api/hexgate_api/jobs/enricher/enforcement.py
@@ -11,7 +11,9 @@ match) then capped at 4 KiB, with a falsy bag normalised to None.
 
 LLM message content (scope ``hexgate.messages``) follows the arguments rule
 — substring key redaction, since a tool-call message carries the same caller
-arguments a decision does — then a head+tail cap per field. The SDK applied
+arguments a decision does, reaching inside ``arguments`` serialized as a JSON
+string the way the raw OpenAI wire shape has it — then a head+tail cap per
+field. The SDK applied
 the same caps before export; re-applying them here is what makes the stored
 row's size a platform guarantee rather than a client courtesy. Content is
 truncated, never rejected: an over-cap prompt is the one an auditor most
@@ -32,6 +34,7 @@ from hexgate.audit import (
     MAX_SYSTEM_INSTRUCTIONS_BYTES,
     SENSITIVE_ARG_KEY_RE,
     SENSITIVE_ATTR_KEY_RE,
+    TOOL_CALL_JSON_KEYS,
     bounded_violations,
     cap_json_head_tail,
     redact,
@@ -75,7 +78,10 @@ def _capped_content(value: Any, *, cap: int) -> tuple[str, bool]:
     never longer than what was found to fit.
     """
     capped, truncated = cap_json_head_tail(
-        redact(value, pattern=SENSITIVE_ARG_KEY_RE), cap=cap
+        redact(
+            value, pattern=SENSITIVE_ARG_KEY_RE, json_string_keys=TOOL_CALL_JSON_KEYS
+        ),
+        cap=cap,
     )
     return json.dumps(capped, default=str), truncated
 

--- a/platform/api/hexgate_api/jobs/enricher/mapping.py
+++ b/platform/api/hexgate_api/jobs/enricher/mapping.py
@@ -22,6 +22,7 @@ from hexgate_api.jobs.enricher.coerce import (
     SpanRejected,
     as_int,
     as_json_dict,
+    as_json_value,
     as_str,
     as_str_list,
     required,
@@ -31,24 +32,37 @@ from hexgate_api.jobs.enricher.enforcement import (
     capped_arguments,
     capped_attributes,
     capped_hint,
+    capped_input_messages,
+    capped_output_messages,
+    capped_system_instructions,
     capped_violations,
 )
 from hexgate_api.query_scope import EventOutOfWindow, validate_event_window
-from hexgate_api.schemas import BanEnforcementEvent, DecisionEvent, LlmInvocationEvent
+from hexgate_api.schemas import (
+    BanEnforcementEvent,
+    DecisionEvent,
+    LlmInvocationEvent,
+    LlmMessageEvent,
+)
 
 _log = logging.getLogger(__name__)
 
 _EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
+# SCOPE_MESSAGES is mapped below but deliberately not accepted yet: the
+# consumer buckets events by exact type and commits the offset after the
+# inserts, so a scope accepted before it has a bucket and an insert would be
+# validated and then dropped with no DLQ record. It joins this tuple in the
+# same change as its consumer bucket; until then it is a loud unknown_scope.
 KNOWN_SCOPES = (semconv.SCOPE_AUDIT, semconv.SCOPE_USAGE, semconv.SCOPE_BANS)
 
-Event = DecisionEvent | LlmInvocationEvent | BanEnforcementEvent
+Event = DecisionEvent | LlmInvocationEvent | BanEnforcementEvent | LlmMessageEvent
 
 
 def _envelope(
     span: Span, attrs: dict[str, Any], resource_attrs: dict[str, Any], scope: str
 ) -> dict[str, Any]:
-    """The AuditEnvelope fields shared by all three event types."""
+    """The AuditEnvelope fields shared by every event type."""
     if span.start_time_unix_nano <= 0:
         raise SpanRejected(
             "span start_time_unix_nano is unset", error_class="validation", scope=scope
@@ -169,6 +183,56 @@ def _usage_fields(attrs: dict[str, Any], span: Span, scope: str) -> dict[str, An
     return fields
 
 
+def _message_fields(attrs: dict[str, Any], scope: str) -> dict[str, Any]:
+    """LLM message content: the ``gen_ai.*`` trio as JSON, capped here before
+    validation so an over-cap prompt is stored short rather than rejected.
+
+    ``truncated`` is the SDK's flag OR'd with this side's own cuts — a row
+    marked untouched must really be the whole message. The two bool flags are
+    handed to the model raw: Pydantic already coerces a bool attribute, and an
+    absent one takes the model's False default.
+    """
+    input_messages, input_cut = capped_input_messages(
+        as_json_value(
+            required(attrs, semconv.GEN_AI_INPUT_MESSAGES, scope=scope),
+            key=semconv.GEN_AI_INPUT_MESSAGES,
+            scope=scope,
+        )
+    )
+    output_messages, output_cut = capped_output_messages(
+        as_json_value(
+            required(attrs, semconv.GEN_AI_OUTPUT_MESSAGES, scope=scope),
+            key=semconv.GEN_AI_OUTPUT_MESSAGES,
+            scope=scope,
+        )
+    )
+    system_instructions, system_cut = capped_system_instructions(
+        as_json_value(
+            attrs.get(semconv.GEN_AI_SYSTEM_INSTRUCTIONS),
+            key=semconv.GEN_AI_SYSTEM_INSTRUCTIONS,
+            scope=scope,
+        )
+    )
+    return {
+        "model": as_str(required(attrs, semconv.GEN_AI_REQUEST_MODEL, scope=scope)),
+        "turn_key": as_str(required(attrs, semconv.TURN_KEY, scope=scope)),
+        "message_seq": as_int(
+            required(attrs, semconv.MESSAGE_SEQ, scope=scope),
+            key=semconv.MESSAGE_SEQ,
+            scope=scope,
+        ),
+        "resynced": attrs.get(semconv.RESYNCED, False),
+        "truncated": True
+        if input_cut or output_cut or system_cut
+        else attrs.get(semconv.TRUNCATED, False),
+        "input_messages": input_messages,
+        "output_messages": output_messages,
+        "system_instructions": system_instructions,
+        # Same nullable contract as the other scopes: absent, never "".
+        "run_id": as_str(attrs.get(semconv.RUN_ID)) or None,
+    }
+
+
 def _ban_fields(attrs: dict[str, Any], scope: str) -> dict[str, Any]:
     return {
         "ban_type": as_str(required(attrs, semconv.BAN_TYPE, scope=scope)),
@@ -193,6 +257,9 @@ def map_span(scope_name: str, span: Span, resource_attrs: dict[str, Any]) -> Eve
     elif scope_name == semconv.SCOPE_USAGE:
         model = LlmInvocationEvent
         payload |= _usage_fields(attrs, span, scope_name)
+    elif scope_name == semconv.SCOPE_MESSAGES:
+        model = LlmMessageEvent
+        payload |= _message_fields(attrs, scope_name)
     else:
         model = BanEnforcementEvent
         payload |= _ban_fields(attrs, scope_name)

--- a/platform/api/hexgate_api/schemas.py
+++ b/platform/api/hexgate_api/schemas.py
@@ -667,6 +667,42 @@ class LlmInvocationEvent(AuditEnvelope):
     run_id: Optional[UUID] = None
 
 
+class LlmMessageEvent(AuditEnvelope):
+    """One LLM call's prompt delta and completion; mirrors the llm_message table.
+
+    The three content fields are the official ``gen_ai.*`` shapes as JSON
+    text, redacted and byte-capped by the enricher before validation. No
+    ``max_length`` here on purpose: the caps truncate, and a bound on this
+    model would turn an over-cap payload into a rejection — the column is an
+    unbounded ``String``, so nothing downstream needs the guard either.
+    """
+
+    model: str = Field(min_length=1, max_length=256)
+    # Identifies the message list this event appends to. One session can hold
+    # several: the main run, each sub-agent and each handoff keeps its own, and
+    # message_seq restarts at 0 in each. The design has the SDK derive it from
+    # the framework's own run identity plus the agent name (see the LLM message
+    # logging spec), which keeps it under agent_name's cap plus an id prefix;
+    # the bound is sized for that, not for a session-wide path.
+    turn_key: str = Field(min_length=1, max_length=512)
+    # Counter within ``turn_key``; UInt32 column, same reasoning as the token
+    # bounds on LlmInvocationEvent.
+    message_seq: int = Field(ge=0, le=UINT32_MAX)
+    # This event restates the whole list (the framework rewrote it) rather
+    # than extending it.
+    resynced: bool = False
+    # Any content field below was cut to its cap — by the SDK before export,
+    # by the enricher, or both.
+    truncated: bool = False
+    input_messages: str
+    output_messages: str
+    system_instructions: str = ""
+    # Run attribution — same tier and same zero-UUID-at-insert-time
+    # substitution as LlmInvocationEvent.run_id, so a transcript stays
+    # attributable to its run when session_id is empty.
+    run_id: Optional[UUID] = None
+
+
 class DecisionAccepted(BaseModel):
     """Response shape for POST /v1/audit/decisions."""
 

--- a/platform/api/tests/jobs/enricher/conftest.py
+++ b/platform/api/tests/jobs/enricher/conftest.py
@@ -5,6 +5,7 @@ can assert ordering, and a job factory wired with those fakes."""
 
 from __future__ import annotations
 
+import json
 import time
 import uuid
 from dataclasses import dataclass, field
@@ -125,6 +126,29 @@ def usage_attrs(**overrides: Any) -> dict[str, Any]:
         semconv.GEN_AI_USAGE_INPUT_TOKENS: 100,
         semconv.GEN_AI_USAGE_OUTPUT_TOKENS: 50,
         semconv.LATENCY_MS: 250,
+    }
+    return {**base, **overrides}
+
+
+def message_attrs(**overrides: Any) -> dict[str, Any]:
+    base = {
+        semconv.EVENT_ID: str(uuid.uuid4()),
+        semconv.AGENT_NAME: "researcher",
+        semconv.GEN_AI_REQUEST_MODEL: "gpt-4o",
+        semconv.TURN_KEY: "run_1:researcher",
+        semconv.MESSAGE_SEQ: 0,
+        semconv.GEN_AI_INPUT_MESSAGES: json.dumps(
+            [{"role": "user", "parts": [{"type": "text", "content": "hello"}]}]
+        ),
+        semconv.GEN_AI_OUTPUT_MESSAGES: json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [{"type": "text", "content": "hi"}],
+                    "finish_reason": "stop",
+                }
+            ]
+        ),
     }
     return {**base, **overrides}
 

--- a/platform/api/tests/jobs/enricher/test_coerce.py
+++ b/platform/api/tests/jobs/enricher/test_coerce.py
@@ -8,6 +8,7 @@ from hexgate_api.jobs.enricher.coerce import (
     SpanRejected,
     as_int,
     as_json_dict,
+    as_json_value,
     as_str,
     as_str_list,
     required,
@@ -77,3 +78,24 @@ def test_as_str_stringifies_with_default() -> None:
     assert as_str(None) == ""
     assert as_str(None, default="x") == "x"
     assert as_str(7) == "7"
+
+
+def test_as_json_value_happy_path() -> None:
+    assert as_json_value('[{"role": "user"}]', key="k", scope="s") == [{"role": "user"}]
+    assert as_json_value(None, key="k", scope="s") is None
+
+
+def test_when_json_value_is_already_decoded_then_accepted() -> None:
+    assert as_json_value(["a"], key="k", scope="s") == ["a"]
+    assert as_json_value({"a": 1}, key="k", scope="s") == {"a": 1}
+
+
+def test_when_json_value_is_invalid_json_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected) as exc:
+        as_json_value("[broken", key="k", scope="s")
+    assert exc.value.error_class == "validation"
+
+
+def test_when_json_value_is_a_non_string_scalar_then_span_rejected() -> None:
+    with pytest.raises(SpanRejected):
+        as_json_value(42, key="k", scope="s")

--- a/platform/api/tests/jobs/enricher/test_dlq.py
+++ b/platform/api/tests/jobs/enricher/test_dlq.py
@@ -12,7 +12,7 @@ from hexgate_api.jobs.enricher.dlq import (
     record_envelope,
     span_envelope,
 )
-from tests.jobs.enricher.conftest import decision_attrs, make_span
+from tests.jobs.enricher.conftest import decision_attrs, make_span, message_attrs
 
 
 def test_span_envelope_happy_path() -> None:
@@ -97,6 +97,35 @@ def test_when_a_dict_field_is_valid_json_but_not_a_dict_then_dlq_drops_it() -> N
     attributes = _envelope_attributes(attrs)
     assert attributes[semconv.ARGUMENTS] == "[UNPARSEABLE]"
     assert attributes[semconv.HINT] == "[UNPARSEABLE]"
+
+
+def test_when_a_message_span_is_rejected_then_dlq_redacts_inside_the_messages() -> None:
+    # hexgate.messages spans are DLQ'd until the consumer stores them, and a
+    # tool-call message carries caller arguments like a decision does — so
+    # the same parse-then-redact has to reach inside the message array.
+    messages = [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool_call",
+                    "name": "login",
+                    "arguments": {"user": "bob", "password": "hunter2"},
+                }
+            ],
+        }
+    ]
+    attrs = message_attrs(**{semconv.GEN_AI_INPUT_MESSAGES: json.dumps(messages)})
+    attributes = _envelope_attributes(attrs)
+    arguments = attributes[semconv.GEN_AI_INPUT_MESSAGES][0]["parts"][0]["arguments"]
+    assert arguments == {"user": "bob", "password": "[REDACTED]"}
+    assert "hunter2" not in json.dumps(attributes)
+
+
+def test_when_a_message_field_is_a_bare_json_string_then_dlq_drops_it() -> None:
+    attrs = message_attrs(**{semconv.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps("hunter2")})
+    attributes = _envelope_attributes(attrs)
+    assert attributes[semconv.GEN_AI_SYSTEM_INSTRUCTIONS] == "[UNPARSEABLE]"
 
 
 def test_when_a_record_is_undecodable_then_envelope_carries_base64() -> None:

--- a/platform/api/tests/jobs/enricher/test_dlq.py
+++ b/platform/api/tests/jobs/enricher/test_dlq.py
@@ -122,6 +122,26 @@ def test_when_a_message_span_is_rejected_then_dlq_redacts_inside_the_messages() 
     assert "hunter2" not in json.dumps(attributes)
 
 
+def test_when_tool_call_arguments_are_a_json_string_then_dlq_still_redacts() -> None:
+    messages = [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool_call",
+                    "name": "login",
+                    "arguments": json.dumps({"user": "bob", "password": "hunter2"}),
+                }
+            ],
+        }
+    ]
+    attrs = message_attrs(**{semconv.GEN_AI_INPUT_MESSAGES: json.dumps(messages)})
+    attributes = _envelope_attributes(attrs)
+    assert "hunter2" not in json.dumps(attributes)
+    arguments = attributes[semconv.GEN_AI_INPUT_MESSAGES][0]["parts"][0]["arguments"]
+    assert json.loads(arguments)["password"] == "[REDACTED]"
+
+
 def test_when_a_message_field_is_a_bare_json_string_then_dlq_drops_it() -> None:
     attrs = message_attrs(**{semconv.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps("hunter2")})
     attributes = _envelope_attributes(attrs)

--- a/platform/api/tests/jobs/enricher/test_enforcement.py
+++ b/platform/api/tests/jobs/enricher/test_enforcement.py
@@ -136,6 +136,27 @@ def test_when_a_tool_call_carries_a_secret_argument_then_redacted() -> None:
     assert arguments == {"user": "bob", "password": "[REDACTED]"}
 
 
+def test_when_tool_call_arguments_are_a_json_string_then_still_redacted() -> None:
+    # Raw OpenAI wire shape: arguments arrive serialized, one JSON level deeper
+    # than as_json_value parsed. The secret must not survive inside the string.
+    messages = [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool_call",
+                    "name": "login",
+                    "arguments": json.dumps({"user": "bob", "password": "hunter2"}),
+                }
+            ],
+        }
+    ]
+    text, _ = capped_input_messages(messages)
+    assert "hunter2" not in text
+    arguments = json.loads(text)[0]["parts"][0]["arguments"]
+    assert json.loads(arguments) == {"user": "bob", "password": "[REDACTED]"}
+
+
 def test_when_output_messages_exceed_cap_then_truncated_to_8_kib() -> None:
     text, truncated = capped_output_messages([_message("o" * 50_000, "assistant")])
     assert truncated is True

--- a/platform/api/tests/jobs/enricher/test_enforcement.py
+++ b/platform/api/tests/jobs/enricher/test_enforcement.py
@@ -4,11 +4,19 @@ from __future__ import annotations
 
 import json
 
-from hexgate.audit import MAX_VIOLATIONS
+from hexgate.audit import (
+    MAX_INPUT_MESSAGES_BYTES,
+    MAX_OUTPUT_MESSAGES_BYTES,
+    MAX_SYSTEM_INSTRUCTIONS_BYTES,
+    MAX_VIOLATIONS,
+)
 from hexgate_api.jobs.enricher.enforcement import (
     capped_arguments,
     capped_attributes,
     capped_hint,
+    capped_input_messages,
+    capped_output_messages,
+    capped_system_instructions,
     capped_violations,
 )
 
@@ -55,3 +63,99 @@ def test_when_violations_exceed_cap_then_bounded() -> None:
     bounded = capped_violations([f"v{i}" for i in range(MAX_VIOLATIONS + 10)])
     assert len(bounded) == MAX_VIOLATIONS
     assert bounded[-1] == "(+11 more)"
+
+
+# --- LLM message content -------------------------------------------------------
+
+
+def _message(content: str, role: str = "user") -> dict:
+    return {"role": role, "parts": [{"type": "text", "content": content}]}
+
+
+def _size(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def test_capped_input_messages_happy_path() -> None:
+    messages = [_message("hello")]
+    text, truncated = capped_input_messages(messages)
+    assert json.loads(text) == messages
+    assert truncated is False
+
+
+def test_when_input_messages_exceed_cap_then_head_and_tail_survive() -> None:
+    # A RAG-style message: the question up front, the retrieved chunks in the
+    # middle, the instruction at the end — the two ends are what an auditor needs.
+    messages = [_message("Q" * 1_000 + "C" * 400_000 + "A" * 1_000)]
+    text, truncated = capped_input_messages(messages)
+    assert truncated is True
+    assert _size(text) <= MAX_INPUT_MESSAGES_BYTES
+    content = json.loads(text)[0]["parts"][0]["content"]
+    assert content.startswith("Q" * 1_000)
+    assert content.endswith("A" * 1_000)
+    assert "...[truncated " in content
+
+
+def test_when_input_messages_are_exactly_at_cap_then_untouched() -> None:
+    # Boundary: the measured quantity is the serialized JSON, so pad the
+    # content until the document is exactly the cap.
+    probe = [_message("")]
+    overhead = len(json.dumps(probe).encode("utf-8"))
+    messages = [_message("x" * (MAX_INPUT_MESSAGES_BYTES - overhead))]
+    text, truncated = capped_input_messages(messages)
+    assert _size(text) == MAX_INPUT_MESSAGES_BYTES
+    assert truncated is False
+    assert json.loads(text) == messages
+
+
+def test_when_input_messages_are_one_byte_over_cap_then_truncated() -> None:
+    probe = [_message("")]
+    overhead = len(json.dumps(probe).encode("utf-8"))
+    messages = [_message("x" * (MAX_INPUT_MESSAGES_BYTES - overhead + 1))]
+    text, truncated = capped_input_messages(messages)
+    assert truncated is True
+    assert _size(text) <= MAX_INPUT_MESSAGES_BYTES
+
+
+def test_when_a_tool_call_carries_a_secret_argument_then_redacted() -> None:
+    # Same rule as decision arguments: a tool-call message holds caller data.
+    messages = [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool_call",
+                    "name": "login",
+                    "arguments": {"user": "bob", "password": "hunter2"},
+                }
+            ],
+        }
+    ]
+    text, _ = capped_input_messages(messages)
+    arguments = json.loads(text)[0]["parts"][0]["arguments"]
+    assert arguments == {"user": "bob", "password": "[REDACTED]"}
+
+
+def test_when_output_messages_exceed_cap_then_truncated_to_8_kib() -> None:
+    text, truncated = capped_output_messages([_message("o" * 50_000, "assistant")])
+    assert truncated is True
+    assert _size(text) <= MAX_OUTPUT_MESSAGES_BYTES
+
+
+def test_capped_system_instructions_happy_path() -> None:
+    parts = [{"type": "text", "content": "You are terse."}]
+    text, truncated = capped_system_instructions(parts)
+    assert json.loads(text) == parts
+    assert truncated is False
+
+
+def test_when_system_instructions_are_absent_then_empty_string() -> None:
+    assert capped_system_instructions(None) == ("", False)
+
+
+def test_when_system_instructions_exceed_cap_then_truncated_to_8_kib() -> None:
+    text, truncated = capped_system_instructions(
+        [{"type": "text", "content": "s" * 50_000}]
+    )
+    assert truncated is True
+    assert _size(text) <= MAX_SYSTEM_INSTRUCTIONS_BYTES

--- a/platform/api/tests/jobs/enricher/test_mapping.py
+++ b/platform/api/tests/jobs/enricher/test_mapping.py
@@ -11,17 +11,24 @@ import pytest
 
 from hexgate.tracing import semconv
 from hexgate_api.jobs.enricher.coerce import SpanRejected
-from hexgate_api.jobs.enricher.mapping import map_span
+from hexgate_api.jobs.enricher.mapping import (
+    KNOWN_SCOPES,
+    _envelope,
+    _message_fields,
+    map_span,
+)
 from hexgate_api.schemas import (
     UINT32_MAX,
     BanEnforcementEvent,
     DecisionEvent,
     LlmInvocationEvent,
+    LlmMessageEvent,
 )
 from tests.jobs.enricher.conftest import (
     ban_attrs,
     decision_attrs,
     make_span,
+    message_attrs,
     usage_attrs,
 )
 
@@ -288,3 +295,129 @@ def test_sdk_usage_span_validates_in_and_out_of_a_run_scope() -> None:
 
     assert str(attributed.run_id) == run_id
     assert detached.run_id is None
+
+
+# --- LLM messages: mapped, not yet accepted -------------------------------------
+#
+# ``SCOPE_MESSAGES`` stays out of KNOWN_SCOPES until the consumer has a bucket
+# and an insert for it, so ``map_span`` still rejects it and these tests call
+# ``_message_fields()`` directly.
+
+
+def _message_event(attrs: dict[str, object]) -> LlmMessageEvent:
+    scope = semconv.SCOPE_MESSAGES
+    span = make_span(attrs)
+    payload = _envelope(span, attrs, {}, scope) | _message_fields(attrs, scope)
+    return LlmMessageEvent(**payload)
+
+
+def test_when_scope_is_messages_then_still_an_unknown_scope_reject() -> None:
+    assert semconv.SCOPE_MESSAGES not in KNOWN_SCOPES
+    with pytest.raises(SpanRejected) as exc:
+        map_span(semconv.SCOPE_MESSAGES, make_span(message_attrs()), {})
+    assert exc.value.error_class == "unknown_scope"
+
+
+def test_message_fields_happy_path() -> None:
+    attrs = message_attrs(
+        **{
+            semconv.SESSION_ID: "sess_1",
+            semconv.MESSAGE_SEQ: 3,
+            semconv.GEN_AI_SYSTEM_INSTRUCTIONS: json.dumps(
+                [{"type": "text", "content": "Be terse."}]
+            ),
+            semconv.RESYNCED: True,
+        }
+    )
+    event = _message_event(attrs)
+
+    assert event.model == "gpt-4o"
+    assert event.session_id == "sess_1"
+    assert event.turn_key == "run_1:researcher"
+    assert event.message_seq == 3
+    assert event.resynced is True
+    assert event.truncated is False
+    assert json.loads(event.input_messages) == json.loads(
+        attrs[semconv.GEN_AI_INPUT_MESSAGES]
+    )
+    assert json.loads(event.output_messages) == json.loads(
+        attrs[semconv.GEN_AI_OUTPUT_MESSAGES]
+    )
+    assert json.loads(event.system_instructions) == [
+        {"type": "text", "content": "Be terse."}
+    ]
+
+
+def test_when_optional_message_attributes_are_absent_then_defaults() -> None:
+    # The SDK omits system_instructions after a turn_key's first event and
+    # omits the flags when false; the row must still validate.
+    event = _message_event(message_attrs())
+    assert event.system_instructions == ""
+    assert event.resynced is False
+    assert event.truncated is False
+    assert event.session_id == ""
+
+
+def test_when_message_span_carries_run_id_then_kept_else_none() -> None:
+    # Same contract as llm_invocation.run_id: joins a transcript to its run
+    # when session_id is empty; absent on the wire, never "".
+    run_id = str(uuid.uuid4())
+    attributed = _message_event(message_attrs(**{semconv.RUN_ID: run_id}))
+    detached = _message_event(message_attrs())
+    assert str(attributed.run_id) == run_id
+    assert detached.run_id is None
+
+
+def test_when_a_flag_is_not_a_bool_then_validation_fails() -> None:
+    # No coercer of our own: the raw attribute reaches the model, and Pydantic
+    # rejects what it cannot read as a bool — a DLQ reject via map_span.
+    with pytest.raises(ValueError):
+        _message_event(message_attrs(**{semconv.RESYNCED: "maybe"}))
+
+
+def test_when_sdk_marked_the_event_truncated_then_the_flag_is_kept() -> None:
+    # This side cut nothing, but the SDK did before export: the stored row
+    # must not claim to be the whole message.
+    event = _message_event(message_attrs(**{semconv.TRUNCATED: True}))
+    assert event.truncated is True
+
+
+def test_when_input_messages_exceed_cap_then_stored_short_and_flagged() -> None:
+    big = [{"role": "user", "parts": [{"type": "text", "content": "x" * 300_000}]}]
+    attrs = message_attrs(**{semconv.GEN_AI_INPUT_MESSAGES: json.dumps(big)})
+    event = _message_event(attrs)
+    assert event.truncated is True
+    assert len(event.input_messages.encode("utf-8")) <= 256 * 1024
+    assert "...[truncated " in event.input_messages
+
+
+@pytest.mark.parametrize(
+    "missing",
+    [
+        semconv.GEN_AI_REQUEST_MODEL,
+        semconv.TURN_KEY,
+        semconv.MESSAGE_SEQ,
+        semconv.GEN_AI_INPUT_MESSAGES,
+        semconv.GEN_AI_OUTPUT_MESSAGES,
+    ],
+)
+def test_when_a_required_message_attribute_is_absent_then_span_rejected(
+    missing: str,
+) -> None:
+    attrs = message_attrs()
+    del attrs[missing]
+    with pytest.raises(SpanRejected) as exc:
+        _message_fields(attrs, semconv.SCOPE_MESSAGES)
+    assert exc.value.error_class == "validation"
+
+
+def test_when_input_messages_json_is_invalid_then_span_rejected() -> None:
+    attrs = message_attrs(**{semconv.GEN_AI_INPUT_MESSAGES: "[broken"})
+    with pytest.raises(SpanRejected):
+        _message_fields(attrs, semconv.SCOPE_MESSAGES)
+
+
+def test_when_message_seq_exceeds_uint32_then_validation_fails() -> None:
+    attrs = message_attrs(**{semconv.MESSAGE_SEQ: UINT32_MAX + 1})
+    with pytest.raises(ValueError):
+        _message_event(attrs)

--- a/platform/api/uv.lock
+++ b/platform/api/uv.lock
@@ -1028,7 +1028,7 @@ wheels = [
 
 [[package]]
 name = "hexgate"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "../../" }
 dependencies = [
     { name = "bashlex" },

--- a/tests/audit/test_message_caps.py
+++ b/tests/audit/test_message_caps.py
@@ -15,7 +15,10 @@ from hexgate.audit import (
     MAX_INPUT_MESSAGES_BYTES,
     MAX_OUTPUT_MESSAGES_BYTES,
     MAX_SYSTEM_INSTRUCTIONS_BYTES,
+    SENSITIVE_ARG_KEY_RE,
+    TOOL_CALL_JSON_KEYS,
     cap_json_head_tail,
+    redact,
     truncate_head_tail,
 )
 
@@ -225,3 +228,49 @@ def test_when_the_cap_is_below_the_wrapper_headroom_then_it_still_returns() -> N
         assert truncated is True
         assert isinstance(out, list) and len(out) == 1
         assert out[0]["_truncated"] is True
+
+
+# --- redact: JSON-string tool-call arguments -----------------------------------------
+
+
+def _tool_call(arguments: Any) -> list[dict[str, Any]]:
+    part = {"type": "tool_call", "name": "login", "arguments": arguments}
+    return [{"role": "assistant", "parts": [part]}]
+
+
+def test_redact_json_string_keys_happy_path() -> None:
+    # The raw OpenAI wire shape: arguments serialized as a JSON string, so the
+    # secret key sits inside a string leaf the key match alone never reaches.
+    messages = _tool_call(json.dumps({"user": "bob", "password": "hunter2"}))
+    out = redact(
+        messages, pattern=SENSITIVE_ARG_KEY_RE, json_string_keys=TOOL_CALL_JSON_KEYS
+    )
+    arguments = out[0]["parts"][0]["arguments"]
+    assert isinstance(arguments, str)  # shape kept
+    assert json.loads(arguments) == {"user": "bob", "password": "[REDACTED]"}
+
+
+def test_when_arguments_string_is_not_json_then_left_untouched() -> None:
+    messages = _tool_call("not json at all")
+    out = redact(
+        messages, pattern=SENSITIVE_ARG_KEY_RE, json_string_keys=TOOL_CALL_JSON_KEYS
+    )
+    assert out[0]["parts"][0]["arguments"] == "not json at all"
+
+
+def test_when_json_string_keys_are_not_given_then_strings_stay_opaque() -> None:
+    # Default behaviour is unchanged for the decision path.
+    text = json.dumps({"password": "hunter2"})
+    out = redact(_tool_call(text), pattern=SENSITIVE_ARG_KEY_RE)
+    assert out[0]["parts"][0]["arguments"] == text
+
+
+def test_when_content_happens_to_be_json_then_it_is_not_rewritten() -> None:
+    # Only the named keys are parsed: a user message whose content is JSON is
+    # data, not a payload to normalise.
+    content = json.dumps({"password": "the word, quoted by the user"})
+    messages = [_message(content)]
+    out = redact(
+        messages, pattern=SENSITIVE_ARG_KEY_RE, json_string_keys=TOOL_CALL_JSON_KEYS
+    )
+    assert out[0]["parts"][0]["content"] == content


### PR DESCRIPTION
Design: [LLM message logging design](https://app.notion.com/p/3d4fb45dbae28141a3c4d32338a0d496) · [implementation spec](https://app.notion.com/p/3d4fb45dbae28109b82fd38cb03b9d11).

## What is changing
`LlmMessageEvent(AuditEnvelope)` in `schemas.py`, mirroring the `llm_message` columns of #183 including `run_id`; `capped_input_messages()` / `capped_output_messages()` / `capped_system_instructions()` in `jobs/enricher/enforcement.py` (key-redact like arguments, head+tail cap via the PR 1 helpers, truncate never reject, each returning the cut flag); `_message_fields()` and a `map_span` branch in `jobs/enricher/mapping.py` that ORs the enricher's cuts into the SDK's `truncated`; `as_json_value()` in `coerce.py` for the array-shaped attributes (the two bool flags reach the model raw — Pydantic coerces them). **`SCOPE_MESSAGES` is not added to `KNOWN_SCOPES` here** — the scope stays a loud `unknown_scope` DLQ reject until PR 4.

`jobs/enricher/dlq.py` now parses and redacts the three `gen_ai.*` message arrays before dead-lettering, the way it already does for `arguments` / `hint` / `attributes` — the DLQ is this PR's intended destination for every message span, and a tool-call message carries the same caller arguments a decision does.

## Why is this change necessary
`consumer.py` buckets events by type and commits the offset after the inserts, so a scope accepted before it has a bucket would be validated and then silently dropped with no DLQ record. Keeping registration for PR 4 means this PR can be reverted alone and main stays non-lossy. The DLQ redaction closes the gap that routing message spans there would otherwise open on a 30-day, no-ACL topic.

## Tests
`platform/api/tests/jobs/enricher/test_mapping.py` (calls `_message_fields()` directly: happy path, absent optional fields, SDK `truncated` kept, over-cap stored short, required attributes, `run_id` in/out); `test_enforcement.py` (cap boundary at and one byte over, head+tail marker, tool-call secret redacted, 8 KiB output/system caps); `test_coerce.py` (`as_json_value`); `test_dlq.py` (secret inside a message array redacted, bare-string field dropped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)