### PR TITLE
feat(sdk): add the MessageCursor delta helper

### DIFF
--- a/hexgate/tracing/messages.py
+++ b/hexgate/tracing/messages.py
@@ -13,16 +13,20 @@ default — a log a customer has to discover and switch on is a log that is not
 there when an incident needs it — and ``HEXGATE_LOG_MESSAGES=0`` turns it off
 without touching the other streams.
 
-Which messages count as "new" is the adapter's job; this module only lays an
-already-derived event out on the wire — redacted, capped and serialised.
+Which messages are "new" is decided here too, by :class:`MessageCursor`: every
+adapter hook is handed the *whole* input list and has to work out what changed
+since its last call. One implementation shared by the four adapters rather than
+four subtly different ones.
 """
 
 from __future__ import annotations
 
 import dataclasses
+import hashlib
 import json
 import logging
 import os
+import threading
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -283,3 +287,206 @@ async def shutdown() -> None:
     times; equivalent to :func:`hexgate.audit.shutdown` — either name flushes
     the whole shared registry."""
     await _shutdown_all()
+
+
+# --- The delta cursor ---------------------------------------------------------
+
+# Fingerprint of the empty prefix — the state a turn_key starts in, so a first
+# call takes the ordinary slice path with count=0 rather than a special case.
+_EMPTY_FINGERPRINT = "0:"
+
+# A fingerprint no list can produce — every real one carries a count and a
+# digest. Stored when fingerprinting failed, so the next call resyncs instead
+# of slicing against a mark we never established.
+_UNMATCHABLE_FINGERPRINT = "?"
+
+
+def _canonical(message: Any) -> bytes:
+    """One message as stable bytes.
+
+    ``sort_keys`` so a dict rebuilt in another key order is still recognised as
+    the same message. ``default=str`` covers a framework object an adapter did
+    not flatten — which makes the fingerprint only as stable as that object's
+    ``__str__``: a type falling back to ``object.__repr__`` stringifies to its
+    memory address and never matches itself, so every call resyncs. Adapters
+    hand over dicts (or pydantic models, whose repr is by value) for that
+    reason.
+
+    ``json.dumps`` raises on a few shapes ``default=`` does not reach — a dict
+    key that is not a scalar, mixed key types under ``sort_keys``, a reference
+    cycle — so callers must treat this as fallible. :meth:`MessageCursor.advance`
+    does.
+    """
+    return json.dumps(message, sort_keys=True, default=str).encode("utf-8")
+
+
+def _digest(first: bytes, last: bytes) -> str:
+    digest = hashlib.blake2b(digest_size=16)
+    digest.update(first)
+    digest.update(b"\x00")
+    digest.update(last)
+    return digest.hexdigest()
+
+
+def _fingerprint(count: int, first: bytes, last: bytes) -> str:
+    """Identify a prefix by its length and its first and last message.
+
+    Not a hash of the whole list: this runs on every LLM call, and the input
+    list is the entire conversation so far — hashing all of it would make each
+    call cost O(conversation). First+last catches what actually happens to
+    these lists. A trim drops the front, so the first message changes; a
+    summary replaces the front with one summary message, same; an append
+    changes the length. What it cannot see is a rewrite strictly in the middle
+    that preserves length, first and last — no framework does that today, and
+    the cost of being wrong is one stale message in the transcript, not a
+    corrupt slice.
+
+    The length leads the string, so a list that shrank below the mark fails the
+    comparison on the count alone and there is no separate length check to
+    forget.
+    """
+    return _EMPTY_FINGERPRINT if count == 0 else f"{count}:{_digest(first, last)}"
+
+
+@dataclass(frozen=True, slots=True)
+class _TurnState:
+    """What the cursor remembers about one message list: how far it has
+    emitted, which messages those were, and the seq the next event gets."""
+
+    count: int
+    fingerprint: str
+    next_seq: int
+
+
+_FRESH_TURN = _TurnState(count=0, fingerprint=_EMPTY_FINGERPRINT, next_seq=0)
+
+
+@dataclass(frozen=True, slots=True)
+class MessageDelta:
+    """What one LLM call adds to a transcript: the messages to emit, the
+    ``message_seq`` to emit them under, and whether they restate the whole list
+    instead of extending it.
+
+    ``seq == 0`` is exactly "first event of this ``turn_key``", which is the
+    adapter's cue to attach ``system_instructions`` — a resync keeps counting,
+    so it never looks like a fresh turn.
+
+    The caller must emit an event for every delta it asks for, empty
+    ``messages`` included. The seq is spent by the call that produced it, so
+    skipping an emit leaves a hole that a reader is specified to read as a lost
+    row. An empty delta is not an anomaly anyway: the input list is unchanged
+    but the completion is still new."""
+
+    messages: list[Any]
+    seq: int
+    resynced: bool
+
+
+class MessageCursor:
+    """Per-``turn_key`` high-water marks, turning each hook's whole input list
+    into just what is new.
+
+    One cursor is shared by every run an adapter serves, so state is keyed by
+    ``turn_key`` — the framework's own identity for *one message list*, not one
+    session. Handoffs and sub-agents share a ``session_id`` while each keeps
+    its own list; keyed by session, a sub-agent's first call would look like a
+    twenty-message jump and resync forever.
+
+    Pure bookkeeping over plain dicts: it never inspects a role, never filters,
+    and never decides to emit. Tool results ride through with everything else —
+    decision events record that a tool was called but never what it returned,
+    so the transcript is the only place that value is stored.
+
+    State is kept until :meth:`reset` drops it, which every adapter owes this
+    class on run end — a few hundred bytes per live message list, and nothing
+    of the conversation itself. That contract is the whole memory bound on
+    purpose: an LRU here would evict a list whose run is still going, and the
+    cursor cannot tell that key apart from one it has never seen, so the
+    comeback would go out as a *fresh turn* — the full history again, at seq 0,
+    not flagged ``resynced``, and with the turn's seq counter rewound past the
+    gap detection the reader relies on. An adapter that forgets ``reset`` leaks
+    slowly and visibly; silently corrupting a transcript is the worse trade.
+    """
+
+    def __init__(self) -> None:
+        self._turns: dict[str, _TurnState] = {}
+        # Adapter hooks are not all async: LangChain runs sync handlers on
+        # whatever thread the chain is on, and one cursor serves concurrent
+        # runs. The critical section is two message hashes, a list slice and
+        # two dict operations.
+        self._lock = threading.Lock()
+
+    def advance(self, turn_key: str, messages: list[Any]) -> MessageDelta:
+        """Record ``messages`` as the current state of ``turn_key`` and return
+        what is new since the last call.
+
+        Extension is the normal case: the prefix we last emitted is still
+        there, so everything past the mark is new. Otherwise the framework
+        rewrote the list to fit a context window — trimmed old turns, or
+        replaced them with a summary — and slicing at a mark that no longer
+        means anything would emit the wrong tail, or nothing at all. Then the
+        whole list goes out under ``resynced``, and the reader is told the
+        history was restated rather than continued.
+
+        Never raises. It runs from a framework hook that re-raises into the
+        agent run, and fingerprinting is the one step here that touches raw,
+        un-flattened framework data — the same rule ``emit_llm_messages`` and
+        ``AuditSender.emit`` already keep, so no adapter has to remember it.
+        A failure degrades to a resync: restating the list is what "I lost my
+        place" already means on the wire, and it costs a bigger event, not a
+        wrong one.
+        """
+        with self._lock:
+            state = self._turns.get(turn_key, _FRESH_TURN)
+            try:
+                new, resynced, mark = self._diff(messages, state)
+            except Exception:
+                _log.exception("fingerprinting messages failed; resyncing %s", turn_key)
+                new, resynced = list(messages), True
+                mark = _TurnState(0, _UNMATCHABLE_FINGERPRINT, 0)
+            self._turns[turn_key] = _TurnState(
+                count=mark.count,
+                fingerprint=mark.fingerprint,
+                next_seq=state.next_seq + 1,
+            )
+            return MessageDelta(messages=new, seq=state.next_seq, resynced=resynced)
+
+    @staticmethod
+    def _diff(
+        messages: list[Any], state: _TurnState
+    ) -> tuple[list[Any], bool, _TurnState]:
+        """Split ``messages`` against ``state`` and fingerprint it for next
+        time. ``messages[0]`` is canonicalised once and used for both
+        fingerprints: in steady state it is the same message every call, and
+        one of these lists can carry an inlined image."""
+        if not messages:
+            return [], state.count > 0, _FRESH_TURN
+        first = _canonical(messages[0])
+        current = _fingerprint(len(messages), first, _canonical(messages[-1]))
+        mark = _TurnState(count=len(messages), fingerprint=current, next_seq=0)
+        if state.count == 0:
+            prefix = _EMPTY_FINGERPRINT
+        elif state.count > len(messages):
+            # The list shrank below the mark, so it cannot carry the prefix we
+            # emitted. The count inside the fingerprint would say so anyway,
+            # but indexing for it would raise first.
+            prefix = _UNMATCHABLE_FINGERPRINT
+        else:
+            prefix = _fingerprint(
+                state.count, first, _canonical(messages[state.count - 1])
+            )
+        if prefix == state.fingerprint:
+            return messages[state.count :], False, mark
+        return list(messages), True, mark
+
+    def reset(self, turn_key: str) -> None:
+        """Forget one message list, on run end. Unknown keys are fine: a run
+        that never emitted still ends, and an adapter should not have to
+        remember whether it did."""
+        with self._lock:
+            self._turns.pop(turn_key, None)
+
+    def clear(self) -> None:
+        """Forget every message list. For process teardown and tests."""
+        with self._lock:
+            self._turns.clear()

--- a/hexgate/tracing/messages.py
+++ b/hexgate/tracing/messages.py
@@ -460,7 +460,8 @@ class MessageCursor:
         fingerprints: in steady state it is the same message every call, and
         one of these lists can carry an inlined image."""
         if not messages:
-            return [], state.count > 0, _FRESH_TURN
+        if not messages:
+            return [], state.count > 0, _TurnState(0, _UNMATCHABLE_FINGERPRINT, 0)
         first = _canonical(messages[0])
         current = _fingerprint(len(messages), first, _canonical(messages[-1]))
         mark = _TurnState(count=len(messages), fingerprint=current, next_seq=0)

--- a/hexgate/tracing/messages.py
+++ b/hexgate/tracing/messages.py
@@ -460,7 +460,6 @@ class MessageCursor:
         fingerprints: in steady state it is the same message every call, and
         one of these lists can carry an inlined image."""
         if not messages:
-        if not messages:
             return [], state.count > 0, _TurnState(0, _UNMATCHABLE_FINGERPRINT, 0)
         first = _canonical(messages[0])
         current = _fingerprint(len(messages), first, _canonical(messages[-1]))

--- a/tests/tracing/test_messages_cursor.py
+++ b/tests/tracing/test_messages_cursor.py
@@ -1,0 +1,257 @@
+"""MessageCursor — turning each hook's whole input list into the delta new to
+that call, per ``hexgate.tracing.semconv``'s one-event-per-LLM-call rule.
+
+The cases are the ones the frameworks actually produce: a plain append, the
+several messages a parallel tool call adds at once, a list the framework
+trimmed to fit a context window, a list it summarised in place, and two lists
+of one session interleaved.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from hexgate.tracing.messages import MessageCursor, MessageDelta
+
+
+def _msg(content: str, role: str = "user") -> dict[str, Any]:
+    return {"role": role, "parts": [{"type": "text", "content": content}]}
+
+
+def _tool_result(call_id: str, content: str) -> dict[str, Any]:
+    return {
+        "role": "tool",
+        "parts": [{"type": "tool_call_response", "id": call_id, "response": content}],
+    }
+
+
+def test_advance_happy_path() -> None:
+    """A first call is entirely new, and the call after it contributes only the
+    messages appended since."""
+    cursor = MessageCursor()
+
+    first = cursor.advance("run-1", [_msg("What is the weather in Paris?")])
+    assert first == MessageDelta(
+        messages=[_msg("What is the weather in Paris?")], seq=0, resynced=False
+    )
+
+    second = cursor.advance(
+        "run-1",
+        [
+            _msg("What is the weather in Paris?"),
+            _msg("Let me check.", role="assistant"),
+            _msg("And in Lyon?"),
+        ],
+    )
+    assert second == MessageDelta(
+        messages=[_msg("Let me check.", role="assistant"), _msg("And in Lyon?")],
+        seq=1,
+        resynced=False,
+    )
+
+
+def test_when_several_messages_appended_then_all_are_new() -> None:
+    """Two parallel tool calls grow the list by three — the assistant message
+    holding both calls plus one result each — and every one of them is emitted.
+    Tool results in particular: a decision event records the call but never its
+    return value, so this is the only place that value is stored."""
+    cursor = MessageCursor()
+    history = [_msg("Weather in Paris and Lyon?")]
+    cursor.advance("run-1", history)
+
+    assistant = _msg("calling get_weather twice", role="assistant")
+    history = [
+        *history,
+        assistant,
+        _tool_result("c1", "24C"),
+        _tool_result("c2", "22C"),
+    ]
+
+    delta = cursor.advance("run-1", history)
+    assert delta.messages == [
+        assistant,
+        _tool_result("c1", "24C"),
+        _tool_result("c2", "22C"),
+    ]
+    assert delta.resynced is False
+    assert delta.seq == 1
+
+
+def test_when_list_is_trimmed_then_resynced() -> None:
+    """The framework drops old turns to fit the context window, so the mark
+    points past the end. Slicing there would emit nothing at all; instead the
+    whole list is restated and the row is flagged."""
+    cursor = MessageCursor()
+    history = [_msg(f"turn {i}") for i in range(6)]
+    cursor.advance("run-1", history)
+
+    trimmed = history[4:]
+    delta = cursor.advance("run-1", trimmed)
+
+    assert delta.messages == trimmed
+    assert delta.resynced is True
+    assert delta.seq == 1
+
+
+def test_when_list_is_summarized_in_place_then_resynced() -> None:
+    """The hard case: the list keeps its length while holding different
+    messages, because the front was replaced by a summary. Slicing at the mark
+    would return the right *number* of messages and the wrong ones."""
+    cursor = MessageCursor()
+    history = [_msg(f"turn {i}") for i in range(4)]
+    cursor.advance("run-1", history)
+
+    summarized = [_msg("summary of turns 0-2", role="system"), *history[1:]]
+    assert len(summarized) == len(history)
+
+    delta = cursor.advance("run-1", summarized)
+    assert delta.messages == summarized
+    assert delta.resynced is True
+
+
+def test_when_two_turn_keys_interleave_then_state_is_per_list() -> None:
+    """A handoff or sub-agent shares the session but keeps its own message
+    list. Keyed per list, each one's deltas and seq counter are its own; keyed
+    per session, the sub-agent's first call would look like a jump and resync
+    forever."""
+    cursor = MessageCursor()
+    main = [_msg("book a flight")]
+    sub = [_msg("find flights to Lyon")]
+
+    assert cursor.advance("main", main).messages == main
+    assert cursor.advance("sub", sub).messages == sub
+
+    main = [*main, _msg("handing off", role="assistant")]
+    sub = [*sub, _msg("AF1234", role="assistant")]
+
+    main_delta = cursor.advance("main", main)
+    sub_delta = cursor.advance("sub", sub)
+
+    assert main_delta.messages == [_msg("handing off", role="assistant")]
+    assert sub_delta.messages == [_msg("AF1234", role="assistant")]
+    assert main_delta.seq == sub_delta.seq == 1
+    assert main_delta.resynced is sub_delta.resynced is False
+
+
+def test_when_nothing_changed_then_delta_is_empty() -> None:
+    """An unchanged input list is a real, empty delta — the completion is still
+    new — and it does not count as a resync."""
+    cursor = MessageCursor()
+    history = [_msg("hello")]
+    cursor.advance("run-1", history)
+
+    delta = cursor.advance("run-1", list(history))
+    assert delta == MessageDelta(messages=[], seq=1, resynced=False)
+
+
+def test_when_resynced_then_seq_keeps_counting() -> None:
+    """A resync restates the history but does not restart the turn: seq stays
+    monotonic, so ``seq == 0`` keeps meaning "first event of this turn_key" —
+    the adapter's cue to attach system_instructions."""
+    cursor = MessageCursor()
+    cursor.advance("run-1", [_msg("a")])
+    cursor.advance("run-1", [_msg("a"), _msg("b")])
+
+    delta = cursor.advance("run-1", [_msg("z")])
+    assert delta.resynced is True
+    assert delta.seq == 2
+    assert cursor.advance("run-1", [_msg("z"), _msg("y")]).seq == 3
+
+
+def test_when_key_order_differs_then_still_an_extension() -> None:
+    """The prefix is fingerprinted on canonical JSON, so a message dict rebuilt
+    in another key order is the same message and does not force a resync."""
+    cursor = MessageCursor()
+    cursor.advance("run-1", [{"role": "user", "content": "hi"}])
+
+    delta = cursor.advance(
+        "run-1", [{"content": "hi", "role": "user"}, _msg("ok", role="assistant")]
+    )
+    assert delta.resynced is False
+    assert delta.messages == [_msg("ok", role="assistant")]
+
+
+def test_when_a_message_cannot_be_fingerprinted_then_it_resyncs_instead_of_raising() -> (
+    None
+):
+    """``advance`` runs from a framework hook that re-raises into the agent
+    run, so it must not raise. A tool result keyed by dates defeats
+    ``json.dumps`` — ``default=`` is consulted for values, never for keys — and
+    the call degrades to a resync rather than killing the run."""
+    cursor = MessageCursor()
+    cursor.advance("run-1", [_msg("what did we sell?")])
+
+    unserializable = {"role": "tool", "parts": [{date(2026, 9, 11): 12}]}
+    delta = cursor.advance("run-1", [_msg("what did we sell?"), unserializable])
+
+    assert delta.resynced is True
+    assert delta.messages == [_msg("what did we sell?"), unserializable]
+    assert delta.seq == 1
+
+
+def test_when_fingerprinting_failed_then_the_next_call_resyncs_too() -> None:
+    """A failed call leaves no usable mark, so the call after it restates the
+    list as well — rather than slicing against a mark that was never
+    established and silently dropping the messages in between."""
+    cursor = MessageCursor()
+    bad = {"role": "tool", "parts": [{date(2026, 9, 11): 12}]}
+    cursor.advance("run-1", [_msg("a"), bad])
+
+    delta = cursor.advance("run-1", [_msg("a"), _msg("b", role="assistant")])
+    assert delta.resynced is True
+    assert delta.messages == [_msg("a"), _msg("b", role="assistant")]
+
+    # Once a mark is back, extension resumes.
+    assert cursor.advance(
+        "run-1", [_msg("a"), _msg("b", role="assistant"), _msg("c")]
+    ) == MessageDelta(messages=[_msg("c")], seq=2, resynced=False)
+
+
+def test_when_messages_are_not_json_serializable_then_still_tracked() -> None:
+    """Adapters may hand over framework objects they did not flatten.
+    ``default=str`` carries them as long as their ``__str__`` is by value — a
+    type left on ``object.__repr__`` stringifies to its address and would
+    resync on every call, which is why adapters pass dicts or pydantic
+    models."""
+
+    class _Opaque:
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def __str__(self) -> str:
+            return f"opaque:{self.text}"
+
+    cursor = MessageCursor()
+    cursor.advance("run-1", [_Opaque("a")])
+
+    delta = cursor.advance("run-1", [_Opaque("a"), _Opaque("b")])
+    assert delta.resynced is False
+    assert [str(m) for m in delta.messages] == ["opaque:b"]
+
+
+def test_reset_happy_path() -> None:
+    """Run end forgets the list, so a reused turn_key starts a fresh turn at
+    seq 0 rather than inheriting the previous run's mark."""
+    cursor = MessageCursor()
+    cursor.advance("run-1", [_msg("a"), _msg("b")])
+    cursor.reset("run-1")
+
+    delta = cursor.advance("run-1", [_msg("a"), _msg("b")])
+    assert delta == MessageDelta(messages=[_msg("a"), _msg("b")], seq=0, resynced=False)
+
+
+def test_when_turn_key_unknown_then_reset_is_a_noop() -> None:
+    """A run that never emitted still ends; the adapter should not have to
+    remember whether it did."""
+    MessageCursor().reset("never-seen")
+
+
+def test_clear_happy_path() -> None:
+    cursor = MessageCursor()
+    cursor.advance("a", [_msg("x")])
+    cursor.advance("b", [_msg("y")])
+    cursor.clear()
+
+    assert cursor.advance("a", [_msg("x")]).seq == 0
+    assert cursor.advance("b", [_msg("y")]).seq == 0

--- a/tests/tracing/test_messages_cursor.py
+++ b/tests/tracing/test_messages_cursor.py
@@ -134,6 +134,44 @@ def test_when_two_turn_keys_interleave_then_state_is_per_list() -> None:
     assert main_delta.resynced is sub_delta.resynced is False
 
 
+def test_when_the_list_is_empty_then_the_comeback_is_flagged() -> None:
+    """An empty input list leaves no prefix to mark, so the call that brings
+    the messages back restates them under ``resynced`` rather than passing them
+    off as an extension.
+
+    The mark could not simply be dropped here: a cleared turn_key would be
+    byte-identical to one never seen, and the comeback would then slice from
+    zero and emit the whole history a second time with ``resynced=False`` — a
+    duplicate with nothing in ``message_seq`` for a reader to key on. Same mark
+    the fingerprinting-failure path uses, for the same reason."""
+    cursor = MessageCursor()
+    history = [_msg("a"), _msg("b")]
+    cursor.advance("run-1", history)
+
+    assert cursor.advance("run-1", []) == MessageDelta(
+        messages=[], seq=1, resynced=True
+    )
+
+    comeback = cursor.advance("run-1", history)
+    assert comeback == MessageDelta(messages=history, seq=2, resynced=True)
+    # And the mark is usable again, so the next call extends rather than
+    # restates.
+    assert cursor.advance("run-1", [*history, _msg("c")]) == MessageDelta(
+        messages=[_msg("c")], seq=3, resynced=False
+    )
+
+
+def test_when_the_first_call_is_empty_then_it_is_not_a_resync() -> None:
+    """Nothing has been emitted yet, so an empty list is not a restatement of
+    anything — adapters split system messages into ``system_instructions``, so
+    a call whose list holds only those hands over ``[]``."""
+    cursor = MessageCursor()
+
+    assert cursor.advance("run-1", []) == MessageDelta(
+        messages=[], seq=0, resynced=False
+    )
+
+
 def test_when_nothing_changed_then_delta_is_empty() -> None:
     """An unchanged input list is a real, empty delta — the completion is still
     new — and it does not count as a resync."""


### PR DESCRIPTION
Design: [LLM message logging design](https://app.notion.com/p/3d4fb45dbae28141a3c4d32338a0d496) · [implementation spec](https://app.notion.com/p/3d4fb45dbae28109b82fd38cb03b9d11). Plan target: merge by **Fri 11 Sep**.

## What is changing
`MessageCursor` in `hexgate/tracing/messages.py`: per-`turn_key` high-water mark (count + prefix fingerprint) → `(new_messages, seq, resynced)`; tool results included, never filtered by role; shrink or in-place rewrite → full list with `resynced=True`; `reset(turn_key)` on run end. Pure functions over plain dicts.

Two design points worth a reviewer's attention, both settled by a grounded review on this branch:

- **`advance()` never raises.** It runs from framework hooks that re-raise into the customer's agent run, and fingerprinting is the one step here touching raw, un-flattened framework data — `json.dumps(sort_keys=True)` still throws on a non-scalar dict key (a tool returning `{date: value}`), mixed key types, or a cycle. Same rule `emit_llm_messages` and `AuditSender.emit` already keep, centralised by #105 so no adapter has to remember it. A failure degrades to a resync and leaves an unmatchable mark, so the *next* call resyncs too rather than slicing against a mark never established.
- **No LRU bound on the state map**, deliberately. An eviction would drop a list whose run is still going, and the cursor cannot tell that key from one it has never seen — so the comeback would go out as a *fresh turn*: full history again, at `seq=0`, not flagged `resynced`, with the turn's counter rewound past the gap detection the reader relies on. `reset()` on run end is the memory contract instead (a few hundred bytes per live list, no conversation content). An adapter that forgets `reset` leaks slowly and visibly; silently corrupting a transcript is the worse trade.

## Why is this change necessary
All four adapters compute the same delta; one implementation instead of four subtly different ones.

The non-obvious part is *what the fingerprint compares against*. Not "the list now" vs "the list last time" — those always differ, since the list grew. It is **the prefix of the list I am holding now** vs **the mark I stored for what I already emitted**:

```
stored: count=5, fp=hash(m0, m4)

append           [m0 m1 m2 m3 m4 m5 m6]
                 └── messages[:5] ──┘   hash(m0, m4) == fp   → emit [m5, m6]

summarise        [s0 m3 m4 m5 m6]
                 └─ messages[:5] ─┘     hash(s0, m6) != fp   → resync, emit all 5
```

A counter alone would be enough if these lists only ever grew. They don't: frameworks trim old turns or replace them with a summary to fit the context window. The trim case makes `messages[5:]` empty, so we would emit nothing, silently, forever. The summarise case is worse — the list can keep its length while holding different messages, so the slice returns real messages that are simply the wrong ones, with a hole before them and nothing to signal it. Hashing only the two endpoints keeps this O(1) per call instead of O(conversation); the blind spot (a rewrite strictly in the middle preserving length and both ends) is documented on `_fingerprint` and costs a stale message, not a corrupt slice.

## Tests
`tests/tracing/test_messages_cursor.py`: append of one, append of several (parallel tool results), trimmed prefix, same-length-different-content, two interleaved `turn_key`s, unchanged list (empty delta, no false resync), seq monotonic across a resync, key-order insensitivity, unserialisable message → resync not raise, and the call after a failure resyncing too.
