### PR TITLE
feat(sdk): compose admission block (role→agent ingress access)

### DIFF
--- a/hexgate/security/compose/grammar.py
+++ b/hexgate/security/compose/grammar.py
@@ -10,7 +10,7 @@ Shape (scope by depth — a block keyword is a sibling of the ``agents``/``roles
 name-map, never a key inside it):
 
     version, import, export          # top-level only
-    boundary / tools / reach / mcp   # at any scope → applies to that scope
+    boundary / tools / reach / mcp / admission   # at any scope → that scope
     agents: { <name>: agent-body }   # top level only; body may add roles:
     roles:  { <name>: role-body }    # agent-body only
 
@@ -45,6 +45,7 @@ RESERVED_NAMES = frozenset(
         "tools",
         "reach",
         "mcp",
+        "admission",
         "agents",
         "roles",
     }
@@ -123,6 +124,10 @@ class BoundaryBlock(BaseModel):
 
     tools: dict[str, CeilingSpec] = Field(default_factory=dict)
     reach: dict[str, ReachSpec] = Field(default_factory=dict)
+    # The ceiling on ingress: may any role *start* this agent at all? Closed-world
+    # like reach — with no admission ceiling, an authored admission grant is
+    # intersected to deny, so a boundary must permit admission to allow it.
+    admission: CeilingSpec | None = None
 
 
 class _GrantScope(BaseModel):
@@ -138,6 +143,10 @@ class _GrantScope(BaseModel):
     tools: dict[str, GrantSpec] = Field(default_factory=dict)
     reach: dict[str, ReachSpec] = Field(default_factory=dict)
     mcp: dict[str, GrantSpec] = Field(default_factory=dict)
+    # Ingress grant: may this scope's role start/enter this agent? Lowers to the
+    # ``agent.run`` key the runtime AgentGate enforces. A single grant (it is about
+    # *this* agent), boundary-ceilinged like reach.
+    admission: GrantSpec | None = None
     imports: list[str] = Field(default_factory=list, alias="import")
 
     # Resolved leaf fragments spliced at this scope — populated by the import

--- a/hexgate/security/compose/grammar.py
+++ b/hexgate/security/compose/grammar.py
@@ -145,7 +145,10 @@ class _GrantScope(BaseModel):
     mcp: dict[str, GrantSpec] = Field(default_factory=dict)
     # Ingress grant: may this scope's role start/enter this agent? Lowers to the
     # ``agent.run`` key the runtime AgentGate enforces. A single grant (it is about
-    # *this* agent), boundary-ceilinged like reach.
+    # *this* agent), boundary-ceilinged like reach. Constraints here gate on
+    # identity/attributes, not ``run.*`` facts: admission fires at run entry,
+    # before a run accrues, so run counters read zero — a run budget belongs on a
+    # tool or reach, not admission.
     admission: GrantSpec | None = None
     imports: list[str] = Field(default_factory=list, alias="import")
 

--- a/hexgate/security/compose/imports.py
+++ b/hexgate/security/compose/imports.py
@@ -153,8 +153,8 @@ def _load(
     if imported.agents:
         raise LinkError(
             f"{target_str}: an imported file must be leaf-only "
-            f"(tools/reach/mcp/boundary); it declares agents:/roles:, which "
-            f"imports do not support yet"
+            f"(tools/reach/mcp/admission/boundary); it declares agents:/roles:, "
+            f"which imports do not support yet"
         )
 
     if name is not None:
@@ -171,7 +171,8 @@ def _load(
 
     if fragment.boundary is not None:
         raise LinkError(
-            f"{target_str}: an imported fragment may only grant (tools/reach/mcp); "
+            f"{target_str}: an imported fragment may only grant "
+            f"(tools/reach/mcp/admission); "
             f"a boundary/ceiling must be authored in the importing file — an "
             f"imported ceiling would intersect and can silently deny every grant"
         )

--- a/hexgate/security/compose/lower.py
+++ b/hexgate/security/compose/lower.py
@@ -39,8 +39,8 @@ def _content_hash(name: str, policy: AgentPolicy) -> str:
 
 
 def _grants_policy(scope: _GrantScope) -> AgentPolicy | None:
-    """An :class:`AgentPolicy` carrying a scope's ``tools``/``mcp``/``reach`` grants
-    (never a boundary). ``None`` when the scope grants nothing."""
+    """An :class:`AgentPolicy` carrying a scope's ``tools``/``mcp``/``reach``/
+    ``admission`` grants (never a boundary). ``None`` when the scope grants nothing."""
     # mcp is readability sugar — an MCP tool is a tool; it composes identically
     # (same key namespace). A name in both blocks is rejected at parse (the
     # grammar's _no_tools_mcp_collision), so here they simply merge.
@@ -54,9 +54,18 @@ def _grants_policy(scope: _GrantScope) -> AgentPolicy | None:
         agents[target] = AgentTargetPolicy(
             via=spec.via, mode=spec.mode, constraints=spec.constraints
         )
-    if not tools and not agents:
+    # admission is the ingress grant (may this role start this agent?); the model
+    # lowers it to the ``agent.run`` key. It's about *this* agent, so a single grant.
+    admission = (
+        BaseToolPolicy(
+            mode=scope.admission.mode, constraints=scope.admission.constraints
+        )
+        if scope.admission is not None
+        else None
+    )
+    if not tools and not agents and admission is None:
         return None
-    return AgentPolicy(tools=tools, agents=agents)
+    return AgentPolicy(tools=tools, agents=agents, admission=admission)
 
 
 def _boundary_policy(block: BoundaryBlock | None) -> AgentPolicy | None:
@@ -74,8 +83,18 @@ def _boundary_policy(block: BoundaryBlock | None) -> AgentPolicy | None:
         )
         for target, spec in block.reach.items()
     }
+    admission = (
+        BaseToolPolicy(
+            mode=block.admission.mode, constraints=block.admission.constraints
+        )
+        if block.admission is not None
+        else None
+    )
     return AgentPolicy(
-        default_policy=BaseToolPolicy(mode="deny"), tools=tools, agents=agents
+        default_policy=BaseToolPolicy(mode="deny"),
+        tools=tools,
+        agents=agents,
+        admission=admission,
     )
 
 

--- a/hexgate/security/policy_set.py
+++ b/hexgate/security/policy_set.py
@@ -264,7 +264,11 @@ def _validate_run_refs(
     before any list-valued path is registered.
     """
     for role, policy in policies.items():
-        for raw in _raw_constraints(policy, tools=policy.tools.values()):
+        # effective_tools, not tools — so a run.* ref on a lowered agent key
+        # (admission ``agent.run`` / reach ``agent.tool:``/``agent.handoff:``) is
+        # validated too, matching :func:`_validate_const_refs`. Walking only
+        # ``tools`` fail-opened run.* constraints on those keys.
+        for raw in _raw_constraints(policy, tools=policy.effective_tools.values()):
             node = parse_constraint(raw)
             _reject_unknown_run_paths(node, role, raw, scalar_paths | list_paths)
             _reject_list_paths_in_scalar_position(node, role, raw, list_paths)

--- a/tests/security/compose/test_compose.py
+++ b/tests/security/compose/test_compose.py
@@ -223,6 +223,82 @@ def test_reach_denied_when_boundary_omits_it_even_if_granted():
     assert tools["agent.tool:evil_bot"]["mode"] == "deny"
 
 
+# --- admission (agent-level ingress, composes via #124) ------------------
+
+
+def test_admission_gates_agent_run_per_role():
+    # `admission` grants the right to START this agent; it lowers to `agent.run`.
+    doc = """
+    boundary:
+      admission: { mode: allow }
+    agents:
+      bot:
+        roles:
+          support: { admission: { mode: allow } }
+          default: {}
+    """
+    ps = resolve_text(doc, agent="bot").policy_set
+
+    def run(r):
+        return ps.evaluate(role=r, tool="agent.run", args={}).outcome.value
+
+    assert run("support") == "allow"
+    # default never granted admission → closed-world deny (the boundary lists it).
+    assert run("default") == "deny"
+
+
+def test_admission_from_an_imported_capability():
+    files = {"admit.yaml": "admission: { mode: allow }\n"}
+    doc = """
+    boundary:
+      admission: { mode: allow }
+    agents:
+      bot:
+        roles:
+          support: { import: [ admit.yaml ] }
+    """
+    ps = resolve_text(doc, agent="bot", loader=lambda n: files[n]).policy_set
+    assert ps.evaluate(role="support", tool="agent.run", args={}).outcome.value == "allow"
+
+
+def test_admission_boundary_ceiling_caps_the_grant():
+    # a boundary admission constraint AND-s onto the grant (ceiling ∩ grant).
+    doc = """
+    boundary:
+      admission: { mode: allow, constraint: "args.amount <= 100" }
+    agents:
+      bot:
+        roles:
+          support: { admission: { mode: allow } }
+    """
+    run = _eff(resolve_text(doc, agent="bot"))["support"]["tools"]["agent.run"]
+    assert run["mode"] == "allow"
+    assert any("100" in c for c in run["constraints"])
+
+
+def test_admission_denied_when_boundary_omits_it_even_if_granted():
+    # closed-world: a boundary that lists no admission ceiling denies the run
+    # even though the role grants it (the agent key isn't permitted).
+    doc = """
+    boundary:
+      tools: { view_orders: { mode: allow } }
+    agents:
+      bot:
+        roles:
+          support:
+            admission: { mode: allow }
+            tools: { view_orders: { mode: allow } }
+    """
+    ps = resolve_text(doc, agent="bot").policy_set
+    assert ps.evaluate(role="support", tool="agent.run", args={}).outcome.value == "deny"
+
+
+def test_agent_named_admission_is_rejected():
+    # `admission` is a reserved block keyword, so an agent can't be named it.
+    with pytest.raises(LinkError, match="reserved"):
+        parse_entry("agents: { admission: { tools: {} } }")
+
+
 # --- imports -------------------------------------------------------------
 
 

--- a/tests/security/compose/test_compose.py
+++ b/tests/security/compose/test_compose.py
@@ -258,7 +258,9 @@ def test_admission_from_an_imported_capability():
           support: { import: [ admit.yaml ] }
     """
     ps = resolve_text(doc, agent="bot", loader=lambda n: files[n]).policy_set
-    assert ps.evaluate(role="support", tool="agent.run", args={}).outcome.value == "allow"
+    assert (
+        ps.evaluate(role="support", tool="agent.run", args={}).outcome.value == "allow"
+    )
 
 
 def test_admission_boundary_ceiling_caps_the_grant():
@@ -290,7 +292,9 @@ def test_admission_denied_when_boundary_omits_it_even_if_granted():
             tools: { view_orders: { mode: allow } }
     """
     ps = resolve_text(doc, agent="bot").policy_set
-    assert ps.evaluate(role="support", tool="agent.run", args={}).outcome.value == "deny"
+    assert (
+        ps.evaluate(role="support", tool="agent.run", args={}).outcome.value == "deny"
+    )
 
 
 def test_agent_named_admission_is_rejected():

--- a/tests/security/compose/test_compose.py
+++ b/tests/security/compose/test_compose.py
@@ -303,6 +303,22 @@ def test_agent_named_admission_is_rejected():
         parse_entry("agents: { admission: { tools: {} } }")
 
 
+def test_run_ref_on_a_lowered_agent_key_is_validated():
+    # run.* validation reaches the lowered agent keys (admission's agent.run,
+    # reach's agent.tool:/agent.handoff:), not just plain tools — an unknown run
+    # path there is rejected at load, not silently fail-open.
+    doc = """
+    boundary:
+      admission: { mode: allow }
+    agents:
+      bot:
+        roles:
+          support: { admission: { mode: allow, constraint: "run.bogus < 1" } }
+    """
+    with pytest.raises(LinkError, match="unknown run"):
+        resolve_text(doc, agent="bot")
+
+
 # --- imports -------------------------------------------------------------
 
 

--- a/tests/security/test_run_refs_validation.py
+++ b/tests/security/test_run_refs_validation.py
@@ -211,3 +211,39 @@ def test_inherited_policy_level_constraint_is_validated() -> None:
                 "default": AgentPolicy.model_validate({"inherits": ["base"]}),
             }
         )
+
+
+def test_run_refs_are_validated_on_an_authored_admission_grant() -> None:
+    # admission/agents blocks stay as AgentPolicy model fields (they land in
+    # effective_tools, not tools), so run.* validation must walk effective_tools
+    # to reach them — else a bad run.* ref on an authored admission grant
+    # fail-opens. This is the authored single-file path the compose front-end's
+    # own test can't exercise (compose folds agent.run straight into tools).
+    policy = AgentPolicy.model_validate(
+        {
+            "admission": {
+                "mode": "allow",
+                "constraints": ["run.definitely_not_a_path < 5"],
+            }
+        }
+    )
+    with pytest.raises(PolicySetError, match="unknown run"):
+        PolicySet({DEFAULT_ROLE_NAME: policy})
+
+
+def test_run_refs_are_validated_on_an_authored_reach_grant() -> None:
+    # Same gap on the reach half: an agents:/reach block's run.* ref must be
+    # validated too.
+    policy = AgentPolicy.model_validate(
+        {
+            "agents": {
+                "other": {
+                    "as": ["handoff"],
+                    "mode": "allow",
+                    "constraints": ["run.definitely_not_a_path < 5"],
+                }
+            }
+        }
+    )
+    with pytest.raises(PolicySetError, match="unknown run"):
+        PolicySet({DEFAULT_ROLE_NAME: policy})

--- a/tests/security/test_run_refs_validation.py
+++ b/tests/security/test_run_refs_validation.py
@@ -238,7 +238,7 @@ def test_run_refs_are_validated_on_an_authored_reach_grant() -> None:
         {
             "agents": {
                 "other": {
-                    "as": ["handoff"],
+                    "via": ["handoff"],
                     "mode": "allow",
                     "constraints": ["run.definitely_not_a_path < 5"],
                 }


### PR DESCRIPTION
Adds `admission:` to the compose front-end — **agent-level ingress**: may this role *start/enter* this agent at all? It's the missing sibling of `reach:` (egress). The compose grammar (#175/#176) shipped tools/reach/mcp but not admission, even though the runtime (`AgentGate`, #124) already enforces it — so agent-level access couldn't be *authored* in compose. This closes that gap.

Off `main` (standalone) — the compose SDK it extends is merged, and it's independent of the open platform/dashboard PRs.

## What it does
- **`admission:` at any scope** — a single grant (it's about *this* agent), parallel to `reach`. In a role body it grants that role the right to run the agent; a top-level/agent boundary sets the ceiling.
- **Lowers to `agent.run`** — routed into `AgentPolicy.admission`, which the model already expands to the `agent.run` synthetic key. So the linker fold, closed-world admission, engine, rego, and signing paths are **unchanged** — this is pure front-end authoring.
- **Closed-world, like reach** — an ungranted role→agent is denied; a boundary that omits admission denies it even if a capability grants it; a boundary admission ceiling AND-s its constraint onto the grant.
- **Importable** — a capability file may carry `admission:` (leaf grant); import messages updated to list it.

```yaml
boundary:
  admission: { mode: allow }          # ceiling: admission is permitted at all
agents:
  billing_bot:
    roles:
      billing: { admission: { mode: allow } }   # only 'billing' may start billing_bot
      support: {}                                # closed-world deny
```

## Important files
- `hexgate/security/compose/grammar.py` — `admission` on `_GrantScope` + `BoundaryBlock`; `"admission"` reserved (block keyword).
- `hexgate/security/compose/lower.py` — lowers `admission:` into `AgentPolicy.admission` (→ `agent.run`), in both the grant and boundary paths.
- `hexgate/security/compose/imports.py` — import error messages list `admission`.
- `tests/security/compose/test_compose.py` — per-role gating, imported admission, boundary-ceiling constraint cap, closed-world deny, reserved-name rejection.

## Notes
- **No endpoint or runtime change.** `agent.run` already flows through resolve/check/preview generically; the platform graph endpoint already draws `role→agent` admission edges + role nodes; `AgentGate` already enforces it. So authoring admission lights up the graph and gates a served agent with nothing downstream to change.
- **Follow-up (dashboard):** the resolved view lists `agent.*` keys (reach today, admission now) as raw tool rows — worth grouping/labelling them as reach/admission in the editor's Resolved tab.
- 1314 SDK tests pass (compose + security + cli), ruff clean; review rounds fixed: stale docstring, weak reserved-name assertion, the `run.*`-at-admission caveat, and — folded in — the `_validate_run_refs` fail-open (it walked `tools` not `effective_tools`, so a `run.*` ref on an authored **admission or reach** grant skipped validation), now pinned by authored-path regression tests.