### PR TITLE
feat(sdk): add LlmMessageEvent and emit_llm_messages

### DIFF
--- a/docs/reference/environment.mdx
+++ b/docs/reference/environment.mdx
@@ -33,6 +33,7 @@ raises a key-named error when the agent is built.
 | `HEXGATE_API_URL` | Platform endpoint. Defaults to Hexgate Cloud (`https://app.hexgate.ai`). Set to `http://localhost:8000` only when self-hosting locally — the key must be minted by whichever platform this points at. |
 | `HEXGATE_OTLP_ENDPOINT` | Where audit, usage and ban spans are exported (OTLP/HTTP). Defaults to `<HEXGATE_API_URL>/v1/traces`, which Hexgate Cloud and the reference deploy both serve. Set it only when the collector lives on a different host than the control plane, e.g. `http://localhost:4318/v1/traces` for a local `make collector-run`. |
 | `HEXGATE_LOCAL_MODE` | Truthy value forces local audit and shorts the platform auto-bind path, even when `HEXGATE_API_KEY` is set. `hexgate chat` sets this automatically. |
+| `HEXGATE_LOG_MESSAGES` | `0` (or `false` / `no` / `off`) switches off LLM message logging — the prompt delta and completion of every model call, exported under scope `hexgate.messages` — while decisions, usage and bans keep flowing. **Default on**: an audit log a customer has to discover and enable is not there when an incident needs it. Content is redacted and byte-capped by the SDK before export, retained 180 days, and stays under your controllership: it is your data, processed on your behalf. |
 | `HEXGATE_BIND_AGENTS` | Truthy value opts a code-built agent into the platform path at construction time (requires `HEXGATE_API_KEY` — the platform path is otherwise opt-in). |
 
 The key and the URL are coupled: a `fty_live_…` key only verifies against the

--- a/hexgate/audit.py
+++ b/hexgate/audit.py
@@ -76,8 +76,9 @@ MAX_VIOLATION_CHARS = 1024
 # Being in the repo is not the same as being in force: that change is
 # operational, so no message cap — 32 KiB or 256 KiB — is safe on a stage until
 # its topics have been altered and its collector and enricher restarted.
-# Nothing emits ``hexgate.messages`` yet, so declaring the constant here is
-# safe; wiring an emitter against a stage that has not been redeployed is not.
+# The emitter exists (``hexgate.tracing.messages``) but no adapter calls it
+# yet, so both stay inert; wiring an adapter hook against a stage that has not
+# been redeployed is what is unsafe.
 # Typical events stay a few KB; this is a ceiling, not a target.
 MAX_INPUT_MESSAGES_BYTES = 256 * 1024
 MAX_OUTPUT_MESSAGES_BYTES = 8 * 1024
@@ -434,7 +435,7 @@ def configure(
     Both args fall back to ``HEXGATE_API_KEY`` / ``HEXGATE_API_URL`` env vars
     (``HEXGATE_OTLP_ENDPOINT`` overrides where spans are exported). Reuses the
     existing sender when the same key was already configured — one sender per
-    key carries decisions, LLM usage and ban enforcements alike; distinct keys
+    key carries decisions, LLM usage, bans and LLM messages alike; distinct keys
     get distinct senders. Returns ``None`` when no api_key is resolvable —
     audit stays inert.
 
@@ -458,6 +459,6 @@ def get_sender(api_key: str | None = None) -> AuditSender | None:
 
 async def shutdown() -> None:
     """Flush queued events and stop every sender in the shared registry —
-    decisions, LLM usage and ban enforcements alike. Safe to call multiple
+    decisions, LLM usage, bans and LLM messages alike. Safe to call multiple
     times."""
     await _shutdown_all()

--- a/hexgate/tracing/_senders.py
+++ b/hexgate/tracing/_senders.py
@@ -45,8 +45,16 @@ this is 8x more round-trips for the same span count, and ``MAX_QUEUE_SIZE``
 stays at OTel's 2048 — a slow collector saturates the queue 8x sooner, and
 ``shutdown()`` has to drain it in 8x more exports inside the same
 ``DEFAULT_EXPORT_TIMEOUT``. Ordinary decision traffic pays that today, before
-anything emits ``hexgate.messages``; revisit the queue size if drops show up
-in the saturation warning below."""
+any adapter emits ``hexgate.messages``; revisit the queue size if drops show up
+in the saturation warning below.
+
+Once message spans flow, the queue is a memory bound as well as a drop bound:
+it counts spans, not bytes, and a queued message span holds its capped JSON
+(up to ~272 KiB). A collector that is slow rather than down — connections
+accepted, exports timing out — lets 2048 such spans accumulate in the customer
+process: tens of MiB for the typical few-KiB event, ~540 MiB if every span
+sits at the cap. Raising ``MAX_QUEUE_SIZE`` to cure drops therefore raises
+that ceiling too; a byte-aware bound is the real fix if it ever bites."""
 
 MAX_QUEUE_SIZE = 2048
 """Spans buffered before the processor evicts the oldest. OTel's own default,
@@ -91,8 +99,11 @@ class SpanEvent(Protocol):
     """Structural type for anything ``AuditSender`` can emit — a frozen event
     dataclass that knows which instrumentation scope it belongs to and how
     to lay itself out as flat span attributes. ``AuditEvent``,
-    ``LlmUsageEvent`` and ``BanEnforcementEvent`` all satisfy this without
-    being imported here."""
+    ``LlmUsageEvent``, ``BanEnforcementEvent`` and ``LlmMessageEvent`` all
+    satisfy this without being imported here. A scope must also be in the
+    tracer table built in ``AuditSender.__init__`` — an event whose scope is
+    missing there is logged and dropped at emit (``emit`` catches the
+    ``KeyError`` like any other failure), so nothing tells the caller."""
 
     SCOPE: ClassVar[str]
     occurred_at: datetime
@@ -204,7 +215,12 @@ class AuditSender:
         self._provider.add_span_processor(self._processor)
         self._tracers = {
             scope: self._provider.get_tracer(scope)
-            for scope in (semconv.SCOPE_AUDIT, semconv.SCOPE_USAGE, semconv.SCOPE_BANS)
+            for scope in (
+                semconv.SCOPE_AUDIT,
+                semconv.SCOPE_USAGE,
+                semconv.SCOPE_BANS,
+                semconv.SCOPE_MESSAGES,
+            )
         }
 
     def _new_exporter(self) -> SpanExporter:
@@ -290,7 +306,7 @@ _logged_local_mode_suppressed = False
 
 # One sender per api_key. A single process may wrap agents for several
 # tenants/keys, and each must export with its own bearer token — so senders
-# are keyed by key rather than kept as a first-wins singleton. All three
+# are keyed by key rather than kept as a first-wins singleton. All four
 # event types share one sender per key; the span's instrumentation scope,
 # not a separate endpoint, tells them apart.
 # The registry is unbounded and assumes a small, fixed key set per process;

--- a/hexgate/tracing/messages.py
+++ b/hexgate/tracing/messages.py
@@ -1,0 +1,285 @@
+"""LLM prompt/completion content as audit events (scope ``hexgate.messages``).
+
+The fourth event stream next to decisions (``hexgate.audit``), token usage
+(``hexgate.usage``) and bans (``hexgate.bans``). One :class:`LlmMessageEvent`
+per model call, carrying only the input messages *new to that call* plus its
+completion — see ``hexgate.tracing.semconv`` for the wire contract and the
+reasoning.
+
+Mirrors ``tracing/usage.py``: the same sender registry, so one api_key means
+one exporter for every event type, and the same ``HEXGATE_LOCAL_MODE`` gate.
+The one addition is ``HEXGATE_LOG_MESSAGES``: message capture is on by
+default — a log a customer has to discover and switch on is a log that is not
+there when an incident needs it — and ``HEXGATE_LOG_MESSAGES=0`` turns it off
+without touching the other streams.
+
+Which messages count as "new" is the adapter's job; this module only lays an
+already-derived event out on the wire — redacted, capped and serialised.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, ClassVar
+from uuid import UUID, uuid4
+
+from hexgate.audit import (
+    MAX_INPUT_MESSAGES_BYTES,
+    MAX_OUTPUT_MESSAGES_BYTES,
+    MAX_SYSTEM_INSTRUCTIONS_BYTES,
+    SENSITIVE_ARG_KEY_RE,
+    TOOL_CALL_JSON_KEYS,
+    cap_json_head_tail,
+    redact,
+)
+from hexgate.runtime.context import get_current_context
+from hexgate.runtime.run_facts import get_run_facts
+from hexgate.tracing import semconv
+from hexgate.tracing._senders import AuditSender, get_or_create_sender
+from hexgate.tracing._senders import get_sender as _get_sender
+from hexgate.tracing._senders import shutdown as _shutdown_all
+
+_log = logging.getLogger(__name__)
+
+# Opt-out switch for this stream only. Unset means on. Read on every emit, not
+# cached at import: a test or an operator flipping it mid-process must see the
+# change, and the read costs nothing next to serialising a prompt.
+LOG_MESSAGES_ENV = "HEXGATE_LOG_MESSAGES"
+
+# The values that switch capture off: the falsy counterparts of the truthy
+# spellings ``HEXGATE_LOCAL_MODE`` accepts, so ``=0`` and its usual synonyms all
+# work. Anything else — ``1``, ``true``, an empty string, a typo — leaves the
+# default (on) in force, so a mistyped value never silently disables the log.
+_OFF_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+def _log_messages_enabled() -> bool:
+    """True unless ``HEXGATE_LOG_MESSAGES`` is set to a falsy value."""
+    return os.environ.get(LOG_MESSAGES_ENV, "").strip().lower() not in _OFF_VALUES
+
+
+def _json_default(obj: Any) -> Any:
+    """``json.dumps`` hook for what the framework hands an adapter: pydantic
+    models (every supported framework's message type), dataclasses and mappings
+    become containers, other iterables become lists, and only a true scalar
+    falls back to ``str()``. Each return value is fed back through ``dumps``,
+    so nested models unwrap all the way down."""
+    dump = getattr(obj, "model_dump", None)
+    if callable(dump):
+        return dump(mode="json")
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    if isinstance(obj, Mapping):
+        return dict(obj)
+    if isinstance(obj, (set, frozenset, tuple)):
+        return list(obj)
+    return str(obj)
+
+
+def _as_json_data(value: Any) -> Any:
+    """Round-trip ``value`` through JSON so what redaction and the caps walk is
+    plain dicts, lists and scalars.
+
+    ``redact`` and ``cap_json_head_tail`` only descend into dicts and lists; a
+    message object they cannot open would be serialised whole by
+    ``json.dumps(default=str)`` — a ``repr()`` in the transcript, with any
+    secret key inside it unredacted. Normalising first closes that gap for
+    every shape the adapters can pass, at the cost of one extra serialisation
+    of a few KB per call."""
+    return json.loads(json.dumps(value, default=_json_default))
+
+
+def _capped_json(value: Any, *, cap: int) -> tuple[str, bool]:
+    """Normalise to JSON data, redact, cap head+tail to ``cap`` serialized
+    bytes, and serialise.
+
+    Redaction uses the ``arguments`` pattern (substring match on key names,
+    recursing into every dict): the tool-call messages inside a prompt carry
+    the same tool arguments the decision event redacts, and blanking them in
+    one place but not the other would leave the secret readable in the
+    transcript. A tool-call part may carry ``arguments`` as a JSON *string*
+    (the raw OpenAI wire shape), so those are parsed, redacted inside and
+    serialised back — the same ``TOOL_CALL_JSON_KEYS`` the enricher passes, so
+    both ends blank the same keys. Message-shape keys (``role``, ``parts``,
+    ``type``, ``content``) never match it, but tool *results* inside the
+    messages get the same rule,
+    so a ``next_page_token`` in a tool response is blanked too — the accepted
+    over-match ``hexgate.audit`` already documents for ``arguments``. Capping
+    measures the same ``json.dumps(default=str)`` it then emits, so what was
+    fitted to the cap is exactly what travels.
+    """
+    capped, truncated = cap_json_head_tail(
+        redact(
+            _as_json_data(value),
+            pattern=SENSITIVE_ARG_KEY_RE,
+            json_string_keys=TOOL_CALL_JSON_KEYS,
+        ),
+        cap=cap,
+    )
+    return json.dumps(capped, default=str), truncated
+
+
+@dataclass(frozen=True, slots=True)
+class LlmMessageEvent:
+    """One LLM call's prompt delta and completion, emitted as a span under
+    scope ``hexgate.messages``. ``occurred_at`` becomes the span's start time.
+
+    ``input_messages`` are the messages new to this call (tool results
+    included), ``output_messages`` its completion, both in the OTel GenAI
+    message shape as plain dicts. ``system_instructions`` rides along on the
+    first event of each ``turn_key`` only, ``None`` otherwise. ``turn_key``
+    names the framework message list this event extends and ``message_seq``
+    counts events within it; ``resynced`` says this event restates the whole
+    list because the framework rewrote it. The caller supplies all of those —
+    this class never decides what is new."""
+
+    SCOPE: ClassVar[str] = semconv.SCOPE_MESSAGES
+
+    agent_name: str
+    model: str
+    input_messages: list[Any]
+    output_messages: list[Any]
+    turn_key: str
+    message_seq: int
+    system_instructions: list[Any] | None = None
+    resynced: bool = False
+    session_id: str = ""
+    user_id: str = ""
+    # Joins this row to the policy_decision and llm_invocation rows of the same
+    # run. ``""`` outside a run scope. A plain field, as on ``LlmUsageEvent``:
+    # llm_message carries one run column.
+    run_id: str = ""
+    event_id: UUID = field(default_factory=uuid4)
+    occurred_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def span_attributes(self) -> dict[str, Any]:
+        """Flat span attributes: the official ``gen_ai.*`` names for model and
+        content, ``sec_ai.*`` for the envelope and the transcript bookkeeping.
+
+        The three content fields travel as JSON strings, each redacted and
+        capped to its own budget here — the single choke point onto the wire,
+        as ``AuditEvent.span_attributes()`` is for ``arguments``. ``truncated``
+        is the OR across them: a reader needs one flag to know the row is
+        lossy, and the head+tail marker inside the field says where. Absent
+        ``system_instructions`` are left out rather than sent as ``None`` or
+        ``""`` — OTel attributes cannot carry null, and the platform column
+        defaults to empty on its own."""
+        input_json, input_cut = _capped_json(
+            self.input_messages, cap=MAX_INPUT_MESSAGES_BYTES
+        )
+        output_json, output_cut = _capped_json(
+            self.output_messages, cap=MAX_OUTPUT_MESSAGES_BYTES
+        )
+        attrs: dict[str, Any] = {
+            semconv.EVENT_ID: str(self.event_id),
+            semconv.AGENT_NAME: self.agent_name,
+            semconv.SESSION_ID: self.session_id,
+            semconv.USER_ID: self.user_id,
+            semconv.GEN_AI_REQUEST_MODEL: self.model,
+            semconv.GEN_AI_INPUT_MESSAGES: input_json,
+            semconv.GEN_AI_OUTPUT_MESSAGES: output_json,
+            semconv.TURN_KEY: self.turn_key,
+            semconv.MESSAGE_SEQ: self.message_seq,
+            semconv.RESYNCED: self.resynced,
+        }
+        truncated = input_cut or output_cut
+        if self.system_instructions is not None:
+            system_json, system_cut = _capped_json(
+                self.system_instructions, cap=MAX_SYSTEM_INSTRUCTIONS_BYTES
+            )
+            attrs[semconv.GEN_AI_SYSTEM_INSTRUCTIONS] = system_json
+            truncated = truncated or system_cut
+        attrs[semconv.TRUNCATED] = truncated
+        # Absent, never "": the platform rejects an empty string, losing the
+        # whole message record rather than just its attribution.
+        if self.run_id:
+            attrs[semconv.RUN_ID] = self.run_id
+        return attrs
+
+
+def emit_llm_messages(
+    agent_name: str,
+    model: str,
+    input_messages: list[Any],
+    output_messages: list[Any],
+    *,
+    turn_key: str,
+    message_seq: int,
+    system_instructions: list[Any] | None = None,
+    resynced: bool = False,
+    api_key: str | None = None,
+) -> None:
+    """Resolve identity from the active HexgateContext scope and emit one
+    :class:`LlmMessageEvent` through the shared sender registry.
+
+    The single entry point every adapter's message hook calls into — never
+    raises, for the same reason ``emit_llm_usage`` never does: the framework
+    hooks it runs from either re-raise or don't guard the call, and a logging
+    failure must not fail the agent run it is logging. A no-op when
+    ``HEXGATE_LOG_MESSAGES`` is set to ``0`` (checked first, so an opted-out
+    process never builds a sender for this stream alone), when no api_key is
+    resolvable, or when ``HEXGATE_LOCAL_MODE`` is on — the last two exactly as
+    for decisions and usage, since the registry is shared.
+    """
+    try:
+        if not _log_messages_enabled():
+            return
+        sender = configure_messages_sender(api_key)
+        if sender is None:
+            return
+        context = get_current_context()
+        sender.emit(
+            LlmMessageEvent(
+                run_id=get_run_facts().id,
+                agent_name=agent_name,
+                model=model,
+                input_messages=input_messages,
+                output_messages=output_messages,
+                turn_key=turn_key,
+                message_seq=message_seq,
+                system_instructions=system_instructions,
+                resynced=resynced,
+                session_id=context.session_id
+                if (context is not None and context.session_id)
+                else "",
+                user_id=context.user_id if context is not None else "",
+            )
+        )
+    except Exception:
+        _log.exception("emit_llm_messages raised; ignoring")
+
+
+def configure_messages_sender(
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> AuditSender | None:
+    """Get-or-create the LLM-messages sender for ``api_key``. Idempotent per
+    key.
+
+    Shares the registry (and the ``HEXGATE_LOCAL_MODE`` gate) with
+    :func:`hexgate.audit.configure` and
+    :func:`hexgate.tracing.usage.configure_usage_sender` via
+    ``hexgate.tracing._senders`` — the same api_key returns the very same
+    sender here; the span's instrumentation scope keeps the event types apart.
+    """
+    return get_or_create_sender(api_key, base_url)
+
+
+def get_messages_sender(api_key: str | None = None) -> AuditSender | None:
+    """Return the LLM-messages sender for ``api_key`` (or ``HEXGATE_API_KEY``),
+    if configured. Never creates one."""
+    return _get_sender(api_key)
+
+
+async def shutdown() -> None:
+    """Flush queued events and stop every sender in the shared registry —
+    decisions, LLM usage, bans and LLM messages alike. Safe to call multiple
+    times; equivalent to :func:`hexgate.audit.shutdown` — either name flushes
+    the whole shared registry."""
+    await _shutdown_all()

--- a/hexgate/tracing/semconv.py
+++ b/hexgate/tracing/semconv.py
@@ -45,7 +45,9 @@ must produce by them):
   sub-agent or handoff has its own) so a reader can detect a missing row;
   ``RESYNCED`` marks an event that restates the whole list because the
   framework rewrote it rather than extending it. ``TRUNCATED`` is set by
-  the SDK when a cap cut any content field.
+  the SDK when a cap cut any content field. ``RUN_ID`` rides along exactly as
+  on usage spans — present inside a run scope, absent outside it — so a
+  transcript joins to the decisions and token usage of the same run.
 """
 
 from __future__ import annotations

--- a/hexgate/tracing/usage.py
+++ b/hexgate/tracing/usage.py
@@ -139,7 +139,7 @@ def get_usage_sender(api_key: str | None = None) -> AuditSender | None:
 
 async def shutdown() -> None:
     """Flush queued events and stop every sender in the shared registry —
-    decisions, LLM usage and ban enforcements alike. Safe to call multiple
+    decisions, LLM usage, bans and LLM messages alike. Safe to call multiple
     times; equivalent to :func:`hexgate.audit.shutdown` — either name
     flushes the whole shared registry."""
     await _shutdown_all()

--- a/tests/tracing/test_messages_emit.py
+++ b/tests/tracing/test_messages_emit.py
@@ -1,0 +1,291 @@
+"""emit_llm_messages() — the single entry point every adapter's message hook
+calls into. Covers identity resolution from the HexgateContext contextvar,
+the ``HEXGATE_LOG_MESSAGES`` opt-out, the no-op path when no sender is
+configured, and the never-raises contract; the sender itself is faked so no
+real registry/network is touched (mirrors tests/tracing/test_usage_emit.py).
+
+The wiring tests at the bottom use the real registry to prove this module
+shares it — and the ``HEXGATE_LOCAL_MODE`` gate — with decisions and usage
+rather than duplicating it."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+import hexgate.audit as audit_mod
+import hexgate.tracing.usage as usage_mod
+from hexgate.runtime import HexgateContext
+from hexgate.runtime.run_facts import run_scope
+from hexgate.tracing import _senders
+from hexgate.tracing import messages as messages_mod
+from hexgate.tracing import semconv
+from hexgate.tracing.messages import LOG_MESSAGES_ENV, emit_llm_messages
+
+_INPUT = [{"role": "user", "parts": [{"type": "text", "content": "hi"}]}]
+_OUTPUT = [{"role": "assistant", "parts": [{"type": "text", "content": "hello"}]}]
+
+
+class _FakeSender:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def emit(self, event: Any) -> None:
+        self.events.append(event)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sender_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset the shared sender registry + clear HEXGATE_* env between tests."""
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed = False
+    monkeypatch.delenv("HEXGATE_API_KEY", raising=False)
+    monkeypatch.delenv("HEXGATE_API_URL", raising=False)
+    monkeypatch.delenv(_senders._LOCAL_MODE_ENV, raising=False)
+    monkeypatch.delenv(LOG_MESSAGES_ENV, raising=False)
+    yield
+    _senders._senders.clear()
+    _senders._logged_local_mode_suppressed = False
+
+
+def _install_fake(monkeypatch: pytest.MonkeyPatch) -> _FakeSender:
+    fake_sender = _FakeSender()
+    monkeypatch.setattr(
+        messages_mod, "configure_messages_sender", lambda api_key=None: fake_sender
+    )
+    return fake_sender
+
+
+def _emit(**overrides: Any) -> None:
+    kwargs: dict[str, Any] = dict(turn_key="run-1", message_seq=0, api_key="k")
+    kwargs.update(overrides)
+    emit_llm_messages("my-agent", "gpt-4o", _INPUT, _OUTPUT, **kwargs)
+
+
+def test_emit_llm_messages_is_a_noop_when_no_sender_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        messages_mod, "configure_messages_sender", lambda api_key=None: None
+    )
+
+    _emit()  # must not raise
+
+
+def test_emit_llm_messages_sends_event_with_given_fields(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_sender = _install_fake(monkeypatch)
+    system = [{"type": "text", "content": "Be brief."}]
+
+    _emit(message_seq=2, system_instructions=system, resynced=True)
+
+    [event] = fake_sender.events
+    assert event.SCOPE == semconv.SCOPE_MESSAGES
+    assert event.agent_name == "my-agent"
+    assert event.model == "gpt-4o"
+    assert event.input_messages == _INPUT
+    assert event.output_messages == _OUTPUT
+    assert event.turn_key == "run-1"
+    assert event.message_seq == 2
+    assert event.system_instructions == system
+    assert event.resynced is True
+    assert event.user_id == ""
+    assert event.session_id == ""
+
+
+async def test_emit_llm_messages_resolves_identity_from_active_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_sender = _install_fake(monkeypatch)
+
+    async with HexgateContext(user_id="alice", session_id="sess-1", user_roles=["dev"]):
+        _emit()
+
+    [event] = fake_sender.events
+    assert event.user_id == "alice"
+    assert event.session_id == "sess-1"
+
+
+def test_when_sender_emit_fails_then_emit_llm_messages_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The adapter hooks this runs from either re-raise on an unhandled
+    exception or don't guard the call at all — a failure here must not fail
+    the agent run whose messages it is logging."""
+
+    class _RaisingSender:
+        def emit(self, event: Any) -> None:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        messages_mod, "configure_messages_sender", lambda api_key=None: _RaisingSender()
+    )
+
+    _emit()  # must not raise
+
+
+def test_emit_llm_messages_passes_api_key_to_configure_messages_sender(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str | None] = []
+
+    def fake_configure(api_key: str | None = None) -> _FakeSender:
+        captured.append(api_key)
+        return _FakeSender()
+
+    monkeypatch.setattr(messages_mod, "configure_messages_sender", fake_configure)
+
+    _emit(api_key="explicit-key")
+
+    assert captured == ["explicit-key"]
+
+
+def test_emit_stamps_the_enclosing_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    """llm_message rows join to the policy_decision and llm_invocation rows of
+    the same run, so the run_id has to reach the event."""
+    fake_sender = _install_fake(monkeypatch)
+
+    with run_scope("agent") as facts:
+        _emit()
+
+    [event] = fake_sender.events
+    assert event.run_id == facts.id
+    assert event.span_attributes()[semconv.RUN_ID] == facts.id
+
+
+def test_emit_outside_a_run_scope_sends_no_run_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_sender = _install_fake(monkeypatch)
+
+    _emit()
+
+    [event] = fake_sender.events
+    assert event.run_id == ""
+    assert semconv.RUN_ID not in event.span_attributes()
+
+
+# ---------------------------------------------------------------------------
+# HEXGATE_LOG_MESSAGES — on by default, opt out with 0
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["0", "false", "FALSE", "no", "off", " 0 "])
+def test_when_log_messages_is_off_then_nothing_is_emitted(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    fake_sender = _install_fake(monkeypatch)
+    monkeypatch.setenv(LOG_MESSAGES_ENV, value)
+
+    _emit()
+
+    assert fake_sender.events == []
+
+
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on", "", "anything"])
+def test_when_log_messages_is_not_a_falsy_value_then_capture_stays_on(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Only an explicit "off" spelling opts out; an empty or unrecognised
+    value keeps the default so a typo never silently disables the log."""
+    fake_sender = _install_fake(monkeypatch)
+    monkeypatch.setenv(LOG_MESSAGES_ENV, value)
+
+    _emit()
+
+    assert len(fake_sender.events) == 1
+
+
+def test_when_opted_out_then_no_sender_is_created_for_this_stream(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opt-out is checked before the registry, so a process that only
+    ever emits messages and has them off never starts an export worker."""
+    calls: list[str | None] = []
+
+    def fake_configure(api_key: str | None = None) -> _FakeSender:
+        calls.append(api_key)
+        return _FakeSender()
+
+    monkeypatch.setattr(messages_mod, "configure_messages_sender", fake_configure)
+    monkeypatch.setenv(LOG_MESSAGES_ENV, "0")
+
+    _emit()
+
+    assert calls == []
+
+
+def test_opt_out_is_read_at_emit_time_not_at_import_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_sender = _install_fake(monkeypatch)
+
+    _emit()
+    monkeypatch.setenv(LOG_MESSAGES_ENV, "0")
+    _emit()
+    monkeypatch.delenv(LOG_MESSAGES_ENV)
+    _emit()
+
+    assert len(fake_sender.events) == 2
+
+
+def test_opt_out_leaves_the_other_streams_alone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``HEXGATE_LOG_MESSAGES=0`` switches off message content only; token
+    usage keeps flowing through the same registry."""
+    fake_sender = _FakeSender()
+    monkeypatch.setattr(
+        messages_mod, "configure_messages_sender", lambda api_key=None: fake_sender
+    )
+    monkeypatch.setattr(
+        usage_mod, "configure_usage_sender", lambda api_key=None: fake_sender
+    )
+    monkeypatch.setenv(LOG_MESSAGES_ENV, "0")
+
+    _emit()
+    usage_mod.emit_llm_usage("my-agent", "gpt-4o", 10, 20, api_key="k")
+
+    [event] = fake_sender.events
+    assert event.SCOPE == semconv.SCOPE_USAGE
+
+
+# ---------------------------------------------------------------------------
+# configure_messages_sender() — thin wiring onto the shared registry
+# ---------------------------------------------------------------------------
+
+
+def test_configure_messages_sender_returns_none_when_no_key_anywhere() -> None:
+    assert messages_mod.configure_messages_sender() is None
+    assert messages_mod.get_messages_sender() is None
+
+
+def test_same_key_shares_the_sender_with_audit_and_usage() -> None:
+    """One HEXGATE_API_KEY, one sender: decisions, usage and messages all
+    export through it; the span's instrumentation scope keeps them apart."""
+    decisions_sender = audit_mod.configure("k1")
+    usage_sender = usage_mod.configure_usage_sender("k1")
+    messages_sender = messages_mod.configure_messages_sender("k1")
+    assert decisions_sender is usage_sender is messages_sender
+
+
+def test_local_mode_suppresses_the_messages_sender_too(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(_senders._LOCAL_MODE_ENV, "1")
+    assert messages_mod.configure_messages_sender("k1") is None
+
+
+def test_emit_llm_messages_is_a_noop_in_local_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real registry, not a fake: local mode is enforced by the shared
+    ``get_or_create_sender`` and this module must not route around it."""
+    monkeypatch.setenv(_senders._LOCAL_MODE_ENV, "1")
+
+    _emit()
+
+    assert _senders._senders == {}

--- a/tests/tracing/test_messages_event.py
+++ b/tests/tracing/test_messages_event.py
@@ -1,0 +1,325 @@
+"""LlmMessageEvent.span_attributes() — the message span's attribute layout per
+``hexgate.tracing.semconv``: official ``gen_ai.*`` names for model and
+content, ``sec_ai.*`` for the envelope and the transcript bookkeeping, with
+the SDK-side caps and redaction applied on the way out."""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+
+from hexgate.audit import (
+    MAX_INPUT_MESSAGES_BYTES,
+    MAX_OUTPUT_MESSAGES_BYTES,
+    MAX_SYSTEM_INSTRUCTIONS_BYTES,
+)
+from hexgate.tracing import semconv
+from hexgate.tracing.messages import LlmMessageEvent
+
+
+def _message(content: str, role: str = "user") -> dict[str, Any]:
+    return {"role": role, "parts": [{"type": "text", "content": content}]}
+
+
+def _event(**overrides: Any) -> LlmMessageEvent:
+    base: dict[str, Any] = dict(
+        agent_name="example_agent",
+        model="gpt-4o",
+        input_messages=[_message("What is the weather in Paris?")],
+        output_messages=[_message("Sunny, 24°C.", role="assistant")],
+        turn_key="run-1",
+        message_seq=0,
+    )
+    return LlmMessageEvent(**{**base, **overrides})
+
+
+def _json_size(text: str) -> int:
+    return len(text.encode("utf-8"))
+
+
+def test_span_attributes_happy_path() -> None:
+    ev = _event(
+        session_id="sess_1",
+        user_id="alice",
+        system_instructions=[{"type": "text", "content": "Be brief."}],
+        message_seq=3,
+        resynced=True,
+    )
+    wire = ev.span_attributes()
+
+    assert LlmMessageEvent.SCOPE == semconv.SCOPE_MESSAGES
+    assert wire[semconv.EVENT_ID] == str(ev.event_id)
+    assert wire[semconv.AGENT_NAME] == "example_agent"
+    assert wire[semconv.SESSION_ID] == "sess_1"
+    assert wire[semconv.USER_ID] == "alice"
+    assert wire[semconv.GEN_AI_REQUEST_MODEL] == "gpt-4o"
+    assert json.loads(wire[semconv.GEN_AI_INPUT_MESSAGES]) == ev.input_messages
+    assert json.loads(wire[semconv.GEN_AI_OUTPUT_MESSAGES]) == ev.output_messages
+    assert (
+        json.loads(wire[semconv.GEN_AI_SYSTEM_INSTRUCTIONS]) == ev.system_instructions
+    )
+    assert wire[semconv.TURN_KEY] == "run-1"
+    assert wire[semconv.MESSAGE_SEQ] == 3
+    assert wire[semconv.RESYNCED] is True
+    assert wire[semconv.TRUNCATED] is False
+    # occurred_at is the span start time; project_id and received_at are
+    # server-resolved — none of them is an attribute.
+    assert not any("occurred_at" in k for k in wire)
+    assert not any("project_id" in k for k in wire)
+    assert not any("received_at" in k for k in wire)
+
+
+def test_span_attributes_content_fields_are_json_strings() -> None:
+    """The wire contract carries the GenAI trio as JSON strings — never as
+    kvlists or flattened keys — so the platform's byte caps measure the same
+    thing the SDK capped."""
+    wire = _event(system_instructions=[]).span_attributes()
+    for key in (
+        semconv.GEN_AI_INPUT_MESSAGES,
+        semconv.GEN_AI_OUTPUT_MESSAGES,
+        semconv.GEN_AI_SYSTEM_INSTRUCTIONS,
+    ):
+        assert type(wire[key]) is str
+        json.loads(wire[key])
+
+
+def test_span_attributes_bookkeeping_types_match_the_contract() -> None:
+    """The wire contract types ``message_seq`` as int and the two flags as
+    bool. The OTLP encoder writes ``bool_value`` only for a Python bool, so a
+    stringified ``"0"`` or ``"false"`` would travel as a string instead."""
+    wire = _event().span_attributes()
+    assert type(wire[semconv.MESSAGE_SEQ]) is int
+    assert type(wire[semconv.RESYNCED]) is bool
+    assert type(wire[semconv.TRUNCATED]) is bool
+
+
+def test_span_attributes_when_system_instructions_are_none_then_the_key_is_absent() -> (
+    None
+):
+    """Only the first event of a ``turn_key`` carries the instructions. The
+    others leave the attribute out entirely: OTel cannot carry null, and ``""``
+    is not valid JSON where the contract promises a JSON string — genuinely
+    empty instructions travel as ``[]``."""
+    wire = _event(system_instructions=None).span_attributes()
+    assert semconv.GEN_AI_SYSTEM_INSTRUCTIONS not in wire
+
+
+def test_event_id_defaults_to_a_stringified_uuid_and_is_unique_per_event() -> None:
+    ev1, ev2 = _event(), _event()
+
+    assert ev1.event_id != ev2.event_id
+    assert ev1.span_attributes()[semconv.EVENT_ID] == str(ev1.event_id)
+
+
+def test_occurred_at_defaults_to_an_aware_utc_datetime() -> None:
+    ev = _event()
+    assert ev.occurred_at.utcoffset() is not None
+    assert ev.occurred_at.utcoffset().total_seconds() == 0
+
+
+def test_span_attributes_omit_run_id_never_send_an_empty_string() -> None:
+    """An empty string is not a UUID: the enricher DLQs the span, losing the
+    transcript row for every model call made outside a run scope."""
+    assert semconv.RUN_ID not in _event().span_attributes()
+
+
+def test_span_attributes_carry_the_run_id_when_inside_a_run() -> None:
+    wire = _event(run_id="9c2f1d3e-0000-4000-8000-000000000001").span_attributes()
+
+    assert wire[semconv.RUN_ID] == "9c2f1d3e-0000-4000-8000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# caps: applied SDK-side, head+tail, flagged once
+# ---------------------------------------------------------------------------
+
+
+def test_when_input_exceeds_its_cap_then_it_is_cut_head_tail_and_flagged() -> None:
+    """A RAG prompt stuffs every retrieved chunk into one message. The start
+    (the question) and the end (the instruction) both survive the cut, the
+    field fits the cap, and ``truncated`` tells the reader the row is lossy."""
+    big = "Q" * 1_000 + "C" * (2 * MAX_INPUT_MESSAGES_BYTES) + "A" * 1_000
+    wire = _event(input_messages=[_message(big)]).span_attributes()
+
+    payload = wire[semconv.GEN_AI_INPUT_MESSAGES]
+    assert _json_size(payload) <= MAX_INPUT_MESSAGES_BYTES
+    [msg] = json.loads(payload)
+    content = msg["parts"][0]["content"]
+    assert content.startswith("QQQ")
+    assert content.endswith("AAA")
+    assert "...[truncated " in content
+    assert wire[semconv.TRUNCATED] is True
+
+
+def test_when_output_exceeds_its_cap_then_only_that_field_is_cut() -> None:
+    wire = _event(
+        output_messages=[_message("X" * (3 * MAX_OUTPUT_MESSAGES_BYTES), "assistant")]
+    ).span_attributes()
+
+    assert _json_size(wire[semconv.GEN_AI_OUTPUT_MESSAGES]) <= MAX_OUTPUT_MESSAGES_BYTES
+    assert json.loads(wire[semconv.GEN_AI_INPUT_MESSAGES]) == _event().input_messages
+    assert wire[semconv.TRUNCATED] is True
+
+
+def test_when_system_instructions_exceed_their_cap_then_truncated_is_set() -> None:
+    wire = _event(
+        system_instructions=[
+            {"type": "text", "content": "S" * (3 * MAX_SYSTEM_INSTRUCTIONS_BYTES)}
+        ]
+    ).span_attributes()
+
+    assert (
+        _json_size(wire[semconv.GEN_AI_SYSTEM_INSTRUCTIONS])
+        <= MAX_SYSTEM_INSTRUCTIONS_BYTES
+    )
+    assert wire[semconv.TRUNCATED] is True
+
+
+def test_span_attributes_do_not_mutate_the_messages_they_were_given() -> None:
+    """The adapter still holds the framework's list after the emit — for the
+    delta cursor's fingerprint, if nothing else — so the cap and the redaction
+    must work on copies."""
+    big = [_message("C" * (2 * MAX_INPUT_MESSAGES_BYTES))]
+    tool_call = [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "type": "tool_call",
+                    "name": "db",
+                    "arguments": {"query": "select 1", "api_key": "sk-live"},
+                }
+            ],
+        }
+    ]
+    before_big, before_tool = copy.deepcopy(big), copy.deepcopy(tool_call)
+
+    _event(input_messages=big, output_messages=tool_call).span_attributes()
+
+    assert big == before_big
+    assert tool_call == before_tool
+
+
+# ---------------------------------------------------------------------------
+# redaction: the tool arguments inside a prompt follow the decision's rule
+# ---------------------------------------------------------------------------
+
+
+def test_when_a_tool_call_carries_a_secret_argument_then_it_is_redacted() -> None:
+    """A decision event blanks ``api_key`` inside ``arguments``; the assistant
+    message that requested the same tool call carries the same arguments, so
+    leaving them readable here would undo that redaction."""
+    tool_call = {
+        "role": "assistant",
+        "parts": [
+            {
+                "type": "tool_call",
+                "name": "db",
+                "arguments": {"query": "select 1", "api_key": "sk-live-123"},
+            }
+        ],
+    }
+    wire = _event(output_messages=[tool_call]).span_attributes()
+
+    [msg] = json.loads(wire[semconv.GEN_AI_OUTPUT_MESSAGES])
+    args = msg["parts"][0]["arguments"]
+    assert args["api_key"] == "[REDACTED]"
+    assert args["query"] == "select 1"
+
+
+def test_when_tool_call_arguments_are_a_json_string_then_secrets_inside_are_redacted() -> (
+    None
+):
+    """The raw OpenAI wire shape serialises ``arguments`` as a JSON string, one
+    level below what key matching sees; the SDK parses that string exactly as
+    the enricher does, so the two ends blank the same keys."""
+    tool_call = {
+        "role": "assistant",
+        "parts": [
+            {
+                "type": "tool_call",
+                "name": "db",
+                "arguments": json.dumps({"query": "select 1", "api_key": "sk-live"}),
+            }
+        ],
+    }
+    wire = _event(output_messages=[tool_call]).span_attributes()
+
+    [msg] = json.loads(wire[semconv.GEN_AI_OUTPUT_MESSAGES])
+    args = json.loads(msg["parts"][0]["arguments"])
+    assert args == {"query": "select 1", "api_key": "[REDACTED]"}
+
+
+class _ToolCallPart(BaseModel):
+    type: str = "tool_call"
+    name: str
+    arguments: dict[str, Any]
+
+
+class _Message(BaseModel):
+    role: str
+    parts: list[_ToolCallPart]
+
+
+def test_when_messages_are_pydantic_models_then_they_are_unwrapped_and_redacted() -> (
+    None
+):
+    """Every supported framework's message type is a pydantic model. Left as
+    an object it would be stored as a ``repr()`` with the secret inside;
+    unwrapped first, the same key rule reaches it."""
+    msg = _Message(
+        role="assistant",
+        parts=[_ToolCallPart(name="db", arguments={"q": "select 1", "token": "t-1"})],
+    )
+    wire = _event(output_messages=[msg]).span_attributes()
+
+    [stored] = json.loads(wire[semconv.GEN_AI_OUTPUT_MESSAGES])
+    assert stored["role"] == "assistant"
+    assert stored["parts"][0]["arguments"] == {"q": "select 1", "token": "[REDACTED]"}
+
+
+def test_when_a_message_is_a_dataclass_then_it_is_unwrapped_and_redacted() -> None:
+    @dataclass
+    class Part:
+        type: str
+        arguments: dict[str, Any]
+
+    @dataclass
+    class Msg:
+        role: str
+        parts: list[Part]
+
+    msg = Msg(role="assistant", parts=[Part("tool_call", {"api_key": "sk-live"})])
+    wire = _event(output_messages=[msg]).span_attributes()
+
+    [stored] = json.loads(wire[semconv.GEN_AI_OUTPUT_MESSAGES])
+    assert stored["parts"][0]["arguments"] == {"api_key": "[REDACTED]"}
+
+
+def test_when_a_leaf_is_an_arbitrary_object_then_it_is_stringified_not_dropped() -> (
+    None
+):
+    class Opaque:
+        def __str__(self) -> str:
+            return "<opaque>"
+
+    wire = _event(
+        input_messages=[{"role": "user", "parts": [Opaque()]}]
+    ).span_attributes()
+
+    [stored] = json.loads(wire[semconv.GEN_AI_INPUT_MESSAGES])
+    assert stored["parts"] == ["<opaque>"]
+
+
+def test_redaction_leaves_message_shape_keys_and_text_content_alone() -> None:
+    """Substring matching on key names must not touch ``role``/``parts``/
+    ``type``/``content``, and never the text itself — a user talking *about*
+    a password is not a secret by key name."""
+    text = "I forgot my password, can you reset the token?"
+    wire = _event(input_messages=[_message(text)]).span_attributes()
+
+    assert json.loads(wire[semconv.GEN_AI_INPUT_MESSAGES]) == [_message(text)]

--- a/tests/tracing/test_sender.py
+++ b/tests/tracing/test_sender.py
@@ -27,6 +27,7 @@ from hexgate.tracing._senders import (
     AuditSender,
     _unix_nanos,
 )
+from hexgate.tracing.messages import LlmMessageEvent
 from hexgate.tracing.usage import LlmUsageEvent
 
 
@@ -96,10 +97,25 @@ def test_emit_selects_the_tracer_by_event_scope() -> None:
         )
     )
     sender.emit(BanEnforcementEvent(ban_type="agent", ban_id="b", agent_name="a"))
+    sender.emit(
+        LlmMessageEvent(
+            agent_name="a",
+            model="m",
+            input_messages=[],
+            output_messages=[],
+            turn_key="t",
+            message_seq=0,
+        )
+    )
     _flush(sender)
 
     scopes = [s.instrumentation_scope.name for s in exporter.get_finished_spans()]
-    assert scopes == [semconv.SCOPE_AUDIT, semconv.SCOPE_USAGE, semconv.SCOPE_BANS]
+    assert scopes == [
+        semconv.SCOPE_AUDIT,
+        semconv.SCOPE_USAGE,
+        semconv.SCOPE_BANS,
+        semconv.SCOPE_MESSAGES,
+    ]
 
 
 def test_emit_span_is_a_root_span_even_inside_a_callers_active_span() -> None:


### PR DESCRIPTION
Design: [LLM message logging design](https://app.notion.com/p/3d4fb45dbae28141a3c4d32338a0d496) · [implementation spec](https://app.notion.com/p/3d4fb45dbae28109b82fd38cb03b9d11). Plan target: merge by **Thu 10 Sep**.

## What is changing
`hexgate/tracing/messages.py`: `LlmMessageEvent` (frozen dataclass, `SCOPE` ClassVar, `span_attributes()` serialising the three content fields as JSON and applying the PR 1 caps), `emit_llm_messages()` reusing `get_or_create_sender` and the `HEXGATE_LOCAL_MODE` gate, `HEXGATE_LOG_MESSAGES=0` opt-out read at emit time. Adds the scope to the tracer tuple at `hexgate/tracing/_senders.py#L178`.

## Why is this change necessary
Mirrors `tracing/usage.py` so message capture and token capture share one sender, one registry and one shutdown. The tracer tuple is hardcoded to three scopes; a scope missing there gets no tracer and fails at emit.

## Tests
`tests/tracing/test_messages_event.py` (attributes, caps applied, `truncated` flag), `test_messages_emit.py` (sender reuse, local mode, opt-out, never raises).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

