### PR TITLE
feat(platform-api, collector): soft-delete devtoken rows and filter revoked keys on every read path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,6 +189,14 @@ postgres-init: postgres-up ## Create the platform-api tables on local Postgres (
 	@# stack's api-init one-shot imports it (docker-compose.deploy.yml).
 	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run python -c \
 		"import asyncio; import hexgate_api.models; from hexgate_api.core.db import init_db; asyncio.run(init_db())"
+	@# create_all adds missing TABLES, never missing columns, so a volume that
+	@# predates a column keeps 500ing at request time with no startup error.
+	@# Every file here is idempotent (IF NOT EXISTS), so replaying the whole
+	@# directory on each init is the cheapest honest local-dev migration story.
+	@# Deployed stacks apply these by hand — see platform/DEPLOY.md section 6.
+	for f in platform/postgres/migrations/*.sql; do \
+		docker exec -i hexgate-postgres psql -v ON_ERROR_STOP=1 -U hexgate -d hexgate < "$$f" >/dev/null; \
+	done
 
 .PHONY: postgres-stop
 postgres-stop: ## Stop Postgres (keeps the data volume)

--- a/Makefile
+++ b/Makefile
@@ -183,8 +183,12 @@ postgres-up: ## Start local Postgres and wait until healthy
 # fresh volume never surfaces as "no such table" on the first request.
 .PHONY: postgres-init
 postgres-init: postgres-up ## Create the platform-api tables on local Postgres (idempotent)
+	@# `import hexgate_api.models` is load-bearing: it registers every table on
+	@# SQLModel.metadata before create_all runs. Without it the metadata is
+	@# empty and this silently creates NOTHING — the same reason the deploy
+	@# stack's api-init one-shot imports it (docker-compose.deploy.yml).
 	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run python -c \
-		"import asyncio; from hexgate_api.core.db import init_db; asyncio.run(init_db())"
+		"import asyncio; import hexgate_api.models; from hexgate_api.core.db import init_db; asyncio.run(init_db())"
 
 .PHONY: postgres-stop
 postgres-stop: ## Stop Postgres (keeps the data volume)

--- a/Makefile
+++ b/Makefile
@@ -328,7 +328,7 @@ platform-api: ## Run the platform API dev server (FastAPI on :8000, SQLite)
 	cd platform/api && uv run uvicorn hexgate_api.main:app --reload --port 8000
 
 .PHONY: platform-api-pg
-platform-api-pg: postgres-up ## Run the platform API against local Postgres (starts PG first)
+platform-api-pg: postgres-init ## Run the platform API against local Postgres (starts PG first)
 	cd platform/api && DATABASE_URL=$(POSTGRES_DSN) uv run uvicorn hexgate_api.main:app --reload --port 8000
 
 .PHONY: platform-api-test
@@ -395,6 +395,24 @@ platform-env-pull: ## Pull platform/.env.<stage> from Scaleway: make platform-en
 .PHONY: _require-stage-env
 _require-stage-env:
 	@test -f platform/.env.$(STAGE) || $(MAKE) platform-env-pull STAGE=$(STAGE)
+
+# Runs BEFORE platform-up on any release that adds a column: init_db() is
+# create_all, which never alters an existing table, and the collector's snapshot
+# query selects the new column — so new images against an unmigrated database
+# take OTLP ingest down. Every file is idempotent, so replaying the whole
+# directory is a no-op when there is nothing new. See platform/DEPLOY.md § 6.
+#
+# Upgrades only: the files ALTER tables the control plane has already created,
+# so on a first-ever deploy there is nothing to migrate (create_all builds the
+# current schema) and this fails on the missing table. Skip it there.
+.PHONY: platform-migrate
+platform-migrate: _require-stage-env ## Apply platform/postgres/migrations/*.sql to a deploy stack: make platform-migrate STAGE=prod
+	$(DEPLOY_COMPOSE) up -d --wait postgres
+	@for f in platform/postgres/migrations/*.sql; do \
+		echo "applying $$f"; \
+		$(DEPLOY_COMPOSE) exec -T postgres \
+			psql -v ON_ERROR_STOP=1 -U hexgate -d hexgate < "$$f" >/dev/null || exit 1; \
+	done
 
 .PHONY: platform-up
 platform-up: _require-stage-env ## Build + (re)start a deploy stack: make platform-up STAGE=prod (default staging)

--- a/docs/internals/audit-pipeline.md
+++ b/docs/internals/audit-pipeline.md
@@ -320,11 +320,12 @@ Per request, the extension:
    keep a stolen key from probing.
 2. **Reads the `token_id` fact** from the authority block (the API key row's
    own id, platform-api #126) and looks it up in a **revocation snapshot** of
-   the key table, polled from Postgres every 20 s. Revoking a key deletes its
-   row, so absence = revoked → **401**. A snapshot older than `max_staleness`
-   (1 h, i.e. Postgres unreachable for that long) makes the extension reject
-   *everything* rather than let revoked keys keep working. Both knobs are
-   env-tunable per stage —
+   the key table, polled from Postgres every 20 s. The snapshot query filters
+   on `revoked_at IS NULL` (platform-api #206), so absence from it = revoked
+   → **401**; the row itself survives as the audit record. A snapshot older
+   than `max_staleness` (1 h, i.e. Postgres unreachable for that long) makes
+   the extension reject *everything* rather than let revoked keys keep
+   working. Both knobs are env-tunable per stage —
    `HEXGATE_COLLECTOR_REVOCATION_POLL_INTERVAL` / `_MAX_STALENESS`.
 3. **Resolves `project_id` from the key's row**, not from the token's own
    `project` fact (a mint-time snapshot) and never from a span attribute, and

--- a/platform/DEPLOY.md
+++ b/platform/DEPLOY.md
@@ -207,6 +207,29 @@ far that did this:
 |---|---|---|
 | OTLP pipeline (collector/redpanda/enricher) | `HEXGATE_OTLP_PORT` | `7001` prod, `7201` staging |
 
+**When a release adds a Postgres column** — `init_db()` is `create_all`, which
+creates missing tables but never adds columns to an existing one, so the schema
+change has to be applied by hand *before* the new images go up. Files live in
+`platform/postgres/migrations/`, are idempotent, and are safe to apply early:
+
+```bash
+cd /srv/hexgate-<stage>
+docker compose -p hexgate-<stage> --env-file platform/.env.<stage> \
+  -f platform/docker-compose.deploy.yml exec -T postgres \
+  psql -v ON_ERROR_STOP=1 -U hexgate -d hexgate \
+  < platform/postgres/migrations/0001_devtoken_soft_delete.sql
+make platform-up STAGE=<stage>
+```
+
+Applying it *after* the deploy is not a slower path, it is an outage: the
+collector's snapshot query selects the new column, so its first load fails, the
+container refuses to boot, and OTLP ingest is down until the migration lands.
+Every bearer-authenticated API route 500s for the same reason.
+
+| Release | Migration |
+|---|---|
+| devtoken soft delete | `0001_devtoken_soft_delete.sql` |
+
 ## Operations
 
 **Back up these volumes** (per env, prefixed `hexgate-prod_` / `hexgate-staging_`):

--- a/platform/DEPLOY.md
+++ b/platform/DEPLOY.md
@@ -184,11 +184,18 @@ curl -X POST https://app.hexgate.ai/v1/auth/register \
 
 ```bash
 cd /srv/hexgate-<stage> && git pull   # or checkout a new tag for prod
+make platform-migrate STAGE=<stage>   # schema BEFORE images — see below; no-op when nothing is new
 make platform-up STAGE=<stage>        # rebuilds changed images, recreates containers
 ```
 
-Promote a release: tag it, `git checkout` it in the prod checkout, re-run
-`make platform-up STAGE=prod`.
+`platform-migrate` runs first on purpose and is safe to run on every upgrade:
+the files are idempotent, so a release that adds no column replays them to no
+effect. Reversing the two is an outage, not a slower path (see below). Skip it
+only on a first-ever deploy, where there is no existing schema to alter.
+
+Promote a release: tag it, `git checkout` it in the prod checkout, then the
+same `platform-migrate` → `platform-up` pair. Rolling *back* past a release
+that added columns has its own step — see below.
 
 Upgrades reuse the env already on the box: `platform-up` only pulls a
 MISSING `.env.<stage>`, never refreshes an existing one. If the secret changed,
@@ -209,26 +216,43 @@ far that did this:
 
 **When a release adds a Postgres column** — `init_db()` is `create_all`, which
 creates missing tables but never adds columns to an existing one, so the schema
-change has to be applied by hand *before* the new images go up. Files live in
-`platform/postgres/migrations/`, are idempotent, and are safe to apply early:
+change has to be applied *before* the new images go up. Files live in
+`platform/postgres/migrations/`, are idempotent, and are applied by
+`make platform-migrate STAGE=<stage>` (the step in the recipe above; it replays
+the whole directory against the stack's Postgres).
+
+Applying them *after* the deploy is not a slower path, it is an outage: the
+collector's snapshot query selects the new column, so its first load fails, the
+container refuses to boot, and OTLP ingest is down until the migration lands.
+Every bearer-authenticated API route 500s for the same reason. Note the
+migration itself is safe to run early — the *old* code never selects the new
+columns — which is why it is unconditional in the recipe.
+
+| Release | Migration |
+|---|---|
+| devtoken soft delete | `0001_devtoken_soft_delete.sql` |
+
+**Rolling back past a migration.** The columns stay behind when the code goes
+away, and old code does not know to filter on them. Nothing here is automatic,
+so a rollback that skips the compensating step below is silent — the stack comes
+up healthy and behaves wrongly.
+
+*Past `0001_devtoken_soft_delete`* — revocation became a soft delete: the row
+survives with `revoked_at` stamped, and every read filters it out. The
+pre-soft-delete code has no such filter, so it resolves those rows as live keys.
+Before checking out a tag older than that release:
 
 ```bash
 cd /srv/hexgate-<stage>
 docker compose -p hexgate-<stage> --env-file platform/.env.<stage> \
   -f platform/docker-compose.deploy.yml exec -T postgres \
   psql -v ON_ERROR_STOP=1 -U hexgate -d hexgate \
-  < platform/postgres/migrations/0001_devtoken_soft_delete.sql
-make platform-up STAGE=<stage>
+  -c "DELETE FROM devtoken WHERE revoked_at IS NOT NULL"
 ```
 
-Applying it *after* the deploy is not a slower path, it is an outage: the
-collector's snapshot query selects the new column, so its first load fails, the
-container refuses to boot, and OTLP ingest is down until the migration lands.
-Every bearer-authenticated API route 500s for the same reason.
-
-| Release | Migration |
-|---|---|
-| devtoken soft delete | `0001_devtoken_soft_delete.sql` |
+Skipping it un-revokes every key revoked while the new code was live, on HTTP,
+WebSocket and OTLP ingest alike. It discards the audit rows, which is the point:
+the old schema has nowhere to keep them.
 
 ## Operations
 

--- a/platform/DEPLOY.md
+++ b/platform/DEPLOY.md
@@ -250,9 +250,16 @@ docker compose -p hexgate-<stage> --env-file platform/.env.<stage> \
   -c "DELETE FROM devtoken WHERE revoked_at IS NOT NULL"
 ```
 
-Skipping it un-revokes every key revoked while the new code was live, on HTTP,
-WebSocket and OTLP ingest alike. It discards the audit rows, which is the point:
-the old schema has nowhere to keep them.
+Skipping it does not expose every surface equally. Revoke also masks the
+secret, and the pre-soft-delete code resolves a key by matching that secret
+exactly, so it can never match a revoked row: bearer HTTP and the WebSocket
+handshake stay refused either way. Two surfaces do regress, both of them ones
+that never look at the secret — **OTLP ingest**, which matches the token's
+`token_id` fact against a snapshot of the whole key table and finds the row
+present again, and the **dashboard's key list**, which reads the rows back
+unfiltered. Run it anyway: those are the surfaces the compensating step exists
+for. It discards the audit rows, which is the point — the old schema has
+nowhere to keep them.
 
 ## Operations
 

--- a/platform/api/hexgate_api/features/tokens/router.py
+++ b/platform/api/hexgate_api/features/tokens/router.py
@@ -18,12 +18,13 @@ from hexgate_api.schemas import (
     TokenMintResponse,
 )
 from hexgate_api.features.tokens.service import (
-    delete_api_key,
     find_token_by_secret,
     list_api_keys,
     mask_secret,
     mint_api_key,
+    revoke_api_key,
 )
+from hexgate_api.models import User
 from hexgate_api.seeds.defaults import ensure_default_project
 
 router = APIRouter()
@@ -113,14 +114,16 @@ async def mint_token(
 @router.delete(
     "/projects/{project_id}/tokens/{token_id}",
     status_code=204,
-    dependencies=[Depends(require_org_member)],
 )
 async def revoke_token(
     project_id: str,
     token_id: str,
+    user: User = Depends(require_org_member),
     session: AsyncSession = Depends(get_session),
 ) -> None:
-    ok = await delete_api_key(session, project_id, token_id)
+    """Soft-delete the key. ``require_org_member`` moves out of the decorator's
+    ``dependencies`` so its ``User`` can be stamped as the revoker."""
+    ok = await revoke_api_key(session, project_id, token_id, revoked_by_user_id=user.id)
     if not ok:
         raise HTTPException(status_code=404, detail="token not found")
 

--- a/platform/api/hexgate_api/features/tokens/service.py
+++ b/platform/api/hexgate_api/features/tokens/service.py
@@ -1,12 +1,12 @@
 """API-key persistence: mint (Biscuit-signed), list, revoke, lookup, mask.
 
-Revocation is a soft delete: :func:`revoke_api_key` stamps ``revoked_at`` and
-the row stays as the audit record. Every read below therefore filters on
-``revoked_at IS NULL`` -- without that, revocation would silently stop working
-on every bearer surface (see :func:`find_token_by_secret`).
+Revocation is a soft delete: :func:`revoke_api_key` stamps ``revoked_at``, masks
+the secret, and the row stays as the audit record. Every read below therefore
+filters on ``revoked_at IS NULL`` -- without that, revocation would silently stop
+working on every bearer surface (see :func:`find_token_by_secret`).
 """
 
-from sqlmodel import select
+from sqlmodel import select, update
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from hexgate_api.core.biscuits import MintRequest, make_envelope, mint_token
@@ -118,15 +118,36 @@ async def revoke_api_key(
     timestamp. The three cases share one guard because they share one response:
     distinguishing them here invites distinguishing them in the reply, which
     would leak whether a token id exists.
+
+    ``revoked_at IS NULL`` is part of the UPDATE's WHERE clause rather than a
+    check on a prior read: two concurrent revokes would both clear a
+    read-then-check, and the second would overwrite the first's actor and
+    timestamp -- losing the audit fact the soft delete exists to record. The
+    row is read first only to mask its secret; the update is the guard, and
+    ``rowcount`` is what decides whether this call was the one that revoked.
     """
     token = await session.get(ApiKey, token_id)
-    if token is None or token.project_id != project_id or token.revoked_at is not None:
+    if token is None or token.project_id != project_id:
         return False
-    token.revoked_at = utcnow()
-    token.revoked_by_user_id = revoked_by_user_id
-    session.add(token)
+    stmt = (
+        update(ApiKey)
+        .where(
+            ApiKey.id == token_id,
+            ApiKey.project_id == project_id,
+            ApiKey.revoked_at.is_(None),  # type: ignore[union-attr]
+        )
+        .values(
+            revoked_at=utcnow(),
+            revoked_by_user_id=revoked_by_user_id,
+            # The audit row keeps who/when, not a usable credential: retaining
+            # the full envelope forever would turn any DB dump -- or a rollback
+            # to code without the revocation filter -- into live keys.
+            secret=mask_secret(token.secret),
+        )
+    )
+    result = await session.exec(stmt)
     await session.commit()
-    return True
+    return result.rowcount == 1
 
 
 def mask_secret(full: str) -> str:

--- a/platform/api/hexgate_api/features/tokens/service.py
+++ b/platform/api/hexgate_api/features/tokens/service.py
@@ -1,13 +1,17 @@
-"""API-key persistence: mint (Biscuit-signed), list, revoke, lookup, mask."""
+"""API-key persistence: mint (Biscuit-signed), list, revoke, lookup, mask.
 
-from datetime import datetime, timezone
+Revocation is a soft delete: :func:`revoke_api_key` stamps ``revoked_at`` and
+the row stays as the audit record. Every read below therefore filters on
+``revoked_at IS NULL`` -- without that, revocation would silently stop working
+on every bearer surface (see :func:`find_token_by_secret`).
+"""
 
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from hexgate_api.core.biscuits import MintRequest, make_envelope, mint_token
 from hexgate_api.core.ids import new_id
-from hexgate_api.models import ApiKey
+from hexgate_api.models import ApiKey, utcnow
 
 
 async def mint_api_key(
@@ -66,30 +70,61 @@ async def mint_api_key(
 
 
 async def list_api_keys(session: AsyncSession, project_id: str) -> list[ApiKey]:
+    """Live keys only. Revoked rows are retained as the audit trail (see
+    :class:`ApiKey`) but never surface in the dashboard's key list."""
     stmt = (
         select(ApiKey)
-        .where(ApiKey.project_id == project_id)
+        .where(
+            ApiKey.project_id == project_id,
+            ApiKey.revoked_at.is_(None),  # type: ignore[union-attr]
+        )
         .order_by(ApiKey.created_at.desc())
     )  # type: ignore[attr-defined]
     return list((await session.exec(stmt)).all())
 
 
 async def find_token_by_secret(session: AsyncSession, secret: str) -> ApiKey | None:
-    """Look up a token by its full secret value. Updates last_used_at on hit."""
-    stmt = select(ApiKey).where(ApiKey.secret == secret)
+    """Look up a live token by its full secret value. Updates last_used_at on hit.
+
+    The ``revoked_at`` filter is the revocation gate for every bearer surface:
+    ``deps/tokens.py`` (``_validate_sdk_token``, ``require_project``),
+    ``deps/ws.py`` (``ws_require_project``) and ``GET /v1/me/key`` all reach
+    revocation through here. Filtering also stops a revoked key from bumping
+    its own ``last_used_at``.
+    """
+    stmt = select(ApiKey).where(
+        ApiKey.secret == secret,
+        ApiKey.revoked_at.is_(None),  # type: ignore[union-attr]
+    )
     token = (await session.exec(stmt)).first()
     if token is not None:
-        token.last_used_at = datetime.now(timezone.utc)
+        token.last_used_at = utcnow()
         session.add(token)
         await session.commit()
     return token
 
 
-async def delete_api_key(session: AsyncSession, project_id: str, token_id: str) -> bool:
+async def revoke_api_key(
+    session: AsyncSession,
+    project_id: str,
+    token_id: str,
+    *,
+    revoked_by_user_id: str,
+) -> bool:
+    """Soft-delete a key, project-scoped.
+
+    False if unknown here or already revoked -- the router turns that into the
+    404 a repeat revoke has always returned, and a second call never moves the
+    timestamp. The three cases share one guard because they share one response:
+    distinguishing them here invites distinguishing them in the reply, which
+    would leak whether a token id exists.
+    """
     token = await session.get(ApiKey, token_id)
-    if token is None or token.project_id != project_id:
+    if token is None or token.project_id != project_id or token.revoked_at is not None:
         return False
-    await session.delete(token)
+    token.revoked_at = utcnow()
+    token.revoked_by_user_id = revoked_by_user_id
+    session.add(token)
     await session.commit()
     return True
 

--- a/platform/api/hexgate_api/models.py
+++ b/platform/api/hexgate_api/models.py
@@ -231,6 +231,9 @@ class ApiKey(SQLModel, table=True):
     Every read path filters on ``revoked_at IS NULL`` -- including the Go
     Collector's snapshot query (``extension/hexgatebiscuitauth/cache.go``),
     which is the OTLP ingest path's only revocation check.
+
+    Revoking also masks ``secret``: the retained row is an audit record, not a
+    store of credentials that outlive their own revocation.
     """
 
     __tablename__ = "devtoken"  # historical name; renaming needs a migration
@@ -239,7 +242,7 @@ class ApiKey(SQLModel, table=True):
     project_id: str = Field(foreign_key="project.id", index=True)
     name: str
     prefix: str  # "fty_test" or "fty_live"
-    secret: str  # full token value; opaque random string for Phase A
+    secret: str  # full token value while live; replaced by its mask on revoke
     scopes_csv: str = ""  # comma-separated for now
     created_at: datetime = Field(
         default_factory=utcnow, sa_type=DateTime(timezone=True)

--- a/platform/api/hexgate_api/models.py
+++ b/platform/api/hexgate_api/models.py
@@ -224,6 +224,15 @@ class Project(SQLModel, table=True):
 
 
 class ApiKey(SQLModel, table=True):
+    """A project's API key. Live while ``revoked_at`` is null; revoke is a soft
+    delete keeping the who/when trail (the row is the audit record), same as
+    :class:`Ban`.
+
+    Every read path filters on ``revoked_at IS NULL`` -- including the Go
+    Collector's snapshot query (``extension/hexgatebiscuitauth/cache.go``),
+    which is the OTLP ingest path's only revocation check.
+    """
+
     __tablename__ = "devtoken"  # historical name; renaming needs a migration
 
     id: str = Field(primary_key=True)
@@ -238,6 +247,10 @@ class ApiKey(SQLModel, table=True):
     last_used_at: Optional[datetime] = Field(
         default=None, sa_type=DateTime(timezone=True)
     )
+    revoked_at: Optional[datetime] = Field(
+        default=None, sa_type=DateTime(timezone=True)
+    )
+    revoked_by_user_id: Optional[str] = Field(default=None, foreign_key="user.id")
 
 
 class Agent(SQLModel, table=True):

--- a/platform/api/tests/features/chat/test_ws_serve.py
+++ b/platform/api/tests/features/chat/test_ws_serve.py
@@ -186,6 +186,42 @@ def test_ws_serve_rejects_unknown_or_revoked_secret(
     assert exc_info.value.code == 4401
 
 
+def test_ws_serve_rejects_a_soft_deleted_secret(
+    client: TestClient, fresh_token: str, session_factory
+) -> None:
+    """The row is still there, ``revoked_at`` is stamped → 4401.
+
+    The test above deletes the row outright, which is what revocation used to
+    be. This is what it is now: the WS gate reaches revocation through
+    ``find_token_by_secret``, so without that filter a revoked key would keep
+    opening chat sockets.
+    """
+    import asyncio
+
+    from hexgate_api.models import ApiKey, utcnow
+    from sqlmodel import select
+
+    async def _revoke_token():
+        async with session_factory() as session:
+            row = (
+                await session.exec(select(ApiKey).where(ApiKey.secret == fresh_token))
+            ).first()
+            assert row is not None
+            row.revoked_at = utcnow()
+            session.add(row)
+            await session.commit()
+
+    asyncio.get_event_loop().run_until_complete(_revoke_token())
+
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(
+            "/v1/serve",
+            subprotocols=[f"bearer.{fresh_token}", "hexgate.v1"],
+        ):
+            pass
+    assert exc_info.value.code == 4401
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------

--- a/platform/api/tests/features/chat/test_ws_serve.py
+++ b/platform/api/tests/features/chat/test_ws_serve.py
@@ -24,20 +24,27 @@ the test suite.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
+
 import pytest
 import pytest_asyncio
 from fastapi.testclient import TestClient
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
-from sqlmodel import SQLModel
+from sqlmodel import SQLModel, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 from starlette.websockets import WebSocketDisconnect
 
 from hexgate_api.core import keystore as keystore_mod
 from hexgate_api.main import app
 from hexgate_api.features.tokens.service import mint_api_key
+from hexgate_api.models import ApiKey, utcnow
 from hexgate_api.seeds.defaults import ensure_default_project
 from hexgate_api.constants import DEFAULT_PROJECT_ID
+
+SessionFactory = async_sessionmaker[AsyncSession]
+TokenRowMutation = Callable[[AsyncSession, ApiKey], Awaitable[None]]
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +114,53 @@ async def fresh_token(session_factory) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_to_key_row(
+    session_factory: SessionFactory, secret: str, mutate: TokenRowMutation
+) -> None:
+    """Run ``mutate`` against the key row holding ``secret``, then commit.
+
+    Sync because the tests around it drive ``TestClient`` from a sync body: the
+    mutation has to be committed before the handshake starts.
+    """
+
+    async def _run() -> None:
+        async with session_factory() as session:
+            row = (
+                await session.exec(select(ApiKey).where(ApiKey.secret == secret))
+            ).first()
+            assert row is not None
+            await mutate(session, row)
+            await session.commit()
+
+    asyncio.get_event_loop().run_until_complete(_run())
+
+
+async def _delete_row(session: AsyncSession, row: ApiKey) -> None:
+    await session.delete(row)
+
+
+async def _stamp_revoked_at(session: AsyncSession, row: ApiKey) -> None:
+    """Stamp by hand rather than through ``revoke_api_key``, so the test
+    exercises the read filter alone and not the revoke path as well."""
+    row.revoked_at = utcnow()
+    session.add(row)
+
+
+def _assert_bearer_rejected(client: TestClient, envelope: str) -> None:
+    with pytest.raises(WebSocketDisconnect) as exc_info:
+        with client.websocket_connect(
+            "/v1/serve",
+            subprotocols=[f"bearer.{envelope}", "hexgate.v1"],
+        ):
+            pass
+    assert exc_info.value.code == 4401
+
+
+# ---------------------------------------------------------------------------
 # Reject paths
 # ---------------------------------------------------------------------------
 
@@ -144,50 +198,25 @@ def test_ws_serve_rejects_when_bearer_is_garbage(client: TestClient) -> None:
     raise TokenError or TokenSignatureError, the handshake closes,
     no info leaked back to the client beyond the close code.
     """
-    with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect(
-            "/v1/serve",
-            subprotocols=["bearer.fty_live_not_a_real_token", "hexgate.v1"],
-        ):
-            pass
-    assert exc_info.value.code == 4401
+    _assert_bearer_rejected(client, "fty_live_not_a_real_token")
 
 
 def test_ws_serve_rejects_unknown_or_revoked_secret(
-    client: TestClient, fresh_token: str, session_factory
+    client: TestClient, fresh_token: str, session_factory: SessionFactory
 ) -> None:
-    """Bearer parses cleanly but isn't in the ApiKey table → 4401.
+    """Bearer parses cleanly but its row is gone from the ApiKey table → 4401.
 
-    Synthesises this by minting a token, then deleting the row before
-    the connection attempt — same shape as a revoke + reuse race.
+    A hard delete is no longer what revocation does, but "row genuinely gone"
+    stays a real state — a row removed by hand, or a project teardown racing a
+    reconnect.
     """
-    import asyncio
+    _apply_to_key_row(session_factory, fresh_token, _delete_row)
 
-    from hexgate_api.models import ApiKey
-    from sqlmodel import select
-
-    async def _delete_token():
-        async with session_factory() as session:
-            row = (
-                await session.exec(select(ApiKey).where(ApiKey.secret == fresh_token))
-            ).first()
-            assert row is not None
-            await session.delete(row)
-            await session.commit()
-
-    asyncio.get_event_loop().run_until_complete(_delete_token())
-
-    with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect(
-            "/v1/serve",
-            subprotocols=[f"bearer.{fresh_token}", "hexgate.v1"],
-        ):
-            pass
-    assert exc_info.value.code == 4401
+    _assert_bearer_rejected(client, fresh_token)
 
 
 def test_ws_serve_rejects_a_soft_deleted_secret(
-    client: TestClient, fresh_token: str, session_factory
+    client: TestClient, fresh_token: str, session_factory: SessionFactory
 ) -> None:
     """The row is still there, ``revoked_at`` is stamped → 4401.
 
@@ -196,30 +225,9 @@ def test_ws_serve_rejects_a_soft_deleted_secret(
     ``find_token_by_secret``, so without that filter a revoked key would keep
     opening chat sockets.
     """
-    import asyncio
+    _apply_to_key_row(session_factory, fresh_token, _stamp_revoked_at)
 
-    from hexgate_api.models import ApiKey, utcnow
-    from sqlmodel import select
-
-    async def _revoke_token():
-        async with session_factory() as session:
-            row = (
-                await session.exec(select(ApiKey).where(ApiKey.secret == fresh_token))
-            ).first()
-            assert row is not None
-            row.revoked_at = utcnow()
-            session.add(row)
-            await session.commit()
-
-    asyncio.get_event_loop().run_until_complete(_revoke_token())
-
-    with pytest.raises(WebSocketDisconnect) as exc_info:
-        with client.websocket_connect(
-            "/v1/serve",
-            subprotocols=[f"bearer.{fresh_token}", "hexgate.v1"],
-        ):
-            pass
-    assert exc_info.value.code == 4401
+    _assert_bearer_rejected(client, fresh_token)
 
 
 # ---------------------------------------------------------------------------

--- a/platform/api/tests/features/tokens/test_tokens.py
+++ b/platform/api/tests/features/tokens/test_tokens.py
@@ -8,6 +8,8 @@ had no coverage of its own. Fixtures mirror `test_projects.py`.
 
 from __future__ import annotations
 
+import asyncio
+
 from biscuit_auth import AuthorizerBuilder, Rule
 from fastapi.testclient import TestClient
 import pytest_asyncio
@@ -22,6 +24,7 @@ from hexgate_api.core.biscuits import parse_envelope, verify_token
 from hexgate_api.core.keystore import FileKeyStore
 from hexgate_api.features.tokens.service import mint_api_key
 from hexgate_api.main import app
+from hexgate_api.models import ApiKey
 from hexgate_api.seeds.defaults import ensure_default_project
 
 
@@ -90,6 +93,21 @@ def _signup_with_project(client: TestClient, email: str) -> str:
     r = client.post(f"/v1/orgs/{org_id}/projects", json={"name": "tokens-project"})
     assert r.status_code == 201, r.text
     return r.json()["id"]
+
+
+def _read_token(session_factory, token_id: str) -> ApiKey | None:
+    """Read the raw row from a sync test, bypassing the service filters.
+
+    ``run_until_complete`` on the ambient loop rather than ``asyncio.run``:
+    the in-memory engine belongs to the fixture's loop, and a fresh one would
+    not see it. Same shape as ``test_ws_serve.py``.
+    """
+
+    async def _get() -> ApiKey | None:
+        async with session_factory() as session:
+            return await session.get(ApiKey, token_id)
+
+    return asyncio.get_event_loop().run_until_complete(_get())
 
 
 # ---------------------------------------------------------------------------
@@ -181,6 +199,122 @@ def test_revoke_token_when_token_already_deleted_then_status_is_404(
 
     r = client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Soft delete — the row is retained as the audit record, and every read path
+# must stop resolving it. Without the filters, flipping the delete to a stamp
+# is a revocation bypass on HTTP, WebSocket and OTLP ingest alike.
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_token_when_revoked_then_the_row_is_retained_with_the_actor(
+    client: TestClient, session_factory
+) -> None:
+    pid = _signup_with_project(client, "audittrail@example.com")
+    me_id = client.get("/v1/users/me").json()["id"]
+    token_id = client.post(
+        f"/v1/projects/{pid}/tokens", json={"name": "traced"}
+    ).json()["id"]
+
+    assert client.delete(f"/v1/projects/{pid}/tokens/{token_id}").status_code == 204
+
+    row = _read_token(session_factory, token_id)
+    assert row is not None, "the row is the audit record; a revoke must not delete it"
+    assert row.revoked_at is not None
+    assert row.revoked_by_user_id == me_id
+
+
+def test_revoke_token_when_revoked_twice_then_the_first_stamp_is_kept(
+    client: TestClient, session_factory
+) -> None:
+    """A repeat revoke 404s (see above) and must not move the timestamp."""
+    pid = _signup_with_project(client, "twicerevoked@example.com")
+    token_id = client.post(f"/v1/projects/{pid}/tokens", json={"name": "twice"}).json()[
+        "id"
+    ]
+
+    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
+    first_stamp = _read_token(session_factory, token_id).revoked_at
+    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
+
+    assert _read_token(session_factory, token_id).revoked_at == first_stamp
+
+
+def test_me_key_when_the_token_is_revoked_then_status_is_401(
+    client: TestClient,
+) -> None:
+    """``GET /v1/me/key`` — the introspection surface (router.py)."""
+    pid = _signup_with_project(client, "introspect@example.com")
+    minted = client.post(f"/v1/projects/{pid}/tokens", json={"name": "introspect"})
+    full, token_id = minted.json()["full"], minted.json()["id"]
+    headers = {"Authorization": f"Bearer {full}"}
+    assert client.get("/v1/me/key", headers=headers).status_code == 200
+
+    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
+
+    assert client.get("/v1/me/key", headers=headers).status_code == 401
+
+
+def test_require_project_when_the_token_is_revoked_then_status_is_401(
+    client: TestClient,
+) -> None:
+    """A bearer-only SDK route — ``require_project`` (deps/tokens.py)."""
+    pid = _signup_with_project(client, "sdkroute@example.com")
+    minted = client.post(f"/v1/projects/{pid}/tokens", json={"name": "sdk"})
+    full, token_id = minted.json()["full"], minted.json()["id"]
+    headers = {"Authorization": f"Bearer {full}"}
+    assert client.get("/v1/agents/nonexistent", headers=headers).status_code == 404
+
+    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
+
+    assert client.get("/v1/agents/nonexistent", headers=headers).status_code == 401
+
+
+async def test_optional_api_key_when_the_token_is_revoked_then_it_raises_401(
+    client: TestClient, session_factory
+) -> None:
+    """``optional_api_key`` has no route wired to it yet, so it is gated here
+    directly — it is the third caller of ``_validate_sdk_token`` and would
+    otherwise be the one surface with no revocation coverage."""
+    from fastapi import HTTPException
+    import pytest
+
+    from hexgate_api.deps.tokens import optional_api_key
+
+    pid = _signup_with_project(client, "optionaldep@example.com")
+    minted = client.post(f"/v1/projects/{pid}/tokens", json={"name": "optional"})
+    full, token_id = minted.json()["full"], minted.json()["id"]
+    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
+
+    async with session_factory() as session:
+        with pytest.raises(HTTPException) as exc_info:
+            await optional_api_key(f"Bearer {full}", session)
+
+    assert exc_info.value.status_code == 401
+
+
+async def test_find_token_by_secret_when_revoked_then_last_used_at_is_not_bumped(
+    client: TestClient, session_factory
+) -> None:
+    """A revoked key must not keep updating its own activity timestamp — the
+    dashboard's "last used" column would otherwise show a revoked key as live."""
+    from hexgate_api.features.tokens.service import find_token_by_secret
+
+    pid = _signup_with_project(client, "notbumped@example.com")
+    minted = client.post(f"/v1/projects/{pid}/tokens", json={"name": "quiet"})
+    full, token_id = minted.json()["full"], minted.json()["id"]
+    client.get("/v1/me/key", headers={"Authorization": f"Bearer {full}"})
+    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
+
+    async with session_factory() as session:
+        before = (await session.get(ApiKey, token_id)).last_used_at
+        assert before is not None, "the pre-revoke introspection should have bumped it"
+
+        assert await find_token_by_secret(session, full) is None
+
+    async with session_factory() as session:
+        assert (await session.get(ApiKey, token_id)).last_used_at == before
 
 
 # ---------------------------------------------------------------------------

--- a/platform/api/tests/features/tokens/test_tokens.py
+++ b/platform/api/tests/features/tokens/test_tokens.py
@@ -22,7 +22,7 @@ from hexgate_api.constants import DEFAULT_PROJECT_ID
 from hexgate_api.core import keystore as keystore_mod
 from hexgate_api.core.biscuits import parse_envelope, verify_token
 from hexgate_api.core.keystore import FileKeyStore
-from hexgate_api.features.tokens.service import mint_api_key
+from hexgate_api.features.tokens.service import mask_secret, mint_api_key
 from hexgate_api.main import app
 from hexgate_api.models import ApiKey
 from hexgate_api.seeds.defaults import ensure_default_project
@@ -228,17 +228,48 @@ def test_revoke_token_when_revoked_then_the_row_is_retained_with_the_actor(
 def test_revoke_token_when_revoked_twice_then_the_first_stamp_is_kept(
     client: TestClient, session_factory
 ) -> None:
-    """A repeat revoke 404s (see above) and must not move the timestamp."""
+    """A repeat revoke 404s and must not move the timestamp or the actor.
+
+    The second call losing the race is the whole point of the conditional
+    UPDATE in ``revoke_api_key``: overwriting the stamp would destroy the audit
+    fact the retained row exists to carry.
+    """
     pid = _signup_with_project(client, "twicerevoked@example.com")
+    me_id = client.get("/v1/users/me").json()["id"]
     token_id = client.post(f"/v1/projects/{pid}/tokens", json={"name": "twice"}).json()[
         "id"
     ]
 
-    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
+    assert client.delete(f"/v1/projects/{pid}/tokens/{token_id}").status_code == 204
     first_stamp = _read_token(session_factory, token_id).revoked_at
-    client.delete(f"/v1/projects/{pid}/tokens/{token_id}")
 
-    assert _read_token(session_factory, token_id).revoked_at == first_stamp
+    assert client.delete(f"/v1/projects/{pid}/tokens/{token_id}").status_code == 404
+
+    row = _read_token(session_factory, token_id)
+    assert row.revoked_at == first_stamp
+    assert row.revoked_by_user_id == me_id
+
+
+def test_revoke_token_when_revoked_then_the_secret_is_masked(
+    client: TestClient, session_factory
+) -> None:
+    """The audit row keeps who/when, not a usable credential.
+
+    A DB dump -- or a rollback to code that does not filter on ``revoked_at``
+    -- would otherwise hand back working keys for every revocation ever made.
+    """
+    pid = _signup_with_project(client, "maskedonrevoke@example.com")
+    minted = client.post(f"/v1/projects/{pid}/tokens", json={"name": "masked"}).json()
+    token_id = minted["id"]
+    full_token = minted["full"]
+
+    assert client.delete(f"/v1/projects/{pid}/tokens/{token_id}").status_code == 204
+
+    stored = _read_token(session_factory, token_id).secret
+    assert stored != full_token
+    assert stored == minted["masked"] == mask_secret(full_token)
+    # The biscuit payload is what authenticates; the envelope prefix is public.
+    assert parse_envelope(full_token)[2] not in stored
 
 
 def test_me_key_when_the_token_is_revoked_then_status_is_401(

--- a/platform/collector/config.yaml
+++ b/platform/collector/config.yaml
@@ -103,10 +103,12 @@ extensions:
     public_key_file: ${env:HEXGATE_COLLECTOR_PUBLIC_KEY_FILE:-../api/data/hexgate.pub}
 
     revocation:
-      # Revoking an API key deletes its row, so the check is a lookup against
-      # a snapshot of the whole key table rather than a flag. The signed
-      # token_id fact is that row's own id (platform-api PR #126), which is
-      # what lets this be keyed on a short id instead of the full secret.
+      # Revoking an API key soft-deletes its row — it survives with
+      # revoked_at stamped (platform-api PR #206) — so the check is a lookup
+      # against a snapshot of the live keys, which is what the query filters
+      # down to. The signed token_id fact is that row's own id (platform-api
+      # PR #126), which is what lets this be keyed on a short id instead of
+      # the full secret.
       #
       # LOCAL DEV ONLY credentials, matching the postgres service in
       # platform/docker-compose.yml — never reuse these anywhere deployed.

--- a/platform/collector/extension/hexgatebiscuitauth/cache.go
+++ b/platform/collector/extension/hexgatebiscuitauth/cache.go
@@ -18,6 +18,14 @@ import (
 // join is needed — project_id is denormalised straight onto the row — and no
 // tenancy filter either, since the Collector serves every project.
 //
+// `revoked_at IS NULL` is the revocation gate. Revoking a key soft-deletes it
+// (tokens/service.py:revoke_api_key) so the row survives as the audit record,
+// which means an unfiltered read here would serve revoked keys forever — this
+// query is the ONLY revocation check on the OTLP ingest path. The column is
+// nullable and was added by platform/postgres/migrations/0001; against a
+// database that predates it this query fails and the Collector refuses to
+// boot (see start()), which is the intended loud failure.
+//
 // The secret column is deliberately not selected. The signed token_id fact
 // *is* the row's primary key (platform-api PR #126), so a verified token can
 // be looked up by that id and the Collector never has to hold full
@@ -25,7 +33,7 @@ import (
 //
 // A full-table read is viable because the row count is small: one row per API
 // key, thousands across the whole platform rather than millions.
-const apiKeyQuery = `SELECT id, project_id FROM devtoken`
+const apiKeyQuery = `SELECT id, project_id FROM devtoken WHERE revoked_at IS NULL`
 
 // loadTimeout bounds a single read of the key table. Without it, a connection
 // that black-holes packets (network partition, an LB holding the socket open)
@@ -37,8 +45,8 @@ const apiKeyQuery = `SELECT id, project_id FROM devtoken`
 const loadTimeout = 10 * time.Second
 
 var (
-	// errUnknownAPIKey means a validly-signed token's id matches no row,
-	// which is what revoking a key leaves behind.
+	// errUnknownAPIKey means a validly-signed token's id matches no
+	// unrevoked row, which is what revoking a key leaves behind.
 	errUnknownAPIKey = errors.New("api key is revoked or unknown")
 
 	// errCacheStale means we can no longer vouch for the revocation list.

--- a/platform/collector/extension/hexgatebiscuitauth/cache_test.go
+++ b/platform/collector/extension/hexgatebiscuitauth/cache_test.go
@@ -94,8 +94,9 @@ func TestRevocationCacheLookup_happy_path(t *testing.T) {
 	assert.Equal(t, "support-bot", projectID)
 }
 
-// Revoking deletes the row (tokens/service.py:delete_api_key), so a revoked key
-// is simply one that is no longer in the snapshot.
+// The snapshot holds only live keys (apiKeyQuery filters on revoked_at IS
+// NULL, matching tokens/service.py:revoke_api_key), so a revoked key is simply
+// one that is no longer in it.
 func TestRevocationCacheLookup_when_token_is_absent_then_the_key_is_unknown(t *testing.T) {
 	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
 	cache := newLoadedCache(map[string]string{"tok_abc": "support-bot"}, now, now)

--- a/platform/collector/extension/hexgatebiscuitauth/cache_test.go
+++ b/platform/collector/extension/hexgatebiscuitauth/cache_test.go
@@ -75,6 +75,15 @@ func newLoadedCache(keys map[string]string, takenAt, now time.Time) *revocationC
 	return cache
 }
 
+// The WHERE clause is the OTLP path's entire revocation check: revoking a key
+// soft-deletes its row, so an unfiltered read would serve revoked keys
+// forever. fakeKeySource above sits downstream of the SQL and cannot catch its
+// removal, and behaviour is covered by the integration suite — this only pins
+// the clause against a silent edit.
+func TestAPIKeyQuery_excludes_revoked_rows(t *testing.T) {
+	assert.Contains(t, apiKeyQuery, "revoked_at IS NULL")
+}
+
 func TestRevocationCacheLookup_happy_path(t *testing.T) {
 	now := time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)
 	cache := newLoadedCache(map[string]string{"tok_abc": "support-bot"}, now.Add(-5*time.Second), now)

--- a/platform/collector/extension/hexgatebiscuitauth/config.go
+++ b/platform/collector/extension/hexgatebiscuitauth/config.go
@@ -79,8 +79,10 @@ type Config struct {
 
 // RevocationConfig controls the in-process cache of live API keys.
 //
-// Revoking a key deletes its row (see tokens/service.py:delete_api_key), so
-// "revoked" means "no longer in the table" — a lookup miss, not a flag.
+// Revoking a key soft-deletes its row (see tokens/service.py:revoke_api_key),
+// stamping revoked_at so the row survives as the audit record. The snapshot
+// query filters those rows out (cache.go:apiKeyQuery), so "revoked" is still a
+// lookup MISS in the cache — the flag lives in Postgres, never in memory here.
 type RevocationConfig struct {
 	// Enabled turns the revocation check on. Defaults to true: a Collector
 	// that only checks signatures would honour a leaked API key forever,

--- a/platform/collector/extension/hexgatebiscuitauth/extension.go
+++ b/platform/collector/extension/hexgatebiscuitauth/extension.go
@@ -182,11 +182,12 @@ func (a *biscuitAuth) resolveProject(id *identity) (string, error) {
 	switch {
 	case errors.Is(err, errUnknownAPIKey):
 		// Worth a Warn even at volume: the signature held, so this key was
-		// minted by us and its row is gone. Revocation is the expected
-		// cause; the other way to get here is a Collector pointed at a
-		// different control-plane database than the one that minted the key,
-		// which is a deployment mistake worth seeing.
-		a.logger.Warn("rejected an API key whose token_id matches no row in devtoken: it was "+
+		// minted by us and it is absent from the snapshot. Revocation is the
+		// expected cause (revoked rows are filtered out of apiKeyQuery); the
+		// other way to get here is a Collector pointed at a different
+		// control-plane database than the one that minted the key, which is a
+		// deployment mistake worth seeing.
+		a.logger.Warn("rejected an API key that resolves to no live row in devtoken: it was "+
 			"revoked, or this Collector is reading a different control-plane database than the "+
 			"one that minted it",
 			zap.String("token_id", id.TokenID),

--- a/platform/collector/integration/harness_test.go
+++ b/platform/collector/integration/harness_test.go
@@ -123,6 +123,22 @@ func connectPostgres(t *testing.T) *pgxpool.Pool {
 		t.Fatal("the devtoken table does not exist in this database.\n" +
 			"Create the schema once with: make collector-test-integration (or make platform-api-pg)")
 	}
+
+	// A volume that predates the soft-delete migration passes the check above
+	// and then fails deep inside pgx when the snapshot query runs. create_all
+	// adds missing TABLES, never missing columns, so this is the common state
+	// of any dev database older than that migration.
+	var hasRevokedAt bool
+	err = pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM information_schema.columns
+		                WHERE table_name = 'devtoken' AND column_name = 'revoked_at')`,
+	).Scan(&hasRevokedAt)
+	require.NoError(t, err)
+	if !hasRevokedAt {
+		t.Fatal("devtoken has no revoked_at column: this database predates the soft-delete\n" +
+			"migration, and create_all does not add columns to existing tables.\n" +
+			"Apply it with: make postgres-init (replays platform/postgres/migrations/)")
+	}
 	return pool
 }
 
@@ -177,13 +193,20 @@ func seedAPIKey(t *testing.T, pool *pgxpool.Pool, secret string) apiKeyFixture {
 	return fixture
 }
 
-// revokeAPIKey deletes the key's row, which is what tokens/service.py's
-// delete_api_key does — revocation is a missing row, not a flag.
+// revokeAPIKey stamps revoked_at, which is what tokens/service.py's
+// revoke_api_key does — revocation is a soft delete, and the Collector's
+// snapshot query filters the row out. A DELETE here would still make the
+// pipeline test pass, but against a mechanism the control plane no longer
+// uses.
+//
+// now() is stamped DB-side so the test process and the Collector need not
+// share a clock.
 func revokeAPIKey(t *testing.T, pool *pgxpool.Pool, tokenID string) {
 	t.Helper()
-	tag, err := pool.Exec(context.Background(), `DELETE FROM devtoken WHERE id = $1`, tokenID)
+	tag, err := pool.Exec(context.Background(),
+		`UPDATE devtoken SET revoked_at = now() WHERE id = $1 AND revoked_at IS NULL`, tokenID)
 	require.NoError(t, err)
-	require.EqualValues(t, 1, tag.RowsAffected(), "the key under test should have existed")
+	require.EqualValues(t, 1, tag.RowsAffected(), "the key under test should have existed and been live")
 }
 
 // ---------------------------------------------------------------------------

--- a/platform/postgres/migrations/0001_devtoken_soft_delete.sql
+++ b/platform/postgres/migrations/0001_devtoken_soft_delete.sql
@@ -1,0 +1,27 @@
+-- Adds the soft-delete / audit columns to devtoken (the ApiKey table).
+--
+-- Applied BY HAND on deployed environments, not by a runner. init_db() is
+-- SQLModel.metadata.create_all (platform/api/hexgate_api/core/db.py:82), which
+-- creates missing TABLES and never adds columns to a table that already
+-- exists -- so a database that has ever run the control plane will not pick
+-- these up on its own. `make postgres-init` replays this directory for local
+-- volumes; deployed stacks apply it as described in platform/DEPLOY.md § 6.
+--
+-- ORDERING: apply this BEFORE deploying the code that references the columns.
+-- Additive and back-compatible in that direction (a running old API never
+-- selects them), and catastrophic in the other: the Collector's snapshot query
+-- filters on revoked_at, so against a database without the column its first
+-- load raises UndefinedColumn, start() returns "initial api-key load: ..." and
+-- the container refuses to boot, taking OTLP ingest down; every
+-- bearer-authenticated API route would 500 on find_token_by_secret.
+--
+-- revoked_by_user_id deliberately carries no REFERENCES clause. create_all
+-- emits one on a fresh database (the SQLModel field declares
+-- foreign_key="user.id", matching Ban.revoked_by_user_id), but the column is
+-- nullable and only ever read for display, so adding a constraint to a live
+-- table is not worth the lock.
+--
+-- Idempotent (IF NOT EXISTS on both), so re-running is a no-op.
+
+ALTER TABLE devtoken ADD COLUMN IF NOT EXISTS revoked_at timestamptz;
+ALTER TABLE devtoken ADD COLUMN IF NOT EXISTS revoked_by_user_id varchar;


### PR DESCRIPTION
Closes #161. Closes #162 (part 2; part 1 shipped in #199, part 3 stays deferred).

Revocation was a hard `DELETE`, so a revoked key left no trace — no timestamp, no revoker, nothing to show an auditor or to explain a support ticket six weeks later. `devtoken` now carries `revoked_at` / `revoked_by_user_id` and the row survives as the audit record.

**These two issues are one change.** Flipping the delete without the read-path filters is a full revocation bypass across OTLP ingest, bearer HTTP and WebSocket, so #162's "fetch non-deleted tokens" lands here rather than separately.

## What changed

| Surface | Change |
|---|---|
| `find_token_by_secret` | `revoked_at IS NULL`. Covers `_validate_sdk_token`, `require_project`, `ws_require_project` and `GET /v1/me/key` in one line — and stops a revoked key bumping its own `last_used_at` |
| `list_api_keys` | same filter; the dashboard's key list |
| `apiKeyQuery` (Go) | same filter. This is the OTLP ingest path's **only** revocation check |
| `delete_api_key` | becomes `revoke_api_key`, stamping who and when |

Naming follows `Ban` (`revoked_at` / `revoked_by_user_id`), not the `deleted_at` the issue text suggests — same idea, and a second name for it would fragment the convention. It also composes with #160's actor columns later.

## Reviewer notes

**A repeat revoke still 404s** and never moves the first timestamp. This diverges from `revoke_ban`, which is idempotent, and it is deliberate: `test_revoke_token_when_token_already_deleted_then_status_is_404` pins today's contract and the dashboard's `revokeToken` is written against it. Changing a status code inside a security fix is scope I did not want.

**No dashboard changes.** `list_api_keys` filters unconditionally — no `include_revoked` parameter. The audit value lands in the database here; surfacing revoked keys in the UI is a separate change with its own design question, and it would pull in `TokenListItem`, `api.ts` and `Tokens.tsx`.

**Scoped to `devtoken` only.** It is the one table with no `UniqueConstraint`, so a retained row costs nothing. Every other candidate (`Project`, `Agent`, `PolicyModule`, `RoleBinding`) would need a partial unique index on `deleted_at IS NULL`, which this codebase avoids because SQLite can't be relied on for it — see `Invitation`'s docstring.

**One drive-by fix, in its own commit.** `make postgres-init` ran `init_db()` without importing `hexgate_api.models`, so `SQLModel.metadata` was empty and `create_all` created **zero tables** — silently, exit code 0. My migration replay turned that into a loud `relation "devtoken" does not exist`, which is how it surfaced. The deploy stack's `api-init` already had the `import hexgate_api.models` workaround; the same one line is now here. Reviewable independently as `c333a23`.

## ⚠️ Deploy ordering — the migration goes first

`create_all` adds missing *tables*, never missing *columns*, so this schema change cannot ride along with the deploy.

| State | Result |
|---|---|
| Column present, old code | Fine — additive column nobody references |
| Column absent, new code | **Ingest outage.** The collector's first snapshot load raises `UndefinedColumn`, `start()` fails, the container refuses to boot. Every bearer-authenticated route 500s |

```bash
cd /srv/hexgate-<stage>
docker compose -p hexgate-<stage> --env-file platform/.env.<stage> \
  -f platform/docker-compose.deploy.yml exec -T postgres \
  psql -v ON_ERROR_STOP=1 -U hexgate -d hexgate \
  < platform/postgres/migrations/0001_devtoken_soft_delete.sql
make platform-up STAGE=<stage>
```

The migration is idempotent and safe to apply early. `DEPLOY.md` § 6 carries this; `make postgres-init` replays the directory locally.

`platform/postgres/migrations/` is a new directory, mirroring the existing hand-applied `platform/clickhouse/migrations/` convention (README Option B). Alembic is still the eventual answer — #160 step 3c is the change that will force it.

## Rollback

Revert the code, **leave the columns** — they are nullable and the old code never selects them. But rows soft-deleted while the new code ran reappear as live keys, so if any real revocation happened first:

```sql
DELETE FROM devtoken WHERE revoked_at IS NOT NULL;
```

That is the one manual step a rollback needs, and skipping it un-revokes keys.

## Testing

`make check-all` exits 0. `make collector-test-integration` passes against real Postgres + Redpanda.

- **6 new API tests** — row retained with the actor, second revoke keeps the first stamp, and one per bearer surface (`/v1/me/key`, `require_project`, `optional_api_key`, plus `last_used_at` not bumped). 652 API tests pass.
- **WebSocket** — a soft-delete twin of the existing 4401 test. The hard-delete one stays; "row genuinely gone" is still a distinct case.
- **The Go filter was mutation-tested.** Removing `WHERE revoked_at IS NULL` makes the integration suite **fail** (the collector logs `"keys": 1` — the revoked key still in the snapshot), so the revocation assertion is load-bearing rather than passing vacuously.
- `revokeAPIKey` in the Go harness is now an `UPDATE`; fixture teardown stays a `DELETE` (that is teardown, not revocation, and the row must leave before the FK deletes).

**`cache_test.go` cannot cover this**, contrary to the issue's suggestion: `fakeKeySource` returns a `map` and sits downstream of the SQL, so a "soft-deleted row" case there would assert nothing new. There is a 4-line string guard on the query constant instead, with the real coverage in the integration suite.

## Not in scope

Soft delete on other tables · revoked keys in the dashboard · `devtoken.user_id` + revoke-on-member-removal (#160 step 3a, lands on this same row) · Alembic · #162 part 3 incremental fetch · an index on `revoked_at` (the read is a deliberate full scan).