### PR TITLE
fix(sdk, collector): apply role-keyed top-level constraints, widen revocation staleness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,12 @@ collector-check: ## Vet + test + build the collector, validate config.yaml (no o
 	cd platform/collector && go vet ./...
 	cd platform/collector && go build -o hexgate-collector ./...
 	cd platform/collector && ./hexgate-collector validate --config=config.yaml
+	# The two revocation knobs are env-overridable (see config.yaml). A valid
+	# pair must be accepted; an INVALID pair must be REFUSED — the refusal is
+	# what proves the env values reached the config struct, so a typo in either
+	# variable name fails here instead of shipping a dead override.
+	cd platform/collector && HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL=5s HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS=30m ./hexgate-collector validate --config=config.yaml
+	cd platform/collector && (! HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL=1m HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS=1s ./hexgate-collector validate --config=config.yaml >/dev/null 2>&1)
 
 # -------- Platform API (FastAPI control plane) --------
 #

--- a/Makefile
+++ b/Makefile
@@ -296,10 +296,8 @@ collector-check: ## Vet + test + build the collector, validate config.yaml (no o
 	cd platform/collector && go vet ./...
 	cd platform/collector && go build -o hexgate-collector ./...
 	cd platform/collector && ./hexgate-collector validate --config=config.yaml
-	# The two revocation knobs are env-overridable (see config.yaml). A valid
-	# pair must be accepted; an INVALID pair must be REFUSED — the refusal is
-	# what proves the env values reached the config struct, so a typo in either
-	# variable name fails here instead of shipping a dead override.
+	# Only a REFUSED invalid pair proves the env values reached the config
+	# struct, so a typo in either variable name fails here.
 	cd platform/collector && HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL=5s HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS=30m ./hexgate-collector validate --config=config.yaml
 	cd platform/collector && (! HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL=1m HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS=1s ./hexgate-collector validate --config=config.yaml >/dev/null 2>&1)
 

--- a/docs/internals/audit-pipeline.md
+++ b/docs/internals/audit-pipeline.md
@@ -322,8 +322,10 @@ Per request, the extension:
    own id, platform-api #126) and looks it up in a **revocation snapshot** of
    the key table, polled from Postgres every 20 s. Revoking a key deletes its
    row, so absence = revoked → **401**. A snapshot older than `max_staleness`
-   (2 min, i.e. Postgres unreachable) makes the extension reject *everything*
-   rather than let revoked keys keep working.
+   (1 h, i.e. Postgres unreachable for that long) makes the extension reject
+   *everything* rather than let revoked keys keep working. Both knobs are
+   env-tunable per stage —
+   `HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL` / `_MAX_STALENESS`.
 3. **Resolves `project_id` from the key's row**, not from the token's own
    `project` fact (a mint-time snapshot) and never from a span attribute, and
    attaches it as client metadata. `include_metadata` on the receiver and
@@ -604,7 +606,7 @@ sort key `(project_id, agent_name, outcome, occurred_at, event_id)` and
 | Failure | Platform behaviour |
 |---------|--------------------|
 | Bad/missing/revoked bearer | Collector 401; the SDK logs and drops the batch |
-| Postgres unreachable > 2 min | Collector's revocation snapshot goes stale → **every** request 401s until Postgres is back (fail closed) |
+| Postgres unreachable > `max_staleness` (1 h) | Collector's revocation snapshot goes stale → **every** request 401s until Postgres is back (fail closed) |
 | Redpanda unreachable | Collector has already acked 200; exporter retries then drops. Invisible to the SDK and to the current healthcheck (§9) |
 | Enricher down / redeploying | Spans buffer in `hexgate.otlp.raw`; nothing lost within the 3-day retention; dashboard lags |
 | ClickHouse unreachable | Enricher retries the batch with backoff (cap 30 s), commits nothing; consumer lag grows; `restart: unless-stopped` |

--- a/docs/policy/constraints.mdx
+++ b/docs/policy/constraints.mdx
@@ -332,11 +332,14 @@ constraints:
 Top-level `constraints:` is new. Single-file policies ignore keys they don't
 recognise, so before this release the block parsed and was silently dropped —
 after it, the same YAML is enforced against every tool the role can reach. If
-you wrote one speculatively, it starts denying on upgrade, and the policy's
-compiled `source_hash` changes with it. Grep your policies for a top-level
-`constraints:` before you roll forward — `hexgate policy show-rego` prints the
-compiled rules if you want to diff exactly what moved. (Composed module policies
-are unaffected: they rejected the key outright, then and now.)
+you wrote one speculatively, it starts denying on upgrade, and the bundle's
+`rego_hash` and `wasm_hash` change with it. Note that `source_hash` does **not**
+move — it is the sha256 of your policy's raw YAML bytes, which the upgrade
+leaves untouched, so diffing it will tell you nothing changed. Grep your
+policies for a top-level `constraints:` before you roll forward — `hexgate
+policy show-rego` prints the compiled rules if you want to diff exactly what
+moved. (Composed module policies are unaffected: they rejected the key outright,
+then and now.)
 
 **Role-keyed documents activate one release later.** A document with a top-level
 `roles:` key validated only what sat *inside* each role, so a `constraints:`

--- a/docs/policy/constraints.mdx
+++ b/docs/policy/constraints.mdx
@@ -320,7 +320,8 @@ constraints:
 ```
 
 <Note>
-  Policy-level constraints belong in a single-file policy. Composed module
+  Policy-level constraints belong in a single-file policy — flat, or role-keyed
+  under `roles:`, where a top-level block unions into every role. Composed module
   policies (`policies/boundaries/`, `policies/capabilities/`) reject them at
   load: the fold composes per-tool rules only, and silently dropping a
   role-wide fence would be fail-open.
@@ -336,6 +337,15 @@ compiled `source_hash` changes with it. Grep your policies for a top-level
 `constraints:` before you roll forward — `hexgate policy show-rego` prints the
 compiled rules if you want to diff exactly what moved. (Composed module policies
 are unaffected: they rejected the key outright, then and now.)
+
+**Role-keyed documents activate one release later.** A document with a top-level
+`roles:` key validated only what sat *inside* each role, so a `constraints:`
+sibling was dropped there even after the release above — including a malformed
+expression, which `hexgate policy validate` could not see either, since there was
+nothing left to validate. It now unions into every role, so the same upgrade note
+applies: grep role-keyed policies too. Any
+*other* unrecognised sibling of `roles:` is now a load error rather than a silent
+drop, naming the key and telling you to move it inside a role.
 
 ## Named constants
 

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -166,7 +166,11 @@ class AgentPolicy(BaseModel):
     # instances, nothing reassigns a field), which is what makes memoizing
     # effective_tools safe. cached_property is a plain descriptor, not a field,
     # so pydantic must leave it alone.
-    model_config = ConfigDict(frozen=True, ignored_types=(cached_property,))
+    # extra="forbid": a mistyped field (``contraints:``) would otherwise be
+    # dropped in silence, and a dropped fence is fail-open.
+    model_config = ConfigDict(
+        frozen=True, ignored_types=(cached_property,), extra="forbid"
+    )
 
     version: int = 1
     inherits: list[str] = Field(default_factory=list)

--- a/hexgate/security/models.py
+++ b/hexgate/security/models.py
@@ -33,6 +33,12 @@ class BaseToolPolicy(BaseModel):
     milestone, these strings carry through verbatim.
     """
 
+    # extra="forbid" for the same reason AgentPolicy sets it: a mistyped field
+    # (``contraints:``) would otherwise be dropped in silence, leaving
+    # ``mode: allow`` with no fence at all. Inherited by FileToolPolicy and
+    # AgentTargetPolicy, so it covers every nested policy scope.
+    model_config = ConfigDict(extra="forbid")
+
     mode: PolicyMode = "deny"
     constraints: list[str] = Field(default_factory=list)
 
@@ -44,6 +50,8 @@ class BaseToolPolicy(BaseModel):
 
 class FileScope(BaseModel):
     """Restrict a file-oriented tool to explicit path patterns."""
+
+    model_config = ConfigDict(extra="forbid")
 
     allowed_paths: list[str] = Field(default_factory=list)
     denied_paths: list[str] = Field(default_factory=list)

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -72,11 +72,8 @@ _ROLES_KEY = "roles"
 _CONSTRAINTS_KEY = "constraints"
 _VERSION_KEY = "version"
 
-# What a roles-shape document may carry beside ``roles:``. Everything else is
-# rejected rather than ignored: that shape validates only what sits under
-# ``roles:``, so an unrecognised sibling parses and then vanishes — the failure
-# mode an enforcement layer can least afford, and how a top-level
-# ``constraints:`` fence came to be silently dropped.
+# Legal siblings of ``roles:``. Anything else is rejected, not ignored: that
+# shape validates only what sits under ``roles:``, so a stray key would vanish.
 _FILE_LEVEL_KEYS = frozenset(
     {_ROLES_KEY, _CONSTRAINTS_KEY, _VERSION_KEY, RESOLVED_POLICY_MARKER}
 )
@@ -396,11 +393,7 @@ def _load_legacy_file(path: Path) -> PolicySet:
 
 
 def _reject_unknown_file_level_keys(payload: dict[str, Any]) -> None:
-    """Fail closed on an unrecognised sibling of ``roles:``.
-
-    Composed module policies are ``extra="forbid"`` at every scope, so the inline
-    shape was the one place a dropped key stayed silent.
-    """
+    """Fail closed on an unrecognised sibling of ``roles:``."""
     unknown = sorted(set(payload) - _FILE_LEVEL_KEYS)
     if unknown:
         allowed = sorted(_FILE_LEVEL_KEYS - {_ROLES_KEY})
@@ -412,12 +405,8 @@ def _reject_unknown_file_level_keys(payload: dict[str, Any]) -> None:
 
 
 def _file_level_constraints(payload: dict[str, Any]) -> list[str]:
-    """The file-level fence list, or empty.
-
-    Shape is checked here rather than at the hoist: a bare string would otherwise
-    splat into single characters, each a valid ``str``, and pydantic would accept
-    the wreckage.
-    """
+    """The file-level fence list, or empty. Shape is checked before the hoist:
+    a bare string would splat into characters, each a valid ``str``."""
     raw = payload.get(_CONSTRAINTS_KEY)
     if raw is None:
         return []
@@ -430,13 +419,8 @@ def _file_level_constraints(payload: dict[str, Any]) -> list[str]:
 
 
 def _with_file_level_constraints(spec: Any, fences: list[str]) -> Any:
-    """Union the file-level fences ahead of a role's own.
-
-    Union, not replace: constraints are the one policy field that unions across
-    ``inherits``, because a child dropping an inherited fence would be fail-open.
-    A file-level fence is the same kind of promise. A non-mapping spec passes
-    through untouched so pydantic reports the shape error.
-    """
+    """Union the file-level fences ahead of a role's own — replacing would let a
+    role drop the file's fence, which is fail-open. Non-mappings pass through."""
     if not fences or not isinstance(spec, dict):
         return spec
     own = spec.get(_CONSTRAINTS_KEY, [])
@@ -456,11 +440,8 @@ def load_policy_set_from_dict(payload: dict[str, Any]) -> PolicySet:
       :func:`load_policy_map` so inheritance and mixin filtering apply.
 
       A file-level ``constraints:`` block unions into every role, so the key
-      means the same thing whether or not the document declares roles (in the
-      flat shape it validates straight onto the single policy). ``version`` is
-      file metadata; any other sibling of ``roles:`` is rejected, because this
-      shape reads policy fields from inside each role and would otherwise
-      discard it silently.
+      means the same thing in both shapes. ``version`` is file metadata; any
+      other sibling of ``roles:`` is rejected rather than silently dropped.
 
     * **Flat single-policy shape** (legacy) — anything else is treated as a
       single :class:`AgentPolicy` and wrapped as the ``default`` role.

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -68,6 +68,19 @@ DEFAULT_ROLE_NAME = "default"
 # so the reserved-name guard still fires on authored source.
 RESOLVED_POLICY_MARKER = "_resolved"
 
+_ROLES_KEY = "roles"
+_CONSTRAINTS_KEY = "constraints"
+_VERSION_KEY = "version"
+
+# What a roles-shape document may carry beside ``roles:``. Everything else is
+# rejected rather than ignored: that shape validates only what sits under
+# ``roles:``, so an unrecognised sibling parses and then vanishes — the failure
+# mode an enforcement layer can least afford, and how a top-level
+# ``constraints:`` fence came to be silently dropped.
+_FILE_LEVEL_KEYS = frozenset(
+    {_ROLES_KEY, _CONSTRAINTS_KEY, _VERSION_KEY, RESOLVED_POLICY_MARKER}
+)
+
 _RUN_ROOT = "run"
 _RUN_PATH_SEGMENTS = 2  # the namespace is flat: run.<name>
 _ORDERED_OPS = frozenset({"<", "<=", ">", ">="})
@@ -382,6 +395,56 @@ def _load_legacy_file(path: Path) -> PolicySet:
     return load_policy_set_from_dict(payload)
 
 
+def _reject_unknown_file_level_keys(payload: dict[str, Any]) -> None:
+    """Fail closed on an unrecognised sibling of ``roles:``.
+
+    Composed module policies are ``extra="forbid"`` at every scope, so the inline
+    shape was the one place a dropped key stayed silent.
+    """
+    unknown = sorted(set(payload) - _FILE_LEVEL_KEYS)
+    if unknown:
+        allowed = sorted(_FILE_LEVEL_KEYS - {_ROLES_KEY})
+        raise PolicySetError(
+            f"unrecognised top-level key(s) {unknown} beside {_ROLES_KEY!r}; "
+            f"a role-keyed document reads policy fields inside each role, so "
+            f"move them under a role. Only {allowed} are file-level keys."
+        )
+
+
+def _file_level_constraints(payload: dict[str, Any]) -> list[str]:
+    """The file-level fence list, or empty.
+
+    Shape is checked here rather than at the hoist: a bare string would otherwise
+    splat into single characters, each a valid ``str``, and pydantic would accept
+    the wreckage.
+    """
+    raw = payload.get(_CONSTRAINTS_KEY)
+    if raw is None:
+        return []
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise PolicySetError(
+            f"top-level {_CONSTRAINTS_KEY!r} must be a list of constraint "
+            f"expressions (got {type(raw).__name__})"
+        )
+    return raw
+
+
+def _with_file_level_constraints(spec: Any, fences: list[str]) -> Any:
+    """Union the file-level fences ahead of a role's own.
+
+    Union, not replace: constraints are the one policy field that unions across
+    ``inherits``, because a child dropping an inherited fence would be fail-open.
+    A file-level fence is the same kind of promise. A non-mapping spec passes
+    through untouched so pydantic reports the shape error.
+    """
+    if not fences or not isinstance(spec, dict):
+        return spec
+    own = spec.get(_CONSTRAINTS_KEY, [])
+    if not isinstance(own, list):
+        return spec
+    return {**spec, _CONSTRAINTS_KEY: [*fences, *own]}
+
+
 def load_policy_set_from_dict(payload: dict[str, Any]) -> PolicySet:
     """Build a :class:`PolicySet` from an already-parsed YAML document.
 
@@ -391,6 +454,13 @@ def load_policy_set_from_dict(payload: dict[str, Any]) -> PolicySet:
       a mapping of ``{role_name: agent_policy_spec}``. Each value is validated
       as an :class:`AgentPolicy`; the resulting map is wrapped via
       :func:`load_policy_map` so inheritance and mixin filtering apply.
+
+      A file-level ``constraints:`` block unions into every role, so the key
+      means the same thing whether or not the document declares roles (in the
+      flat shape it validates straight onto the single policy). ``version`` is
+      file metadata; any other sibling of ``roles:`` is rejected, because this
+      shape reads policy fields from inside each role and would otherwise
+      discard it silently.
 
     * **Flat single-policy shape** (legacy) — anything else is treated as a
       single :class:`AgentPolicy` and wrapped as the ``default`` role.
@@ -407,10 +477,14 @@ def load_policy_set_from_dict(payload: dict[str, Any]) -> PolicySet:
     for SDK-local agents.
     """
     context = {"resolved": True} if payload.get(RESOLVED_POLICY_MARKER) else None
-    if isinstance(payload.get("roles"), dict):
+    if isinstance(payload.get(_ROLES_KEY), dict):
+        _reject_unknown_file_level_keys(payload)
+        fences = _file_level_constraints(payload)
         role_policies = {
-            role_name: AgentPolicy.model_validate(spec or {}, context=context)
-            for role_name, spec in payload["roles"].items()
+            role_name: AgentPolicy.model_validate(
+                _with_file_level_constraints(spec or {}, fences), context=context
+            )
+            for role_name, spec in payload[_ROLES_KEY].items()
         }
         return load_policy_map(role_policies)
     flat = {k: v for k, v in payload.items() if k != RESOLVED_POLICY_MARKER}

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -396,7 +396,7 @@ def _reject_unknown_file_level_keys(payload: dict[str, Any]) -> None:
     """Fail closed on an unrecognised sibling of ``roles:``."""
     unknown = sorted(set(payload) - _FILE_LEVEL_KEYS)
     if unknown:
-        allowed = sorted(_FILE_LEVEL_KEYS - {_ROLES_KEY})
+        allowed = sorted(_FILE_LEVEL_KEYS - {_ROLES_KEY, RESOLVED_POLICY_MARKER})
         raise PolicySetError(
             f"unrecognised top-level key(s) {unknown} beside {_ROLES_KEY!r}; "
             f"a role-keyed document reads policy fields inside each role, so "

--- a/platform/.env.sample
+++ b/platform/.env.sample
@@ -28,6 +28,15 @@ HEXGATE_POSTGRES_PASSWORD=<strong-password>
 # Mandatory: the API refuses to start with the committed dev default.
 HEXGATE_CLICKHOUSE_PASSWORD=<strong-password>
 
+# ── Collector revocation cache (optional) ────────────────────────────────
+# poll_interval = steady-state window in which a revoked key still works.
+# max_staleness = how long the collector serves its last snapshot while
+# refreshes FAIL (a Postgres outage), after which it rejects every request.
+# Omit both to take the shipped defaults (20s / 1h). Never set either to a
+# blank value — see the collector service in docker-compose.deploy.yml.
+# HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL=20s
+# HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS=1h
+
 # ── Web security ─────────────────────────────────────────────────────────
 HEXGATE_COOKIE_SECURE=1
 HEXGATE_DASHBOARD_URL=https://app.<prod:hexgate.ai|staging:staging.hexgate.ai>

--- a/platform/.env.sample
+++ b/platform/.env.sample
@@ -29,11 +29,9 @@ HEXGATE_POSTGRES_PASSWORD=<strong-password>
 HEXGATE_CLICKHOUSE_PASSWORD=<strong-password>
 
 # ── Collector revocation cache (optional) ────────────────────────────────
-# poll_interval = steady-state window in which a revoked key still works.
-# max_staleness = how long the collector serves its last snapshot while
-# refreshes FAIL (a Postgres outage), after which it rejects every request.
-# Omit both to take the shipped defaults (20s / 1h). Never set either to a
-# blank value — see the collector service in docker-compose.deploy.yml.
+# poll_interval = how long a revoked key still works. max_staleness = how long
+# the collector serves its last snapshot while refreshes fail. Omit for the
+# shipped defaults; never set blank (the collector refuses to boot).
 # HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL=20s
 # HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS=1h
 

--- a/platform/DEPLOY.md
+++ b/platform/DEPLOY.md
@@ -230,6 +230,19 @@ alone boots the api fine but leaves the collector crash-looping on the missing
 public key — restore both files (or regenerate the public half by hand from
 the private one) until the keystore learns to rewrite it on load.
 
+**Revocation cache tuning** — the collector authenticates every OTLP request
+against an in-process snapshot of the `devtoken` table. `poll_interval`
+(default 20s) is the steady-state window in which an already-revoked key still
+works. `max_staleness` (default 1h) is how long the collector keeps serving its
+last snapshot while refreshes are *failing*, after which it rejects every
+request. Tune per stage with `HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL` /
+`HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS` in `.env.<stage>`; omit them to
+take the defaults, and never set either blank (the collector refuses to boot).
+Lowering `max_staleness` tightens the revoked-key window during a Postgres
+outage at the cost of ingest availability — below a few minutes, routine
+database maintenance becomes total span loss, and the collector's healthcheck
+stays green through it.
+
 **Schema changes** apply only on an empty volume; changing one after first boot
 needs a manual migration.
 

--- a/platform/DEPLOY.md
+++ b/platform/DEPLOY.md
@@ -230,18 +230,14 @@ alone boots the api fine but leaves the collector crash-looping on the missing
 public key — restore both files (or regenerate the public half by hand from
 the private one) until the keystore learns to rewrite it on load.
 
-**Revocation cache tuning** — the collector authenticates every OTLP request
-against an in-process snapshot of the `devtoken` table. `poll_interval`
-(default 20s) is the steady-state window in which an already-revoked key still
-works. `max_staleness` (default 1h) is how long the collector keeps serving its
-last snapshot while refreshes are *failing*, after which it rejects every
-request. Tune per stage with `HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL` /
-`HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS` in `.env.<stage>`; omit them to
-take the defaults, and never set either blank (the collector refuses to boot).
-Lowering `max_staleness` tightens the revoked-key window during a Postgres
-outage at the cost of ingest availability — below a few minutes, routine
-database maintenance becomes total span loss, and the collector's healthcheck
-stays green through it.
+**Revocation cache tuning** — `poll_interval` (20s) is how long a revoked key
+still works; `max_staleness` (1h) is how long the collector serves its last
+snapshot while refreshes *fail*, after which it rejects every request. Tune per
+stage with `HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL` /
+`HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS` in `.env.<stage>`; never set either
+blank (the collector refuses to boot). Lowering `max_staleness` below a few
+minutes makes routine database maintenance total span loss, reported as a green
+healthcheck.
 
 **Schema changes** apply only on an empty volume; changing one after first boot
 needs a manual migration.

--- a/platform/api/hexgate_api/features/agents/router.py
+++ b/platform/api/hexgate_api/features/agents/router.py
@@ -186,6 +186,8 @@ async def api_update_agent(
     from hexgate_api.core.locks import project_lock
 
     await ensure_default_project(session)
+    if body.policy_yaml is not None:
+        _reject_unloadable_policy(body.policy_yaml)
     # Hold the project lock: this compiles + writes a bundle, so it must not
     # interleave with recompile_project (a concurrent policy write) and commit
     # out of order. See core.locks.
@@ -219,7 +221,45 @@ async def api_validate_policy(
     """Parse ``policy.yaml`` end-to-end + check every ``constraints`` string.
 
     Server-side validation keeps one source of truth on grammar — the same
-    parsers the SDK enforces with at run time. Handles both shapes:
+    parsers the SDK enforces with at run time. See
+    :func:`_validate_policy_document` for what the pass covers; the save route
+    runs the identical check, so a policy that validates here is one that saves
+    and a policy that saves is one that validated.
+    """
+    return _validate_policy_document(body.policy_yaml)
+
+
+# A policy the loader rejects is the author's mistake, not a server fault, and
+# it is not a request-shape error FastAPI could have caught — 422 is the code
+# the /validate route's own contract already implies for a document it fails.
+POLICY_REJECTED_STATUS = 422
+
+
+def _reject_unloadable_policy(policy_yaml: str) -> None:
+    """Refuse a save whose policy would compile to nothing.
+
+    ``compile_bundle`` degrades *every* compile failure to "store no bundle",
+    which is right when ``opa`` is absent but wrong for a broken document: the
+    save returned 200, the agent's three bundle columns were nulled, and
+    enforcement silently dropped to the SDK's pydantic fallback with no
+    diagnostic on the wire. Gate on the same check ``/validate`` runs so the two
+    routes cannot disagree about which documents are loadable, and so a typo in
+    a fence is a failed request instead of a quietly unenforced policy.
+    """
+    result = _validate_policy_document(policy_yaml)
+    if result.ok:
+        return
+    raise HTTPException(
+        status_code=POLICY_REJECTED_STATUS,
+        detail={
+            "message": "policy_yaml did not validate; nothing was saved",
+            "errors": [error.model_dump() for error in result.errors],
+        },
+    )
+
+
+def _validate_policy_document(policy_yaml: str) -> ValidatePolicyResponse:
+    """Validate a policy document the whole way down. Handles both shapes:
 
     * flat single-policy document → validated as one :class:`AgentPolicy`
     * inline-roles document (top-level ``roles:`` map) → each entry
@@ -250,7 +290,7 @@ async def api_validate_policy(
 
     errors: list[PolicyValidationError] = []
     try:
-        parsed = yaml.safe_load(body.policy_yaml) or {}
+        parsed = yaml.safe_load(policy_yaml) or {}
     except MarkedYAMLError as exc:
         line = exc.problem_mark.line + 1 if exc.problem_mark else None
         return ValidatePolicyResponse(
@@ -259,6 +299,21 @@ async def api_validate_policy(
                 PolicyValidationError(
                     line=line,
                     message=f"YAML parse: {exc.problem or exc}",
+                )
+            ],
+        )
+
+    # Valid YAML that isn't a mapping (a bare list, a scalar) parses fine and
+    # then has no keys to walk — report it rather than letting every `.get`
+    # below raise.
+    if not isinstance(parsed, dict):
+        return ValidatePolicyResponse(
+            ok=False,
+            errors=[
+                PolicyValidationError(
+                    message=(
+                        f"policy must be a YAML mapping, got {type(parsed).__name__}"
+                    )
                 )
             ],
         )

--- a/platform/api/hexgate_api/features/agents/router.py
+++ b/platform/api/hexgate_api/features/agents/router.py
@@ -6,6 +6,7 @@ two routes that compile+sign a bundle (update, register).
 
 import base64
 import hashlib
+from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Response
 from sqlmodel.ext.asyncio.session import AsyncSession
@@ -33,6 +34,9 @@ from hexgate_api.features.agents.service import (
     update_agent,
 )
 from hexgate_api.seeds.defaults import ensure_default_project
+
+if TYPE_CHECKING:
+    from hexgate.security.policy_set import PolicySet
 
 router = APIRouter()
 
@@ -222,6 +226,10 @@ async def api_validate_policy(
       validated as an :class:`AgentPolicy`, then every constraint inside
       every tool is parsed against the M1 grammar.
 
+    Either way the document then goes through :func:`_load_document`, the same
+    loader the compiler and the SDK use, so ``ok`` can't report a document
+    those two reject — see that function for what the per-role pass misses.
+
     Returns a flat list of ``{role, line, message}`` diagnostics. ``role``
     is ``None`` for top-level YAML / schema errors; populated when the
     failure lives inside a specific role's section.
@@ -297,38 +305,62 @@ async def api_validate_policy(
             )
         _check_policy(policy, None)
 
+    policy_set, document_error = _load_document(parsed)
+    # Only when the per-role pass found nothing: the loader fails on the same
+    # cause, so reporting it too would just duplicate a diagnostic that already
+    # names the offending role.
+    if document_error is not None and not errors:
+        errors.append(document_error)
+
     return ValidatePolicyResponse(
-        ok=not errors, errors=errors, warnings=_default_role_warnings(parsed, errors)
+        ok=not errors,
+        errors=errors,
+        warnings=[] if errors else _default_role_warnings(policy_set),
     )
 
 
-def _default_role_warnings(
-    parsed: dict, errors: list[PolicyValidationError]
-) -> list[PolicyValidationError]:
-    """Authoring lints over the document as a whole (no-op if it didn't parse).
+def _load_document(
+    parsed: dict,
+) -> "tuple[PolicySet | None, PolicyValidationError | None]":
+    """Load the document the way the SDK does at run time — the final gate.
 
-    Needs a fully loaded :class:`PolicySet` — inheritance and mixins resolved —
-    which the per-role checks above don't build, validating roles in isolation.
+    Returns the loaded set for the lints below, or the failure to report. The
+    per-role pass validates each role in isolation, so it never sees file-level
+    grammar (an unknown sibling of ``roles:``, a malformed top-level
+    ``constraints:`` block) or a failure needing the resolved set (inheritance,
+    mixins, ``consts`` references). Reporting these keeps ``ok`` from
+    disagreeing with the loader the compiler and the SDK both go through — a
+    document that validates here has to be one they accept.
     """
-    if errors:
-        return []
-
     from pydantic import ValidationError
 
-    from hexgate.security.analyzer import check_default_role_exposure
     from hexgate.security.policy_set import (
         PolicySetError,
         load_policy_set_from_dict,
     )
 
     try:
-        policy_set = load_policy_set_from_dict(parsed)
-    except (PolicySetError, ValidationError):
-        # Inheritance/mixin failures the per-role checks don't cover. Surfacing
-        # them here would widen this endpoint's error contract, and dropping the
-        # lint can't make a broken document look clean — `ok` comes from
-        # `errors`, and the CLI and platform build both still reject these.
+        return load_policy_set_from_dict(parsed), None
+    except PolicySetError as exc:
+        return None, PolicyValidationError(message=str(exc))
+    except ValidationError as exc:
+        return None, PolicyValidationError(
+            message=f"policy schema: {exc.errors()[0]['msg']}"
+        )
+
+
+def _default_role_warnings(
+    policy_set: "PolicySet | None",
+) -> list[PolicyValidationError]:
+    """Authoring lints over the document as a whole.
+
+    Needs a fully loaded :class:`PolicySet` — inheritance and mixins resolved —
+    which the per-role checks don't build, validating roles in isolation.
+    """
+    if policy_set is None:
         return []
+
+    from hexgate.security.analyzer import check_default_role_exposure
 
     return [
         PolicyValidationError(

--- a/platform/api/tests/features/agents/test_agents.py
+++ b/platform/api/tests/features/agents/test_agents.py
@@ -160,6 +160,74 @@ def test_put_agent_partial_update_preserves_other_fields(
     assert after["agent_yaml"] == before["agent_yaml"]
 
 
+def test_put_agent_rejects_a_policy_that_does_not_load(client: TestClient) -> None:
+    """A broken policy fails the save instead of nulling the bundle behind a 200.
+
+    ``compile_bundle`` degrades any compile failure to "no bundle", so this used
+    to save, drop the agent's bundle, and fall back to the pydantic engine with
+    nothing on the wire to say so.
+    """
+    before = client.get(f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot").json()
+
+    resp = client.put(
+        f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot",
+        json={
+            "policy_yaml": (
+                "version: 1\n"
+                "roles:\n"
+                "  default:\n"
+                "    tools:\n"
+                "      refund_order:\n"
+                "        mode: allow\n"
+                "        constraints:\n"
+                "          - args.amount ~~ 50\n"
+            )
+        },
+    )
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert "nothing was saved" in detail["message"]
+    assert detail["errors"][0]["role"] == "default"
+
+    after = client.get(f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot").json()
+    assert after["policy_yaml"] == before["policy_yaml"]
+
+
+def test_put_agent_rejects_a_mistyped_tool_level_fence(client: TestClient) -> None:
+    """``contraints:`` on a tool is a dropped cap, so the save must fail.
+
+    The document- and role-level guards never saw this one — it parsed as an
+    ``allow`` with no constraints at all.
+    """
+    resp = client.put(
+        f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot",
+        json={
+            "policy_yaml": (
+                "version: 1\n"
+                "roles:\n"
+                "  default:\n"
+                "    tools:\n"
+                "      refund_order:\n"
+                "        mode: allow\n"
+                "        contraints:\n"
+                "          - args.amount <= 500\n"
+            )
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_put_agent_without_policy_yaml_skips_the_policy_gate(
+    client: TestClient,
+) -> None:
+    """The gate reads ``policy_yaml``; an update that omits it still saves."""
+    resp = client.put(
+        f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot",
+        json={"system_md": "Only the prompt changed."},
+    )
+    assert resp.status_code == 200
+
+
 def test_list_agents_returns_three_string_fields(client: TestClient) -> None:
     """The /agents collection endpoint returns the same three-field shape."""
     resp = client.get(f"/v1/projects/{DEFAULT_PROJECT_ID}/agents")
@@ -226,6 +294,20 @@ def test_validate_reports_yaml_parse_error_with_line(client: TestClient) -> None
     assert err["role"] is None
     assert err["line"] is not None and err["line"] >= 1
     assert "YAML parse" in err["message"]
+
+
+def test_validate_reports_a_non_mapping_document(client: TestClient) -> None:
+    """Valid YAML that isn't a mapping has no keys to walk — report it rather
+    than raising on the first lookup."""
+    resp = client.post(
+        f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot/validate",
+        json={"policy_yaml": "- refund_order\n- web_search\n"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    [err] = body["errors"]
+    assert "must be a YAML mapping" in err["message"]
 
 
 def test_validate_reports_constraint_grammar_error_inside_role(

--- a/platform/api/tests/features/agents/test_agents.py
+++ b/platform/api/tests/features/agents/test_agents.py
@@ -395,9 +395,80 @@ def test_validate_reports_no_warnings_when_the_document_has_errors(
     assert body["warnings"] == []
 
 
+def test_validate_rejects_an_unknown_sibling_of_roles(client: TestClient) -> None:
+    """A mistyped file-level key is a load error, so validate must not pass it.
+
+    The per-role pass only walks what sits under ``roles:``. Answering ``ok``
+    here sent the operator on to save a document the compiler drops the bundle
+    for, leaving the agent unable to load its policy at all.
+    """
+    resp = client.post(
+        f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot/validate",
+        json={
+            "policy_yaml": (
+                "contraints:\n"
+                "  - run.tool_calls < 5\n"
+                "roles:\n"
+                "  default:\n"
+                "    default_policy: { mode: allow }\n"
+            )
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert "contraints" in body["errors"][0]["message"]
+
+
+def test_validate_rejects_a_malformed_file_level_constraints_block(
+    client: TestClient,
+) -> None:
+    """The file-level fence is grammar-checked, not just the per-role ones."""
+    resp = client.post(
+        f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot/validate",
+        json={
+            "policy_yaml": (
+                "constraints: run.tool_calls < 5\n"
+                "roles:\n"
+                "  default:\n"
+                "    default_policy: { mode: allow }\n"
+            )
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert "constraints" in body["errors"][0]["message"]
+
+
+def test_validate_accepts_a_file_level_constraints_block(client: TestClient) -> None:
+    """The hoisted fence is legal — the guards above must not reject the shape
+    the SDK now supports."""
+    resp = client.post(
+        f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot/validate",
+        json={
+            "policy_yaml": (
+                "version: 1\n"
+                "constraints:\n"
+                "  - run.tool_calls < 20\n"
+                "roles:\n"
+                "  default:\n"
+                "    tools:\n"
+                "      read_ticket: { mode: allow }\n"
+            )
+        },
+    )
+    body = resp.json()
+    assert body["ok"] is True, body
+    assert body["errors"] == []
+
+
 def test_validate_unresolvable_inheritance_does_not_500(client: TestClient) -> None:
     """Roles that each parse but whose inheritance can't resolve reach the
-    PolicySet build and must degrade to "no lint", never a crash."""
+    PolicySet build and must be reported there, never crash.
+
+    The per-role pass can't see a link failure, so this used to answer ``ok``
+    for a document the compiler and the SDK both reject."""
     resp = client.post(
         f"/v1/projects/{DEFAULT_PROJECT_ID}/agents/support_bot/validate",
         json={
@@ -417,8 +488,8 @@ def test_validate_unresolvable_inheritance_does_not_500(client: TestClient) -> N
     )
     assert resp.status_code == 200
     body = resp.json()
-    # Unchanged error contract: the per-role checks passed, so ok stays True.
-    assert body["ok"] is True
+    assert body["ok"] is False
+    assert "does_not_exist" in body["errors"][0]["message"]
     assert body["warnings"] == []
 
 
@@ -714,11 +785,11 @@ def _trivial_policy_yaml() -> str:
     """A policy that compiles cleanly — enough to trigger bundle signing."""
     return (
         "version: 1\n"
-        "name: default\n"
-        "rules:\n"
-        "  - effect: allow\n"
-        "    when:\n"
-        "      tool: any\n"
+        "default_policy:\n"
+        "  mode: deny\n"
+        "tools:\n"
+        "  read_ticket:\n"
+        "    mode: allow\n"
     )
 
 

--- a/platform/collector/config.yaml
+++ b/platform/collector/config.yaml
@@ -115,12 +115,28 @@ extensions:
       # pgx wants a plain postgres:// URL, not the postgresql+asyncpg:// form
       # the Python side's DATABASE_URL uses.
       dsn: ${env:HEXGATE_COLLECTOR_POSTGRES_DSN:-postgres://hexgate:hexgate-dev-password@localhost:5433/hexgate}
-      # Also the worst-case window in which an already-revoked key still works.
-      poll_interval: 20s
+      # Steady-state revocation latency: the worst-case window in which an
+      # already-revoked key still works while refreshes are SUCCEEDING.
+      poll_interval: ${env:HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL:-20s}
       # How long a snapshot may go un-refreshed before this stops trusting it
       # and rejects everything. Without it, a Postgres outage would freeze the
       # revocation list and revoked keys would keep working for its duration.
-      max_staleness: 2m
+      #
+      # An hour, not the 2m first shipped: 2m sits below the length of routine
+      # control-plane maintenance (minor-version upgrade, volume resize, slow
+      # restart), so a blip became total ingest rejection — and the deploy
+      # healthcheck stays green through exactly that failure (see the collector
+      # service in docker-compose.deploy.yml), making it silent and lossy. The
+      # trade is bounded: this widens the revoked-key window only while
+      # refreshes are FAILING; poll_interval above governs steady state.
+      #
+      # Both are per-stage overridable. The env default applies only when the
+      # variable is UNSET — a variable set to an empty string resolves to 0s and
+      # the collector refuses to boot, which is why the deploy stack passes
+      # these with non-empty fallbacks. Keep the literals in lockstep with
+      # defaultPollInterval / defaultMaxStaleness in
+      # extension/hexgatebiscuitauth/config.go.
+      max_staleness: ${env:HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS:-1h}
 
 service:
   extensions: [hexgatebiscuitauth]

--- a/platform/collector/config.yaml
+++ b/platform/collector/config.yaml
@@ -115,27 +115,13 @@ extensions:
       # pgx wants a plain postgres:// URL, not the postgresql+asyncpg:// form
       # the Python side's DATABASE_URL uses.
       dsn: ${env:HEXGATE_COLLECTOR_POSTGRES_DSN:-postgres://hexgate:hexgate-dev-password@localhost:5433/hexgate}
-      # Steady-state revocation latency: the worst-case window in which an
-      # already-revoked key still works while refreshes are SUCCEEDING.
+      # Steady-state revocation latency: how long a revoked key still works
+      # while refreshes SUCCEED.
       poll_interval: ${env:HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL:-20s}
-      # How long a snapshot may go un-refreshed before this stops trusting it
-      # and rejects everything. Without it, a Postgres outage would freeze the
-      # revocation list and revoked keys would keep working for its duration.
-      #
-      # An hour, not the 2m first shipped: 2m sits below the length of routine
-      # control-plane maintenance (minor-version upgrade, volume resize, slow
-      # restart), so a blip became total ingest rejection — and the deploy
-      # healthcheck stays green through exactly that failure (see the collector
-      # service in docker-compose.deploy.yml), making it silent and lossy. The
-      # trade is bounded: this widens the revoked-key window only while
-      # refreshes are FAILING; poll_interval above governs steady state.
-      #
-      # Both are per-stage overridable. The env default applies only when the
-      # variable is UNSET — a variable set to an empty string resolves to 0s and
-      # the collector refuses to boot, which is why the deploy stack passes
-      # these with non-empty fallbacks. Keep the literals in lockstep with
-      # defaultPollInterval / defaultMaxStaleness in
-      # extension/hexgatebiscuitauth/config.go.
+      # How long a snapshot may go un-refreshed before this rejects every
+      # request. An hour because 2m sat under routine control-plane maintenance,
+      # which the deploy healthcheck reports as green. Keep in lockstep with the
+      # extension's defaults.
       max_staleness: ${env:HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS:-1h}
 
 service:

--- a/platform/collector/extension/hexgatebiscuitauth/config.go
+++ b/platform/collector/extension/hexgatebiscuitauth/config.go
@@ -46,14 +46,9 @@ import (
 // Defaults for the revocation cache. The 15-30s poll window comes from the
 // design doc; 20s sits in the middle of it.
 //
-// max_staleness is an hour, not the 2m first shipped: it bounds only how long a
-// snapshot may go UN-REFRESHED, so a value below the length of routine
-// control-plane maintenance (minor-version upgrade, volume resize, slow
-// restart) turns a database blip into total ingest rejection — silently, since
-// the deploy healthcheck stays green through it. Steady-state revocation
-// latency is defaultPollInterval, which is unchanged. Both are overridable per
-// stage; the literals in platform/collector/config.yaml must stay in lockstep
-// with these.
+// max_staleness bounds only how long a snapshot may go UN-REFRESHED, so a value
+// under the length of routine control-plane maintenance turns a database blip
+// into total ingest rejection. Keep in lockstep with config.yaml's literals.
 const (
 	defaultPollInterval = 20 * time.Second
 	defaultMaxStaleness = time.Hour

--- a/platform/collector/extension/hexgatebiscuitauth/config.go
+++ b/platform/collector/extension/hexgatebiscuitauth/config.go
@@ -45,9 +45,18 @@ import (
 
 // Defaults for the revocation cache. The 15-30s poll window comes from the
 // design doc; 20s sits in the middle of it.
+//
+// max_staleness is an hour, not the 2m first shipped: it bounds only how long a
+// snapshot may go UN-REFRESHED, so a value below the length of routine
+// control-plane maintenance (minor-version upgrade, volume resize, slow
+// restart) turns a database blip into total ingest rejection — silently, since
+// the deploy healthcheck stays green through it. Steady-state revocation
+// latency is defaultPollInterval, which is unchanged. Both are overridable per
+// stage; the literals in platform/collector/config.yaml must stay in lockstep
+// with these.
 const (
 	defaultPollInterval = 20 * time.Second
-	defaultMaxStaleness = 2 * time.Minute
+	defaultMaxStaleness = time.Hour
 )
 
 // devPostgresPassword is the committed local-dev credential from

--- a/platform/collector/extension/hexgatebiscuitauth/config_test.go
+++ b/platform/collector/extension/hexgatebiscuitauth/config_test.go
@@ -33,6 +33,17 @@ func TestCreateDefaultConfig_happy_path(t *testing.T) {
 	assert.Empty(t, cfg.PublicKeyFile)
 }
 
+// The literal values, not just the wiring. TestCreateDefaultConfig_happy_path
+// above asserts the default config carries the package constants, which stays
+// green whatever those constants are — so nothing there pins the two numbers an
+// operator actually gets. The max_staleness assertion is the one that would
+// catch a revert to a window too short to survive routine control-plane
+// maintenance; see the const block's comment for why an hour.
+func TestRevocationDefaults_happy_path(t *testing.T) {
+	assert.Equal(t, 20*time.Second, defaultPollInterval)
+	assert.Equal(t, time.Hour, defaultMaxStaleness)
+}
+
 func TestConfigValidate_when_no_public_key_is_set_then_an_error_is_returned(t *testing.T) {
 	cfg := validConfig()
 	cfg.PublicKeyFile = ""

--- a/platform/collector/extension/hexgatebiscuitauth/config_test.go
+++ b/platform/collector/extension/hexgatebiscuitauth/config_test.go
@@ -33,12 +33,8 @@ func TestCreateDefaultConfig_happy_path(t *testing.T) {
 	assert.Empty(t, cfg.PublicKeyFile)
 }
 
-// The literal values, not just the wiring. TestCreateDefaultConfig_happy_path
-// above asserts the default config carries the package constants, which stays
-// green whatever those constants are — so nothing there pins the two numbers an
-// operator actually gets. The max_staleness assertion is the one that would
-// catch a revert to a window too short to survive routine control-plane
-// maintenance; see the const block's comment for why an hour.
+// The literal values: the default-config test above compares the constants with
+// themselves, so it stays green whatever they become.
 func TestRevocationDefaults_happy_path(t *testing.T) {
 	assert.Equal(t, 20*time.Second, defaultPollInterval)
 	assert.Equal(t, time.Hour, defaultMaxStaleness)

--- a/platform/docker-compose.deploy.yml
+++ b/platform/docker-compose.deploy.yml
@@ -253,6 +253,14 @@ services:
       # are fine, matching the api's DATABASE_URL assembly.
       HEXGATE_COLLECTOR_POSTGRES_DSN: host=postgres port=5432 dbname=hexgate user=hexgate
       PGPASSWORD: ${HEXGATE_POSTGRES_PASSWORD:?set HEXGATE_POSTGRES_PASSWORD in .env.<env>}
+      # Revocation cache tuning, both optional. Non-empty fallbacks on purpose:
+      # the collector's ${env:X:-default} applies only when X is UNSET, so a
+      # passthrough resolving to an empty string would arrive as 0s and the
+      # collector would refuse to boot. Compose's `:-` covers unset AND empty,
+      # so an omitted (or blank) key in .env.<env> lands the literal below.
+      # Keep in lockstep with platform/collector/config.yaml.
+      HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL: ${HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL:-20s}
+      HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS: ${HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS:-1h}
     volumes:
       - hexgate-keys:/keys:ro
     depends_on:

--- a/platform/docker-compose.deploy.yml
+++ b/platform/docker-compose.deploy.yml
@@ -253,12 +253,9 @@ services:
       # are fine, matching the api's DATABASE_URL assembly.
       HEXGATE_COLLECTOR_POSTGRES_DSN: host=postgres port=5432 dbname=hexgate user=hexgate
       PGPASSWORD: ${HEXGATE_POSTGRES_PASSWORD:?set HEXGATE_POSTGRES_PASSWORD in .env.<env>}
-      # Revocation cache tuning, both optional. Non-empty fallbacks on purpose:
-      # the collector's ${env:X:-default} applies only when X is UNSET, so a
-      # passthrough resolving to an empty string would arrive as 0s and the
-      # collector would refuse to boot. Compose's `:-` covers unset AND empty,
-      # so an omitted (or blank) key in .env.<env> lands the literal below.
-      # Keep in lockstep with platform/collector/config.yaml.
+      # Optional. Non-empty fallbacks on purpose: the collector's ${env:X:-…}
+      # applies only when X is UNSET, so a blank passthrough would arrive as 0s
+      # and refuse to boot. Compose's `:-` covers blank too.
       HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL: ${HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL:-20s}
       HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS: ${HEXGATE_COLLECTOR_REVOCATION_MAX_STALENESS:-1h}
     volumes:

--- a/tests/security/test_policy_set.py
+++ b/tests/security/test_policy_set.py
@@ -96,13 +96,8 @@ def test_resolved_marker_admits_lowered_agent_keys_flat_form() -> None:
 
 
 def test_top_level_constraints_reach_every_role() -> None:
-    """A ``constraints:`` sibling of ``roles:`` fences every role.
-
-    The same block in a flat (no ``roles:``) document validates straight onto the
-    single policy, so the roles shape has to mean the same thing — otherwise one
-    key means two different things depending on whether the file happens to
-    declare roles, and the fence an author wrote silently does nothing.
-    """
+    """A ``constraints:`` sibling of ``roles:`` fences every role — the same block
+    in a flat document validates straight onto the single policy."""
     ps = load_policy_set_from_dict(
         {
             "constraints": ["run.tool_calls < 20"],
@@ -117,9 +112,8 @@ def test_top_level_constraints_reach_every_role() -> None:
 
 
 def test_top_level_constraints_union_with_a_role_own_fence() -> None:
-    """Hoisting unions, never replaces — constraints are the one field that
-    unions across ``inherits`` precisely because dropping an inherited fence
-    would be fail-open, and the file-level block is the same kind of fence."""
+    """Hoisting unions, never replaces: a role dropping the file's fence would be
+    fail-open."""
     ps = load_policy_set_from_dict(
         {
             "constraints": ["run.tool_calls < 20"],
@@ -138,13 +132,8 @@ def test_top_level_constraints_union_with_a_role_own_fence() -> None:
 
 
 def test_unknown_key_beside_roles_is_rejected() -> None:
-    """An unrecognised sibling of ``roles:`` fails closed instead of vanishing.
-
-    This is the defect class the top-level ``constraints:`` drop belonged to: the
-    roles shape validated only what sat under ``roles:``, so any other key parsed
-    and was discarded. Composed module policies are ``extra="forbid"`` at every
-    scope; this brings the roles shape into line.
-    """
+    """An unrecognised sibling of ``roles:`` fails closed instead of vanishing —
+    the defect class the dropped ``constraints:`` block belonged to."""
     with pytest.raises(PolicySetError, match="tools"):
         load_policy_set_from_dict(
             {
@@ -155,12 +144,8 @@ def test_unknown_key_beside_roles_is_rejected() -> None:
 
 
 def test_file_level_keys_beside_roles_are_accepted() -> None:
-    """``version`` and the resolved marker are legitimate file-level siblings.
-
-    Pins the resolve→build round-trip: ``hexgate policy resolve`` emits
-    ``{"roles": …, "_resolved": True}`` for a multi-role result, and that document
-    must keep loading.
-    """
+    """``version`` and the resolved marker stay legal siblings — pins the
+    resolve→build round-trip, which emits both for a multi-role result."""
     ps = load_policy_set_from_dict(
         {
             "version": 1,

--- a/tests/security/test_policy_set.py
+++ b/tests/security/test_policy_set.py
@@ -12,6 +12,7 @@ from hexgate.security import (
     RESOLVED_POLICY_MARKER,
     AgentPolicy,
     BaseToolPolicy,
+    FileToolPolicy,
     PolicySet,
     PolicySetError,
     load_policy_map,
@@ -185,6 +186,87 @@ def test_mistyped_key_in_a_flat_document_is_rejected() -> None:
                 "default_policy": {"mode": "allow"},
             }
         )
+
+
+def test_mistyped_key_on_a_tool_is_rejected() -> None:
+    """The likeliest place to fat-finger a fence is the tool that needs it.
+
+    Rejecting only the document and role scopes left ``mode: allow`` with an
+    empty ``constraints`` list — an unlimited call where a cap was authored.
+    """
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AgentPolicy.model_validate(
+            {
+                "tools": {
+                    "refund_order": {
+                        "mode": "allow",
+                        "contraints": ["args.amount <= 500"],
+                    }
+                }
+            }
+        )
+
+
+def test_mistyped_key_in_a_file_scope_is_rejected() -> None:
+    """A dropped ``allowed_paths`` leaves an empty FileScope, which the file
+    gate reads as 'no path restriction' rather than 'nothing allowed'."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AgentPolicy.model_validate(
+            {
+                "tools": {
+                    "read_file": {
+                        "mode": "allow",
+                        "file_scope": {"alowed_paths": ["/srv/**"]},
+                    }
+                }
+            }
+        )
+
+
+def test_mistyped_key_on_an_agent_target_is_rejected() -> None:
+    """``via`` defaults to both transfer modes, so dropping a mistyped ``vai``
+    widens reach to the handoff path the author meant to withhold."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AgentPolicy.model_validate(
+            {"agents": {"billing": {"mode": "allow", "vai": ["tool"]}}}
+        )
+
+
+def test_mistyped_key_on_admission_is_rejected() -> None:
+    """Admission carries the run-wide fence; a silent drop admits the run."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AgentPolicy.model_validate(
+            {"admission": {"mode": "allow", "contraints": ["run.tool_calls < 20"]}}
+        )
+
+
+def test_mistyped_key_on_default_policy_is_rejected() -> None:
+    """The default policy governs every unlisted tool, so its fence is the
+    broadest one a silent drop can remove."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AgentPolicy.model_validate(
+            {"default_policy": {"mode": "allow", "contraints": ["args.amount <= 500"]}}
+        )
+
+
+def test_file_scope_still_selects_the_file_tool_policy_arm() -> None:
+    """``ToolPolicy`` is a union, and forbidding extras makes the base arm
+    reject ``file_scope`` — so this pins that the union still falls through to
+    :class:`FileToolPolicy` instead of failing the whole document."""
+    policy = AgentPolicy.model_validate(
+        {
+            "tools": {
+                "read_file": {
+                    "mode": "allow",
+                    "file_scope": {"allowed_paths": ["/srv/**"]},
+                }
+            }
+        }
+    )
+    tool = policy.tools["read_file"]
+    assert isinstance(tool, FileToolPolicy)
+    assert tool.file_scope is not None
+    assert tool.file_scope.allowed_paths == ["/srv/**"]
 
 
 def test_file_level_key_error_hides_the_resolved_marker() -> None:

--- a/tests/security/test_policy_set.py
+++ b/tests/security/test_policy_set.py
@@ -156,6 +156,54 @@ def test_file_level_keys_beside_roles_are_accepted() -> None:
     assert ps.policy_for("default").tools["agent.run"].mode == "allow"
 
 
+def test_mistyped_key_inside_a_role_is_rejected() -> None:
+    """A role spec fails closed on an unrecognised field too.
+
+    Rejecting only siblings of ``roles:`` left the same silent drop one level
+    down — the likelier place to write the fence, since that is where every
+    other policy field lives.
+    """
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        load_policy_set_from_dict(
+            {
+                "roles": {
+                    "default": {
+                        "contraints": ["run.tool_calls < 20"],
+                        "default_policy": {"mode": "allow"},
+                    }
+                }
+            }
+        )
+
+
+def test_mistyped_key_in_a_flat_document_is_rejected() -> None:
+    """Same guard on the flat shape, which validates as one policy."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        load_policy_set_from_dict(
+            {
+                "contraints": ["run.tool_calls < 20"],
+                "default_policy": {"mode": "allow"},
+            }
+        )
+
+
+def test_file_level_key_error_hides_the_resolved_marker() -> None:
+    """The advertised key list stays authorable.
+
+    ``_resolved`` is legal but internal: setting it by hand loads the document
+    as already-resolved, which switches off the reserved-tool-name guard. An
+    author reading this error must not be pointed at it.
+    """
+    with pytest.raises(PolicySetError) as exc_info:
+        load_policy_set_from_dict(
+            {
+                "contraints": ["run.tool_calls < 20"],
+                "roles": {"default": {"default_policy": {"mode": "allow"}}},
+            }
+        )
+    assert RESOLVED_POLICY_MARKER not in str(exc_info.value)
+
+
 def test_load_policy_set_none_returns_deny_default() -> None:
     """``None`` yields a deny-by-default fallback role."""
     ps = load_policy_set(None)

--- a/tests/security/test_policy_set.py
+++ b/tests/security/test_policy_set.py
@@ -95,6 +95,82 @@ def test_resolved_marker_admits_lowered_agent_keys_flat_form() -> None:
     assert ps.policy_for(None).tools["agent.tool:billing-bot"].mode == "allow"
 
 
+def test_top_level_constraints_reach_every_role() -> None:
+    """A ``constraints:`` sibling of ``roles:`` fences every role.
+
+    The same block in a flat (no ``roles:``) document validates straight onto the
+    single policy, so the roles shape has to mean the same thing — otherwise one
+    key means two different things depending on whether the file happens to
+    declare roles, and the fence an author wrote silently does nothing.
+    """
+    ps = load_policy_set_from_dict(
+        {
+            "constraints": ["run.tool_calls < 20"],
+            "roles": {
+                "support": {"default_policy": {"mode": "allow"}},
+                "admin": {"default_policy": {"mode": "allow"}},
+            },
+        }
+    )
+    for role in ("support", "admin"):
+        assert ps.policy_for(role).constraints == ["run.tool_calls < 20"]
+
+
+def test_top_level_constraints_union_with_a_role_own_fence() -> None:
+    """Hoisting unions, never replaces — constraints are the one field that
+    unions across ``inherits`` precisely because dropping an inherited fence
+    would be fail-open, and the file-level block is the same kind of fence."""
+    ps = load_policy_set_from_dict(
+        {
+            "constraints": ["run.tool_calls < 20"],
+            "roles": {
+                "support": {
+                    "default_policy": {"mode": "allow"},
+                    "constraints": ["args.amount <= 500"],
+                }
+            },
+        }
+    )
+    assert ps.policy_for("support").constraints == [
+        "run.tool_calls < 20",
+        "args.amount <= 500",
+    ]
+
+
+def test_unknown_key_beside_roles_is_rejected() -> None:
+    """An unrecognised sibling of ``roles:`` fails closed instead of vanishing.
+
+    This is the defect class the top-level ``constraints:`` drop belonged to: the
+    roles shape validated only what sat under ``roles:``, so any other key parsed
+    and was discarded. Composed module policies are ``extra="forbid"`` at every
+    scope; this brings the roles shape into line.
+    """
+    with pytest.raises(PolicySetError, match="tools"):
+        load_policy_set_from_dict(
+            {
+                "tools": {"refund": {"mode": "allow"}},
+                "roles": {"default": {"default_policy": {"mode": "allow"}}},
+            }
+        )
+
+
+def test_file_level_keys_beside_roles_are_accepted() -> None:
+    """``version`` and the resolved marker are legitimate file-level siblings.
+
+    Pins the resolve→build round-trip: ``hexgate policy resolve`` emits
+    ``{"roles": …, "_resolved": True}`` for a multi-role result, and that document
+    must keep loading.
+    """
+    ps = load_policy_set_from_dict(
+        {
+            "version": 1,
+            RESOLVED_POLICY_MARKER: True,
+            "roles": {"default": {"tools": {"agent.run": {"mode": "allow"}}}},
+        }
+    )
+    assert ps.policy_for("default").tools["agent.run"].mode == "allow"
+
+
 def test_load_policy_set_none_returns_deny_default() -> None:
     """``None`` yields a deny-by-default fallback role."""
     ps = load_policy_set(None)


### PR DESCRIPTION
Two independent changes on one branch

## 1. `fix(sdk)` — a role-keyed policy's top-level `constraints:` was silently dropped

`load_policy_set_from_dict` validated only the values under `roles:`, so every other top-level key parsed and was discarded. An author wrote a role-wide fence, got no fence, and no error. The flat shape was never affected — there the whole payload validates as one `AgentPolicy` — so the same key meant two different things depending on whether the document declared roles.

- A file-level `constraints:` block now **unions** into every role. Union, not replace: a role dropping the file's fence would be fail-open, the same reason constraints union across `inherits`.
- Any **other** unrecognised sibling of `roles:` is now a `PolicySetError` naming the key. That closes the defect class rather than this one instance, and matches composed module policies, which are already `extra="forbid"` at every scope.
- The block's own shape is checked before the hoist — a bare string would otherwise splat into single characters, each a valid `str`.

Verified past the unit tests: the fence compiles into the **Rego** bundle per role, so this holds on the WASM engine and not only the pydantic path; and the resolve → build round-trip still loads, since `hexgate policy resolve` emits `{"roles": …, "_resolved": true}` for a multi-role result.

**Upgrade note** — anyone who wrote such a fence speculatively starts denying on upgrade, and the policy's compiled `source_hash` moves with it. Documented in `docs/policy/constraints.mdx`, alongside the note #155 wrote for the flat shape.

Found by a code review of #155 (already merged), then reproduced before being fixed.

## 2. `feat(collector)` — revocation `max_staleness` 2m → 1h, both knobs env-tunable

2m sat under the length of routine control-plane maintenance (minor-version upgrade, volume resize, slow restart), so a Postgres blip meant **total ingest rejection** — silently, because the deploy healthcheck is a TCP-connect probe that stays green while every request 401s, and refused spans never reach the Redpanda buffer that exists to absorb this.

- `poll_interval` stays 20s, so steady-state revocation latency is unchanged. The widened window applies only while refreshes are **failing**.
- Both knobs override via `HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL` / `_MAX_STALENESS`, per stage, no image rebuild.
- The env default applies only when a variable is **unset**, so the deploy stack passes them with non-empty fallbacks: a blank value arrives as `0s` and the collector refuses to boot (verified against the built binary).

`collector-check` gained an accepted *and* a refused override case. The refusal is the load-bearing one — it can only fail if the env values actually reached the config struct, so a typo in either variable name fails the build instead of shipping a dead override.

## Testing

`make check-all` green: SDK 2570 passed, platform-api 638, dashboard 218, collector `ok` plus the three `validate` cases. The platform-api run matters here specifically — it compiles signed bundles through the same policy loader, so the new strict rejection could have broken bundle compilation. It didn't.

## Not in scope

Three further findings from the same review of #155, none addressed here:

- a named-export import (`caps.yaml#export`) drops the imported file's own top-level `boundary:` while a whole-file import of that same file raises — same fail-open class, reproduced;
- `agent.run` admission is audited outside `run_scope` on the LangChain / LangGraph / OpenAI paths but inside it on Google, so the row admitting a run has no `run_id` to join on;
- the CLI's constraint localization doesn't reach the file-level block, so a malformed expression there reports as a schema error rather than `default → <policy>`.
